### PR TITLE
Make editor handle edge cases better: only render breakpoints when text isn't loading

### DIFF
--- a/public/js/components/Editor.js
+++ b/public/js/components/Editor.js
@@ -17,7 +17,7 @@ const { DOM: dom, PropTypes } = React;
 require("./Editor.css");
 
 function isSourceForFrame(source, frame) {
-  return frame && frame.location.sourceId === source.get("id");
+  return source && frame && frame.location.sourceId === source.get("id");
 }
 
 /**
@@ -161,19 +161,21 @@ const Editor = React.createClass({
   },
 
   render() {
-    const breakpoints = this.props.breakpoints.valueSeq();
+    const { breakpoints, sourceText } = this.props;
+    const isLoading = sourceText && sourceText.get("loading");
 
     return (
       dom.div(
         { className: "editor-wrapper devtools-monospace" },
         dom.div({ className: "editor-mount" }),
-        breakpoints.map(bp => {
-          return Breakpoint({
-            key: makeLocationId(bp.location),
-            breakpoint: bp,
-            editor: this.editor && this.editor.codeMirror
-          });
-        })
+        !isLoading &&
+          breakpoints.valueSeq().map(bp => {
+            return Breakpoint({
+              key: makeLocationId(bp.location),
+              breakpoint: bp,
+              editor: this.editor && this.editor.codeMirror
+            });
+          })
       )
     );
   }


### PR DESCRIPTION
A few more code paths came up while testing. The breakpoint won't show if a source text hasn't been loaded yet, because it'll try to added the breakpoint icons to the editor while showing "Loading...", and then it won't re-add them when the real text appears. This is because we've optimized the breakpoints so that they only touch the editor when needed (they don't always re-add themselves).

Also if you close all the tabs and open them the `isSourceForFrame` errors of paused, so that's fixed.