### PR TITLE
File search close

### DIFF
--- a/public/images/Svg.js
+++ b/public/images/Svg.js
@@ -30,7 +30,10 @@ module.exports = function(name, props) { // eslint-disable-line
   if (!svg[name]) {
     throw new Error("Unknown SVG: " + name);
   }
-  let className = props ? `${name} ${props.className}` : name;
+  let className = name;
+  if (props && props.className) {
+    className = `${name} ${props.className}`;
+  }
   if (name === "subSettings") {
     className = "";
   }

--- a/public/js/components/App.css
+++ b/public/js/components/App.css
@@ -84,4 +84,15 @@ body {
 
 .search-container {
   display: flex;
+  flex: 1;
+}
+
+.search-container .autocomplete {
+  flex: 1;
+}
+
+.search-container .close-button {
+  width: 16px;
+  margin-top: 2em;
+  margin-right: 2em;
 }

--- a/public/js/components/App.css
+++ b/public/js/components/App.css
@@ -81,3 +81,7 @@ body {
   text-align: center;
   width: 100%;
 }
+
+.search-container {
+  display: flex;
+}

--- a/public/js/components/App.js
+++ b/public/js/components/App.js
@@ -14,6 +14,7 @@ const SplitBox = createFactory(require("./SplitBox"));
 const RightSidebar = createFactory(require("./RightSidebar"));
 const SourceTabs = createFactory(require("./SourceTabs"));
 const SourceFooter = createFactory(require("./SourceFooter"));
+const Svg = require("./utils/Svg");
 const Autocomplete = createFactory(require("./Autocomplete"));
 const { getSelectedSource, getSources } = require("../selectors");
 const { endTruncateStr } = require("../utils/utils");
@@ -75,14 +76,22 @@ const App = React.createClass({
     }
   },
 
+  closeSourcesSearch() {
+    this.setState({ searchOn: false });
+  },
+
   renderSourcesSearch() {
-    return Autocomplete({
-      selectItem: result => {
-        this.props.selectSource(result.id);
-        this.setState({ searchOn: false });
-      },
-      items: searchResults(this.props.sources)
-    });
+    return dom.div({ className: "search-container" },
+      Autocomplete({
+        selectItem: result => {
+          this.props.selectSource(result.id);
+          this.setState({ searchOn: false });
+        },
+        items: searchResults(this.props.sources)
+      }),
+      dom.div({ className: "close-button" },
+      Svg("close", { onClick: this.closeSourcesSearch }))
+    );
   },
 
   renderEditor() {


### PR DESCRIPTION
Associated with #584 adds the file search close button. I noticed a bug with `Svg` when I passed the `onClick` without the `className` prop also existing. Fixed this in a single commit that I can roll back and put in another PR.

Also still working on styling. Need some guidance there on what CSS is appropriate (in terms of units to use, flexbox, etc)

Screenshot
![screenshot_20160829_140522](https://cloud.githubusercontent.com/assets/580982/18065587/ab5ca204-6df1-11e6-9312-cd26efb508da.png)
