### PR TITLE
Fix for issue 627 - scrollbar added

### DIFF
--- a/public/js/components/RightSidebar.css
+++ b/public/js/components/RightSidebar.css
@@ -6,7 +6,7 @@
 }
 
 .right-sidebar .accordion {
-  overflow-y: scroll;
+  overflow-y: auto;
 }
 
 .command-bar {


### PR DESCRIPTION
The scroll came from the `overflow-y` value, I changed this to `auto` which gives us the expected behavior and no scrollbar till needed.