### PR TITLE
Fix refreshing while paused

### DIFF
--- a/public/js/clients/firefox.js
+++ b/public/js/clients/firefox.js
@@ -104,6 +104,11 @@ function initPage(actions) {
 
   tabTarget.on("will-navigate", actions.willNavigate);
   tabTarget.on("navigate", actions.navigate);
+  tabTarget.on("frame-update", function(_, packet) {
+    if (packet.destroyAll) {
+      actions.willNavigate();
+    }
+  });
 
   // Listen to all the requested events.
   setupEvents({ threadClient, actions });


### PR DESCRIPTION
When the debuggee is paused it stops sending "will-navigate" events, which means that it's possible to refresh the debuggee and still show all of the pause data in the debugger.