### PR TITLE
Fix unit tests

### DIFF
--- a/config/feature.js
+++ b/config/feature.js
@@ -1,10 +1,7 @@
 "use strict";
 
 const pick = require("lodash/get");
-
-let config = typeof window != "undefined" ? DebuggerConfig : {};
-const originalConfig = Object.assign({}, config);
-
+let config;
 /**
  * Gets a config value for a given key
  * e.g "chrome.webSocketPort"
@@ -24,12 +21,11 @@ function isFirefoxPanel() {
 }
 
 function isFirefox() {
-  return /firefox/i.test(navigator.userAgent)
+  return /firefox/i.test(navigator.userAgent);
 }
 
-// only used for testing purposes
-function setConfig(stub) {
-  config = stub;
+function setConfig(value) {
+  config = value;
 }
 
 function getConfig() {

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -1,4 +1,4 @@
-/* global window, document */
+/* global window, document, DebuggerConfig */
 
 const { bindActionCreators, combineReducers } = require("redux");
 const { Provider } = require("react-redux");
@@ -8,7 +8,10 @@ const React = require("react");
 const DevToolsUtils = require("devtools-sham/shared/DevToolsUtils");
 const AppConstants = require("devtools-sham/sham/appconstants").AppConstants;
 const { injectGlobals } = require("./utils/debug");
-const { isEnabled, isFirefoxPanel, isDevelopment } = require("../../config/feature");
+const { isEnabled, isFirefoxPanel,
+        isDevelopment, setConfig } = require("../../config/feature");
+
+setConfig(DebuggerConfig);
 
 // Set various flags before requiring app code.
 if (isEnabled("logging.client")) {

--- a/public/js/test/node-unit-tests.js
+++ b/public/js/test/node-unit-tests.js
@@ -1,9 +1,13 @@
 const glob = require("glob").sync;
 const path = require("path");
 const Mocha = require("mocha");
+const getConfig = require("../../../config/config").getConfig;
+const setConfig = require("../../../config/feature").setConfig;
 
 require("amd-loader");
 require("babel-register");
+
+setConfig(getConfig());
 
 const webpack = require("webpack");
 const webpackConfig = require("../../../webpack.config");


### PR DESCRIPTION
The unit tests were not getting the config values, which were needed for getting the source map base url.

The fix is to change the way the config was being set so that it's always set with `setConfig` at the right time.

There are two cases to keep in mind:
+ **local scripts** (dev-server, unit tests, ...) need to set the config at the top if they're going to use features.
+ **app** needs to set the config at the top of main.js, based off of the DebuggerConfig global. I'd prefer if debuggerConfig were a module that could be required, but i'm not sure if that's possible.



