### PR TITLE
update the todomvc port for npm run firefox

### DIFF
--- a/bin/firefox-driver.js
+++ b/bin/firefox-driver.js
@@ -39,7 +39,7 @@ function start() {
 
 if (shouldStart) {
   const driver = start();
-  driver.get("http://localhost:8000/todomvc");
+  driver.get("http://localhost:7999/todomvc");
   setInterval(() => {}, 100);
 }
 

--- a/bin/firefox-driver.js
+++ b/bin/firefox-driver.js
@@ -1,7 +1,7 @@
 "use strict";
 
-const webdriver = require('selenium-webdriver');
-const firefox = require('selenium-webdriver/firefox');
+const webdriver = require("selenium-webdriver");
+const firefox = require("selenium-webdriver/firefox");
 const By = webdriver.By;
 const until = webdriver.until;
 const Key = webdriver.Key;
@@ -10,7 +10,7 @@ const shouldStart = process.argv.indexOf("--start") > 0;
 const useWebSocket = process.argv.indexOf("--websocket") > 0;
 
 function firefoxBinary() {
-  var binary = new firefox.Binary();
+  let binary = new firefox.Binary();
   binary.addArguments("--start-debugger-server",
     useWebSocket ? "ws:6080" : "6080");
 
@@ -18,11 +18,11 @@ function firefoxBinary() {
 }
 
 function firefoxProfile() {
-  var profile = new firefox.Profile();
-  profile.setPreference('devtools.debugger.remote-port', 6080);
-  profile.setPreference("devtools.debugger.remote-enabled",  true);
-  profile.setPreference("devtools.chrome.enabled",  true);
-  profile.setPreference("devtools.debugger.prompt-connection",  false);
+  let profile = new firefox.Profile();
+  profile.setPreference("devtools.debugger.remote-port", 6080);
+  profile.setPreference("devtools.debugger.remote-enabled", true);
+  profile.setPreference("devtools.chrome.enabled", true);
+  profile.setPreference("devtools.debugger.prompt-connection", false);
   profile.setPreference("devtools.debugger.remote-use-websocket", useWebSocket);
 
   return profile;
@@ -30,7 +30,7 @@ function firefoxProfile() {
 
 function start() {
   let options = new firefox.Options();
-  options.setProfile(firefoxProfile())
+  options.setProfile(firefoxProfile());
   options.setBinary(firefoxBinary());
 
   const driver = new firefox.Driver(options);
@@ -43,4 +43,4 @@ if (shouldStart) {
   setInterval(() => {}, 100);
 }
 
-module.exports = { start, By, Key, until }
+module.exports = { start, By, Key, until };


### PR DESCRIPTION
In #453 the examples directory began running off the port `7999`, this was forgotten in the update.