### PR TITLE
default to selecting the first item in the search list

### DIFF
--- a/public/js/components/Autocomplete.js
+++ b/public/js/components/Autocomplete.js
@@ -5,6 +5,8 @@ const classnames = require("classnames");
 require("./Autocomplete.css");
 const Svg = require("./utils/Svg");
 
+const INITIAL_SELECTED_INDEX = 0;
+
 const Autocomplete = React.createClass({
   propTypes: {
     selectItem: PropTypes.func,
@@ -16,7 +18,7 @@ const Autocomplete = React.createClass({
   getInitialState() {
     return {
       inputValue: "",
-      selectedIndex: -1
+      selectedIndex: INITIAL_SELECTED_INDEX
     };
   },
 
@@ -64,7 +66,7 @@ const Autocomplete = React.createClass({
         ref: "searchInput",
         onChange: (e) => this.setState({
           inputValue: e.target.value,
-          selectedIndex: -1
+          selectedIndex: INITIAL_SELECTED_INDEX
         }),
         onFocus: e => this.setState({ focused: true }),
         onBlur: e => this.setState({ focused: false }),


### PR DESCRIPTION
With this change the first item in the search list will always be selected such that if you only have one file matching your query you can open it by hitting enter instead of navigating to it first.

I added an `INITIAL_SELECTED_INDEX` const to handle the two locations where the initial selected index needs to be set.  Though it felt like it might be overkill given the situation the default param isn't really necessary for this to work properly as the other value will be changed as soon as there is typing activity.

Multiple items:
![screen shot 2016-09-13 at 13 59 41](https://cloud.githubusercontent.com/assets/2134/18473018/0230ecfa-79bb-11e6-894d-8353cba83315.png)

Only one item:
![screen shot 2016-09-13 at 13 59 51](https://cloud.githubusercontent.com/assets/2134/18473029/1a199de4-79bb-11e6-9599-2043e05a4de0.png)
