### PR TITLE
Cleanup editor-select test

### DIFF
--- a/public/js/test/mochitest/head.js
+++ b/public/js/test/mochitest/head.js
@@ -267,7 +267,9 @@ const selectors = {
   callStackHeader: ".call-stack-pane ._header",
   frame: index => `.frames ul li:nth-child(${index})`,
   gutter: i => `.CodeMirror-code *:nth-child(${i}) .CodeMirror-linenumber`,
-  pauseOnExceptions: ".pause-exceptions"
+  pauseOnExceptions: ".pause-exceptions",
+  breakpoint: ".CodeMirror-code > .new-breakpoint",
+  codeMirror: ".CodeMirror"
 }
 
 function getSelector(elementName, ...args) {


### PR DESCRIPTION
Cleaned up an *older* test with some of the new helpers

+ introduce invokeInTab
+ add some helper functions
+ remove selectors

it might be easier to look at the commit as i needed to include another commit for the work