### PR TITLE
Fix console test

### DIFF
--- a/public/js/test/mochitest/browser_dbg-console.js
+++ b/public/js/test/mochitest/browser_dbg-console.js
@@ -27,10 +27,7 @@ function getSplitConsole(dbg) {
 
 add_task(function* () {
   Services.prefs.setBoolPref("devtools.toolbox.splitconsoleEnabled", true);
-  const dbg = yield initDebugger(
-    "doc-script-switching-01.html",
-    "script-switching-01.js"
-  );
+  const dbg = yield initDebugger("doc-script-switching.html");
 
   yield getSplitConsole(dbg);
   ok(dbg.toolbox.splitConsole, "Split console is shown.");


### PR DESCRIPTION
The console test was 404ing because it wasn't using the right example page. Also, you don't need to wait on any sources if you're not going to actually test them. You only need to list ones you care about.