### PR TITLE
expose actions to rest of devtools

### DIFF
--- a/public/js/main.js
+++ b/public/js/main.js
@@ -41,6 +41,13 @@ if (isDevelopment()) {
   injectGlobals({ store });
 }
 
+// Expose the bound actions so external things can do things like
+// selecting a source.
+window.actions = {
+  selectSource: actions.selectSource,
+  selectSourceURL: actions.selectSourceURL
+};
+
 function renderRoot(component) {
   const mount = document.querySelector("#mount");
 


### PR DESCRIPTION
This is a stopgap solution so the Firefox panel has the ability to select a source from other places like the console. Eventually, we probably want to be explicit about the global API we expose and only expose things like `selectSource`.