### PR TITLE
increase Firefox timeout (avoids false positives)

### DIFF
--- a/public/js/clients/firefox.js
+++ b/public/js/clients/firefox.js
@@ -64,7 +64,7 @@ function connectClient() {
     }
 
     deferred.resolve([]);
-  }, 1000);
+  }, 6000);
 
   debuggerClient.connect().then(() => {
     isConnected = true;


### PR DESCRIPTION
There would be certain times where I couldn't connect to Firefox, and I realized it was because of this timeout. For various reasons my computer would be slow sometimes. Let's kick this really high because it's *super* annoying to have a flaky connection.