### PR TITLE
Clear source maps on navigation

### DIFF
--- a/public/js/actions/index.js
+++ b/public/js/actions/index.js
@@ -1,28 +1,11 @@
-const constants = require("../constants");
 const breakpoints = require("./breakpoints");
 const eventListeners = require("./event-listeners");
 const sources = require("./sources");
 const tabs = require("./tabs");
 const pause = require("./pause");
-
-function willNavigate() {
-  return { type: constants.NAVIGATE };
-}
-
-function navigate() {
-  return ({ dispatch }) => {
-    // We need to load all the sources again because they might have
-    // come from bfcache, so we won't get a `newSource` notification.
-    //
-    // TODO: This seems to be buggy on the debugger server side. When
-    // the page is loaded from bfcache, we still get sources from the
-    // *previous* page as well. For now, emulate the current debugger
-    // behavior by not showing sources loaded by bfcache.
-    // return dispatch(sources.loadSources());
-  };
-}
+const navigation = require("./navigation");
 
 module.exports = (Object.assign(
-  ({ willNavigate, navigate }: any),
+  navigation,
   breakpoints, eventListeners, sources, tabs, pause
 ) : typeof breakpoints);

--- a/public/js/actions/navigation.js
+++ b/public/js/actions/navigation.js
@@ -1,0 +1,25 @@
+const constants = require("../constants");
+const { clearData } = require("../utils/source-map");
+
+function willNavigate() {
+  clearData();
+  return { type: constants.NAVIGATE };
+}
+
+function navigate() {
+  return ({ dispatch }) => {
+    // We need to load all the sources again because they might have
+    // come from bfcache, so we won't get a `newSource` notification.
+    //
+    // TODO: This seems to be buggy on the debugger server side. When
+    // the page is loaded from bfcache, we still get sources from the
+    // *previous* page as well. For now, emulate the current debugger
+    // behavior by not showing sources loaded by bfcache.
+    // return dispatch(sources.loadSources());
+  };
+}
+
+module.exports = {
+  willNavigate,
+  navigate
+};

--- a/public/js/utils/source-map-worker.js
+++ b/public/js/utils/source-map-worker.js
@@ -134,6 +134,11 @@ function createSourceMap({ source, mappings, code }) {
   return generator.toJSON();
 }
 
+function clearData() {
+  sourceMapConsumers.clear();
+  sourceNodes.clear();
+}
+
 const publicInterface = {
   getOriginalSourcePosition,
   getGeneratedSourceLocation,
@@ -144,7 +149,8 @@ const publicInterface = {
   isGenerated,
   getGeneratedSourceId,
   createSourceMap,
-  makeOriginalSource
+  makeOriginalSource,
+  clearData
 };
 
 self.onmessage = function(msg) {

--- a/public/js/utils/source-map.js
+++ b/public/js/utils/source-map.js
@@ -33,6 +33,7 @@ const isOriginal = sourceMapTask("isOriginal");
 const isGenerated = sourceMapTask("isGenerated");
 const getGeneratedSourceId = sourceMapTask("getGeneratedSourceId");
 const createSourceMap = sourceMapTask("createSourceMap");
+const clearData = sourceMapTask("clearData");
 
 function _shouldSourceMap(generatedSource) {
   return isEnabled("features.sourceMaps") && generatedSource.sourceMapURL;
@@ -131,5 +132,6 @@ module.exports = {
   isOriginal,
   isGenerated,
   getGeneratedSourceId,
-  createSourceMap
+  createSourceMap,
+  clearData
 };


### PR DESCRIPTION
Fixes #480. 

The problem is that source map data in the worker is not being cleared during debuggee navigation.

There are a couple ways to clear the data:
+ data is kept in a weak map with object references
+ data is kept in a reducer, which observes the navigation event
+ the navigate action calls a source map method to clear the data

We discussed this problem a week or two ago and agreed it would be nice to use either option 1 or 2. Unfortunately, I'm not sure how to do that when the data is kept in the worker. I don't think option 3, is that bad though, as it is quite common for an action to do the side-effect work, whether it's talking to a stateful store, client, or in this case worker through an API.