### PR TITLE
Make `download-firefox-artifact` properly clean up so it can update Firefox

### DIFF
--- a/bin/download-firefox-artifact
+++ b/bin/download-firefox-artifact
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 ROOT=`dirname $0`
-FIREFOX_PATH="$ROOT/../firefox"
+FIREFOX_PATH=$(cd "$ROOT/../firefox"; pwd)
 
 # check that mercurial is installed
 if [ -z "`command -v hg`" ]; then
@@ -12,6 +12,23 @@ fi
 if [ -d "$FIREFOX_PATH" ]; then
     # If we already have Firefox locally, just update it
     cd "$FIREFOX_PATH";
+
+    if [ -n "`hg status`" ]; then
+        read -p "There are local changes to Firefox which will be overwritten. Are you sure? [Y/n] " -r
+        if [[ $REPLY == "n" ]]; then
+            exit 0;
+        fi
+
+        # If the mochitest dir has been symlinked, remove it as revert
+        # does not follow symlinks.
+        if [ -h "$FIREFOX_PATH/devtools/client/debugger/new/test/mochitest" ]; then
+           rm "$FIREFOX_PATH/devtools/client/debugger/new/test/mochitest";
+        fi
+
+        hg revert -a
+        hg purge
+    fi
+
     hg pull
 else
     echo "Downloading Firefox source code, requires about 10-30min depending on connection"

--- a/bin/make-firefox-bundle
+++ b/bin/make-firefox-bundle
@@ -20,9 +20,11 @@ fi
 
 (
     cd "$DEBUGGER_PATH";
-    if ! git log --oneline bundle.js | head -n 1 |
-            grep "UPDATE_BUNDLE" > /dev/null; then
-        echo "\033[31mWARNING\033[0m: local changes detected on mozilla-central";
+    if [ -d "DEBUGGER_PATH/.git" ]; then
+        if ! git log --oneline bundle.js | head -n 1 |
+                grep "UPDATE_BUNDLE" > /dev/null; then
+            echo "\033[31mWARNING\033[0m: bundle has changed on mozilla-central";
+        fi
     fi
 );
 

--- a/bin/prepare-mochitests-dev
+++ b/bin/prepare-mochitests-dev
@@ -3,14 +3,8 @@
 ROOT=`dirname $0`
 FIREFOX_PATH="$ROOT/../firefox"
 
-# If we don't have a local copy of firefox, download it
-if [ ! -d firefox ]; then
-  "$ROOT/download-firefox-artifact"
-  # check that the download exited successfully
-  if [ $? -ne 0 ]; then
-      exit 1;
-  fi
-fi
+# This will either download or update the local Firefox repo
+"$ROOT/download-firefox-artifact"
 
 # Update the debugger files, build firefox, and run all the mochitests
 "$ROOT/make-firefox-bundle" "$FIREFOX_PATH" --symlink-mochitests

--- a/docs/mochitests.md
+++ b/docs/mochitests.md
@@ -12,9 +12,9 @@ If you haven't set up the mochitest environment yet, just run this:
 ./bin/prepare-mochitests-dev
 ```
 
-This will download a local copy of Firefox (or update it if it already exists), set up an [artifact build](https://developer.mozilla.org/en-US/docs/Mozilla/Developer_guide/Build_Instructions/Artifact_builds) (just think of a super fast Firefox build) and set up the environment. If you are doing this the first time, it may take a while (10-15 minutes). Most of that is downloading Firefox, later updates will be much quicker.
+This will set up everything you need. You should run this *every time* to start working on mochitests, as it makes sure your local copy of Firefox is up-to-date.
 
-**Note**: You should run this whenever you start working on mochitests. It ensures that the symlink is set up, the latest debugger code is used, and will update the local Firefox repo since it already exists, so you will be using the latest Firefox code.
+On the first run, this will download a local copy of Firefox and set up an [artifact build](https://developer.mozilla.org/en-US/docs/Mozilla/Developer_guide/Build_Instructions/Artifact_builds) (just think of a super fast Firefox build). It may take a while (10-15 minutes) to download and build Firefox.
 
 Now, you can run the mochitests like this:
 


### PR DESCRIPTION
There are a few ways we could improve the scripts, but the biggest pain right now is `prepare-mochitests-dev` doesn't actually make sure everything is up-to-date. If will fail to update Firefox after the first run because `hg pull` will fail because there are local changes. This cleans up the repo to make sure there are no local changes.
