### PR TITLE
Show "this" in the scopes pane

### DIFF
--- a/public/js/clients/firefox/events.js
+++ b/public/js/clients/firefox/events.js
@@ -27,6 +27,7 @@ function createFrame(frame) {
       line: frame.where.line,
       column: frame.where.column
     }),
+    this: frame.this,
     scope: frame.environment
   });
 }

--- a/public/js/test/cypress/commands/debugger.js
+++ b/public/js/test/cypress/commands/debugger.js
@@ -31,7 +31,11 @@ function scopesPane() {
 }
 
 function scopeAtIndex(index) {
-  return scopesPane().find(".scopes-list > .tree").children().eq(index);
+  return scopes().children().eq(index);
+}
+
+function scopes() {
+  return scopesPane().find(".scopes-list > .tree");
 }
 /**
   DOM commands
@@ -161,6 +165,7 @@ Object.assign(window, {
   callStackFrameAtIndex,
   toggleScopes,
   scopeAtIndex,
+  scopes,
   selectScope,
   sourceTab,
   resume,

--- a/public/js/test/integration/tests.js
+++ b/public/js/test/integration/tests.js
@@ -10,6 +10,10 @@ describe("Tests", function() {
     addTodo();
     callStackFrameAtIndex(0).contains("initialize");
 
+    scopeAtIndex(0).click();
+    scopes().contains("<this>");
+
+
     // select the second frame and check to see the source updated
     selectCallStackFrame(1);
     sourceTab().contains("backbone.js");
@@ -137,21 +141,21 @@ describe("Tests", function() {
   it("(Firefox) exception", function() {
     debugPage("exceptions.html");
     scopeAtIndex(0).click();
-    scopeAtIndex(1).contains("reachable")
+    scopes().contains("reachable")
 
     resume();
     scopeAtIndex(0).click();
-    scopeAtIndex(1).contains("Error")
+    scopes().contains("Error")
 
     resume();
     scopeAtIndex(0).click();
-    scopeAtIndex(1).contains("Error")
+    scopes().contains("Error")
 
     resume();
     stepOver();
     stepOver();
     scopeAtIndex(0).click();
-    scopeAtIndex(1).contains("unreachable")
+    scopes().contains("unreachable")
 
     cy.navigate("exceptions.html")
     goToSource("exceptions")

--- a/public/js/types.js
+++ b/public/js/types.js
@@ -43,6 +43,7 @@ const Frame = t.struct({
   id: t.String,
   displayName: t.String,
   location: Location,
+  this: t.union([t.Object, t.Nil]),
   scope: t.union([t.Object, t.Nil])
 }, "Frame");
 


### PR DESCRIPTION
It turned out that we were no longer showing the <this> property in the scopes pane. This happened because `this` wasn't being added to frames.