### PR TITLE
Do not show source footer is no features are enabled

### DIFF
--- a/public/js/components/SourceFooter.js
+++ b/public/js/components/SourceFooter.js
@@ -82,7 +82,8 @@ const SourceFooter = React.createClass({
   },
 
   render() {
-    if (!this.props.selectedSource) {
+    if (!this.props.selectedSource ||
+        (!isEnabled("prettyPrint") && !isEnabled("blackBox"))) {
       return null;
     }
 


### PR DESCRIPTION
Right now we should the pretty-print button even though it doesn't work. It depends on sourcemaps being enabled. Let's hide it for now.