### PR TITLE
Never merge in local config when targeting the Firefox panel

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -9,10 +9,17 @@ const development = require("./development.json");
 const envConfig = process.env.TARGET === "firefox-panel" ?
    firefoxPanel : development;
 
-const localConfig = fs.existsSync(path.join(__dirname, "./local.json")) ?
-  require("./local.json") : {};
+let config;
 
-let config = _.merge({}, envConfig, localConfig);
+if(process.env.TARGET === "firefox-panel") {
+  config = firefoxPanel;
+}
+else {
+  const localConfig = fs.existsSync(path.join(__dirname, "./local.json")) ?
+        require("./local.json") : {};
+
+  config = _.merge({}, envConfig, localConfig);
+}
 
 function getConfig() {
   return config;


### PR DESCRIPTION
It's dangerous to pull in the local config when targeting the Firefox panel, as you most likely have development prefs on.