### PR TITLE
Move makeOriginalSource to source-map-utils

### DIFF
--- a/public/js/utils/source-map-utils.js
+++ b/public/js/utils/source-map-utils.js
@@ -1,0 +1,13 @@
+
+function makeOriginalSource({ url, source, id = 1 }) {
+  const generatedSourceId = source.id;
+  return {
+    url,
+    id: `${generatedSourceId}/originalSource${id}`,
+    isPrettyPrinted: false
+  };
+}
+
+module.exports = {
+  makeOriginalSource
+};

--- a/public/js/utils/source-map-worker.js
+++ b/public/js/utils/source-map-worker.js
@@ -1,4 +1,6 @@
 const { SourceMapConsumer, SourceNode, SourceMapGenerator } = require("source-map");
+const { makeOriginalSource } = require("./source-map-utils");
+
 const toPairs = require("lodash/toPairs");
 
 let sourceMapConsumers = new Map();
@@ -129,15 +131,6 @@ function createOriginalSources(generatedSource, sourceMap) {
     }));
 }
 
-function makeOriginalSource({ url, source, id = 1 }) {
-  const generatedSourceId = source.id;
-  return {
-    url,
-    id: `${generatedSourceId}/originalSource${id}`,
-    isPrettyPrinted: false
-  };
-}
-
 function createSourceMap({ source, mappings, code }) {
   const generator = new SourceMapGenerator({ file: source.url });
   mappings.forEach(mapping => generator.addMapping(mapping));
@@ -162,7 +155,6 @@ const publicInterface = {
   isGenerated,
   getGeneratedSourceId,
   createSourceMap,
-  makeOriginalSource,
   clearData
 };
 

--- a/public/js/utils/source-map.js
+++ b/public/js/utils/source-map.js
@@ -1,4 +1,5 @@
 const { workerTask } = require("./utils");
+const { makeOriginalSource } = require("./source-map-utils");
 
 import type { Location } from "./actions/types";
 
@@ -22,15 +23,6 @@ const sourceMapTask = function(method) {
     return workerTask(sourceMapWorker, { method, args });
   };
 };
-
-function makeOriginalSource({ url, source, id = 1 }) {
-  const generatedSourceId = source.id;
-  return {
-    url,
-    id: JSON.stringify({ generatedSourceId, id }),
-    isPrettyPrinted: false
-  };
-}
 
 const getOriginalSourcePosition = sourceMapTask("getOriginalSourcePosition");
 const getGeneratedSourceLocation = sourceMapTask("getGeneratedSourceLocation");


### PR DESCRIPTION
This fixes a small inconsistency with `makeOriginalSource`. It also introduces a shared utility for source maps, which we can now use because the worker is being bundled with webpack.

Please ignore the irony that the source map worker is itself source mapped :P 