### PR TITLE
Fix source map breakpoints

### DIFF
--- a/public/js/clients/firefox/commands.js
+++ b/public/js/clients/firefox/commands.js
@@ -46,6 +46,7 @@ function sourceContents(sourceId) {
 
 function setBreakpoint(location, condition) {
   const sourceClient = threadClient.source({ actor: location.sourceId });
+
   return sourceClient.setBreakpoint({
     line: location.line,
     column: location.column,


### PR DESCRIPTION
Fixes #486.

There was an issue where firefox would not pause when a breakpoint was set in an original source. It turns out that the issue stemmed from the column being passed in as 0, which firefox treated as a column number that had to be deciphered. 

https://dxr.mozilla.org/mozilla-central/source/devtools/server/actors/source.js#859