### PR TITLE
Persist selected source across debuggee refreshes

### DIFF
--- a/public/js/clients/firefox.js
+++ b/public/js/clients/firefox.js
@@ -93,11 +93,6 @@ function initPage(actions) {
 
   tabTarget.on("will-navigate", actions.willNavigate);
   tabTarget.on("navigate", actions.navigate);
-  tabTarget.on("frame-update", function(_, packet) {
-    if (packet.destroyAll) {
-      actions.willNavigate();
-    }
-  });
 
   // Listen to all the requested events.
   setupEvents({ threadClient, actions });

--- a/public/js/reducers/sources.js
+++ b/public/js/reducers/sources.js
@@ -100,10 +100,12 @@ function update(state = State(), action: Action) : Record<SourcesState> {
       }
 
       return _updateText(state, action, [action.originalSource]);
+
     case "NAVIGATE":
-      // Reset the entire state to just the initial state, a blank state
-      // if you will.
-      return State();
+      const source = state.selectedSource;
+      const sourceUrl = source && source.get("url");
+      return State()
+        .set("pendingSelectedSourceURL", sourceUrl);
   }
 
   return state;

--- a/public/js/test/integration/tests.js
+++ b/public/js/test/integration/tests.js
@@ -172,9 +172,7 @@ describe("Tests", function() {
    * reload
    */
   it("(Firefox) navigation", function() {
-    debugPage("exceptions.html");
-
-    cy.navigate("todomvc");
+    debugPage("todomvc");
     sourcesList().contains("bower_components");
 
     cy.navigate("increment");


### PR DESCRIPTION
Fixes #526.

There's a similar problem with tabs, which this does not address.