### PR TITLE
fix download firefox artifact script

### DIFF
--- a/bin/download-firefox-artifact
+++ b/bin/download-firefox-artifact
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 ROOT=`dirname $0`
-FIREFOX_PATH=$(cd "$ROOT/../firefox"; pwd)
+FIREFOX_PATH="$ROOT/../firefox"
 
 # check that mercurial is installed
 if [ -z "`command -v hg`" ]; then
@@ -10,6 +10,9 @@ if [ -z "`command -v hg`" ]; then
 fi
 
 if [ -d "$FIREFOX_PATH" ]; then
+    # convert path to absolute path
+    FIREFOX_PATH=$(cd "$ROOT/../firefox"; pwd)
+
     # If we already have Firefox locally, just update it
     cd "$FIREFOX_PATH";
 


### PR DESCRIPTION
When the firefox directory didn’t exist the `cd` command in FIREFOX_PATH would fail.  However we do want the absolute path so we reset the variable after we check the directory does exist.