### PR TITLE
Add codemirror documents

### DIFF
--- a/public/js/actions/navigation.js
+++ b/public/js/actions/navigation.js
@@ -1,5 +1,6 @@
 const constants = require("../constants");
-const { clearData } = require("../utils/source-map");
+const { clearSourceMaps } = require("../utils/source-map");
+const { clearDocuments } = require("../utils/source-documents");
 
 /**
  * Redux actions for the navigation state
@@ -11,7 +12,9 @@ const { clearData } = require("../utils/source-map");
  * @static
  */
 function willNavigate() {
-  clearData();
+  clearSourceMaps();
+  clearDocuments();
+
   return { type: constants.NAVIGATE };
 }
 

--- a/public/js/actions/sources.js
+++ b/public/js/actions/sources.js
@@ -18,6 +18,7 @@ const { updateFrameLocations } = require("../utils/pause");
 const constants = require("../constants");
 const invariant = require("invariant");
 const { isEnabled } = require("../feature");
+const { removeDocument } = require("../utils/source-documents");
 
 const {
   createOriginalSources, getOriginalSourceTexts,
@@ -177,6 +178,7 @@ function selectSource(id, options = {}) {
  * @static
  */
 function closeTab(id) {
+  removeDocument(id);
   return {
     type: constants.CLOSE_TAB,
     id: id,

--- a/public/js/components/Editor.js
+++ b/public/js/components/Editor.js
@@ -179,31 +179,19 @@ const Editor = React.createClass({
     const { sourceText, selectedLocation } = nextProps;
 
     if (!sourceText) {
-      return;
+      this.showMessage("");
+    } else if (!isTextForSource(sourceText)) {
+      this.showMessage(sourceText.get("error") || "Loading...");
+    } else if (this.props.sourceText !== sourceText) {
+      this.showSourceText(sourceText, selectedLocation);
     }
 
-    if (sourceText.get("loading")) {
-      return this.setLoading();
-    }
-
-    if (this.props.sourceText !== sourceText) {
-      this.updateEditor(sourceText, selectedLocation);
-      resizeBreakpointGutter(this.editor.codeMirror);
-    }
+    resizeBreakpointGutter(this.editor.codeMirror);
   },
 
-  setLoading() {
-    let doc = getDocument("loading");
-    if (doc) {
-      this.editor.replaceDocument(doc);
-      return doc;
-    }
-
-    doc = this.editor.createDocument();
-    setDocument("loading", doc);
-    this.editor.replaceDocument(doc);
-
-    doc.setValue("Loading...");
+  showMessage(msg) {
+    this.editor.replaceDocument(this.editor.createDocument());
+    this.setText(msg);
     this.editor.setMode({ name: "text" });
   },
 
@@ -212,7 +200,7 @@ const Editor = React.createClass({
    * document with the correct mode and text.
    *
    */
-  updateEditor(sourceText, selectedLocation) {
+  showSourceText(sourceText, selectedLocation) {
     let doc = getDocument(selectedLocation.sourceId);
     if (doc) {
       this.editor.replaceDocument(doc);
@@ -222,11 +210,6 @@ const Editor = React.createClass({
     doc = this.editor.createDocument();
     setDocument(selectedLocation.sourceId, doc);
     this.editor.replaceDocument(doc);
-
-    if (sourceText.get("error")) {
-      this.setText(sourceText.get("error"));
-      this.editor.setMode({ name: "text" });
-    }
 
     this.setText(sourceText.get("text"));
     this.setMode(sourceText);

--- a/public/js/utils/source-documents.js
+++ b/public/js/utils/source-documents.js
@@ -1,0 +1,24 @@
+let sourceDocs = {};
+
+function getDocument(key) {
+  return sourceDocs[key];
+}
+
+function setDocument(key, doc) {
+  sourceDocs[key] = doc;
+}
+
+function removeDocument(key) {
+  delete sourceDocs[key];
+}
+
+function clearDocuments() {
+  sourceDocs = {};
+}
+
+module.exports = {
+  getDocument,
+  setDocument,
+  removeDocument,
+  clearDocuments
+};

--- a/public/js/utils/source-editor.js
+++ b/public/js/utils/source-editor.js
@@ -39,6 +39,21 @@ class SourceEditor {
   }
 
   /**
+   * Replaces the current document with a new source document
+   */
+  replaceDocument(doc) {
+    this.editor.swapDoc(doc);
+  }
+
+  /**
+   * Creates a CodeMirror Document
+   * @returns CodeMirror.Doc
+   */
+  createDocument() {
+    return new CodeMirror.Doc("");
+  }
+
+  /**
    * Aligns the provided line to either "top", "center" or "bottom" of the
    * editor view with a maximum margin of MAX_VERTICAL_OFFSET lines from top or
    * bottom.

--- a/public/js/utils/source-map-worker.js
+++ b/public/js/utils/source-map-worker.js
@@ -127,7 +127,7 @@ function createSourceMap({ source, mappings, code }) {
   return generator.toJSON();
 }
 
-function clearData() {
+function clearSourceMaps() {
   sourceMapConsumers.clear();
   sourceNodes.clear();
 }
@@ -139,7 +139,7 @@ const publicInterface = {
   getOriginalSourceUrls,
   getOriginalTexts,
   createSourceMap,
-  clearData
+  clearSourceMaps
 };
 
 self.onmessage = function(msg) {

--- a/public/js/utils/source-map.js
+++ b/public/js/utils/source-map.js
@@ -37,7 +37,7 @@ const createOriginalSources = sourceMapTask("createOriginalSources");
 const getOriginalSourceUrls = sourceMapTask("getOriginalSourceUrls");
 const getOriginalTexts = sourceMapTask("getOriginalTexts");
 const createSourceMap = sourceMapTask("createSourceMap");
-const clearData = sourceMapTask("clearData");
+const clearSourceMaps = sourceMapTask("clearSourceMaps");
 
 function _shouldSourceMap(source) {
   return isEnabled("sourceMaps") && source.sourceMapURL;
@@ -154,7 +154,7 @@ module.exports = {
   isMapped,
   getGeneratedSourceId,
   createSourceMap,
-  clearData,
+  clearSourceMaps,
   restartWorker,
   destroy
 };


### PR DESCRIPTION
I'm sharing this version early because this is the core logic as I see it now. It does some things well, it doesn't try to do others :)

Things it does:
* keep a list of docs per source
* swaps between them so big sources are only loaded once
* keeps scroll position
* handles breakpoints (probably re-renders every time)

Things it doesn't do:
* doesn't delete docs when a tab is closed or navigation - handling closed tabs is easier than navigation as the state is in the component. I might move the state somewhere else to handle navigation, we'll see. 
* doesn't handle loading - i'm planning on adding a spinner
* doesn't handle errors - i'm working on the assumption that errors are permanent, a.k.a the source text is not re-fetched and can become valid. 

Things it might do:
* it probably works for pretty printing and source maps out of the box