### PR TITLE
Fixed starting Firefox debugging server with the WebSocket option

### DIFF
--- a/bin/firefox-driver.js
+++ b/bin/firefox-driver.js
@@ -11,7 +11,8 @@ const useWebSocket = process.argv.indexOf("--websocket") > 0;
 
 function firefoxBinary() {
   var binary = new firefox.Binary();
-  binary.addArguments('--start-debugger-server', '6080')
+  binary.addArguments("--start-debugger-server",
+    useWebSocket ? "ws:6080" : "6080");
 
   return binary;
 }


### PR DESCRIPTION
If the `firefox-driver` script is given the `--websocket` option, it didn't really start the WebSocket server, because of how the `--start-debugger-server` option works:

- `--start-debugger-server` use pref values `d.d.remote-port` and `d.d.remote-websocket`. This is new behavior for the port pref after landing [bug 1286281](https://bugzilla.mozilla.org/show_bug.cgi?id=1286281). Before that, the port pref wasn't consulted at all and the default port was hardcoded as 6000.
- `--start-debugger-server 6578` start the classic (non-WebSocket) server on port 6578, don't look at any prefs (that's why we're adding the `ws:` prefix in this patch)
- `--start-debugger-server ws:6578` start the WebSocket server on port 6578.

If the `firefox-driver` script didn't have to be compatible with builds older than the latest Nightly, the right solution would be to set the right prefs in the `firefoxProfile` function, and then `firefoxBinary` would always pass just `--start-debugger-server`.