### PR TITLE
Remove styles link

### DIFF
--- a/bin/development-server.js
+++ b/bin/development-server.js
@@ -5,6 +5,8 @@
 require("babel-register");
 
 const path = require("path");
+const fs = require("fs");
+const Mustache = require("mustache");
 const webpack = require("webpack");
 const express = require("express");
 const webpackDevMiddleware = require("webpack-dev-middleware");
@@ -63,7 +65,10 @@ app.use(express.static("public"));
 
 // Routes
 app.get("/", function(req, res) {
-  res.sendFile(path.join(__dirname, "../index.html"));
+  const tplPath = path.join(__dirname, "../index.html");
+  const tplFile = fs.readFileSync(tplPath, "utf8");
+  const isDevelopment = feature.isDevelopment();
+  res.send(Mustache.render(tplFile, { isDevelopment }));
 });
 
 app.get("/get", function(req, res) {

--- a/index.html
+++ b/index.html
@@ -4,7 +4,10 @@
     <title>Firefox Debugger</title>
     <meta charset="utf8" />
     <link rel="shortcut icon" href="images/favicon.png" type="image/png" />
+
+    {{^isDevelopment}}
     <link rel="stylesheet" href="public/build/styles.css" type="text/css" />
+    {{/isDevelopment}}
   </head>
 
   <body>

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "minimist": "^1.2.0",
     "mocha": "^2.4.5",
     "mocha-circleci-reporter": "0.0.1",
+    "mustache": "^2.2.1",
     "net": "^1.0.2",
     "node-static": "^0.7.7",
     "npm": "^3.10.7",


### PR DESCRIPTION
This removes the index.html styles link as we now have a different index in the panel, which is fine because they're doing different things.

I've heard from contributors that the error is confusing and it'd be nice to smooth out the getting started experience