### PR TITLE
Add mochitest infrastructure

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -5,3 +5,4 @@ public/js/test/cypress/**
 public/js/test/integration/**
 public/js/test/unit-sources/**
 public/js/lib/**
+public/js/test/mochitest/head.js

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ npm-debug.log
 .idea/
 .vscode/
 cypress/screenshots
+firefox

--- a/bin/download-firefox-artifact
+++ b/bin/download-firefox-artifact
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+ROOT=`dirname $0`
+FIREFOX_PATH="$ROOT/../firefox"
+
+if [ -d "$FIREFOX_PATH" ]; then
+    # If we already have Firefox locally, just update it
+    cd "$FIREFOX_PATH";
+    hg pull
+else
+    hg clone https://hg.mozilla.org/mozilla-central/ "$FIREFOX_PATH"
+    cd "$FIREFOX_PATH"
+
+    # Make an artifcat build so it builds much faster
+    echo "
+ac_add_options --enable-artifact-builds
+mk_add_options MOZ_OBJDIR=./objdir-frontend
+" > .mozconfig
+fi

--- a/bin/make-firefox-bundle
+++ b/bin/make-firefox-bundle
@@ -5,6 +5,11 @@ if [ -z "$1" ]; then
    exit 1
 fi
 
+if [ "$2" == "--symlink-mochitests" ]; then
+  SYMLINK_MOCHITESTS=1
+fi
+
+ROOT=`dirname $0`
 DEBUGGER_PATH="$1/devtools/client/debugger/new"
 REV=`git log -1 --pretty=oneline`
 
@@ -13,6 +18,13 @@ if [ ! -d "$DEBUGGER_PATH" ]; then
    exit 2
 fi
 
+(
+    cd "$DEBUGGER_PATH";
+    if ! git log --oneline . | head -n 1 |
+            grep "UPDATE_BUNDLE" > /dev/null; then
+        echo "\033[31mWARNING\033[0m: local changes detected on mozilla-central";
+    fi
+);
 
 TARGET=firefox-panel webpack
 echo "// Generated from: $REV\n" | cat - public/build/bundle.js > "$DEBUGGER_PATH/bundle.js"
@@ -20,3 +32,13 @@ cp public/build/pretty-print-worker.js "$DEBUGGER_PATH"
 cp public/build/source-map-worker.js "$DEBUGGER_PATH"
 cp public/build/styles.css "$DEBUGGER_PATH"
 cp public/images/* "$DEBUGGER_PATH/images"
+
+rm -r "$DEBUGGER_PATH/test/mochitest"
+if [ -n "$SYMLINK_MOCHITESTS" ]; then
+    ln -s `pwd -P`"/$ROOT/../public/js/test/mochitest/" "$DEBUGGER_PATH/test/mochitest"
+else
+    rsync -avz public/js/test/mochitest/ "$DEBUGGER_PATH/test/mochitest"
+fi
+
+# Make sure a rebuild uses the new tests
+touch "$DEBUGGER_PATH/test/mochitest/browser.ini"

--- a/bin/prepare-mochitests-dev
+++ b/bin/prepare-mochitests-dev
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+ROOT=`dirname $0`
+FIREFOX_PATH="$ROOT/../firefox"
+
+# If we don't have a local copy of firefox, download it
+if [ ! -d firefox ]; then
+  "$ROOT/download-firefox-artifact"
+fi
+
+# Update the debugger files, build firefox, and run all the mochitests
+"$ROOT/make-firefox-bundle" "$FIREFOX_PATH" --symlink-mochitests
+cd "$FIREFOX_PATH"
+./mach build

--- a/bin/run-mochitests-docker
+++ b/bin/run-mochitests-docker
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+TARGET=firefox-panel ./node_modules/.bin/webpack
+
+docker run -it \
+  -v `pwd`/public/build/bundle.js:/firefox/devtools/client/debugger/new/bundle.js \
+  -v `pwd`/public/build/pretty-print-worker.js:/firefox/devtools/client/debugger/new/pretty-print-worker.js \
+  -v `pwd`/public/build/source-map-worker.js:/firefox/devtools/client/debugger/new/source-map-worker.js \
+  -v `pwd`/public/build/styles.css:/firefox/devtools/client/debugger/new/styles.css \
+  -v `pwd`/public/images:/firefox/devtools/client/debugger/new/images \
+  -v `pwd`/public/js/test/mochitest:/firefox/devtools/client/debugger/new/test/mochitest \
+  -v "/tmp/.X11-unix:/tmp/.X11-unix:rw" \
+  -e "DISPLAY=unix$DISPLAY" \
+  --ipc host \
+  jlongster/mochitest-runner \
+  /bin/bash -c "export SHELL=/bin/bash; cd firefox && touch devtools/client/debugger/new/test/mochitest/browser.ini && ./mach mochitest --subsuite devtools devtools/client/debugger/new/test/mochitest/"

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,8 @@
 machine:
   node:
     version: 6.3
+  services:
+    - docker
 
 checkout:
   post:
@@ -9,6 +11,7 @@ test:
   override:
     - mkdir -p $CIRCLE_TEST_REPORTS/mocha
     - node public/js/test/node-unit-tests.js --ci
+    - ./bin/run-mochitests-docker
     - npm run firefox-unit-test
     - node_modules/.bin/cypress ci b07646ab-ddfa-442b-b63f-aebf00452de8
     - node_modules/.bin/cypress ci b07646ab-ddfa-442b-b63f-aebf00452de8
@@ -32,3 +35,4 @@ dependencies:
     - ./bin/install-chrome
     - ./bin/install-firefox
     - node_modules/.bin/cypress install
+    - docker pull jlongster/mochitest-runner

--- a/docs/mochitests.md
+++ b/docs/mochitests.md
@@ -1,0 +1,103 @@
+We use [mochitests](https://developer.mozilla.org/en-US/docs/Mozilla/Projects/Mochitest) to do integration testing. Mochitests are part of Firefox and allow us to test the debugger literally as you would use it (as a devtools panel). While we are developing the debugger locally in a tab, it's important that we test it as a devtools panel.
+
+Mochitests require a local checkout of the Firefox source code. This is because they are used to test a lot of Firefox, and you would usually run them inside Firefox. We are developing the debugger outside of Firefox, but still want to test it as a devtools panel, so we've figured out a way to use them. It may not be elegant, but it allows us to ensure a high quality Firefox debugger.
+
+Mochitests live in `public/js/test/mochitest`.
+
+## Getting Started
+
+If you haven't set up the mochitest environment yet, just run this:
+
+```
+./bin/prepare-mochitests-dev
+```
+
+This will download a local copy of Firefox (or update it if it already exists), set up an [artifact build](https://developer.mozilla.org/en-US/docs/Mozilla/Developer_guide/Build_Instructions/Artifact_builds) (just think of a super fast Firefox build) and set up the environment. If you are doing this the first time, it may take a while (10-15 minutes). Most of that is downloading Firefox, later updates will be much quicker.
+
+Now, you can run the mochitests like this:
+
+```
+cd firefox
+./mach mochitest --subsuite devtools devtools/client/debugger/new/test/mochitest/
+```
+
+This works because we've symlinked the local mochitests into where the debugger lives in Firefox. Any changes to the tests in `public/js/test/mochitest` will be reflected and you can re-run the tests.
+
+Visit the [mochitest](https://developer.mozilla.org/en-US/docs/Mozilla/Projects/Mochitest) MDN page to learn more about mochitests and more advanced arguments. A few tips:
+
+* Passing `--jsdebugger` will open a JavaScript debugger and allow you to debug the tests (sometimes can be fickle)
+* Add `{ "logging": { "actions": true } }` to your local config file to see verbose logs of all the redux actions
+
+## Watching for Changes
+
+The mochitest are running against the compiled debugger bundle inside the Firefox checkout. This means that you need to update the bundle whenever you make code changes. `prepare-mochitests-dev` does this for you initially, but you can manually update it with:
+
+```
+./bin/make-firefox-bundle firefox
+```
+
+That will build the debugger and copy over all the relevant files into `firefox`, including mochitests. If you want it to only symlink the mochitests directory, pass `--symlink-mochitests` (which is what `prepare-mochitests-dev` does).
+
+It's annoying to have to manually update the bundle every single time though. If you want to automatically update the bundle in Firefox whenever you make a change, run this:
+
+```
+npm run mochitests-watch
+```
+
+Now you can make code changes the the bundle will be automatically built for you inside `firefox`, and you can simply run mochitests and edit code as much as you like.
+
+## Adding New Tests
+
+If you add new tests, make sure to list them in the `browser.ini` file. You will see the other tests there. Add a new entry with the same format as the others. You can also add new JS or HTML files by listing in under `support-files`.
+
+## API
+
+In addition to the standard mochtest API, we provide the following functions to help write tests. All of these expect a `dbg` context which is returned from `initDebugger` which should be called at the beginning of the test. An example skeleton test looks like this:
+
+```js
+const TAB_URL = EXAMPLE_URL + "doc_simple.html";
+
+add_task(function* () {
+  const dbg = yield initDebugger(TAB_URL, "code_simple.js");
+  // do some stuff
+  ok(state.foo, "Foo is OK");
+});
+```
+
+Any of the below APIs that takes a `url` will match it as a substring, meaning that `foo.js` will match a source with the URL `http://example.com/foo.js`.
+
+* `findSource(dbg, url)` - Returns a source that matches the URL
+* `selectSource(dbg, url)` - Selects the source
+* `stepOver(dbg)` - Steps over
+* `stepIn(dbg)` - Steps in
+* `stepOut(dbg)` - Steps out
+* `resume(dbg)` - Resumes
+* `addBreakpoint(dbg, sourceId, line, col?)` - Add a breakpoint to a source at line/col
+* `waitForPaused(dbg)` - Waits for the debugger to be fully paused
+* `waitForState(dbg, predicate)` - Waits for `predicate(state)` to be true. `state` is the redux app state
+* `waitForThreadEvents(dbg, eventName)` - Waits for specific thread events
+* `waitForDispatch(dbg, type)` - Wait for a specific action type to be dispatch. If an async action, will wait for it to be done.
+
+## Writing Tests
+
+Here are a few tips for writing mochitests:
+
+* Only write mochitests for testing the interaction of multiple components on the page and to make sure that the protocol is working.
+* By default, use the above builtin functions to drive the interaction and only dig into the DOM when you specifically want to test a component. For example, most tests should use the `addBreakpoint` command to add breakpoints, but certain tests may specifically want to test the editor gutter and left-click on that DOM element to add a breakpoint.
+* The `dbg` object has the following properties:
+** `actions` - Redux actions (already bound to the store)
+** `selectors` - State selectors
+** `getState` - Function to get current state
+** `store` - Redux store
+** `toolbox` - Devtools toolbox
+** `win` - The current debugger window
+* You can assert DOM structure like `is(dbg.win.querySelectorAll("#foo").length, 1, "...")`
+* If you need to access the content page, use `ContentTask.spawn`:
+
+```js
+ContentTask.spawn(gBrowser.selectedBrowser, null, function* () {
+  content.wrappedJSObject.foo();
+});
+```
+
+The above calls the function `foo` that exists in the page itself. You can also access the DOM this way: `content.document.querySelector`, if you want to click a button or do other things. You can even you use assertions inside this callback to check DOM state.

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "firefox": "node bin/firefox-driver --start",
     "cypress": "./node_modules/.bin/cypress run --port 2021",
     "cypress-intermittents": "for i in {1..100}; do time npm run cypress; done | tee cypress-run.log",
+    "mochitests-watch": "MOCHITESTS=true TARGET=firefox-panel webpack --watch",
     "prepublish": "webpack"
   },
   "dependencies": {

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -92,6 +92,7 @@ if (connTarget) {
     renderRoot(App);
   });
 } else if (isFirefoxPanel()) {
+  const selectors = require("./selectors");
   // The toolbox already provides the tab to debug.
   function bootstrap({ threadClient, tabTarget }) {
     firefox.setThreadClient(threadClient);
@@ -100,7 +101,19 @@ if (connTarget) {
     renderRoot(App);
   }
 
-  module.exports = { bootstrap, store, actions, selectors };
+  module.exports = {
+    bootstrap,
+    store: store,
+    actions: actions,
+    selectors: selectors,
+
+    // Remove these once we update the API on m-c
+    setThreadClient: firefox.setThreadClient,
+    setTabTarget: firefox.setTabTarget,
+    initPage: firefox.initPage,
+    renderApp: () => renderRoot(App),
+    getActions: () => actions
+  };
 } else {
   renderRoot(Tabs);
   connectClients().then(tabs => {

--- a/public/js/test/mochitest/.eslintrc
+++ b/public/js/test/mochitest/.eslintrc
@@ -1,0 +1,42 @@
+{
+  "globals": {
+    "add_task": false,
+    "Assert": false,
+    "BrowserTestUtils": false,
+    "content": false,
+    "ContentTask": false,
+    "ContentTaskUtils": false,
+    "EventUtils": false,
+    "executeSoon": false,
+    "expectUncaughtException": false,
+    "export_assertions": false,
+    "extractJarToTmp": false,
+    "finish": false,
+    "getJar": false,
+    "getRootDirectory": false,
+    "getTestFilePath": false,
+    "gBrowser": false,
+    "gTestPath": false,
+    "info": false,
+    "is": false,
+    "isnot": false,
+    "ok": false,
+    "registerCleanupFunction": false,
+    "requestLongerTimeout": false,
+    "SimpleTest": false,
+    "SpecialPowers": false,
+    "TestUtils": false,
+    "thisTestLeaksUncaughtRejectionsAndShouldBeFixed": false,
+    "todo": false,
+    "todo_is": false,
+    "todo_isnot": false,
+    "waitForClipboard": false,
+    "waitForExplicitFinish": false,
+    "waitForFocus": false,
+
+    // Globals introduced in debugger-specific head.js
+    "EXAMPLE_URL": false,
+    "openNewTabAndToolbox": false,
+    "waitForThreadEvents": false
+  }
+}

--- a/public/js/test/mochitest/browser.ini
+++ b/public/js/test/mochitest/browser.ini
@@ -1,0 +1,13 @@
+[DEFAULT]
+tags = devtools
+subsuite = devtools
+support-files =
+  head.js
+  !/devtools/client/commandline/test/helpers.js
+  !/devtools/client/framework/test/shared-head.js
+  doc_event-listeners-02.html
+  doc_simple.html
+  code_simple.js
+  code_simple2.js
+
+[browser_dbg_add-breakpoint.js]

--- a/public/js/test/mochitest/browser_dbg_add-breakpoint.js
+++ b/public/js/test/mochitest/browser_dbg_add-breakpoint.js
@@ -1,0 +1,24 @@
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
+
+const TAB_URL = EXAMPLE_URL + "doc_simple.html";
+
+add_task(function* () {
+  const dbg = yield initDebugger(TAB_URL, "code_simple.js");
+  const { actions, getState, selectors } = dbg;
+
+  const source = findSource(dbg, "code_simple.js");
+
+  yield addBreakpoint(dbg, source.id, 4);
+
+  ContentTask.spawn(gBrowser.selectedBrowser, null, function* () {
+    content.wrappedJSObject.foo();
+  });
+
+  yield waitForPaused(dbg);
+  yield stepIn(dbg);
+  yield selectSource(dbg, "code_simple2.js");
+
+  yield resume(dbg);
+  ok(true);
+});

--- a/public/js/test/mochitest/code_simple.js
+++ b/public/js/test/mochitest/code_simple.js
@@ -1,0 +1,5 @@
+function foo() {
+  var x = 3;
+  var y = 4;
+  return x + y;
+}

--- a/public/js/test/mochitest/code_simple2.js
+++ b/public/js/test/mochitest/code_simple2.js
@@ -1,0 +1,3 @@
+function BAR(x, y, z, w) {
+  return x*y*z*w;
+}

--- a/public/js/test/mochitest/doc_event-listeners-02.html
+++ b/public/js/test/mochitest/doc_event-listeners-02.html
@@ -1,0 +1,53 @@
+<!-- Any copyright is dedicated to the Public Domain.
+     http://creativecommons.org/publicdomain/zero/1.0/ -->
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8"/>
+    <title>Debugger test page</title>
+  </head>
+ 
+  <body>
+    <button>Click me!</button>
+    <input type="text" onchange="changeHandler()">
+ 
+    <script type="text/javascript">
+      window.addEventListener("load", function onload() {
+        window.removeEventListener("load", onload);
+        function initialSetup(event) {
+          debugger;
+          var button = document.querySelector("button");
+          button.onclick = clickHandler;
+        }
+        function clickHandler(event) {
+          window.foobar = "clickHandler";
+        }
+        function changeHandler(event) {
+          window.foobar = "changeHandler";
+        }
+        function keyupHandler(event) {
+          window.foobar = "keyupHandler";
+        }
+        function keydownHandler(event) {
+          window.foobar = "keydownHandler";
+        }
+ 
+        var button = document.querySelector("button");
+        button.onclick = initialSetup;
+ 
+        var input = document.querySelector("input");
+        input.addEventListener("keyup", keyupHandler, true);
+ 
+        window.addEventListener("keydown", keydownHandler, true);
+        document.body.addEventListener("keydown", keydownHandler, true);
+ 
+        window.changeHandler = changeHandler;
+      });
+ 
+      function addBodyClickEventListener() {
+        document.body.addEventListener("click", function() { debugger; });
+      }
+    </script>
+  </body>
+ 
+</html>

--- a/public/js/test/mochitest/doc_simple.html
+++ b/public/js/test/mochitest/doc_simple.html
@@ -1,0 +1,14 @@
+<!-- Any copyright is dedicated to the Public Domain.
+     http://creativecommons.org/publicdomain/zero/1.0/ -->
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8"/>
+    <title>Debugger test page</title>
+  </head>
+ 
+  <body>
+    <script src="code_simple.js"></script>
+    <script src="code_simple2.js"></script>
+  </body>
+</html>

--- a/public/js/test/mochitest/head.js
+++ b/public/js/test/mochitest/head.js
@@ -1,0 +1,176 @@
+/* -*- indent-tabs-mode: nil; js-indent-level: 2 -*- */
+/* vim: set ft=javascript ts=2 et sw=2 tw=80: */
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+// shared-head.js handles imports, constants, and utility functions
+Services.scriptloader.loadSubScript("chrome://mochitests/content/browser/devtools/client/framework/test/shared-head.js", this);
+var { Toolbox } = require("devtools/client/framework/toolbox");
+const EXAMPLE_URL = "http://example.com/browser/devtools/client/debugger/new/test/mochitest/";
+
+// Wait until an action of `type` is dispatched. This is different
+// then `_afterDispatchDone` because it doesn't wait for async actions
+// to be done/errored. Use this if you want to listen for the "start"
+// action of an async operation (somewhat rare).
+function waitForNextDispatch(store, type) {
+  return new Promise(resolve => {
+    store.dispatch({
+      // Normally we would use `services.WAIT_UNTIL`, but use the
+      // internal name here so tests aren't forced to always pass it
+      // in
+      type: "@@service/waitUntil",
+      predicate: action => action.type === type,
+      run: (dispatch, getState, action) => {
+        resolve(action);
+      }
+    });
+  });
+}
+
+// Wait until an action of `type` is dispatched. If it's part of an
+// async operation, wait until the `status` field is "done" or "error"
+function _afterDispatchDone(store, type) {
+  return new Promise(resolve => {
+    store.dispatch({
+      // Normally we would use `services.WAIT_UNTIL`, but use the
+      // internal name here so tests aren't forced to always pass it
+      // in
+      type: "@@service/waitUntil",
+      predicate: action => {
+        if (action.type === type) {
+          return action.status ?
+            (action.status === "done" || action.status === "error") :
+            true;
+        }
+      },
+      run: (dispatch, getState, action) => {
+        resolve(action);
+      }
+    });
+  });
+}
+
+function waitForDispatch(dbg, type, eventRepeat = 1) {
+  let count = 0;
+
+  return Task.spawn(function* () {
+    info("Waiting for " + type + " to dispatch " + eventRepeat + " time(s)");
+    while (count < eventRepeat) {
+      yield _afterDispatchDone(dbg.store, type);
+      count++;
+      info(type + " dispatched " + count + " time(s)");
+    }
+  });
+}
+
+function waitForThreadEvents(dbg, eventName) {
+  info("Waiting for thread event '" + eventName + "' to fire.");
+  const thread = dbg.toolbox.threadClient;
+
+  return new Promise(function(resolve, reject) {
+    thread.addListener(eventName, function onEvent(eventName, ...args) {
+      info("Thread event '" + eventName + "' fired.");
+      thread.removeListener(eventName, onEvent);
+      resolve.apply(resolve, args);
+    });
+  });
+}
+
+function waitForState(dbg, predicate) {
+  return new Promise(resolve => {
+    const unsubscribe = dbg.store.subscribe(() => {
+      if (predicate(dbg.store.getState())) {
+        unsubscribe();
+        resolve();
+      }
+    });
+  });
+}
+
+const waitForPaused = Task.async(function* (dbg) {
+  // We want to make sure that we get both a real paused event and
+  // that the state is fully populated. The client may do some more
+  // work (call other client methods) before populating the state.
+  return Promise.all([
+    yield waitForThreadEvents(dbg, "paused"),
+    yield waitForState(dbg, state => dbg.selectors.getPause(state))
+  ]);
+});
+
+const initDebugger = Task.async(function* (url, ...sources) {
+  const toolbox = yield openNewTabAndToolbox(url, "jsdebugger");
+  const win = toolbox.getPanel("jsdebugger").panelWin;
+  const store = win.Debugger.store;
+  const { getSources } = win.Debugger.selectors;
+
+  const dbg = {
+    actions: win.Debugger.actions,
+    selectors: win.Debugger.selectors,
+    getState: store.getState,
+    store: store,
+    toolbox: toolbox,
+    win: win
+  };
+
+  yield Promise.all(sources.map(url => {
+    return waitForState(dbg, state => {
+      return getSources(state).some(s => s.get("url").includes(url));
+    });
+  }));
+
+  return dbg;
+});
+
+function findSource(dbg, url) {
+  const sources = dbg.selectors.getSources(dbg.getState());
+  const source = sources.find(s => s.get("url").includes(url));
+
+  if(!source) {
+    throw new Error("Unable to find source: " + matchingStr);
+  }
+
+  return source.toJS();
+}
+
+function selectSource(dbg, url) {
+  info("Selecting source: " + url);
+  const source = findSource(dbg, url);
+  dbg.actions.selectSource(source.id);
+
+  return waitForDispatch(dbg, "LOAD_SOURCE_TEXT");
+}
+
+function stepOver(dbg) {
+  info("Stepping over");
+  dbg.actions.stepOver();
+  return waitForPaused(dbg);
+}
+
+function stepIn(dbg) {
+  info("Stepping in");
+  dbg.actions.stepIn();
+  return waitForPaused(dbg);
+}
+
+function stepOut(dbg) {
+  info("Stepping out");
+  dbg.actions.stepOut();
+  return waitForPaused(dbg);
+}
+
+function resume(dbg) {
+  info("Resuming");
+  dbg.actions.resume();
+  return waitForThreadEvents(dbg, "resumed");
+}
+
+function addBreakpoint(dbg, sourceId, line, col) {
+  return dbg.actions.addBreakpoint({ sourceId, line, col });
+}
+
+Services.prefs.setBoolPref("devtools.debugger.new-debugger-frontend", true);
+registerCleanupFunction(() => {
+  Services.prefs.setBoolPref("devtools.debugger.new-debugger-frontend", false);
+})

--- a/webpack.config.devtools.js
+++ b/webpack.config.devtools.js
@@ -16,6 +16,11 @@ const nativeMapping = {
 
 module.exports = webpackConfig => {
   webpackConfig.output.library = "Debugger";
+
+  if(process.env.MOCHITESTS) {
+    webpackConfig.output.path = path.join(__dirname, "firefox/devtools/client/debugger/new");
+  }
+
   webpackConfig.externals = [
     function(context, request, callback) {
       const mod = path.join(context.replace(__dirname + "/", ""), request);
@@ -29,9 +34,7 @@ module.exports = webpackConfig => {
         return;
       }
       callback();
-    },
-
-    { codemirror: "var devtoolsRequire('devtools/client/sourceeditor/editor')" }
+    }
   ];
 
   // Remove the existing DefinePlugin so we can override it.


### PR DESCRIPTION
This is my final pass on the mochitest infrastructure. It should actually work! This implements running them locally and on try. Locally it downloads an artifact build of Firefox and you should be up an running in ~10 min, and future builds should be almost instantaneous. For debugging you'll probably want to cd into the Firefox directory itself and use mochitests like normal, not through `npm run mochitests`. On CI, it runs them in a pre-built docker container.

This pulls over @jasonLaster's great work from bug [1294686](https://bugzilla.mozilla.org/show_bug.cgi?id=1294686) because we need to actually commit the mochitests here. We still need to land a few bits in that bug to make these run (modifying other `moz.build`s etc), but the `head.js` and a simple test was copied into here. It gives us a starting point.

**Don't merge this** yet; it will not work until relevant bits are landed in bug 1294686. Once they do, I'll update the Firefox in docker and they should be running in CI.