### PR TITLE
add direcory listing for examples folder

### DIFF
--- a/bin/development-server.js
+++ b/bin/development-server.js
@@ -10,6 +10,7 @@ const express = require("express");
 const webpackDevMiddleware = require("webpack-dev-middleware");
 const webpackHotMiddleware = require("webpack-hot-middleware");
 const http = require("http");
+const serveIndex = require("serve-index");
 
 // Setup Config
 const getConfig = require("../config/config").getConfig;
@@ -79,6 +80,7 @@ app.listen(8000, "0.0.0.0", function(err, result) {
 
 const examples = express();
 examples.use(express.static("public/js/test/examples"));
+examples.use(serveIndex("public/js/test/examples", { icons: true }));
 examples.listen(7999, "0.0.0.0", function(err, result) {
   console.log("View debugger examples at http://localhost:7999");
 });

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "react-hot-loader": "^1.3.0",
     "rimraf": "^2.5.2",
     "selenium-webdriver": "^2.53.2",
+    "serve-index": "^1.8.0",
     "style-loader": "^0.13.1",
     "stylelint": "^6.2.2",
     "webpack": "1.13.1",


### PR DESCRIPTION
currently accessing localhost:7999 results in 404, so initially I thought is was broken (I knew about it from the console of the development server)
So this adds the directory listing from which the examples are accessible