### PR TITLE
Toggle breakpoint should wait for breakpoint to be active

### DIFF
--- a/public/js/test/cypress/commands/debugger.js
+++ b/public/js/test/cypress/commands/debugger.js
@@ -86,7 +86,12 @@ function toggleBreakpoint(linenumber) {
   });
 
   cy.get(".CodeMirror")
-    .contains(".CodeMirror-linenumber", linenumber).click();
+    .contains(".CodeMirror-linenumber", linenumber)
+    .click()
+
+  cy.get(".CodeMirror")
+    .contains(".CodeMirror-linenumber", linenumber)
+    .should("not.have.class", "breakpoint-disabled")
 }
 
 function addWatchExpression(expression) {


### PR DESCRIPTION
This helps address the cypress intermittent problem where we see that the call stack frames are empty when we expect to be paused.

I believe the problem is largely due to adding a breakpoint and not waiting for the breakpoint to be active. This can take a little longer on CI because the app pauses and resumes as well.