### PR TITLE
Add test for making sure selected source persists across reloads

### DIFF
--- a/public/js/test/mochitest/head.js
+++ b/public/js/test/mochitest/head.js
@@ -256,8 +256,8 @@ function resume(dbg) {
   return waitForThreadEvents(dbg, "resumed");
 }
 
-function reload(dbg) {
-  return dbg.client.reload();
+function reload(dbg, ...sources) {
+  return dbg.client.reload().then(() => waitForSources(...sources));
 }
 
 function navigate(dbg, url, ...sources) {


### PR DESCRIPTION
This will close #646. Adds a few assertions to the navigation test to make sure the selected source is correct after reloads.