### PR TITLE
Fix some of the flakiness in the integration tests

### DIFF
--- a/public/js/test/cypress/commands.js
+++ b/public/js/test/cypress/commands.js
@@ -32,6 +32,7 @@ Cypress.addParentCommand("debuggee", function(callback) {
 
   const script = getFunctionBody(callback);
 
+  cy.wait(1000);
   return cy.window().then(win => {
     win.injectDebuggee();
     return win.client.debuggeeCommand(script);

--- a/public/js/test/cypress/commands/todomvc.js
+++ b/public/js/test/cypress/commands/todomvc.js
@@ -1,5 +1,6 @@
 function addTodo() {
   cy.debuggee(() => {
+    localStorage.clear();
     dbg.type("#new-todo", "hi");
     dbg.type("#new-todo", "{enter}");
   });


### PR DESCRIPTION
1. Add a wait before the debuggee command.
The theory is that maybe the breakpoint is not set or something like
that that's keeping the debuggee from pausing

2. Clear localstorage
I have no idea how many todos are saved, it could be in the thousands by
now. This clears the list so that it doesn't create performance issues.