### PR TITLE
Stub debuggee evaluation

### DIFF
--- a/public/js/clients/chrome/commands.js
+++ b/public/js/clients/chrome/commands.js
@@ -81,6 +81,11 @@ function evaluate(script) {
   });
 }
 
+function debuggeeCommand(script) {
+  evaluate(script);
+  return Promise.resolve();
+}
+
 function navigate(url) {
   return pageAgent.navigate(url, (_, result) => {
     return result;
@@ -98,6 +103,7 @@ const clientCommands = {
   setBreakpoint,
   removeBreakpoint,
   evaluate,
+  debuggeeCommand,
   navigate
 };
 

--- a/public/js/clients/firefox.js
+++ b/public/js/clients/firefox.js
@@ -100,7 +100,7 @@ function initPage(actions) {
   tabTarget = getTabTarget();
   threadClient = getThreadClient();
 
-  setupCommands({ threadClient, tabTarget });
+  setupCommands({ threadClient, tabTarget, debuggerClient });
 
   tabTarget.on("will-navigate", actions.willNavigate);
   tabTarget.on("navigate", actions.navigate);

--- a/public/js/components/Frames.js
+++ b/public/js/components/Frames.js
@@ -52,11 +52,13 @@ function Frames({ frames, selectedFrame, selectFrame }) {
 
 module.exports = connect(
   state => ({
-    frames: getFrames(state).map(frame => {
-      return Object.assign({}, frame, {
-        source: getSource(state, frame.location.sourceId).toJS()
-      });
-    }),
+    frames: getFrames(state)
+      .filter(frame => getSource(state, frame.location.sourceId))
+      .map(frame => {
+        return Object.assign({}, frame, {
+          source: getSource(state, frame.location.sourceId).toJS()
+        });
+      }),
     selectedFrame: getSelectedFrame(state)
   }),
   dispatch => bindActionCreators(actions, dispatch)

--- a/public/js/test/cypress/commands.js
+++ b/public/js/test/cypress/commands.js
@@ -34,16 +34,7 @@ Cypress.addParentCommand("debuggee", function(callback) {
 
   return cy.window().then(win => {
     win.injectDebuggee();
-    // NOTE: we should be returning a promise here.
-    // The problem is if, the client pauses we need to handle that
-    // gracefully and resume. We did this on the test-server.
-    win.client.evaluate(script).then(response => {
-      if (response.exception) {
-        const errorMsg = response.exceptionMessage;
-        const commandInput = response.input;
-        console.error(`${errorMsg}\n For command:\n${commandInput}`);
-      }
-    });
+    return win.client.debuggeeCommand(script);
   });
 });
 

--- a/public/js/test/cypress/commands/debugger.js
+++ b/public/js/test/cypress/commands/debugger.js
@@ -78,6 +78,10 @@ function toggleBreakpoint(linenumber) {
     .contains(".CodeMirror-linenumber", linenumber).click();
 }
 
+function addWatchExpression(expression) {
+  cy.get(".input-expression").type(`${expression}{enter}`)
+}
+
 function selectBreakpointInList(index) {
   breakpointAtIndex(index).click();
 }
@@ -147,5 +151,6 @@ Object.assign(window, {
   stepIn,
   stepOut,
   stepOver,
-  prettyPrint
+  prettyPrint,
+  addWatchExpression
 })

--- a/public/js/test/integration/todomvc.js
+++ b/public/js/test/integration/todomvc.js
@@ -4,6 +4,7 @@ describe("Todo MVC", function() {
     debugPage("todomvc");
     goToSource("todo-view");
     toggleBreakpoint(33);
+    addWatchExpression("this");
 
     // pause and check the first frame
     addTodo();

--- a/public/js/test/integration/todomvc.js
+++ b/public/js/test/integration/todomvc.js
@@ -57,8 +57,6 @@ describe("Todo MVC", function() {
     callStackFrameAtIndex(0).contains("save");
   });
 
-  // for(var i=0; i<10; i++) {}
-
   it("(Chrome) Source Maps", function() {
     debugPage("increment", "Chrome");
 

--- a/public/js/test/utils/debuggee.js
+++ b/public/js/test/utils/debuggee.js
@@ -112,7 +112,7 @@ function injectDebuggee() {
     return Promise.resolve(injectedDebuggee);
   }
 
-  return window.client.evaluate(debuggeeStatement).then(result => {
+  return window.client.debuggeeCommand(debuggeeStatement).then(result => {
     injectedDebuggee = result;
   });
 }


### PR DESCRIPTION
@jbhoosreddy and I noticed when we were working on adding an integration test for watch expressions that the expressions were not evaluated until the debugger had resumed. 

The reason for this was that the debugger pauses in the integration tests by running a console evaluation like `dbg.click("button")`, which does not return until the debugger resumes. The console has a mechanism for only running one evaluation at a time, so it blocks subsequent evals. 

We get around this problem by creating a new evaluate method that includes a timeout, which will simulate an evaluation response. In the case of firefox, we also have to clear the internal pending requests store.
