### PR TITLE
Always render editor so only 1 CodeMirror instance is created

### DIFF
--- a/public/js/components/App.css
+++ b/public/js/components/App.css
@@ -72,19 +72,15 @@ body {
   transition: opacity 200ms;
 }
 
-.welcomebox {
-  margin: 50px auto;
-  padding: 20px;
-  font-size: 1.25em;
-  color: var(--theme-gray-darker);
-  font-weight: lighter;
-  text-align: center;
-  width: 100%;
-}
-
 .search-container {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
   display: flex;
-  flex: 1;
+  z-index: 200;
+  background-color: rgba(221, 225, 228, 0.66);
 }
 
 .search-container .autocomplete {
@@ -93,6 +89,6 @@ body {
 
 .search-container .close-button {
   width: 16px;
-  margin-top: 2em;
-  margin-right: 2em;
+  margin-top: 25px;
+  margin-right: 20px;
 }

--- a/public/js/components/App.js
+++ b/public/js/components/App.js
@@ -16,7 +16,7 @@ const SourceTabs = createFactory(require("./SourceTabs"));
 const SourceFooter = createFactory(require("./SourceFooter"));
 const Svg = require("./utils/Svg");
 const Autocomplete = createFactory(require("./Autocomplete"));
-const { getSelectedSource, getSources } = require("../selectors");
+const { getSources, getSelectedSource } = require("../selectors");
 const { endTruncateStr } = require("../utils/utils");
 const { KeyShortcuts } = require("../lib/devtools-sham/client/shared/key-shortcuts");
 const { isHiddenSource, getURL } = require("../utils/sources-tree");
@@ -41,8 +41,8 @@ function searchResults(sources) {
 const App = React.createClass({
   propTypes: {
     sources: PropTypes.object,
-    selectedSource: PropTypes.object,
-    selectSource: PropTypes.func
+    selectSource: PropTypes.func,
+    selectedSource: PropTypes.object
   },
 
   displayName: "App",
@@ -94,15 +94,6 @@ const App = React.createClass({
     );
   },
 
-  renderEditor() {
-    return dom.div(
-      { className: "editor-container" },
-      SourceTabs(),
-      Editor(),
-      SourceFooter()
-    );
-  },
-
   renderWelcomeBox() {
     const modifierTxt = Services.appinfo.OS === "Darwin" ? "Cmd" : "Ctrl";
     return dom.div(
@@ -112,16 +103,17 @@ const App = React.createClass({
   },
 
   renderCenterPane() {
-    let centerPane;
-    if (this.state.searchOn) {
-      centerPane = this.renderSourcesSearch();
-    } else if (this.props.selectedSource) {
-      centerPane = this.renderEditor();
-    } else {
-      centerPane = this.renderWelcomeBox();
-    }
-
-    return dom.div({ className: "center-pane" }, centerPane);
+    return dom.div(
+      { className: "center-pane" },
+      dom.div(
+        { className: "editor-container" },
+        SourceTabs(),
+        Editor(),
+        !this.props.selectedSource ? this.renderWelcomeBox() : null,
+        this.state.searchOn ? this.renderSourcesSearch() : null,
+        SourceFooter()
+      )
+    );
   },
 
   render: function() {

--- a/public/js/components/Autocomplete.css
+++ b/public/js/components/Autocomplete.css
@@ -25,6 +25,7 @@
 
 .autocomplete li {
   border-top: 2px solid #dde1e4;
+  background-color: #fcfcfc;
   padding: 10px;
 }
 
@@ -43,12 +44,10 @@
 }
 
 .autocomplete li .title {
-  font-size: 0.8em;
   line-height: 1.5em;
 }
 
 .autocomplete li .subtitle {
-  font-size: 0.7em;
   line-height: 1.5em;
   color: grey;
 }
@@ -60,13 +59,12 @@
   line-height: 2.5em;
   height: 2.5em;
   padding-left: 25px;
-  font-size: 0.8em;
 }
 
 .autocomplete svg {
   width: 16px;
   position: absolute;
-  top: calc(2.5em - 12px);
+  top: 25px;
   left: 27px;
 }
 

--- a/public/js/components/Editor.css
+++ b/public/js/components/Editor.css
@@ -65,3 +65,19 @@
 .debug-line .CodeMirror-activeline-background {
   display: none;
 }
+
+.welcomebox {
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  left: 0;
+  padding: 50px 0;
+  text-align: center;
+  font-size: 1.25em;
+  color: var(--theme-gray-darker);
+  background-color: #fcfcfc;
+  font-weight: lighter;
+  text-align: center;
+  z-index: 100;
+}

--- a/public/js/components/Editor.js
+++ b/public/js/components/Editor.js
@@ -66,9 +66,12 @@ const Editor = React.createClass({
     );
 
     this.editor.codeMirror.on("gutterClick", this.onGutterClick);
-    this.setText(this.props.sourceText.get("text"));
     resizeBreakpointGutter(this.editor.codeMirror);
     debugGlobal("cm", this.editor.codeMirror);
+
+    if (this.props.sourceText) {
+      this.setText(this.props.sourceText.get("text"));
+    }
   },
 
   onGutterClick(cm, line, gutter, ev) {

--- a/public/js/components/SourceFooter.js
+++ b/public/js/components/SourceFooter.js
@@ -24,9 +24,9 @@ function debugBtn(onClick, type, className = "active", tooltip) {
 
 const SourceFooter = React.createClass({
   propTypes: {
-    selectedSource: ImPropTypes.map.isRequired,
+    selectedSource: ImPropTypes.map,
     togglePrettyPrint: PropTypes.func,
-    sourceText: ImPropTypes.map.isRequired,
+    sourceText: ImPropTypes.map,
     selectSource: PropTypes.func,
     prettySource: ImPropTypes.map
   },
@@ -82,6 +82,10 @@ const SourceFooter = React.createClass({
   },
 
   render() {
+    if (!this.props.selectedSource) {
+      return null;
+    }
+
     return dom.div({ className: "source-footer" },
       dom.div({ className: "command-bar" },
         this.blackboxButton(),


### PR DESCRIPTION
I made these changes a little quickly, so I'm open to a better way. This always renders the editor in the background, and renders everything else "above" it. The nice thing (I think) is that now the source header (and eventually the footer) is always rendered which I think makes it look more consistent.

This is required so that we only ever create 1 CodeMirror instance, and it makes our `Editor` component more reliable because on the initial render the `this.editor` instance is null (it hasn't been mounted yet). Not all renders are "updates" so `this.editor` will always reliably be there, so breakpoints will always show up, etc.