### PR TITLE
(wip) proof of concept of action testing

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -2,3 +2,6 @@
 .*node_modules/cjson.*
 .*node_modules/fbjs.*
 .*node_modules/npm.*
+
+[libs]
+flow/mocha.js

--- a/flow/mocha.js
+++ b/flow/mocha.js
@@ -1,0 +1,3 @@
+
+declare var describe: (name: string, func: () => void) => void;
+declare var it: (desc: string, func: () => void) => void;

--- a/public/js/actions/index.js
+++ b/public/js/actions/index.js
@@ -1,3 +1,5 @@
+// @flow
+
 const constants = require("../constants");
 const breakpoints = require("./breakpoints");
 const eventListeners = require("./event-listeners");

--- a/public/js/actions/tests/newSource.js
+++ b/public/js/actions/tests/newSource.js
@@ -1,10 +1,9 @@
 const { constants, selectors, createStore } = require("../../utils/test-head");
-const fixtures = require("../../test/fixtures/foobar.json");
 const { getSourceById } = selectors;
-const sourcesFixtures = fixtures.sources.sources;
-
-const store = createStore();
 const expect = require("expect.js");
+
+const fixtures = require("../../test/fixtures/todoSources.json");
+const fakeSources = fixtures.sources;
 
 // Write our own `newSource` to bypass the batching logic.
 function newSource(source) {
@@ -14,14 +13,36 @@ function newSource(source) {
   };
 }
 
+// "prepopulate" various stores here
+let store = createStore();
+store.dispatch(newSource(fakeSources["backbone.js"]));
+store.dispatch(newSource(fakeSources["todo.js"]));
+store.dispatch(newSource(fakeSources["jquery.js"]));
+const stateWith3Sources = store.getState();
+
+store = createStore();
+store.dispatch(newSource(fakeSources["jquery.js"]));
+store.dispatch(addBreakpoint({ sourceId: "jquery.js", line: 3 }));
+const stateWith1SourceAndBreakpoint = store.getState();
+// etc etc...
+
+
 describe("newSource", () => {
   it("adding two sources", () => {
-    store.dispatch(newSource(sourcesFixtures.fooSourceActor));
-    store.dispatch(newSource(sourcesFixtures.barSourceActor));
-    const foo = getSourceById(store.getState(), "fooSourceActor");
-    const bar = getSourceById(store.getState(), "barSourceActor");
+    const { dispatch, getState } = createStore();
+    dispatch(newSource(fakeSources["base.js"]));
+    dispatch(newSource(fakeSources["jquery.js"]));
 
-    expect(foo.get("id")).to.equal("fooSourceActor");
-    expect(bar.get("id")).to.equal("barSourceActor");
+    const base = getSourceById(getState(), "base.js");
+    const jquery = getSourceById(getState(), "jquery.js");
+    expect(base.get("id")).to.equal("base.js");
+    expect(jquery.get("id")).to.equal("jquery.js");
+  });
+
+  it("select source", () => {
+    // mockClient to be defined
+    const { dispatch, getState } = createStore(mockClient, stateWith3Sources);
+    dispatch(selectSource("base.js"));
+    // do some assertion here...
   });
 });

--- a/public/js/reducers/tests/sources.js
+++ b/public/js/reducers/tests/sources.js
@@ -1,8 +1,5 @@
 // @flow
 
-declare var describe: (name: string, func: () => void) => void;
-declare var it: (desc: string, func: () => void) => void;
-
 const { State, update } = require("../sources");
 const fixtures = require("../../test/fixtures/foobar.json");
 const fakeSources = fixtures.sources.sources;

--- a/public/js/test/fixtures/todoSources.json
+++ b/public/js/test/fixtures/todoSources.json
@@ -1,0 +1,59 @@
+{
+  "sources": {
+    "base.js": {
+      "id": "base.js",
+      "url": "http://localhost:8000/todomvc/bower_components/todomvc-common/base.js",
+      "isPrettyPrinted": false
+    },
+    "jquery.js": {
+      "id": "jquery.js",
+      "url": "http://localhost:8000/todomvc/bower_components/jquery/jquery.js",
+      "isPrettyPrinted": false
+    },
+    "underscore.js": {
+      "id": "underscore.js",
+      "url": "http://localhost:8000/todomvc/bower_components/underscore/underscore.js",
+      "isPrettyPrinted": false
+    },
+    "backbone.js": {
+      "id": "backbone.js",
+      "url": "http://localhost:8000/todomvc/bower_components/backbone/backbone.js",
+      "isPrettyPrinted": false
+    },
+    "backbone.localStorage.js": {
+      "id": "backbone.localStorage.js",
+      "url": "http://localhost:8000/todomvc/bower_components/backbone.localStorage/backbone.localStorage.js",
+      "isPrettyPrinted": false
+    },
+    "todo.js": {
+      "id": "todo.js",
+      "url": "http://localhost:8000/todomvc/js/models/todo.js",
+      "isPrettyPrinted": false
+    },
+    "todos.js": {
+      "id": "todos.js",
+      "url": "http://localhost:8000/todomvc/js/collections/todos.js",
+      "isPrettyPrinted": false
+    },
+    "todo-view.js": {
+      "id": "todo-view.js",
+      "url": "http://localhost:8000/todomvc/js/views/todo-view.js",
+      "isPrettyPrinted": false
+    },
+    "app-view.js": {
+      "id": "app-view.js",
+      "url": "http://localhost:8000/todomvc/js/views/app-view.js",
+      "isPrettyPrinted": false
+    },
+    "router.js": {
+      "id": "router.js",
+      "url": "http://localhost:8000/todomvc/js/routers/router.js",
+      "isPrettyPrinted": false
+    },
+    "app.js": {
+      "id": "app.js",
+      "url": "http://localhost:8000/todomvc/js/app.js",
+      "isPrettyPrinted": false
+    }
+  }
+}

--- a/public/js/test/integration/fixtures.js
+++ b/public/js/test/integration/fixtures.js
@@ -1,6 +1,6 @@
 // turn theses tests on when you want to write new fixture data
 // you also need to turn on the cypress-server to be able to save the fixtures.
-xdescribe("Fixtures", function() {
+describe("Fixtures", function() {
   /**
    An example of the debugger not being paused.
    */
@@ -51,6 +51,15 @@ xdescribe("Fixtures", function() {
 
     resume();
     toggleBreakpoint(11);
+    cy.reload();
+  });
+
+  /**
+   todomvc protocol objects
+   */
+  it("todomvc protocol objects", function() {
+    debugPage("todomvc");
+    cy.saveProtocolObjects("todoSources");
     cy.reload();
   });
 });


### PR DESCRIPTION
**Don't merge**, just a proof of concept. I wanted to show what I was thinking about how to structure our action/reducer tests. This is just a small step from where we are now, but I think solves some key issues.

The main file to look at is `public/js/actions/tests/newSource.js`. There are few flow tweaks in here that you can ignore. The key points:

* Don't rely as much on the full app state. I created a new cypress command `saveProtocolObjects` (name to be improved) that saves the parts that we really care about. Right now I think the sources are all we really need. Eventually we'll probably need some of the "loaded objects" and things like that.
* It also normalizes the fixture data, namely any actor IDs, so you should be getting the exact same data every time. This fixes the problem where updating the fixtures updates all of the actor IDs (resulting in a large change). And it makes it easy to reference (`sourcesFixture["jquery.js"]`)
* Tests create a new store every single time, but they can optionally "preload" the store with an existing state snapshot. This lets you load the world at any point in time, and make sure that the necessary state transitions happen after certain actions.

This is just a prototype, this isn't merge-able but wanted to talk about our strategy.