### PR TITLE
Disable source maps + blackboxing

### DIFF
--- a/public/js/clients/firefox.js
+++ b/public/js/clients/firefox.js
@@ -111,6 +111,11 @@ function initPage(actions) {
     threadClient.addListener(eventName, clientEvents[eventName]);
   });
 
+  threadClient.reconfigure({
+    "useSourceMaps": false,
+    "autoBlackBox": false
+  });
+
   // In Firefox, we need to initially request all of the sources which
   // makes the server iterate over them and fire individual
   // `newSource` notifications. We don't need to do anything with the


### PR DESCRIPTION
This is not technically needed, but I feel better explicitly disabling these two features so that we can a) operate confidently that they are disabled, b) rip out the functionality later.