### PR TITLE
make ManagedTree use item's key as index instead of instance

### DIFF
--- a/public/js/components/Sources.css
+++ b/public/js/components/Sources.css
@@ -61,7 +61,9 @@ ul.sources-list {
   top: 1px;
 }
 
-.worker {
+.worker,
+.folder {
+  position: relative;
   top: 2px;
 }
 

--- a/public/js/components/utils/ManagedTree.js
+++ b/public/js/components/utils/ManagedTree.js
@@ -8,16 +8,21 @@ let ManagedTree = React.createClass({
   displayName: "ManagedTree",
 
   getInitialState() {
-    return { expanded: new WeakMap(),
+    return { expanded: new Set(),
              focusedItem: null };
   },
 
-  setExpanded(item, expanded) {
-    const e = this.state.expanded;
-    e.set(item, expanded);
-    this.setState({ expanded: e });
+  setExpanded(item, isExpanded) {
+    const expanded = this.state.expanded;
+    const key = this.props.getKey(item);
+    if (isExpanded) {
+      expanded.add(key);
+    } else {
+      expanded.delete(key);
+    }
+    this.setState({ expanded });
 
-    if (expanded && this.props.onExpand) {
+    if (isExpanded && this.props.onExpand) {
       this.props.onExpand(item);
     } else if (!expanded && this.props.onCollapse) {
       this.props.onCollapse(item);
@@ -38,7 +43,7 @@ let ManagedTree = React.createClass({
     const { expanded, focusedItem } = this.state;
 
     const props = Object.assign({}, this.props, {
-      isExpanded: item => expanded.get(item),
+      isExpanded: item => expanded.has(this.props.getKey(item)),
       focused: focusedItem,
 
       onExpand: item => this.setExpanded(item, true),

--- a/public/js/lib/tree.js
+++ b/public/js/lib/tree.js
@@ -202,7 +202,7 @@ const Tree = module.exports = createClass({
 
   componentDidMount() {
     window.addEventListener("resize", this._updateHeight);
-    this._autoExpand();
+    this._autoExpand(this.props);
     this._updateHeight();
   },
 
@@ -211,12 +211,12 @@ const Tree = module.exports = createClass({
   },
 
   componentWillReceiveProps(nextProps) {
-    this._autoExpand();
+    this._autoExpand(nextProps);
     this._updateHeight();
   },
 
-  _autoExpand() {
-    if (!this.props.autoExpandDepth) {
+  _autoExpand(props) {
+    if (!props.autoExpandDepth) {
       return;
     }
 
@@ -224,22 +224,22 @@ const Tree = module.exports = createClass({
     // not use the usual DFS infrastructure because we don't want to ignore
     // collapsed nodes.
     const autoExpand = (item, currentDepth) => {
-      if (currentDepth >= this.props.autoExpandDepth ||
+      if (currentDepth >= props.autoExpandDepth ||
           this.state.seen.has(item)) {
         return;
       }
 
-      this.props.onExpand(item);
+      props.onExpand(item);
       this.state.seen.add(item);
 
-      const children = this.props.getChildren(item);
+      const children = props.getChildren(item);
       const length = children.length;
       for (let i = 0; i < length; i++) {
         autoExpand(children[i], currentDepth + 1);
       }
     };
 
-    const roots = this.props.getRoots();
+    const roots = props.getRoots();
     const length = roots.length;
     for (let i = 0; i < length; i++) {
       autoExpand(roots[i], 0);


### PR DESCRIPTION
I think the only reason we couldn't do this before is because keys weren't properly computed for the object inspector, but now they are. Keys should always be unique, so we can use that to track which ones are expanded or not. This solves the issues with the sources tree because the collapsing generates a new tree each time. Now it properly expands initially.