### PR TITLE
sources header uses the default colour

### DIFF
--- a/public/js/components/Sources.css
+++ b/public/js/components/Sources.css
@@ -8,7 +8,6 @@
 .sources-header {
   height: 30px;
   border-bottom: 1px solid var(--theme-gray);
-  color: var(--theme-splitter-color);
   padding-left: 10px;
   line-height: 30px;
   font-size: 0.9em;


### PR DESCRIPTION
This PR would change the sources header to use the darker default colour text.

Here's a comparison of the sources header with and without the grey colour.

<img width="327" alt="screen shot 2016-08-11 at 2 06 13 pm" src="https://cloud.githubusercontent.com/assets/2134/17604956/fd98f6ae-5fcc-11e6-8e03-67475d0be19f.png">
<img width="326" alt="screen shot 2016-08-11 at 2 06 01 pm" src="https://cloud.githubusercontent.com/assets/2134/17604955/fd96c08c-5fcc-11e6-8619-250ff9a0e693.png">

@helenvholmes ?