### PR TITLE
add watchExpressions feature flag and related docs

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -8,6 +8,7 @@ All default config values are in [`config/development.json`](./development.json)
 * `features` debugger related features
   * `tabs` Enables source view tabs in the editor (CodeMirror)
   * `sourceMaps` Enables source map loading when available
+  * `watchExpressions` Enables accordion component for working with watch expressions
 * `chrome` Chrome browser related flags
   * `debug` Enables listening for remotely debuggable Chrome browsers
   * `webSocketPort` Configures the web socket port specified when launching Chrome from the command line

--- a/config/development.json
+++ b/config/development.json
@@ -7,7 +7,8 @@
   "features": {
     "tabs": true,
     "sourceMaps": true,
-    "prettyPrint": false
+    "prettyPrint": false,
+    "watchExpressions": false
   },
   "chrome": {
     "debug": false,

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -1,0 +1,40 @@
+## Feature Flags
+
+The debugger.html project has a system for [feature flags](https://en.wikipedia.org/wiki/Feature_toggle), a system that allows us to ship certain features which are off by default.  Features must be in active development with the intention of landing in the core; feature flags are not intended for landing broken code or features which are not under active development.
+
+Feature flags toggle features that are either:
+* experimental or in a testing phase
+* designed to be configured by the user
+
+Periodically feature flags are removed as features are either out of the experimental phase and merged into the core or are removed and no longer available.  In the future we may turn on certain features for subsets of the population.
+
+## Configure
+
+All feature flags are configured in the [config directory](./config/).  See the [config/README](./config/README.md) for descriptions of each flag.
+
+## Development
+
+When developing features behind a feature flag there are resources within the codebase to help you.  Here are steps to follow when creating a feature flag.
+
+- Add an option to the [config/development.json](../config/development.json) file, default to `false` (off)
+- Create a corresponding entry in the [config/README](./config/README.md) that describes the flag
+- Add the code required to create the feature flag
+
+The `isEnabled` function checks the truthy value of a feature flag.  Pass in the full object name and location for the value.  Features are located within the `features` object and therefore have the name `features.X` where `X` is the name of the feature being described.
+
+### Example
+
+Search for [isEnabled](https://github.com/devtools-html/debugger.html/search?utf8=%E2%9C%93&q=isEnabled) in the code to find more examples.
+
+```js
+// within the components directory you can require isEnabled
+const { isEnabled } = require("../feature");
+
+// feature check can be done in render() method
+render() {
+  if (!isEnabled("features.pokemon-go")) {
+    return null;
+  }
+  return dom.div(null, 'pokestop!');
+}
+```


### PR DESCRIPTION
Need to add flag docs for `watchExpressions`.  This situation also has me thinking that I want a CI test or bot who looks for feature flag usage and warns if you didn't add it to the development.json file; too big a job for now.

I also wanted to have some docs to point to to help guide issues like #437 