### PR TITLE
Fix Pretty Print tests

### DIFF
--- a/public/js/actions/sources.js
+++ b/public/js/actions/sources.js
@@ -196,6 +196,11 @@ function blackbox(source, shouldBlackBox) {
 function togglePrettyPrint(id) {
   return ({ dispatch, getState, client }) => {
     const source = getSource(getState(), id).toJS();
+    const sourceText = getSourceText(getState(), id).toJS();
+
+    if (sourceText.loading) {
+      return;
+    }
 
     if (!isEnabled("prettyPrint") || source.isPrettyPrinted) {
       return {};
@@ -210,7 +215,6 @@ function togglePrettyPrint(id) {
       source,
       originalSource,
       [PROMISE]: (async function () {
-        const sourceText = getSourceText(getState(), source.id).toJS();
         const text = await _prettyPrintSource({ source, sourceText, url });
 
         dispatch(selectSource(originalSource.id));

--- a/public/js/components/Editor.js
+++ b/public/js/components/Editor.js
@@ -179,7 +179,7 @@ module.exports = connect(
     const selectedId = selectedSource && selectedSource.get("id");
 
     return {
-      selectedSource: selectedSource,
+      selectedSource,
       sourceText: getSourceText(state, selectedId),
       breakpoints: getBreakpointsForSource(state, selectedId),
       selectedFrame: getSelectedFrame(state)

--- a/public/js/test/cypress/commands.js
+++ b/public/js/test/cypress/commands.js
@@ -35,7 +35,7 @@ Cypress.addParentCommand("debuggee", function(callback) {
   return cy.window().then(win => {
     win.injectDebuggee();
     return win.client.debuggeeCommand(script);
-  });
+  }).wait(1000);
 });
 
 Cypress.addParentCommand("navigate", function(url) {

--- a/public/js/test/cypress/commands/debugger.js
+++ b/public/js/test/cypress/commands/debugger.js
@@ -123,7 +123,7 @@ function stepOut() {
 }
 
 function prettyPrint() {
-  return sourceFooter().get("span.prettyPrint").click()
+  return sourceFooter().get("span.prettyPrint.active").click()
 }
 
 /**


### PR DESCRIPTION
I've been noticing an increase in cypress intermittents, this is not necessarily a surprise because we've added a lot more tests and increased the steps in the existing tests.

I think these fixes are a step in the right direction:

1. I noticed that some tests were attempting to pretty print a file before it had loaded. now the tests waits until the button is active, which is only the case after it has loaded. And if for any reason the action is invoked early, it bails.
2. I noticed many cases where the tests did not pause. I believe this is due to pretty print sending two client evals in quick succession. Now all evals have a mandatory 1 second wait period.

After these fixes, i did not see any errors when i ran the pretty print test 20 times.