### PR TITLE
check for hg command and successful exit of it

### DIFF
--- a/bin/download-firefox-artifact
+++ b/bin/download-firefox-artifact
@@ -3,12 +3,23 @@
 ROOT=`dirname $0`
 FIREFOX_PATH="$ROOT/../firefox"
 
+# check that mercurial is installed
+command -v hg >/dev/null 2>&1 || {
+  echo >&2 "mercurial is required for mochitests, use 'brew install mercurial' on MacOS";
+  exit 1;
+}
+
 if [ -d "$FIREFOX_PATH" ]; then
     # If we already have Firefox locally, just update it
     cd "$FIREFOX_PATH";
     hg pull
 else
+    echo "Downloading Firefox source code, requires about 30 min depending on connection"
     hg clone https://hg.mozilla.org/mozilla-central/ "$FIREFOX_PATH"
+    # if somebody cancels (ctrl-c) out of the long download don't continue
+    if [ $? -ne 0 ]; then
+        exit 1;
+    fi
     cd "$FIREFOX_PATH"
 
     # Make an artifcat build so it builds much faster

--- a/bin/download-firefox-artifact
+++ b/bin/download-firefox-artifact
@@ -4,17 +4,17 @@ ROOT=`dirname $0`
 FIREFOX_PATH="$ROOT/../firefox"
 
 # check that mercurial is installed
-command -v hg >/dev/null 2>&1 || {
+if [ -z "`command -v hg`" ]; then
   echo >&2 "mercurial is required for mochitests, use 'brew install mercurial' on MacOS";
   exit 1;
-}
+fi
 
 if [ -d "$FIREFOX_PATH" ]; then
     # If we already have Firefox locally, just update it
     cd "$FIREFOX_PATH";
     hg pull
 else
-    echo "Downloading Firefox source code, requires about 30 min depending on connection"
+    echo "Downloading Firefox source code, requires about 10-30min depending on connection"
     hg clone https://hg.mozilla.org/mozilla-central/ "$FIREFOX_PATH"
     # if somebody cancels (ctrl-c) out of the long download don't continue
     if [ $? -ne 0 ]; then

--- a/bin/prepare-mochitests-dev
+++ b/bin/prepare-mochitests-dev
@@ -6,6 +6,10 @@ FIREFOX_PATH="$ROOT/../firefox"
 # If we don't have a local copy of firefox, download it
 if [ ! -d firefox ]; then
   "$ROOT/download-firefox-artifact"
+  # check that the download exited successfully
+  if [ $? -ne 0 ]; then
+      exit 1;
+  fi
 fi
 
 # Update the debugger files, build firefox, and run all the mochitests


### PR DESCRIPTION
* `download-firefox-artifact` 
 * checks for the `hg` command using `command -v` which I believe is the recommended style.  Offers the homebrew command to install mercurial.
 * checks that `hg clone` exits successfully for any reason, otherwise the `cd $FIREFOX_PATH` fails and the script continues to write a mozconfig file
* `prepare-mochitests-dev`
 * checks that the download command exited successfully before continuing 

My bash scripting is really rusty :shipit: 