### PR TITLE
adds overlay message to Chrome

### DIFF
--- a/public/js/clients/chrome.js
+++ b/public/js/clients/chrome.js
@@ -66,7 +66,7 @@ function initPage(actions) {
   const agents = connection._agents;
 
   setupCommands({ agents: agents });
-  setupEvents({ actions })
+  setupEvents({ actions, agents })
 
   agents.Debugger.enable();
   agents.Debugger.setPauseOnExceptions("none");

--- a/public/js/clients/chrome/events.js
+++ b/public/js/clients/chrome/events.js
@@ -1,9 +1,11 @@
 const { Source, Location, Frame } = require("../../types");
 
 let actions;
+let pageAgent;
 
 function setupEvents(dependencies) {
   actions = dependencies.actions;
+  pageAgent = dependencies.agents.Page;
 }
 
 // Debugger Events
@@ -44,10 +46,13 @@ async function paused(
     type: reason
   }, data);
 
+  pageAgent.setOverlayMessage("Paused in debugger.html");
+
   await actions.paused({ frame, why, frames });
 }
 
 function resumed() {
+  pageAgent.setOverlayMessage(undefined);
   actions.resumed();
 }
 

--- a/public/js/lib/chrome-remote-debug-protocol/docs.md
+++ b/public/js/lib/chrome-remote-debug-protocol/docs.md
@@ -21,7 +21,7 @@ InspectorBackend.registerCommand("Page.enable", [], [], false);
 InspectorBackend.registerCommand("Debugger.getBacktrace", [], ["callFrames", "asyncStackTrace"], false);
 ```
 
-#### Steps to upgrade `inspectorBackend.js`:
+#### Steps to upgrade `api.js`:
 
 + add line `/* eslint-disable */`
 + add line `var WebInspector = {}, window = window || {};`
@@ -35,7 +35,6 @@ InspectorBackend.registerCommand("Debugger.getBacktrace", [], ["callFrames", "as
 ```js
 module.exports = {
   InspectorBackendClass,
-  WebSocketConnection: WebInspector.WebSocketConnection,
-  generateCommands: WebInspector.InspectorBackendHostedMode.generateCommands
+  WebSocketConnection: WebInspector.WebSocketConnection
 };
 ```


### PR DESCRIPTION
_This isn't a priority but only affects the Chrome code._

By adding the `setOverlayMessage` method to both the pause and resume events we get the Chrome overlay in the debugger.  The overlay has working buttons, they seem to send messages directly to the debugger and our interface receives the new state and behaves correctly.

![screen shot 2016-08-15 at 11 19 57 am](https://cloud.githubusercontent.com/assets/2134/17674668/63bf0e6c-62db-11e6-905f-3f96853186e4.png)

**NOTE** the method [setOverlayMethod](https://chromedevtools.github.io/debugger-protocol-viewer/1-1/Debugger/#method-setOverlayMessage) is part of the 1.1 stable debug protocol.  Though as you can see it is listed in the Debugger domain and yet it was [moved to the Page](https://codereview.chromium.org/801363004/) domain a while back.  Finally it appears to have been removed completely from future versions, Chrome Canary returns an error when this method is sent.  The overlay still exists in Canary but it seems access to presenting it via the protocol has been removed.