### PR TITLE
Propery clean up the editor and sourcemap worker on shutdown

### DIFF
--- a/public/js/components/Editor.js
+++ b/public/js/components/Editor.js
@@ -156,6 +156,11 @@ const Editor = React.createClass({
     }
   },
 
+  componentWillUnmount() {
+    this.editor.destroy();
+    this.editor = null;
+  },
+
   componentWillReceiveProps(nextProps) {
     // Clear the currently highlighted line
     if (isSourceForFrame(this.props.selectedSource, this.props.selectedFrame)) {

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -67,6 +67,11 @@ function renderRoot(component) {
   );
 }
 
+function unmountRoot() {
+  const mount = document.querySelector("#mount");
+  ReactDOM.unmountComponentAtNode(mount);
+}
+
 function getTargetFromQuery() {
   const href = window.location.href;
   const nodeMatch = href.match(/ws=([^&#]*)/);
@@ -92,16 +97,19 @@ if (connTarget) {
     renderRoot(App);
   });
 } else if (isFirefoxPanel()) {
-  // The toolbox already provides the tab to debug.
-  function bootstrap({ threadClient, tabTarget }) {
-    firefox.setThreadClient(threadClient);
-    firefox.setTabTarget(tabTarget);
-    firefox.initPage(actions);
-    renderRoot(App);
-  }
+  const sourceMap = require("./utils/source-map");
 
   module.exports = {
-    bootstrap,
+    bootstrap: ({ threadClient, tabTarget }) => {
+      firefox.setThreadClient(threadClient);
+      firefox.setTabTarget(tabTarget);
+      firefox.initPage(actions);
+      renderRoot(App);
+    },
+    destroy: () => {
+      unmountRoot();
+      sourceMap.destroy();
+    },
     store: store,
     actions: actions,
     selectors: selectors,

--- a/public/js/utils/source-editor.js
+++ b/public/js/utils/source-editor.js
@@ -18,6 +18,10 @@ class SourceEditor {
     this.editor = CodeMirror(node, this.opts);
   }
 
+  destroy() {
+    // No need to do anything.
+  }
+
   get codeMirror() {
     return this.editor;
   }

--- a/public/js/utils/source-map.js
+++ b/public/js/utils/source-map.js
@@ -17,16 +17,11 @@ function restartWorker() {
 }
 restartWorker();
 
-// This is a temporary workaround for the worker not terminating on
-// page load.
-//
-// TODO: Create a proper shutdown function that the panel calls, and
-// make sure in a local debugging context that it dies with the page
-// naturally (as it should).
-if (typeof window !== "undefined") {
-  window.addEventListener("unload", function() {
+function destroy() {
+  if (sourceMapWorker) {
     sourceMapWorker.terminate();
-  });
+    sourceMapWorker = null;
+  }
 }
 
 const sourceMapTask = function(method) {
@@ -160,5 +155,6 @@ module.exports = {
   getGeneratedSourceId,
   createSourceMap,
   clearData,
-  restartWorker
+  restartWorker,
+  destroy
 };


### PR DESCRIPTION
This should fix all our testing problems. The editor is properly cleaned up (required because the mozilla-central needs to do some cleanup or else it will leak) and the sourcemap worker is terminated. We expose a new `destroy` method which is called from the panel.

