### PR TITLE
throttle sources tree instead of debounce

### DIFF
--- a/public/js/components/SourcesTree.js
+++ b/public/js/components/SourcesTree.js
@@ -1,18 +1,16 @@
 const React = require("react");
 const { DOM: dom, PropTypes } = React;
+const classnames = require("classnames");
+const ImPropTypes = require("react-immutable-proptypes");
+const { Set } = require("immutable");
 
 const {
   nodeHasChildren, createParentMap, addToTree,
   collapseTree, createTree
 } = require("../utils/sources-tree.js");
-
-const classnames = require("classnames");
-const ImPropTypes = require("react-immutable-proptypes");
-const { Set } = require("immutable");
-const debounce = require("lodash/debounce");
-
 const ManagedTree = React.createFactory(require("./utils/ManagedTree"));
 const Svg = require("./utils/Svg");
+const { throttle } = require("../utils/utils");
 
 let SourcesTree = React.createClass({
   propTypes: {
@@ -26,12 +24,16 @@ let SourcesTree = React.createClass({
     return createTree(this.props.sources);
   },
 
-  componentWillMount() {
-    this.debouncedUpdate = debounce(this.debouncedUpdate, 50);
-  },
+  queueUpdate: throttle(function() {
+    if (!this.isMounted()) {
+      return;
+    }
+
+    this.forceUpdate();
+  }, 50),
 
   shouldComponentUpdate() {
-    this.debouncedUpdate();
+    this.queueUpdate();
     return false;
   },
 
@@ -65,14 +67,6 @@ let SourcesTree = React.createClass({
     this.setState({ uncollapsedTree,
                     sourceTree,
                     parentMap: createParentMap(sourceTree) });
-  },
-
-  debouncedUpdate() {
-    if (!this.isMounted()) {
-      return;
-    }
-
-    this.forceUpdate();
   },
 
   focusItem(item) {

--- a/public/js/utils/utils.js
+++ b/public/js/utils/utils.js
@@ -172,6 +172,19 @@ function updateObj<T>(obj: T, fields: $Shape<T>) : T {
   return Object.assign({}, obj, fields);
 }
 
+function throttle(func: any, ms: number) {
+  let timeout, _this;
+  return function(...args: any) {
+    _this = this;
+    if (!timeout) {
+      timeout = setTimeout(() => {
+        func.apply(_this, ...args);
+        timeout = null;
+      }, ms);
+    }
+  };
+}
+
 module.exports = {
   asPaused,
   handleError,
@@ -186,5 +199,6 @@ module.exports = {
   mapObject,
   compose,
   log,
-  updateObj
+  updateObj,
+  throttle
 };


### PR DESCRIPTION
We shouldn't be debouncing. Previously the action was throttled, which means you are guaranteed to render about every 50ms, instead of lots of sources continually debouncing and not rendering anything for several seconds. This changes when we moved this logic into the component.

I noticed this when trying to load a site with lots of sources: the sources tree is just blank for 5-10 seconds while it's loading. Not it continually renders the tree as they come in.