### PR TITLE
breakpoint list formatting tweaks

### DIFF
--- a/public/js/components/Breakpoints.css
+++ b/public/js/components/Breakpoints.css
@@ -1,26 +1,15 @@
-.breakpoints-list {
-  padding-bottom: 10px;
-}
 
 .breakpoints-list .breakpoint {
   font-size: 12px;
   color: var(--theme-content-color1);
-  margin-top: 0.5em;
+  margin: 0.25em 0;
+  padding: 0.25em 0;
   line-height: 1em;
-  display: flex;
-  flex-flow: row;
-  align-items: center;
 }
 
-.breakpoints-list .breakpoint input {
-  flex: 0 1 content;
-  order: 1;
-}
-
-/*
 .breakpoints-list .breakpoint.paused {
+  background-color: var(--theme-toolbar-background-alt);
 }
-*/
 
 .breakpoints-list .breakpoint.disabled .breakpoint-label {
   color: var(--theme-content-color3);
@@ -33,8 +22,7 @@
 }
 
 .breakpoints-list .breakpoint-label {
-  flex: 1 0 auto;
-  order: 2;
+  display: inline-block;
 }
 
 .breakpoints-list .pause-indicator {

--- a/public/js/components/Breakpoints.js
+++ b/public/js/components/Breakpoints.js
@@ -2,7 +2,6 @@ const React = require("react");
 const { connect } = require("react-redux");
 const { bindActionCreators } = require("redux");
 const ImPropTypes = require("react-immutable-proptypes");
-const Isvg = React.createFactory(require("react-inlinesvg"));
 const classnames = require("classnames");
 const actions = require("../actions");
 const { getSource, getPause, getBreakpoints } = require("../selectors");
@@ -32,8 +31,9 @@ function renderSourceLocation(source, line) {
   const url = basename(source.get("url"));
   // const line = url !== "" ? `: ${line}` : "";
   return url !== "" ?
-    dom.div({ className: "location" },
-      `${endTruncateStr(url, 30)}${line}`
+    dom.div(
+      { className: "location" },
+      `${endTruncateStr(url, 30)}: ${line}`
     ) : null;
 }
 
@@ -72,33 +72,24 @@ const Breakpoints = React.createClass({
     const isCurrentlyPaused = breakpoint.isCurrentlyPaused;
     const isDisabled = breakpoint.disabled;
 
-    const isPausedIcon = isCurrentlyPaused && Isvg({
-      className: "pause-indicator",
-      src: "images/pause-circle.svg"
-    });
-
     return dom.div(
-      {},
-      dom.div(
-        {
-          className: classnames({
-            breakpoint,
-            paused: isCurrentlyPaused,
-            disabled: isDisabled
-          }),
-          key: locationId,
-          onClick: () => this.selectBreakpoint(breakpoint)
-        },
-        dom.input({
-          type: "checkbox",
-          checked: !isDisabled,
-          onChange: () => this.handleCheckbox(breakpoint)
+      {
+        className: classnames({
+          breakpoint,
+          paused: isCurrentlyPaused,
+          disabled: isDisabled
         }),
-        dom.div(
-          { className: "breakpoint-label", title: breakpoint.text },
-          dom.div({}, renderSourceLocation(breakpoint.location.source, line))
-        ),
-        isPausedIcon
+        key: locationId,
+        onClick: () => this.selectBreakpoint(breakpoint)
+      },
+      dom.input({
+        type: "checkbox",
+        checked: !isDisabled,
+        onChange: () => this.handleCheckbox(breakpoint)
+      }),
+      dom.div(
+        { className: "breakpoint-label", title: breakpoint.text },
+        dom.div({}, renderSourceLocation(breakpoint.location.source, line))
       ),
       dom.div({ className: "breakpoint-snippet" }, snippet)
     );

--- a/public/js/utils/source-map.js
+++ b/public/js/utils/source-map.js
@@ -23,7 +23,7 @@ restartWorker();
 // TODO: Create a proper shutdown function that the panel calls, and
 // make sure in a local debugging context that it dies with the page
 // naturally (as it should).
-if(typeof window !== 'undefined') {
+if (typeof window !== "undefined") {
   window.addEventListener("unload", function() {
     sourceMapWorker.terminate();
   });


### PR DESCRIPTION
This changes the breakpoint list to show filename and line as "foo.js: 5" instead of "foo.js5". It also fixed a margin issue with the "no breakpoints" message; there was a big margin on the bottom of it. The HTML/CSS has been simplified too so that the whole area is a clickable breakpoint item (previously, only the file/line was).

There's a new proposal in here: in order to simplify the markup and CSS, I wanted see what it would be like to avoid flexbox for this small thing, and it works pretty well. The only hard-ish part was the paused icon, and personally I think it would be better if we just highlighted the breakpoint:

<img width="324" alt="screen shot 2016-09-08 at 4 58 35 pm" src="https://cloud.githubusercontent.com/assets/17031/18366888/6cf192b6-75e6-11e6-927c-7942b760cac8.png">

(The background color could be whatever)

I'm not sure of the benefit of an icon here, as it's not a button or anything. What do you all think?

I can revert some of this if needed, but we should land this soon because I don't want to update the debugger on m-c with the current bp styles.