### PR TITLE
Exclude internal sources

### DIFF
--- a/public/js/clients/chrome/events.js
+++ b/public/js/clients/chrome/events.js
@@ -11,6 +11,10 @@ function scriptParsed(scriptId, url, startLine, startColumn,
              endLine, endColumn, executionContextId, hash,
              isContentScript, isInternalScript, isLiveEdit,
              sourceMapURL, hasSourceURL, deprecatedCommentWasUsed) {
+  if (isInternalScript || isContentScript) {
+    return;
+  }
+
   actions.newSource(Source({
     id: scriptId,
     url,


### PR DESCRIPTION
found this small bug while comparing chrome and firefox source events for the sources tree expand/collapse issue.