### PR TITLE
Add test for navigation

### DIFF
--- a/public/js/test/cypress/commands/debuggee.js
+++ b/public/js/test/cypress/commands/debuggee.js
@@ -1,0 +1,24 @@
+
+function navigateBack() {
+  cy.debuggee(() => {
+    window.history.back();
+  });
+}
+
+function navigateForward() {
+  cy.debuggee(() => {
+    window.history.forward();
+  });
+}
+
+function reload() {
+  cy.debuggee(() => {
+    window.location.reload()
+  });
+}
+
+Object.assign(window, {
+  navigateForward,
+  navigateBack,
+  reload
+})

--- a/public/js/test/cypress/commands/debugger.js
+++ b/public/js/test/cypress/commands/debugger.js
@@ -79,6 +79,10 @@ function goToSource(source) {
   cy.get(".autocomplete .results li").first().click()
 }
 
+function sourcesList() {
+  return cy.get(".sources-list")
+}
+
 function toggleBreakpoint(linenumber) {
   cy.window().then(win => {
     cy.wrap(win.cm)
@@ -162,6 +166,7 @@ Object.assign(window, {
   toggleScopes,
   scopeAtIndex,
   selectScope,
+  sourcesList,
   sourceTab,
   resume,
   stepIn,

--- a/public/js/test/integration/tests.js
+++ b/public/js/test/integration/tests.js
@@ -158,6 +158,28 @@ describe("Tests", function() {
   });
 
   /**
+   * navigate to todomvc
+   * navigate to increment
+   * go back to todomvc
+   * go forward to increment
+   * reload
+   */
+  it("(Firefox) navigation", function() {
+    debugPage("exceptions.html");
+
+    cy.navigate("todomvc");
+    sourcesList().contains("bower_components");
+
+    cy.navigate("increment");
+    sourcesList().contains("bower_components").should("not.exist");
+    sourcesList().contains("increment");
+
+    reload();
+    sourcesList().contains("bower_components").should("not.exist");
+    sourcesList().contains("increment");
+  })
+
+  /**
    * * invoke an eval
    * * invoke an eval with a source url
    */


### PR DESCRIPTION
Adds a test that walks through all of the navigation commands and makes sure the sources list is uptodate.

We'll be able to incorporate source tabs and breakpoint behavior when the other PRs land.