### PR TITLE
Exclude debugger eval sources

### DIFF
--- a/public/js/clients/firefox/events.js
+++ b/public/js/clients/firefox/events.js
@@ -62,6 +62,11 @@ function newSource(_, packet) {
   if (NEW_SOURCE_IGNORED_URLS.indexOf(source.url) > -1) {
     return;
   }
+
+  if (source.introductionType == "debugger eval") {
+    return;
+  }
+
   actions.newSource(Source({
     id: source.actor,
     url: source.url,


### PR DESCRIPTION
It looks like debugger evals were being added as sources. There's an ignore clause above that checks for debugger code eval source urls, is that needed?