### PR TITLE
Add mochitest runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ public/js/test/cypress/screenshots/
 .idea/
 .vscode/
 cypress
+firefox

--- a/bin/download-firefox-artifact
+++ b/bin/download-firefox-artifact
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+ROOT=`dirname $0`
+FIREFOX_PATH="$ROOT/../firefox"
+
+if [ -d "$FIREFOX_PATH" ]; then
+    cd "$FIREFOX_PATH";
+    hg pull
+else
+    hg clone https://hg.mozilla.org/mozilla-central/ "$FIREFOX_PATH"
+    cd "$FIREFOX_PATH"
+
+    echo "
+ac_add_options --enable-artifact-builds
+mk_add_options MOZ_OBJDIR=./objdir-frontend
+" > .mozconfig
+fi

--- a/bin/make-firefox-bundle
+++ b/bin/make-firefox-bundle
@@ -13,6 +13,13 @@ if [ ! -d "$DEBUGGER_PATH" ]; then
    exit 2
 fi
 
+(
+    cd "$DEBUGGER_PATH";
+    if ! git log --oneline . | head -n 1 |
+            grep "UPDATE_BUNDLE" > /dev/null; then
+        echo "\033[31mWARNING\033[0m: local changes detected on mozilla-central";
+    fi
+);
 
 TARGET=firefox-panel webpack
 echo "// Generated from: $REV\n" | cat - public/build/bundle.js > "$DEBUGGER_PATH/bundle.js"
@@ -20,3 +27,4 @@ cp public/build/pretty-print-worker.js "$DEBUGGER_PATH"
 cp public/build/source-map-worker.js "$DEBUGGER_PATH"
 cp public/build/styles.css "$DEBUGGER_PATH"
 cp public/images/* "$DEBUGGER_PATH/images"
+rsync -avz public/js/test/mochitest/ "$DEBUGGER_PATH/test/mochitest"

--- a/bin/run-mochitests
+++ b/bin/run-mochitests
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+ROOT=`dirname $0`
+FIREFOX_PATH="$ROOT/../firefox"
+
+if [ ! -d firefox ]; then
+  ./download-firefox-artifact
+fi
+
+./make-firefox-bundle "$FIREFOX_PATH"
+cd "$FIREFOX_PATH"
+./mach build
+./mach mochitest --subsuite devtools devtools/client/debugger/new/test/mochitest/
+

--- a/circle.yml
+++ b/circle.yml
@@ -10,6 +10,7 @@ test:
     - mkdir -p $CIRCLE_TEST_REPORTS/mocha
     - node public/js/test/node-unit-tests.js --ci
     - npm run firefox-unit-test
+    - npm run mochitest
     - node_modules/.bin/cypress ci b07646ab-ddfa-442b-b63f-aebf00452de8
     - node_modules/.bin/cypress ci b07646ab-ddfa-442b-b63f-aebf00452de8
   pre:
@@ -31,4 +32,5 @@ dependencies:
     - npm install
     - ./bin/install-chrome
     - ./bin/install-firefox
+    - ./bin/download-firefox-artifact
     - node_modules/.bin/cypress install

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "firefox": "node bin/firefox-driver --start",
     "cypress": "./node_modules/.bin/cypress run --port 2021",
     "cypress-intermittents": "for i in {1..100}; do time npm run cypress; done | tee cypress-run.log",
+    "mochitest": "./bin/run-mochitests",
     "prepublish": "webpack"
   },
   "dependencies": {


### PR DESCRIPTION
After all of my research for taskcluster, this is all we need right now. This will add ~10 min to our CI, but that's ok, because we really have to get tests running for the debugger actually in the Firefox panel.

In the near future, we can work on integration tests that run in content normally. We should talk about how we can write tests that could potentially be run in both worlds, because we always need the integration tests to be running on try for every commit, and we need them to be running with the debugger in the panel. The only way to test it as part of browser chrome is to use mochitests.