### PR TITLE
Fix #334 - editor loses context

### DIFF
--- a/public/js/components/Editor.js
+++ b/public/js/components/Editor.js
@@ -60,6 +60,7 @@ const Editor = React.createClass({
       );
     }
 
+    this.setText(this.props.sourceText.get("text"));
     resizeBreakpointGutter(this.editor);
   },
 
@@ -106,14 +107,24 @@ const Editor = React.createClass({
       return;
     }
 
-    // Only reset the editor text if the source has changed.
-    // + Resetting the text will remove the breakpoints.
-    // + Comparing the source text is probably inneficient.
-    if (newSourceText.get("text") != this.editor.getValue()) {
-      this.editor.setValue(newSourceText.get("text"));
-    }
+    this.setText(newSourceText.get("text"));
 
     resizeBreakpointGutter(this.editor);
+  },
+
+  // Only reset the editor text if the source has changed.
+  // * Resetting the text will remove the breakpoints.
+  // * Comparing the source text is probably inneficient.
+  setText(text) {
+    if (!text || !this.editor) {
+      return;
+    }
+
+    if (text == this.editor.getValue()) {
+      return;
+    }
+
+    this.editor.setValue(text);
   },
 
   componentWillReceiveProps(nextProps) {


### PR DESCRIPTION
The editor is blank after a file search. This is due to the fact that a render happens with the default text "..." and the source text is not updated.

We fix this by always calling setText when the component mounts, in most cases it's a no-op, but it does fix the case where the editor is dis-mounted and then mounted again.