### PR TITLE
move network timeout code to connect() Fixes #377

### DIFF
--- a/public/js/clients/chrome.js
+++ b/public/js/clients/chrome.js
@@ -45,6 +45,9 @@ function connectClient() {
   const url = `http://localhost:${webSocketPort}/json/list`;
   networkRequest(url).then(body => {
     deferred.resolve(createTabs(body))
+  }).catch(err => {
+    console.log(err);
+    deferred.reject();
   });
 
   return deferred.promise;

--- a/public/js/clients/firefox.js
+++ b/public/js/clients/firefox.js
@@ -47,7 +47,6 @@ function createTabs(tabs) {
 
 function connectClient() {
   const deferred = defer();
-  let isConnected = false;
   const useProxy = !getValue("firefox.webSocketConnection");
   const portPref = useProxy ? "firefox.proxyPort" : "firefox.webSocketPort";
   const webSocketPort = getValue(portPref);
@@ -57,17 +56,7 @@ function connectClient() {
     new DebuggerTransport(socket) : new WebSocketDebuggerTransport(socket);
   debuggerClient = new DebuggerClient(transport);
 
-  // TODO: the timeout logic should be moved to DebuggerClient.connect.
-  setTimeout(() => {
-    if (isConnected) {
-      return;
-    }
-
-    deferred.resolve([]);
-  }, 6000);
-
   debuggerClient.connect().then(() => {
-    isConnected = true;
     return debuggerClient.listTabs().then(response => {
       deferred.resolve(createTabs(response.tabs));
     });

--- a/public/js/utils/networkRequest.js
+++ b/public/js/utils/networkRequest.js
@@ -1,11 +1,19 @@
 const { log } = require("./utils");
 
 function networkRequest(url) {
-  return fetch(`/get?url=${url}`)
-    .then(res => res.json())
-    .catch(res => {
-      log(`failed to request ${url}`);
-    });
+  return Promise.race([
+    fetch(`/get?url=${url}`)
+      .then(res => {
+        if (res.status >= 200 && res.status < 300) {
+          return res.json();
+        }
+        log(`failed to request ${url}`);
+        return Promise.resolve([]);
+      }),
+    new Promise((resolve, reject) => {
+      setTimeout(() => reject(new Error("Connect timeout error")), 6000);
+    })
+  ]);
 }
 
 module.exports = {


### PR DESCRIPTION
Catch errors and reject the promise in chrome client
Remove the timeout function from the firefox client and move it to the `shared/client/main DebuggerClient.connect` function
Use a similar Promise.race() style for handling the timeout in both `networkRequest` and `DebuggerClient.connect`
In the DebuggerClient I used the `new Promise()` style of promises but the rest of the code uses `deferred`.  I wanted to keep a similar style to the rest of the code but it just feels awkward here.  I can rework it to use deferred if that’s needed.  I don't really understand the sham directory.