### PR TITLE
s/jlongster/devtools-html/

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,15 +140,15 @@ With node running in _inspect mode_ go to your browser running `localhost:8000` 
 
 ### Reporting Bugs :bug:
 
-If you find an issue with the code please do [file an issue](https://github.com/jlongster/debugger.html/issues/new) and tag it with the label [bug](https://github.com/jlongster/debugger.html/labels/bug).  We'll do our best to review the issue in a timely manner and respond.
+If you find an issue with the code please do [file an issue](https://github.com/devtools-html/debugger.html/issues/new) and tag it with the label [bug](https://github.com/devtools-html/debugger.html/labels/bug).  We'll do our best to review the issue in a timely manner and respond.
 
 ### Suggesting Enhancements :new:
 
-We are actively investigating ways of support enhancement requests in the project so these instructions are subject to change.  For now please create an issue, tag it with the [enhancement](https://github.com/jlongster/debugger.html/labels/enhancement) label and we will attempt to respond.
+We are actively investigating ways of support enhancement requests in the project so these instructions are subject to change.  For now please create an issue, tag it with the [enhancement](https://github.com/devtools-html/debugger.html/labels/enhancement) label and we will attempt to respond.
 
 ### Writing Documentation :book:
 
-Documentation is as important as code and we need your help to maintain clear and usable documentation.  If you find an error in here or other project documentation please [file an issue](https://github.com/jlongster/debugger.html/issues/new) and tag it with the label [docs](https://github.com/jlongster/debugger.html/labels/docs).
+Documentation is as important as code and we need your help to maintain clear and usable documentation.  If you find an error in here or other project documentation please [file an issue](https://github.com/devtools-html/debugger.html/issues/new) and tag it with the label [docs](https://github.com/devtools-html/debugger.html/labels/docs).
 
 ### Writing Code :computer:
 
@@ -158,15 +158,15 @@ We have a number of tools to help you with your code contributions, the followin
 
 If this is your first time contributing any code take a look through the `first-timers-only` issues:
 
-* [first-timers-only](https://github.com/jlongster/debugger.html/labels/first-timers-only) - issues which should have clear expectations and a mentor to help you through
+* [first-timers-only](https://github.com/devtools-html/debugger.html/labels/first-timers-only) - issues which should have clear expectations and a mentor to help you through
 
 If you've contributed to an open source project before, but would like to help this one please take a look through the `up for grabs` issues:
 
-* [up for grabs](https://github.com/jlongster/debugger.html/labels/up%20for%20grabs) - issues which should have clear requirements and a difficulty level set as a label
+* [up for grabs](https://github.com/devtools-html/debugger.html/labels/up%20for%20grabs) - issues which should have clear requirements and a difficulty level set as a label
 
 To begin your work make sure you follow these steps:
 
-* [Fork this project](https://github.com/jlongster/debugger.html#fork-destination-box)
+* [Fork this project](https://github.com/devtools-html/debugger.html#fork-destination-box)
 * Create a branch to start your work `git checkout -b your-feature-name`
 * Commit your work
 * Create a pull request
@@ -232,7 +232,7 @@ $ npm run lint
 
 ##### Lint CSS
 
-We use [Stylelint](http://stylelint.io/) to maintain our CSS styles.  The [.stylelintrc](https://github.com/jlongster/debugger.html/blob/master/.stylelintrc) file contains the style definitions, please adhere to those styles when making changes.
+We use [Stylelint](http://stylelint.io/) to maintain our CSS styles.  The [.stylelintrc](https://github.com/devtools-html/debugger.html/blob/master/.stylelintrc) file contains the style definitions, please adhere to those styles when making changes.
 
 To test your CSS changes run the command:
 
@@ -242,7 +242,7 @@ $ npm run lint-css
 
 ##### Lint JS
 
-We use [eslint](http://eslint.org/) to maintain our JavaScript styles.  The [.eslintrc](https://github.com/jlongster/debugger.html/blob/master/.eslintrc) file contains our style definitions, please adhere to those styles when making changes.
+We use [eslint](http://eslint.org/) to maintain our JavaScript styles.  The [.eslintrc](https://github.com/devtools-html/debugger.html/blob/master/.eslintrc) file contains our style definitions, please adhere to those styles when making changes.
 
 To test your JS changes run the command:
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ debugger.html is a hackable debugger for modern times, built from the ground up 
 
 <!-- _headline screenshots_ -->
 
-![Circle CI status](https://circleci.com/gh/jlongster/debugger.html.svg??&style=shield)
+![Circle CI status](https://circleci.com/gh/devtools-html/debugger.html.svg??&style=shield)
 [![npm version](https://img.shields.io/npm/v/debugger.html.svg)](https://www.npmjs.com/package/debugger.html)
 
 ## Getting Started
@@ -37,7 +37,7 @@ This is an open source project and we would love your help. We have prepared a [
       * [Linting][linting]
       * [Storybook][storybook]
 
-We use the [up for grabs](https://github.com/jlongster/debugger.html/labels/up%20for%20grabs) label to indicate this work is open for anyone to take.  If you already know what you're doing and want to dive in, take a look at those issues.
+We use the [up for grabs](https://github.com/devtools-html/debugger.html/labels/up%20for%20grabs) label to indicate this work is open for anyone to take.  If you already know what you're doing and want to dive in, take a look at those issues.
 
 ## Discussion
 

--- a/docs/integration-tests.md
+++ b/docs/integration-tests.md
@@ -20,7 +20,7 @@ stepOut();
 
 The tests are driven with javascript [events](https://developer.mozilla.org/en-US/docs/Web/API/Document/createEvent)
 like click, keypress, or change that simulate a user interacting with the debugger. All of the events are wrapped with
-debugger specific commands like `stepIn` or `selectSource` [commands](https://github.com/jlongster/debugger.html/blob/master/public/js/test/cypress/commands/debugger.js#L110-L112).
+debugger specific commands like `stepIn` or `selectSource` [commands](https://github.com/devtools-html/debugger.html/blob/master/public/js/test/cypress/commands/debugger.js#L110-L112).
 
 #### Running tests
 + `npm run firefox` - launch firefox

--- a/package.json
+++ b/package.json
@@ -2,6 +2,14 @@
   "name": "debugger.html",
   "version": "0.0.5",
   "license": "MPL-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/devtools-html/debugger.html.git"
+  },
+  "bugs": {
+    "url": "https://github.com/devtools-html/debugger.html/issues"
+  },
+  "homepage": "https://github.com/devtools-html/debugger.html#readme",
   "scripts": {
     "flow": "flow",
     "start": "node bin/development-server",

--- a/public/js/components/Editor.css
+++ b/public/js/components/Editor.css
@@ -6,7 +6,7 @@
 
 /**
  * There's a known codemirror flex issue with chrome that this addresses.
- * BUG https://github.com/jlongster/debugger.html/issues/63
+ * BUG https://github.com/devtools-html/debugger.html/issues/63
  */
 .editor-wrapper {
   position: absolute;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -96,12 +96,12 @@ if (isDevelopment()) {
   webpackConfig.plugins.push(new ExtractTextPlugin("styles.css"));
 }
 
-if(isFirefoxPanel()) {
+if (isFirefoxPanel()) {
   webpackConfig = require("./webpack.config.devtools")(webpackConfig);
 }
 
 // NOTE: This is only needed to fix a bug with chrome devtools' debugger and
-// destructuring params https://github.com/jlongster/debugger.html/issues/67
+// destructuring params https://github.com/devtools-html/debugger.html/issues/67
 if (isEnabled("transformParameters")) {
   webpackConfig.module.loaders.forEach(spec => {
     if (spec.isJavaScriptLoader) {


### PR DESCRIPTION
Most things will redirect properly, but there’s no reason to create confusion.