### PR TITLE
Add circle master success/fail notifications

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -33,3 +33,8 @@ dependencies:
     - ./bin/install-chrome
     - ./bin/install-firefox
     - docker pull jlongster/mochitest-runner
+experimental:
+  notify:
+    branches:
+      only:
+        - master


### PR DESCRIPTION
This will ping us in #devtools-html when master fails or succeeds. 

It's helpful if we remove the protected branch.