### PR TITLE
added module which wraps nodeJS path module (#451)

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "immutable": "^3.7.6",
     "invariant": "^2.2.1",
     "lodash": "^4.13.1",
-    "path-browser-wrapper": "^1.0.0",
+    "path-browser-wrapper": "^1.0.1",
     "pretty-fast": "^0.2.0",
     "react": "=0.14.7",
     "react-dom": "=0.14.7",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "immutable": "^3.7.6",
     "invariant": "^2.2.1",
     "lodash": "^4.13.1",
+    "path-browser-wrapper": "^1.0.0",
     "pretty-fast": "^0.2.0",
     "react": "=0.14.7",
     "react-dom": "=0.14.7",

--- a/public/js/components/Frames.js
+++ b/public/js/components/Frames.js
@@ -5,7 +5,7 @@ const { bindActionCreators } = require("redux");
 const { connect } = require("react-redux");
 const actions = require("../actions");
 const { endTruncateStr } = require("../utils/utils");
-const { basename } = require("../utils/path");
+const { basename } = require("path-browser-wrapper");
 const { getFrames, getSelectedFrame, getSource } = require("../selectors");
 
 if (typeof window == "object") {

--- a/public/js/selectors.js
+++ b/public/js/selectors.js
@@ -4,7 +4,7 @@ import type { Record } from "./utils/makeRecord";
 import type { SourcesState } from "./reducers/sources";
 
 const URL = require("url");
-const path = require("./utils/path");
+const path = require("path-browser-wrapper");
 const sources = require("./reducers/sources");
 const pause = require("./reducers/pause");
 const breakpoints = require("./reducers/breakpoints");

--- a/public/js/utils/path.js
+++ b/public/js/utils/path.js
@@ -1,20 +1,2 @@
-function basename(path) {
-  return path.split("/").pop();
-}
-
-function dirname(path) {
-  const idx = path.lastIndexOf("/");
-  return path.slice(0, idx);
-}
-
-function isURL(str) {
-  return str.indexOf("://") !== -1;
-}
-
-function isAbsolute(str) {
-  return str[0] === "/";
-}
-
-module.exports = {
-  basename, dirname, isURL, isAbsolute
-};
+const path = require("path-browser-wrapper");
+module.exports = path;

--- a/public/js/utils/path.js
+++ b/public/js/utils/path.js
@@ -1,2 +1,0 @@
-const path = require("path-browser-wrapper");
-module.exports = path;


### PR DESCRIPTION
So I managed to implement what I had in mind.

The problem with other path libraries was that they tried to port the core NodeJS path library but they were not actively maintained.

In this module, it wraps around the nodeJS core library itself, so any changes to that would propagate to our project also.

Another plus is that it ports all of NodeJS path module except resolve and relative, which utilize process module and cannot be ported. (Also trying to port them won't make total sense for the browser.)

@jasonLaster as per your suggestion, I made an npm package for this. It's funny because I spent quite some time on this PR which doesn't really change anything. But I learned a lot of different things. Thanks!

Let me know if you find any issues. 😜 