### PR TITLE
Hide breakpoints from other pages

### DIFF
--- a/public/js/components/Breakpoints.js
+++ b/public/js/components/Breakpoints.js
@@ -114,7 +114,8 @@ function _getBreakpoints(state) {
     bp.locationId = locationId;
     bp.isCurrentlyPaused = isCurrentlyPaused;
     return bp;
-  });
+  })
+  .filter(bp => bp.location.source);
 }
 
 module.exports = connect(


### PR DESCRIPTION
Fixes #479.

This is a simple fix. I'd like to re-think how we're storing breakpoints later when we introduce a localstorage backed pref system. My thinking is that it would be nice to store breakpoints in local storage so that we can access them after the debugger is closed/re-opened. If we start doing that, it might make sense to only load breakpoints for a page when the debugger starts.