### PR TITLE
Add mercurial back to requirements for mochitests

### DIFF
--- a/docs/mochitests.md
+++ b/docs/mochitests.md
@@ -8,6 +8,7 @@ Mochitests live in `public/js/test/mochitest`.
 
 **Requirements**
 
+* mercurial ( `brew install mercurial` )
 * autoconf213 ( `brew install autoconf213 && brew unlink autoconf` )
 
 If you haven't set up the mochitest environment yet, just run this:


### PR DESCRIPTION
Accidentally removed this entirely when removing the `hg purge` requirement.