### PR TITLE
Fix 751 - Make the hardcoded development web server port number 8000 …

### DIFF
--- a/bin/development-server.js
+++ b/bin/development-server.js
@@ -82,18 +82,25 @@ app.get("/get", function(req, res) {
   httpReq.on("statusCode", err => res.status(err.message).send(err.message));
 });
 
-// Listen
-app.listen(8000, "0.0.0.0", function(err, result) {
+// Listen'
+const serverPort = feature.getValue("development.serverPort");
+app.listen(serverPort, "0.0.0.0", function(err, result) {
   if (err) {
     console.log(err);
+  } else {
+    console.log(`Development Server Listening at http://localhost:${serverPort}`);
   }
-
-  console.log("Development Server Listening at http://localhost:8000");
 });
 
 const examples = express();
 examples.use(express.static("public/js/test/examples"));
 examples.use(serveIndex("public/js/test/examples", { icons: true }));
-examples.listen(7999, "0.0.0.0", function(err, result) {
-  console.log("View debugger examples at http://localhost:7999");
+
+const examplesPort = feature.getValue("development.examplesPort");
+examples.listen(examplesPort, "0.0.0.0", function(err, result) {
+  if (err) {
+    console.log(err);
+  } else {
+    console.log(`View debugger examples at http://localhost:${examplesPort}`);
+  }
 });

--- a/config/README.md
+++ b/config/README.md
@@ -17,6 +17,9 @@ All default config values are in [`config/development.json`](./development.json)
   * `proxyPort` Port used by the development server run with `npm start`
   * `webSocketConnection` Favours Firefox WebSocket connection over the [firefox-proxy](../bin/firefox-proxy), :warning: Experimental feature and requires [bug 1286281](https://bugzilla.mozilla.org/show_bug.cgi?id=1286281)
   * `geckoDir` Local location of Firefox source code _only needed by project maintainers_
+*  `development` Development server related settings
+  * `serverPort` Listen Port used by the development server
+  * `examplesPort` Listen Port used to serve examples
 * `hotReloading` enables [Hot Reloading](../docs/local-development.md#hot-reloading) of CSS and React
 
 ### Create a local config file

--- a/config/development.json
+++ b/config/development.json
@@ -20,5 +20,9 @@
     "proxyPort": 9000,
     "webSocketConnection": false,
     "webSocketPort": 6080
+  },
+  "development": {
+    "serverPort": 8000,
+    "examplesPort": 7999
   }
 }


### PR DESCRIPTION
#751 - fixes issues/751
@jasonLaster - Based on your patch.  I've added additional code to print correct port number to console.

Added development key to config/development.json, added default values for 
serverPort: 8000
examplesPort: 7999

Updated config/README.md to include reference to new config values
Updated bin/development-server.js to read port values, apply them server and print out correct values to console

Tested with the following keys/value in development.json:

  "development": {
    "serverPort": 8000,
    "examplesPort": 7999
  }

Tested with local.json override:

{
  "development": {
    "serverPort": 8001,
    "examplesPort": 7998
  }
}
