### PR TITLE
Add editor story

### DIFF
--- a/public/js/components/EditorBreakpoint.js
+++ b/public/js/components/EditorBreakpoint.js
@@ -50,6 +50,10 @@ const Breakpoint = React.createClass({
   },
 
   componentWillUnmount() {
+    if (!this.props.editor) {
+      return;
+    }
+
     const bp = this.props.breakpoint;
     const line = bp.location.line - 1;
 

--- a/public/js/components/stories/Editor.js
+++ b/public/js/components/stories/Editor.js
@@ -17,4 +17,5 @@ function renderEditor(fixtureName) {
 }
 
 storiesOf("Editor", module)
-  .add("TodoMVC", () => renderEditor("todomvc"));
+  .add("Source + Breakpoints", () => renderEditor("todomvcUpdateOnEnter"))
+  .add("No Source Selected", () => renderEditor("todomvc"));


### PR DESCRIPTION
This adds a second story for the Editor, which has a selected source and some breakpoints. Unfortunately, I found that for toggling between stories breaks the editor. I believe it has something to do with the provider not supporting changing the store, but i'm not sure.