### PR TITLE
use flex box for breakpoint component

### DIFF
--- a/public/js/components/Breakpoints.css
+++ b/public/js/components/Breakpoints.css
@@ -1,9 +1,16 @@
 .breakpoints-list .breakpoint {
   font-size: 12px;
-  list-style: none;
   color: var(--theme-content-color1);
   margin: 0.5em 0;
   line-height: 1em;
+  display: flex;
+  flex-flow: row;
+  align-items: center;
+}
+
+.breakpoints-list .breakpoint input {
+  flex: 0 1 content;
+  order: 1;
 }
 
 /*
@@ -22,9 +29,11 @@
 }
 
 .breakpoints-list .breakpoint-label {
-  display: inline-block;
+  flex: 1 0 auto;
+  order: 2;
 }
 
 .breakpoints-list .pause-indicator {
-  float: right;
+  flex: 0 1 content;
+  order: 3;
 }


### PR DESCRIPTION
I’ve been seeing a falling float in the breakpoint list.  The pause icon keeps wrapping around and falling into the next line.  This changes the list items to use flex box instead which won’t allow for the same float issues.

![screen shot 2016-08-08 at 2 38 05 pm](https://cloud.githubusercontent.com/assets/2134/17498937/3434d296-5d7f-11e6-9db9-ab0f4d8f2fe0.png)
