### PR TITLE
Use CodeMirror from mozilla-central when in panel

### DIFF
--- a/public/js/components/Editor.js
+++ b/public/js/components/Editor.js
@@ -143,10 +143,8 @@ const Editor = React.createClass({
       value: " "
     });
 
-    this.editor.appendTo(
-      ReactDOM.findDOMNode(this).querySelector(".editor-mount"),
-      null,
-      true
+    this.editor.appendToLocalElement(
+      ReactDOM.findDOMNode(this).querySelector(".editor-mount")
     );
 
     this.editor.codeMirror.on("gutterClick", this.onGutterClick);

--- a/public/js/utils/source-editor.js
+++ b/public/js/utils/source-editor.js
@@ -14,7 +14,7 @@ class SourceEditor {
     this.opts = opts;
   }
 
-  appendTo(node, env, noIframe) {
+  appendToLocalElement(node) {
     this.editor = CodeMirror(node, this.opts);
   }
 

--- a/webpack.config.devtools.js
+++ b/webpack.config.devtools.js
@@ -10,8 +10,7 @@ const ignoreRegexes = [
 ];
 
 const nativeMapping = {
-  // Don't map this until bug 1295318 lands
-  // "public/js/utils/source-editor": "devtools/client/sourceeditor/editor"
+  "public/js/utils/source-editor": "devtools/client/sourceeditor/editor",
   "public/js/test/test-flag": "devtools/shared/flags",
 
   // React can be required a few different ways, make sure they are


### PR DESCRIPTION
This will pass once [bug 1295213](https://bugzilla.mozilla.org/show_bug.cgi?id=1295213) lands. All tests currently still pass, which is great. From here we could play with enabling code search, maybe?

Hoping to land that bug today, or at the latest tomorrow. Should have this before enabling it on nightly tomorrow.