### PR TITLE
Upgrade Storybook

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -1,12 +1,8 @@
-"use strict";
-
 const { configure } = require("@kadira/storybook");
 const { setConfig } = require("../config/feature");
 
 require("../public/js/lib/themes/light-theme.css");
-
 setConfig(DebuggerConfig);
-
 
 function loadStories() {
   require("../public/js/components/stories");

--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -1,5 +1,3 @@
-"use strict";
-
 const path = require("path");
 const webpack = require("webpack");
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -294,6 +294,7 @@ $ npm run lint-js
 Storybook is our local development and testing utility that allows you to see how an individual component like the breakpoint list view or the call stack view react to any changes to style and code you've made.
 
 ```
+$ npm i -g @kadira/storybook
 $ npm run storybook
 ```
 

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -50,6 +50,7 @@ Storybook is a local development environment for react components for viewing co
 + quickly work on a component with hot reloading
 
 **Getting Started:**
+* install storybook `npm i -g @kadira/storybook`
 + start storybook `npm run storybook`
 + edit a component story in `public/js/components/stories`
 

--- a/package.json
+++ b/package.json
@@ -20,12 +20,13 @@
     "test-all": "npm run test; npm run lint; npm run flow; npm run firefox-unit-test",
     "mocha-server": "node bin/mocha-server.js",
     "firefox-unit-test": "node bin/firefox-driver --test",
-    "storybook": "start-storybook -p 9001 -s public",
+    "storybook": "start-storybook -p 6006",
     "firefox": "node bin/firefox-driver --start",
     "mochitests-watch": "MOCHITESTS=true TARGET=firefox-panel webpack --watch",
     "prepublish": "webpack",
     "build-docs": "documentation build --format html --shallow  --document-exported --output docs/reference/ public/js/actions/",
-    "prepush": "npm run lint"
+    "prepush": "npm run lint",
+    "build-storybook": "build-storybook"
   },
   "dependencies": {
     "classnames": "^2.2.5",
@@ -48,7 +49,6 @@
     "tcomb": "^3.1.0"
   },
   "devDependencies": {
-    "@kadira/storybook": "^1.17.1",
     "amd-loader": "0.0.5",
     "babel": "^6.5.2",
     "babel-cli": "^6.7.5",


### PR DESCRIPTION
I followed the `getstorybook` steps to see if there was a better way to install storybook, ofcourse now that i did, i learned that it was just an install tool and i had been tricked into upgrading. 

That's not all bad:
* we got access to `build-storybook` which will be great for the website
* we can use their awesome suite of plugins
* we're up to date

I think at this point it would make more sense to encourage people to install storybook globally and run it that way. Then it's not a flakey step in our install process.