### PR TITLE
remove accordion isvg svg css selector

### DIFF
--- a/public/images/Svg.js
+++ b/public/images/Svg.js
@@ -30,7 +30,7 @@ module.exports = function(name, props) { // eslint-disable-line
   if (!svg[name]) {
     throw new Error("Unknown SVG: " + name);
   }
-  let className = props ? `${name} ` + props.className : name;
+  let className = props ? `${name} ${props.className}` : name;
   if (name === "subSettings") {
     className = "";
   }

--- a/public/js/components/Accordion.css
+++ b/public/js/components/Accordion.css
@@ -23,17 +23,6 @@
   background-color: var(--theme-selection-color);
 }
 
-/* TODO: change this class name */
-.accordion .isvg svg {
-  fill: var(--theme-splitter-color);
-  float: left;
-  margin-right: 3px;
-  margin-top: 3px;
-  transform: rotate(-90deg);
-  transition: all 0.25s ease;
-  width: 10px;
-}
-
 .accordion ._header:hover svg {
   fill: var(--theme-gray-darker);
 }


### PR DESCRIPTION
The CSS for the accordion arrow was nearly identical to the arrow CSS
except for an additional 2px of margin-right.
I ended up hunting in Svg.js and saw this odd combination of template
literals and string addition that I needed to fix.

This fixes #430 