### PR TITLE
Add chrome tests for source maps

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -5,9 +5,11 @@ test:
     - node_modules/.bin/cypress ci b07646ab-ddfa-442b-b63f-aebf00452de8
     - node_modules/.bin/cypress ci b07646ab-ddfa-442b-b63f-aebf00452de8
   pre:
-    - node bin/development-server.js:
+    - DEBUG_CHROME=true node bin/development-server.js:
         background: true
     - node bin/firefox-driver --start:
+        background: true
+    - /opt/google/chrome/google-chrome --remote-debugging-port=9222 --no-first-run:
         background: true
     - sleep 30
   post:

--- a/config/config.js
+++ b/config/config.js
@@ -9,10 +9,16 @@ const development = require("./development.json");
 const envConfig = process.env.TARGET === "firefox-panel" ?
    firefoxPanel : development;
 
+const shouldDebugChrome = !!process.env.DEBUG_CHROME;
+
 const localConfig = fs.existsSync(path.join(__dirname, "./local.json")) ?
   require("./local.json") : {};
 
 let config = _.merge({}, envConfig, localConfig);
+
+if (shouldDebugChrome) {
+  config.chrome.debug = true;
+}
 
 function getConfig() {
   return config;
@@ -20,4 +26,4 @@ function getConfig() {
 
 module.exports = {
   getConfig
-}
+};

--- a/public/js/clients/chrome.js
+++ b/public/js/clients/chrome.js
@@ -17,14 +17,11 @@ Array.prototype.peekLast = function() {
 let connection;
 
 function createTabs(tabs) {
-  const blacklist = ["New Tab", "Inspectable pages"];
 
   return tabs
     .filter(tab => {
       const isPage = tab.type == "page";
-      const isBlacklisted = blacklist.indexOf(tab.title) != -1;
-
-      return isPage && !isBlacklisted;
+      return isPage;
     })
     .map(tab => {
       return Tab({

--- a/public/js/test/cypress/commands/debugger.js
+++ b/public/js/test/cypress/commands/debugger.js
@@ -43,8 +43,8 @@ function scopeAtIndex(index) {
  */
 function debugPage(urlPart, browser = "Firefox") {
   debugFirstTab(browser);
-  cy.navigate(urlPart);
   cy.wait(1000);
+  cy.navigate(urlPart)
   cy.reload();
   cy.wait(1000);
 }

--- a/public/js/test/integration/todomvc.js
+++ b/public/js/test/integration/todomvc.js
@@ -45,28 +45,21 @@ describe("Todo MVC", function() {
     cy.reload();
   });
 
-  // this is a simple test that will test the Chrome
-  // client. At some point we will replace it with a
-  // mocha macro `withBrowsers("chrome", "firefox", function() {})`
-  // that will wrap these tests call each `it` in both browser contexts.
-  xit("(Chrome) Test Pausing", function() {
-    debugPage("todomvc", "Chrome");
-    goToSource("localhost:7999/js/views/todo-view");
-    toggleBreakpoint(33);
+  it("(Chrome) Source Maps", function() {
+    debugPage("increment", "Chrome");
 
-    // pause and check the first frame
-    addTodo();
+    goToSource("localhost:7999/increment.js");
+    cy.wait(1000)
+    toggleBreakpoint(3);
+    cy.wait(1000)
+
+    cy.debuggee(() => {
+      dbg.click("button");
+    });
+
+    cy.wait(1000);
     toggleCallStack();
-    toggleScopes();
-    callStackFrameAtIndex(0).contains("initialize");
-
-    // select the second frame and check to see the source updated
-    selectCallStackFrame(1);
-    sourceTab().contains("backbone.js");
-
-    stepIn();
-    stepOver();
-    stepOut();
+    callStackFrameAtIndex(0).contains("exports.increment");
 
     cy.reload();
   });


### PR DESCRIPTION
Fixes #405. 

Notes:
* Adds an env flag for debugging chrome
* Adds the "Inspectable Pages" tab to the list
* Adds a test for debugging an app with source maps

Note: the test is actually flakey now and half the time does not pause even though the breakpoint is added and button clicked... Looking into the protocol now