### PR TITLE
Add disabled state for breakpoint markers

### DIFF
--- a/public/js/components/Editor.css
+++ b/public/js/components/Editor.css
@@ -31,6 +31,10 @@
   right: -4px;
 }
 
+.editor.new-breakpoint.breakpoint-disabled svg {
+  opacity: 0.3;
+}
+
 .editor-mount,
 .CodeMirror {
   width: 100%;

--- a/public/js/components/Editor.js
+++ b/public/js/components/Editor.js
@@ -161,8 +161,7 @@ const Editor = React.createClass({
   },
 
   render() {
-    const breakpoints = this.props.breakpoints.valueSeq()
-          .filter(bp => !bp.disabled);
+    const breakpoints = this.props.breakpoints.valueSeq();
 
     return (
       dom.div(

--- a/public/js/components/EditorBreakpoint.js
+++ b/public/js/components/EditorBreakpoint.js
@@ -1,9 +1,13 @@
 const React = require("react");
 const { PropTypes } = React;
+const classnames = require("classnames");
 
-function makeMarker() {
+function makeMarker(isDisabled) {
   let marker = document.createElement("div");
-  marker.className = "editor new-breakpoint";
+  marker.className = classnames(
+    "editor new-breakpoint",
+    { "breakpoint-disabled": isDisabled }
+  );
 
   let svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
   svg.setAttribute("viewBox", "0 0 60 12");
@@ -29,12 +33,17 @@ const Breakpoint = React.createClass({
   addBreakpoint() {
     const bp = this.props.breakpoint;
     const line = bp.location.line - 1;
-    this.props.editor.setGutterMarker(line, "breakpoints", makeMarker());
+    this.props.editor.setGutterMarker(
+      line,
+      "breakpoints",
+      makeMarker(bp.disabled)
+    );
     this.props.editor.addLineClass(line, "line", "new-breakpoint");
   },
 
   shouldComponentUpdate(nextProps) {
-    return this.props.editor !== nextProps.editor;
+    return this.props.editor !== nextProps.editor ||
+      this.props.breakpoint.disabled !== nextProps.breakpoint.disabled;
   },
 
   componentDidMount() {


### PR DESCRIPTION
Hi,

I came across #548 through up-for-grabs.net, thought i'd have a look at it 😃

This will show disabled breakpoint gutter markers but faded out so you can tell the difference.

<img width="983" alt="screen shot 2016-08-22 at 19 11 53" src="https://cloud.githubusercontent.com/assets/3685626/17865902/55a54b5e-689c-11e6-848a-45a8fbd97fc7.png">

It looks as though the Editor isn't ready for unit tests yet? (Correct me if i'm wrong!) So i didn't write any for this but existing unit tests pass.

Please let me know if there's any problems or i've missed anything.

Thanks,
Matt