### PR TITLE
always render connect message immediately & tweak styles

### DIFF
--- a/public/js/components/Tabs.css
+++ b/public/js/components/Tabs.css
@@ -45,16 +45,15 @@
   color: var(--theme-highlight-bluegrey);
 }
 
-.not-connected-message {
+.connect-message {
   margin: 20px;
   padding: 50px 100px;
+  text-align: center;
+  color: #9a9a9a;
+}
+
+.connect-message.not-connected {
   border: 1px solid #dddddd;
   background-color: #fbfbfb;
   color: #9a9a9a;
-  text-align: center;
-}
-
-.node-message {
-  margin: 3em 0;
-  text-align: center;
 }

--- a/public/js/components/Tabs.js
+++ b/public/js/components/Tabs.js
@@ -1,5 +1,6 @@
 const React = require("react");
 const { connect } = require("react-redux");
+const classnames = require("classnames");
 const { getTabs } = require("../selectors");
 
 require("./Tabs.css");
@@ -34,23 +35,29 @@ function renderTabs(tabTitle, tabs, paramName) {
   );
 }
 
-function renderMessage(tabsIsEmpty) {
+function renderMessage(noTabs) {
   return dom.div(
-    { className: "not-connected-message" },
-    !tabsIsEmpty || "No remote tabs found. ",
-    "You may be looking to ",
-    dom.a({ href: `/?ws=${document.location.hostname}:9229/node` },
-      "connect to Node"), ".", dom.br(),
-    "Make sure you run ",
-    dom.a({ href: "https://github.com/devtools-html/debugger.html/blob/master/CONTRIBUTING.md#firefox" },
-      "Firefox"),
-    ", ",
-    dom.a({ href: "https://github.com/devtools-html/debugger.html/blob/master/CONTRIBUTING.md#chrome" },
-      "Chrome"),
-    " or ",
-    dom.a({ href: "https://github.com/devtools-html/debugger.html/blob/master/CONTRIBUTING.md#nodejs" },
-      "Node"),
-    " with the right flags."
+    { className: classnames("connect-message", { "not-connected": noTabs })},
+    dom.p(
+      null,
+      noTabs && "No remote tabs found. ",
+      "You may be looking to ",
+      dom.a({ href: `/?ws=${document.location.hostname}:9229/node` }, "connect to Node"),
+      "."
+    ),
+    dom.p(
+      null,
+      "Make sure you run ",
+      dom.a({ href: "https://github.com/devtools-html/debugger.html/blob/master/CONTRIBUTING.md#firefox" },
+            "Firefox"),
+      ", ",
+      dom.a({ href: "https://github.com/devtools-html/debugger.html/blob/master/CONTRIBUTING.md#chrome" },
+            "Chrome"),
+      " or ",
+      dom.a({ href: "https://github.com/devtools-html/debugger.html/blob/master/CONTRIBUTING.md#nodejs" },
+            "Node"),
+      " with the right flags."
+    )
   );
 }
 function Tabs({ tabs }) {

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -100,8 +100,8 @@ if (connTarget) {
     renderApp: () => renderRoot(App)
   };
 } else {
+  renderRoot(Tabs);
   connectClients().then(tabs => {
     actions.newTabs(tabs);
-    renderRoot(Tabs);
   });
 }


### PR DESCRIPTION
When I want to connect to node, I open the debugger and click on the "connect to node" link.

But the "not connected" message doesn't show until the Firefox connection times out. We should just go ahead and show the "not connected" message by default, and when it finds tabs it will re-render and show the normal tabs page. The `Tabs` component is already listening to the tab state so all we need to do is render the `Tabs` component immediately.

I also updated the styles because the styles for the "not connected" component don't really apply on the main tabs page.