### PR TITLE
Add Key Shortcuts library

### DIFF
--- a/bin/development-server.js
+++ b/bin/development-server.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+
 "use strict";
 
 require("babel-register");
@@ -51,7 +52,6 @@ if (feature.isEnabled("hotReloading")) {
 }
 
 // Static middleware
-app.use(express.static("public/js/test/examples"));
 app.use(express.static("public"));
 
 // Routes
@@ -75,4 +75,10 @@ app.listen(8000, "0.0.0.0", function(err, result) {
   }
 
   console.log("Development Server Listening at http://localhost:8000");
+});
+
+const examples = express();
+examples.use(express.static("public/js/test/examples"));
+examples.listen(7999, "0.0.0.0", function(err, result) {
+  console.log("View debugger examples at http://localhost:7999");
 });

--- a/public/js/components/App.js
+++ b/public/js/components/App.js
@@ -15,6 +15,7 @@ const SourceFooter = createFactory(require("./SourceFooter"));
 const Autocomplete = createFactory(require("./Autocomplete"));
 const { getSelectedSource, getSources } = require("../selectors");
 const { endTruncateStr } = require("../utils/utils");
+const { KeyShortcuts } = require("../lib/devtools-sham/client/shared/key-shortcuts");
 
 const App = React.createClass({
   propTypes: {
@@ -32,18 +33,17 @@ const App = React.createClass({
   },
 
   componentDidMount() {
-    window.addEventListener("keydown", this.toggleSourcesSearch, false);
+    this.shortcuts = new KeyShortcuts({ window });
+    this.shortcuts.on("Cmd+P", this.toggleSourcesSearch);
   },
 
   componentWillUnmount() {
-    window.removeEventListener("keydown", this.toggleSourcesSearch, false);
+    this.shortcuts.off("Cmd+P", this.toggleSourcesSearch);
   },
 
-  toggleSourcesSearch(e) {
-    if ((e.metaKey || e.ctrlKey) && e.key == "p") {
-      this.setState({ searchOn: !this.state.searchOn });
-      e.preventDefault();
-    }
+  toggleSourcesSearch(key, e) {
+    e.preventDefault();
+    this.setState({ searchOn: !this.state.searchOn });
   },
 
   renderSourcesSearch() {

--- a/public/js/lib/devtools-sham/client/shared/key-shortcuts.js
+++ b/public/js/lib/devtools-sham/client/shared/key-shortcuts.js
@@ -1,0 +1,238 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+"use strict";
+
+const Services = require("Services");
+const EventEmitter = require("devtools/shared/event-emitter");
+const isOSX = Services.appinfo.OS === "Darwin";
+
+// List of electron keys mapped to DOM API (DOM_VK_*) key code
+const ElectronKeysMapping = {
+  "F1": "DOM_VK_F1",
+  "F2": "DOM_VK_F2",
+  "F3": "DOM_VK_F3",
+  "F4": "DOM_VK_F4",
+  "F5": "DOM_VK_F5",
+  "F6": "DOM_VK_F6",
+  "F7": "DOM_VK_F7",
+  "F8": "DOM_VK_F8",
+  "F9": "DOM_VK_F9",
+  "F10": "DOM_VK_F10",
+  "F11": "DOM_VK_F11",
+  "F12": "DOM_VK_F12",
+  "F13": "DOM_VK_F13",
+  "F14": "DOM_VK_F14",
+  "F15": "DOM_VK_F15",
+  "F16": "DOM_VK_F16",
+  "F17": "DOM_VK_F17",
+  "F18": "DOM_VK_F18",
+  "F19": "DOM_VK_F19",
+  "F20": "DOM_VK_F20",
+  "F21": "DOM_VK_F21",
+  "F22": "DOM_VK_F22",
+  "F23": "DOM_VK_F23",
+  "F24": "DOM_VK_F24",
+  "Space": "DOM_VK_SPACE",
+  "Backspace": "DOM_VK_BACK_SPACE",
+  "Delete": "DOM_VK_DELETE",
+  "Insert": "DOM_VK_INSERT",
+  "Return": "DOM_VK_RETURN",
+  "Enter": "DOM_VK_RETURN",
+  "Up": "DOM_VK_UP",
+  "Down": "DOM_VK_DOWN",
+  "Left": "DOM_VK_LEFT",
+  "Right": "DOM_VK_RIGHT",
+  "Home": "DOM_VK_HOME",
+  "End": "DOM_VK_END",
+  "PageUp": "DOM_VK_PAGE_UP",
+  "PageDown": "DOM_VK_PAGE_DOWN",
+  "Escape": "DOM_VK_ESCAPE",
+  "Esc": "DOM_VK_ESCAPE",
+  "Tab": "DOM_VK_TAB",
+  "VolumeUp": "DOM_VK_VOLUME_UP",
+  "VolumeDown": "DOM_VK_VOLUME_DOWN",
+  "VolumeMute": "DOM_VK_VOLUME_MUTE",
+  "PrintScreen": "DOM_VK_PRINTSCREEN",
+};
+
+/**
+ * Helper to listen for keyboard events decribed in .properties file.
+ *
+ * let shortcuts = new KeyShortcuts({
+ *   window
+ * });
+ * shortcuts.on("Ctrl+F", event => {
+ *   // `event` is the KeyboardEvent which relates to the key shortcuts
+ * });
+ *
+ * @param DOMWindow window
+ *        The window object of the document to listen events from.
+ * @param DOMElement target
+ *        Optional DOM Element on which we should listen events from.
+ *        If omitted, we listen for all events fired on `window`.
+ */
+function KeyShortcuts({ window, target }) {
+  this.window = window;
+  this.target = target || window;
+  this.keys = new Map();
+  this.eventEmitter = new EventEmitter();
+  this.target.addEventListener("keydown", this);
+}
+
+/*
+ * Parse an electron-like key string and return a normalized object which
+ * allow efficient match on DOM key event. The normalized object matches DOM
+ * API.
+ *
+ * @param DOMWindow window
+ *        Any DOM Window object, just to fetch its `KeyboardEvent` object
+ * @param String str
+ *        The shortcut string to parse, following this document:
+ *        https://github.com/electron/electron/blob/master/docs/api/accelerator.md
+ */
+KeyShortcuts.parseElectronKey = function (window, str) {
+  let modifiers = str.split("+");
+  let key = modifiers.pop();
+
+  let shortcut = {
+    ctrl: false,
+    meta: false,
+    alt: false,
+    shift: false,
+    // Set for character keys
+    key: undefined,
+    // Set for non-character keys
+    keyCode: undefined,
+  };
+  for (let mod of modifiers) {
+    if (mod === "Alt") {
+      shortcut.alt = true;
+    } else if (["Command", "Cmd"].includes(mod)) {
+      shortcut.meta = true;
+    } else if (["CommandOrControl", "CmdOrCtrl"].includes(mod)) {
+      if (isOSX) {
+        shortcut.meta = true;
+      } else {
+        shortcut.ctrl = true;
+      }
+    } else if (["Control", "Ctrl"].includes(mod)) {
+      shortcut.ctrl = true;
+    } else if (mod === "Shift") {
+      shortcut.shift = true;
+    } else {
+      console.error("Unsupported modifier:", mod, "from key:", str);
+      return null;
+    }
+  }
+
+  // Plus is a special case. It's a character key and shouldn't be matched
+  // against a keycode as it is only accessible via Shift/Capslock
+  if (key === "Plus") {
+    key = "+";
+  }
+
+  if (typeof key === "string" && key.length === 1) {
+    // Match any single character
+    shortcut.key = key.toLowerCase();
+  } else if (key in ElectronKeysMapping) {
+    // Maps the others manually to DOM API DOM_VK_*
+    key = ElectronKeysMapping[key];
+    shortcut.keyCode = window.KeyboardEvent[key];
+    // Used only to stringify the shortcut
+    shortcut.keyCodeString = key;
+  } else {
+    console.error("Unsupported key:", key);
+    return null;
+  }
+
+  return shortcut;
+};
+
+KeyShortcuts.stringify = function (shortcut) {
+  let list = [];
+  if (shortcut.alt) {
+    list.push("Alt");
+  }
+  if (shortcut.ctrl) {
+    list.push("Ctrl");
+  }
+  if (shortcut.meta) {
+    list.push("Cmd");
+  }
+  if (shortcut.shift) {
+    list.push("Shift");
+  }
+  let key;
+  if (shortcut.key) {
+    key = shortcut.key.toUpperCase();
+  } else {
+    key = shortcut.keyCodeString;
+  }
+  list.push(key);
+  return list.join("+");
+};
+
+KeyShortcuts.prototype = {
+  destroy() {
+    this.target.removeEventListener("keydown", this);
+    this.keys.clear();
+  },
+
+  doesEventMatchShortcut(event, shortcut) {
+    if (shortcut.meta != event.metaKey) {
+      return false;
+    }
+    if (shortcut.ctrl != event.ctrlKey) {
+      return false;
+    }
+    if (shortcut.alt != event.altKey) {
+      return false;
+    }
+    // Shift is a special modifier, it may implicitely be required if the
+    // expected key is a special character accessible via shift.
+    if (shortcut.shift != event.shiftKey && event.key &&
+        event.key.match(/[a-zA-Z]/)) {
+      return false;
+    }
+    if (shortcut.keyCode) {
+      return event.keyCode == shortcut.keyCode;
+    }
+    // For character keys, we match if the final character is the expected one.
+    // But for digits we also accept indirect match to please azerty keyboard,
+    // which requires Shift to be pressed to get digits.
+    return event.key.toLowerCase() == shortcut.key ||
+      (shortcut.key.match(/[0-9]/) &&
+       event.keyCode == shortcut.key.charCodeAt(0));
+  },
+
+  handleEvent(event) {
+    for (let [key, shortcut] of this.keys) {
+      if (this.doesEventMatchShortcut(event, shortcut)) {
+        this.eventEmitter.emit(key, event);
+      }
+    }
+  },
+
+  on(key, listener) {
+    if (typeof listener !== "function") {
+      throw new Error("KeyShortcuts.on() expects a function as " +
+                      "second argument");
+    }
+    if (!this.keys.has(key)) {
+      let shortcut = KeyShortcuts.parseElectronKey(this.window, key);
+      // The key string is wrong and we were unable to compute the key shortcut
+      if (!shortcut) {
+        return;
+      }
+      this.keys.set(key, shortcut);
+    }
+    this.eventEmitter.on(key, listener);
+  },
+
+  off(key, listener) {
+    this.eventEmitter.off(key, listener);
+  },
+};
+exports.KeyShortcuts = KeyShortcuts;

--- a/public/js/lib/devtools-sham/client/shared/key-shortcuts.js
+++ b/public/js/lib/devtools-sham/client/shared/key-shortcuts.js
@@ -4,7 +4,7 @@
 
 "use strict";
 
-const Services = require("Services");
+const { Services } = require("Services");
 const EventEmitter = require("devtools/shared/event-emitter");
 const isOSX = Services.appinfo.OS === "Darwin";
 

--- a/public/js/lib/devtools/client/shared/shim/Services.js
+++ b/public/js/lib/devtools/client/shared/shim/Services.js
@@ -1,0 +1,598 @@
+/* -*- indent-tabs-mode: nil; js-indent-level: 2 -*- */
+/* vim: set ts=2 et sw=2 tw=80: */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+"use strict";
+
+/* globals localStorage, window, document, NodeFilter */
+
+// Some constants from nsIPrefBranch.idl.
+const PREF_INVALID = 0;
+const PREF_STRING = 32;
+const PREF_INT = 64;
+const PREF_BOOL = 128;
+const NS_PREFBRANCH_PREFCHANGE_TOPIC_ID = "nsPref:changed";
+
+/**
+ * Create a new preference object.
+ *
+ * @param {PrefBranch} branch the branch holding this preference
+ * @param {String} name the base name of this preference
+ * @param {String} fullName the fully-qualified name of this preference
+ */
+function Preference(branch, name, fullName) {
+  this.branch = branch;
+  this.name = name;
+  this.fullName = fullName;
+  this.defaultValue = null;
+  this.hasUserValue = false;
+  this.userValue = null;
+  this.type = null;
+}
+
+Preference.prototype = {
+  /**
+   * Return this preference's current value.
+   *
+   * @return {Any} The current value of this preference.  This may
+   *         return a string, a number, or a boolean depending on the
+   *         preference's type.
+   */
+  get: function () {
+    if (this.hasUserValue) {
+      return this.userValue;
+    }
+    return this.defaultValue;
+  },
+
+  /**
+   * Set the preference's value.  The new value is assumed to be a
+   * user value.  After setting the value, this function emits a
+   * change notification.
+   *
+   * @param {Any} value the new value
+   */
+  set: function (value) {
+    if (!this.hasUserValue || value !== this.userValue) {
+      this.userValue = value;
+      this.hasUserValue = true;
+      this.saveAndNotify();
+    }
+  },
+
+  /**
+   * Set the default value for this preference, and emit a
+   * notification if this results in a visible change.
+   *
+   * @param {Any} value the new default value
+   */
+  setDefault: function (value) {
+    if (this.defaultValue !== value) {
+      this.defaultValue = value;
+      if (!this.hasUserValue) {
+        this.saveAndNotify();
+      }
+    }
+  },
+
+  /**
+   * If this preference has a user value, clear it.  If a change was
+   * made, emit a change notification.
+   */
+  clearUserValue: function () {
+    if (this.hasUserValue) {
+      this.userValue = null;
+      this.hasUserValue = false;
+      this.saveAndNotify();
+    }
+  },
+
+  /**
+   * Helper function to write the preference's value to local storage
+   * and then emit a change notification.
+   */
+  saveAndNotify: function () {
+    let store = {
+      type: this.type,
+      defaultValue: this.defaultValue,
+      hasUserValue: this.hasUserValue,
+      userValue: this.userValue,
+    };
+
+    localStorage.setItem(this.fullName, JSON.stringify(store));
+    this.branch._notify(this.name);
+  },
+
+  /**
+   * Change this preference's value without writing it back to local
+   * storage.  This is used to handle changes to local storage that
+   * were made externally.
+   *
+   * @param {Number} type one of the PREF_* values
+   * @param {Any} userValue the user value to use if the pref does not exist
+   * @param {Any} defaultValue the default value to use if the pref
+   *        does not exist
+   * @param {Boolean} hasUserValue if a new pref is created, whether
+   *        the default value is also a user value
+   * @param {Object} store the new value of the preference.  It should
+   *        be of the form {type, defaultValue, hasUserValue, userValue};
+   *        where |type| is one of the PREF_* type constants; |defaultValue|
+   *        and |userValue| are the default and user values, respectively;
+   *        and |hasUserValue| is a boolean indicating whether the user value
+   *        is valid
+   */
+  storageUpdated: function (type, userValue, hasUserValue, defaultValue) {
+    this.type = type;
+    this.defaultValue = defaultValue;
+    this.hasUserValue = hasUserValue;
+    this.userValue = userValue;
+    // There's no need to write this back to local storage, since it
+    // came from there; and this avoids infinite event loops.
+    this.branch._notify(this.name);
+  },
+};
+
+/**
+ * Create a new preference branch.  This object conforms largely to
+ * nsIPrefBranch and nsIPrefService, though it only implements the
+ * subset needed by devtools.
+ *
+ * @param {PrefBranch} parent the parent branch, or null for the root
+ *        branch.
+ * @param {String} name the base name of this branch
+ * @param {String} fullName the fully-qualified name of this branch
+ */
+function PrefBranch(parent, name, fullName) {
+  this._parent = parent;
+  this._name = name;
+  this._fullName = fullName;
+  this._observers = {};
+  this._children = {};
+
+  if (!parent) {
+    this._initializeRoot();
+  }
+}
+
+PrefBranch.prototype = {
+  PREF_INVALID: PREF_INVALID,
+  PREF_STRING: PREF_STRING,
+  PREF_INT: PREF_INT,
+  PREF_BOOL: PREF_BOOL,
+
+  /** @see nsIPrefBranch.root.  */
+  get root() {
+    return this._fullName;
+  },
+
+  /** @see nsIPrefBranch.getPrefType.  */
+  getPrefType: function (prefName) {
+    return this._findPref(prefName).type;
+  },
+
+  /** @see nsIPrefBranch.getBoolPref.  */
+  getBoolPref: function (prefName) {
+    let thePref = this._findPref(prefName);
+    if (thePref.type !== PREF_BOOL) {
+      throw new Error(`${prefName} does not have bool type`);
+    }
+    return thePref.get();
+  },
+
+  /** @see nsIPrefBranch.setBoolPref.  */
+  setBoolPref: function (prefName, value) {
+    if (typeof value !== "boolean") {
+      throw new Error("non-bool passed to setBoolPref");
+    }
+    let thePref = this._findOrCreatePref(prefName, value, true, value);
+    if (thePref.type !== PREF_BOOL) {
+      throw new Error(`${prefName} does not have bool type`);
+    }
+    thePref.set(value);
+  },
+
+  /** @see nsIPrefBranch.getCharPref.  */
+  getCharPref: function (prefName) {
+    let thePref = this._findPref(prefName);
+    if (thePref.type !== PREF_STRING) {
+      throw new Error(`${prefName} does not have string type`);
+    }
+    return thePref.get();
+  },
+
+  /** @see nsIPrefBranch.setCharPref.  */
+  setCharPref: function (prefName, value) {
+    if (typeof value !== "string") {
+      throw new Error("non-string passed to setCharPref");
+    }
+    let thePref = this._findOrCreatePref(prefName, value, true, value);
+    if (thePref.type !== PREF_STRING) {
+      throw new Error(`${prefName} does not have string type`);
+    }
+    thePref.set(value);
+  },
+
+  /** @see nsIPrefBranch.getIntPref.  */
+  getIntPref: function (prefName) {
+    let thePref = this._findPref(prefName);
+    if (thePref.type !== PREF_INT) {
+      throw new Error(`${prefName} does not have int type`);
+    }
+    return thePref.get();
+  },
+
+  /** @see nsIPrefBranch.setIntPref.  */
+  setIntPref: function (prefName, value) {
+    if (typeof value !== "number") {
+      throw new Error("non-number passed to setIntPref");
+    }
+    let thePref = this._findOrCreatePref(prefName, value, true, value);
+    if (thePref.type !== PREF_INT) {
+      throw new Error(`${prefName} does not have int type`);
+    }
+    thePref.set(value);
+  },
+
+  /** @see nsIPrefBranch.clearUserPref */
+  clearUserPref: function (prefName) {
+    let thePref = this._findPref(prefName);
+    thePref.clearUserValue();
+  },
+
+  /** @see nsIPrefBranch.prefHasUserValue */
+  prefHasUserValue: function (prefName) {
+    let thePref = this._findPref(prefName);
+    return thePref.hasUserValue;
+  },
+
+  /** @see nsIPrefBranch.addObserver */
+  addObserver: function (domain, observer, holdWeak) {
+    if (domain !== "" && !domain.endsWith(".")) {
+      throw new Error("invalid domain to addObserver: " + domain);
+    }
+    if (holdWeak) {
+      throw new Error("shim prefs only supports strong observers");
+    }
+
+    if (!(domain in this._observers)) {
+      this._observers[domain] = [];
+    }
+    this._observers[domain].push(observer);
+  },
+
+  /** @see nsIPrefBranch.removeObserver */
+  removeObserver: function (domain, observer) {
+    if (!(domain in this._observers)) {
+      return;
+    }
+    let index = this._observers[domain].indexOf(observer);
+    if (index >= 0) {
+      this._observers[domain].splice(index, 1);
+    }
+  },
+
+  /** @see nsIPrefService.savePrefFile */
+  savePrefFile: function (file) {
+    if (file) {
+      throw new Error("shim prefs only supports null file in savePrefFile");
+    }
+    // Nothing to do - this implementation always writes back.
+  },
+
+  /** @see nsIPrefService.getBranch */
+  getBranch: function (prefRoot) {
+    if (!prefRoot) {
+      return this;
+    }
+    if (prefRoot.endsWith(".")) {
+      prefRoot = prefRoot.slice(0, -1);
+    }
+    // This is a bit weird since it could erroneously return a pref,
+    // not a pref branch.
+    return this._findPref(prefRoot);
+  },
+
+  /**
+   * Helper function to find either a Preference or PrefBranch object
+   * given its name.  If the name is not found, throws an exception.
+   *
+   * @param {String} prefName the fully-qualified preference name
+   * @return {Object} Either a Preference or PrefBranch object
+   */
+  _findPref: function (prefName) {
+    let branchNames = prefName.split(".");
+    let branch = this;
+
+    for (let branchName of branchNames) {
+      branch = branch._children[branchName];
+      if (!branch) {
+        throw new Error("could not find pref branch " + prefName);
+      }
+    }
+
+    return branch;
+  },
+
+  /**
+   * Helper function to notify any observers when a preference has
+   * changed.  This will also notify the parent branch for further
+   * reporting.
+   *
+   * @param {String} relativeName the name of the updated pref,
+   *        relative to this branch
+   */
+  _notify: function (relativeName) {
+    for (let domain in this._observers) {
+      if (relativeName.startsWith(domain)) {
+        // Allow mutation while walking.
+        let localList = this._observers[domain].slice();
+        for (let observer of localList) {
+          try {
+            observer.observe(this, NS_PREFBRANCH_PREFCHANGE_TOPIC_ID,
+                             relativeName);
+          } catch (e) {
+            console.error(e);
+          }
+        }
+      }
+    }
+
+    if (this._parent) {
+      this._parent._notify(this._name + "." + relativeName);
+    }
+  },
+
+  /**
+   * Helper function to create a branch given an array of branch names
+   * representing the path of the new branch.
+   *
+   * @param {Array} branchList an array of strings, one per component
+   *        of the branch to be created
+   * @return {PrefBranch} the new branch
+   */
+  _createBranch: function (branchList) {
+    let parent = this;
+    for (let branch of branchList) {
+      if (!parent._children[branch]) {
+        parent._children[branch] = new PrefBranch(parent, branch,
+                                                  parent.root + "." + branch);
+      }
+      parent = parent._children[branch];
+    }
+    return parent;
+  },
+
+  /**
+   * Create a new preference.  The new preference is assumed to be in
+   * local storage already, and the new value is taken from there.
+   *
+   * @param {String} keyName the full-qualified name of the preference.
+   *        This is also the name of the key in local storage.
+   * @param {Any} userValue the user value to use if the pref does not exist
+   * @param {Any} defaultValue the default value to use if the pref
+   *        does not exist
+   * @param {Boolean} hasUserValue if a new pref is created, whether
+   *        the default value is also a user value
+   */
+  _findOrCreatePref: function (keyName, userValue, hasUserValue, defaultValue) {
+    let branchName = keyName.split(".");
+    let prefName = branchName.pop();
+
+    let branch = this._createBranch(branchName);
+    if (!(prefName in branch._children)) {
+      if (hasUserValue && typeof (userValue) !== typeof (defaultValue)) {
+        throw new Error("inconsistent values when creating " + keyName);
+      }
+
+      let type;
+      switch (typeof (defaultValue)) {
+        case "boolean":
+          type = PREF_BOOL;
+          break;
+        case "number":
+          type = PREF_INT;
+          break;
+        case "string":
+          type = PREF_STRING;
+          break;
+        default:
+          throw new Error("unhandled argument type: " + typeof (defaultValue));
+      }
+
+      let thePref = new Preference(branch, prefName, keyName);
+      thePref.storageUpdated(type, userValue, hasUserValue, defaultValue);
+      branch._children[prefName] = thePref;
+    }
+
+    return branch._children[prefName];
+  },
+
+  /**
+   * Helper function that is called when local storage changes.  This
+   * updates the preferences and notifies pref observers as needed.
+   *
+   * @param {StorageEvent} event the event representing the local
+   *        storage change
+   */
+  _onStorageChange: function (event) {
+    if (event.storageArea !== localStorage) {
+      return;
+    }
+    // Ignore delete events.  Not clear what's correct.
+    if (event.key === null || event.newValue === null) {
+      return;
+    }
+
+    let {type, userValue, hasUserValue, defaultValue} =
+        JSON.parse(event.newValue);
+    if (event.oldValue === null) {
+      this._findOrCreatePref(event.key, userValue, hasUserValue, defaultValue);
+    } else {
+      let thePref = this._findPref(event.key);
+      thePref.storageUpdated(type, userValue, hasUserValue, defaultValue);
+    }
+  },
+
+  /**
+   * Helper function to initialize the root PrefBranch.
+   */
+  _initializeRoot: function () {
+    if (localStorage.length === 0) {
+      // FIXME - this is where we'll load devtools.js to install the
+      // default prefs.
+    }
+
+    // Read the prefs from local storage and create the local
+    // representations.
+    for (let i = 0; i < localStorage.length; ++i) {
+      let keyName = localStorage.key(i);
+      let {userValue, hasUserValue, defaultValue} =
+          JSON.parse(localStorage.getItem(keyName));
+      this._findOrCreatePref(keyName, userValue, hasUserValue, defaultValue);
+    }
+
+    this._onStorageChange = this._onStorageChange.bind(this);
+    window.addEventListener("storage", this._onStorageChange);
+  },
+};
+
+const Services = {
+  /**
+   * An implementation of nsIPrefService that is based on local
+   * storage.  Only the subset of nsIPrefService that is actually used
+   * by devtools is implemented here.
+   */
+  prefs: new PrefBranch(null, "", ""),
+
+  /**
+   * An implementation of Services.appinfo that holds just the
+   * properties needed by devtools.
+   */
+  appinfo: {
+    get OS() {
+      const os = window.navigator.userAgent;
+      if (os) {
+        if (os.includes("Linux")) {
+          return "Linux";
+        } else if (os.includes("Windows")) {
+          return "WINNT";
+        } else if (os.includes("Mac")) {
+          return "Darwin";
+        }
+      }
+      return "Unknown";
+    },
+
+    // It's fine for this to be an approximation.
+    get name() {
+      return window.navigator.userAgent;
+    },
+
+    // It's fine for this to be an approximation.
+    get version() {
+      return window.navigator.appVersion;
+    },
+
+    // This is only used by telemetry, which is disabled for the
+    // content case.  So, being totally wrong is ok.
+    get is64Bit() {
+      return true;
+    },
+  },
+
+  /**
+   * A no-op implementation of Services.telemetry.  This supports just
+   * the subset of Services.telemetry that is used by devtools.
+   */
+  telemetry: {
+    getHistogramById: function (name) {
+      return {
+        add: () => {}
+      };
+    },
+
+    getKeyedHistogramById: function (name) {
+      return {
+        add: () => {}
+      };
+    },
+  },
+
+  /**
+   * An implementation of Services.focus that holds just the
+   * properties and methods needed by devtools.
+   * @see nsIFocusManager.idl for details.
+   */
+  focus: {
+    // These values match nsIFocusManager in order to make testing a
+    // bit simpler.
+    MOVEFOCUS_FORWARD: 1,
+    MOVEFOCUS_BACKWARD: 2,
+
+    get focusedElement() {
+      if (!document.hasFocus()) {
+        return null;
+      }
+      return document.activeElement;
+    },
+
+    moveFocus: function (window, startElement, type, flags) {
+      if (flags !== 0) {
+        throw new Error("shim Services.focus.moveFocus only accepts flags===0");
+      }
+      if (type !== Services.focus.MOVEFOCUS_FORWARD
+          && type !== Services.focus.MOVEFOCUS_BACKWARD) {
+        throw new Error("shim Services.focus.moveFocus only supports " +
+                        " MOVEFOCUS_FORWARD and MOVEFOCUS_BACKWARD");
+      }
+
+      if (!startElement) {
+        startElement = document.activeElement || document;
+      }
+
+      let iter = document.createTreeWalker(document, NodeFilter.SHOW_ELEMENT, {
+        acceptNode: function (node) {
+          let tabIndex = node.getAttribute("tabindex");
+          if (tabIndex === "-1") {
+            return NodeFilter.FILTER_SKIP;
+          }
+          node.focus();
+          if (document.activeElement == node) {
+            return NodeFilter.FILTER_ACCEPT;
+          }
+          return NodeFilter.FILTER_SKIP;
+        }
+      });
+
+      iter.currentNode = startElement;
+
+      // Sets the focus via side effect in the filter.
+      if (type === Services.focus.MOVEFOCUS_FORWARD) {
+        iter.nextNode();
+      } else {
+        iter.previousNode();
+      }
+    },
+  },
+};
+
+/**
+ * Create a new preference.  This is used during startup (see
+ * devtools/client/preferences/devtools.js) to install the
+ * default preferences.
+ *
+ * @param {String} name the name of the preference
+ * @param {Any} value the default value of the preference
+ */
+function pref(name, value) {
+  let thePref = Services.prefs._findOrCreatePref(name, value, true, value);
+  thePref.setDefault(value);
+}
+
+exports.Services = Services;
+// This is exported to silence eslint and, at some point, perhaps to
+// provide it when loading devtools.js in order to install the default
+// preferences.
+exports.pref = pref;

--- a/public/js/lib/devtools/client/shared/shim/Services.js
+++ b/public/js/lib/devtools/client/shared/shim/Services.js
@@ -448,9 +448,13 @@ PrefBranch.prototype = {
     // representations.
     for (let i = 0; i < localStorage.length; ++i) {
       let keyName = localStorage.key(i);
-      let {userValue, hasUserValue, defaultValue} =
-          JSON.parse(localStorage.getItem(keyName));
-      this._findOrCreatePref(keyName, userValue, hasUserValue, defaultValue);
+      try {
+        let {userValue, hasUserValue, defaultValue} =
+            JSON.parse(localStorage.getItem(keyName));
+
+        this._findOrCreatePref(keyName, userValue, hasUserValue, defaultValue);
+      } catch (e) {
+      }
     }
 
     this._onStorageChange = this._onStorageChange.bind(this);

--- a/public/js/test/cypress/commands.js
+++ b/public/js/test/cypress/commands.js
@@ -46,7 +46,7 @@ Cypress.addParentCommand("debuggee", function(callback) {
 });
 
 Cypress.addParentCommand("navigate", function(url) {
-  url = "http://localhost:8000/" + url;
+  url = "http://localhost:7999/" + url;
   return cy.window().then(win => {
     return win.client.navigate(url);
   });

--- a/public/js/test/cypress/commands/debugger.js
+++ b/public/js/test/cypress/commands/debugger.js
@@ -42,7 +42,6 @@ function scopeAtIndex(index) {
   be able to be removed if the test waits for the elements to appear.
  */
 function debugPage(urlPart, browser = "Firefox") {
-  url = "http://localhost:8000/" + urlPart;
   cy.visit("http://localhost:8000");
   cy.get(`.${browser} .tab`).first().click();
   cy.wait(1000);

--- a/public/js/test/integration/todomvc.js
+++ b/public/js/test/integration/todomvc.js
@@ -2,7 +2,7 @@
 describe("Todo MVC", function() {
   it("(Firefox) Test Pausing", function() {
     debugPage("todomvc");
-    goToSource("localhost:8000/js/views/todo-view");
+    goToSource("localhost:7999/js/views/todo-view");
     toggleBreakpoint(33);
 
     // pause and check the first frame
@@ -29,7 +29,7 @@ describe("Todo MVC", function() {
     debugPage("todomvc");
 
     // test adding breakpoints
-    goToSource("localhost:8000/js/views/todo-view");
+    goToSource("localhost:7999/js/views/todo-view");
     toggleBreakpoint(33);
     goToSource("app-view");
     toggleBreakpoint(35);
@@ -51,7 +51,7 @@ describe("Todo MVC", function() {
   // that will wrap these tests call each `it` in both browser contexts.
   xit("(Chrome) Test Pausing", function() {
     debugPage("todomvc", "Chrome");
-    goToSource("localhost:8000/js/views/todo-view");
+    goToSource("localhost:7999/js/views/todo-view");
     toggleBreakpoint(33);
 
     // pause and check the first frame

--- a/public/js/utils/event-emitter.js
+++ b/public/js/utils/event-emitter.js
@@ -1,0 +1,126 @@
+let EventEmitter = function() {};
+
+const defer = require("./defer");
+
+/**
+ * Decorate an object with event emitter functionality.
+ *
+ * @param Object objectToDecorate
+ *        Bind all public methods of EventEmitter to
+ *        the objectToDecorate object.
+ */
+EventEmitter.decorate = function(objectToDecorate) {
+  let emitter = new EventEmitter();
+  objectToDecorate.on = emitter.on.bind(emitter);
+  objectToDecorate.off = emitter.off.bind(emitter);
+  objectToDecorate.once = emitter.once.bind(emitter);
+  objectToDecorate.emit = emitter.emit.bind(emitter);
+};
+
+EventEmitter.prototype = {
+  /**
+   * Connect a listener.
+   *
+   * @param string event
+   *        The event name to which we're connecting.
+   * @param function listener
+   *        Called when the event is fired.
+   */
+  on(event, listener) {
+    if (!this._eventEmitterListeners) {
+      this._eventEmitterListeners = new Map();
+    }
+    if (!this._eventEmitterListeners.has(event)) {
+      this._eventEmitterListeners.set(event, []);
+    }
+    this._eventEmitterListeners.get(event).push(listener);
+  },
+
+  /**
+   * Listen for the next time an event is fired.
+   *
+   * @param string event
+   *        The event name to which we're connecting.
+   * @param function listener
+   *        (Optional) Called when the event is fired. Will be called at most
+   *        one time.
+   * @return promise
+   *        A promise which is resolved when the event next happens. The
+   *        resolution value of the promise is the first event argument. If
+   *        you need access to second or subsequent event arguments (it's rare
+   *        that this is needed) then use listener
+   */
+  once(event, listener) {
+    let deferred = defer();
+
+    let handler = (_, first, ...rest) => {
+      this.off(event, handler);
+      if (listener) {
+        listener.apply(null, [event, first, ...rest]);
+      }
+      deferred.resolve(first);
+    };
+
+    handler._originalListener = listener;
+    this.on(event, handler);
+
+    return deferred.promise;
+  },
+
+  /**
+   * Remove a previously-registered event listener.  Works for events
+   * registered with either on or once.
+   *
+   * @param string event
+   *        The event name whose listener we're disconnecting.
+   * @param function listener
+   *        The listener to remove.
+   */
+  off(event, listener) {
+    if (!this._eventEmitterListeners) {
+      return;
+    }
+    let listeners = this._eventEmitterListeners.get(event);
+    if (listeners) {
+      this._eventEmitterListeners.set(event, listeners.filter(l => {
+        return l !== listener && l._originalListener !== listener;
+      }));
+    }
+  },
+
+  /**
+   * Emit an event.  All arguments to this method will
+   * be sent to listener functions.
+   */
+  emit(event) {
+    if (!this._eventEmitterListeners
+        || !this._eventEmitterListeners.has(event)) {
+      return;
+    }
+
+    let originalListeners = this._eventEmitterListeners.get(event);
+    for (let listener of this._eventEmitterListeners.get(event)) {
+      // If the object was destroyed during event emission, stop
+      // emitting.
+      if (!this._eventEmitterListeners) {
+        break;
+      }
+
+      // If listeners were removed during emission, make sure the
+      // event handler we're going to fire wasn't removed.
+      if (originalListeners === this._eventEmitterListeners.get(event) ||
+        this._eventEmitterListeners.get(event).some(l => l === listener)) {
+        try {
+          listener.apply(null, arguments);
+        } catch (ex) {
+          // Prevent a bad listener from interfering with the others.
+          let msg = ex + ": " + ex.stack;
+          console.error(msg);
+          dump(msg + "\n");
+        }
+      }
+    }
+  }
+};
+
+module.exports = EventEmitter;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -33,6 +33,10 @@ let webpackConfig = {
   resolve: {
     alias: {
       "devtools/client/shared/vendor/react": "react",
+      "devtools/shared/event-emitter": path.join(
+        __dirname,
+        "./public/js/utils/event-emitter"
+      ),
       "devtools": path.join(__dirname, "./public/js/lib/devtools"),
       "devtools-sham": path.join(__dirname, "./public/js/lib/devtools-sham"),
       "sdk": path.join(__dirname, "./public/js/lib/devtools-sham/sdk"),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -35,7 +35,11 @@ let webpackConfig = {
       "devtools/client/shared/vendor/react": "react",
       "devtools": path.join(__dirname, "./public/js/lib/devtools"),
       "devtools-sham": path.join(__dirname, "./public/js/lib/devtools-sham"),
-      "sdk": path.join(__dirname, "./public/js/lib/devtools-sham/sdk")
+      "sdk": path.join(__dirname, "./public/js/lib/devtools-sham/sdk"),
+      "Services": path.join(
+        __dirname,
+        "./public/js/lib/devtools/client/shared/shim/Services"
+      )
     }
   },
   module: {


### PR DESCRIPTION
Fixes #360.

This PR adds the key-shortcuts library, Services Shim, and EventEmitter.

Notes:
+ key shortcuts library gives us an api for setting keyboard events. It did not support preventDefault, so i added a patch that I will also land in m-c.
+ services shim - adds lots of useful properties that are de-privileged. I'm most excited about prefs. Prefs however tried tor read local storage items with the assumption that they were all JSON parseable, which was not the case because todomvc shoves some random stuff in there. Consequently I moved the debugger examples to port 7999.
+ EventEmitter is a general purpose utility in m-c. It is being added to our utils directory because I had to rip out the `logEvent` function which assumes dump is available. There's also a lot of factory setup, which is not necessary. We might be able to reconcile these changes by injecting a dump console.log with webpack's define plugin if we want to
