### PR TITLE
Make source tree item key unique

### DIFF
--- a/public/js/components/SourcesTree.js
+++ b/public/js/components/SourcesTree.js
@@ -158,7 +158,7 @@ let SourcesTree = React.createClass({
         return [];
       },
       getRoots: () => sourceTree.contents,
-      getKey: (item, i) => item.path,
+      getKey: (item, i) => item.path + i,
       itemHeight: 30,
       autoExpandDepth: 2,
       onFocus: this.focusItem,


### PR DESCRIPTION
Fixes #435. It's possible that two sources will have the same path. This caused two issues:
+ we got a react warning that children had the same key
+ it was causing the tree to be collapsed initially


![screen shot 2016-08-03 at 3 09 35 pm](https://cloud.githubusercontent.com/assets/254562/17378559/6e768ed2-598c-11e6-9879-af41fed4a3ad.png)