### PR TITLE
use unique breakpoint class to not clash with mozilla-central

### DIFF
--- a/public/js/components/Editor.css
+++ b/public/js/components/Editor.css
@@ -22,7 +22,7 @@
   left: 0;
 }
 
-.editor.breakpoint svg {
+.editor.new-breakpoint svg {
   fill: var(--theme-selection-background);
   width: 60px;
   height: 12px;
@@ -38,17 +38,13 @@
   background-color: white;
 }
 
-.editor.breakpoint:hover {
-  cursor: pointer;
-}
-
 /* set the linenumber white when there is a breakpoint */
-.breakpoint .CodeMirror-linenumber {
+.new-breakpoint .CodeMirror-linenumber {
   color: white;
 }
 
 /* move the breakpoint below the linenumber */
-.breakpoint .CodeMirror-gutter-elt:last-child {
+.new-breakpoint .CodeMirror-gutter-elt:last-child {
   z-index: 0;
 }
 

--- a/public/js/components/EditorBreakpoint.js
+++ b/public/js/components/EditorBreakpoint.js
@@ -3,7 +3,7 @@ const { PropTypes } = React;
 
 function makeMarker() {
   let marker = document.createElement("div");
-  marker.className = "editor breakpoint";
+  marker.className = "editor new-breakpoint";
 
   let svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
   svg.setAttribute("viewBox", "0 0 60 12");
@@ -30,7 +30,7 @@ const Breakpoint = React.createClass({
     const bp = this.props.breakpoint;
     const line = bp.location.line - 1;
     this.props.editor.setGutterMarker(line, "breakpoints", makeMarker());
-    this.props.editor.addLineClass(line, "line", "breakpoint");
+    this.props.editor.addLineClass(line, "line", "new-breakpoint");
   },
 
   shouldComponentUpdate(nextProps) {
@@ -58,7 +58,7 @@ const Breakpoint = React.createClass({
     const line = bp.location.line - 1;
 
     this.props.editor.setGutterMarker(line, "breakpoints", null);
-    this.props.editor.removeLineClass(line, "line", "breakpoint");
+    this.props.editor.removeLineClass(line, "line", "new-breakpoint");
   },
 
   render() {


### PR DESCRIPTION
Using just "breakpoint" clashes with m-c. It pulls in CSS that applies a style to `.breakpoint` so it messes with our breakpoint (and actually adds the old breakpoint on top of ours). The reason I didn't see this before was that we aren't loading the SVGs so I didn't see the SVG that m-c CSS was adding.

Tweaking our class with avoid all these issues. It's a little unfortunate, but an easy change that will avoid any clashing for now.

I initially tried to move the breakpoint-specific CSS from CodeMirror to the old debugger, but that doesn't work because it pulls it in in an iframe, so you can't style it from the outside. This will have to do for now.