### PR TITLE
adds greenkeeper attribute with ignore to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,5 +110,14 @@
   },
   "files": [
     "public"
-  ]
+  ],
+  "greenkeeper": {
+    "ignore": [
+      "react",
+      "react-dom",
+      "react-redux",
+      "redux",
+      "codemirror"
+    ]
+  }
 }


### PR DESCRIPTION
This change will allow us to try out using greenkeeper and not be annoyed by PRs for modules we cannot update.

Here are the dependencies we currently have: (checked the ones I thought we wanted to pin, might have missed some)

- [ ] classnames
- [x] codemirror
- [ ] express
- [ ] fuzzaldrin-plus
- [ ] immutable
- [ ] invariant
- [ ] lodash
- [ ] pretty-fast
- [x] react
- [x] react-dom
- [ ] react-immutable-proptypes
- [ ] react-inlinesvg
- [x] react-redux
- [x] redux
- [ ] source-map
- [ ] svg-inline-loader
- [ ] svg-inline-react
- [ ] tcomb

> we should remove `tcomb`, will do in a separate PR

I didn't do anything on the `devDependencies` as I think getting those PRs could be useful.