### PR TITLE
Enable chrome locally

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,18 +125,6 @@ Start by running Chrome with remote debugging turned on, this command also creat
 ```
 > If this command doesn't work for your OS or Chrome version see the other [Chrome commands for running in a debuggable state](./docs/remotely-debuggable-browsers.md#chrome)
 
-Now turn on Chrome debugging in the config by [creating a local config file](#create-a-local-config-file)
-
-* Edit the `config/local.json` you just created to change the value of `chrome.debug` to be `true`
-
-```json
-"chrome": {
-  "debug": true
-}
-```
-
-* Restart your development server by typing `ctrl+c` in the Terminal and run `npm start` again
-* Reload `localhost:8000` (you should now see a Chrome tabs section)
 
 #### Node.js
 

--- a/config/development.json
+++ b/config/development.json
@@ -14,7 +14,7 @@
     "search": true
   },
   "chrome": {
-    "debug": false,
+    "debug": true,
     "webSocketPort": 9222
   },
   "firefox": {

--- a/public/js/clients/firefox.js
+++ b/public/js/clients/firefox.js
@@ -63,7 +63,7 @@ function connectClient() {
     });
   }).catch(err => {
     console.log(err);
-    deferred.reject();
+    deferred.resolve([]);
   });
 
   return deferred.promise;

--- a/public/js/clients/index.js
+++ b/public/js/clients/index.js
@@ -42,14 +42,9 @@ function startDebuggingTab(targetEnv, tabId, actions) {
   });
 }
 
-function connectClients() {
-  return Promise.all([
-    firefox.connectClient(),
-    chrome.connectClient()
-  ]).then(results => {
-    const [firefoxTabs, chromeTabs] = results;
-    return firefoxTabs.concat(chromeTabs).filter(i => i);
-  });
+function connectClients(onConnect) {
+  firefox.connectClient().then(onConnect);
+  chrome.connectClient().then(onConnect);
 }
 
 module.exports = {

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -117,7 +117,5 @@ if (connTarget) {
   };
 } else {
   renderRoot(Tabs);
-  connectClients().then(tabs => {
-    actions.newTabs(tabs);
-  });
+  connectClients(tabs => actions.newTabs(tabs));
 }


### PR DESCRIPTION
I was talking with a contributor and the question of getting setup with chrome came up and I found it was very complicated. He ran into two problems:

1. Firefox had to be on
2. enabling local.json was not intuitive

Neither of these things is a deal breaker, but for many people there's already going on when getting started and any extra steps can be intimidating.

This fixes that by enabling chrome by default and fixing the firefox connection so that it handles not connecting gracefully.

I also sped up the timeouts so that the toolbox shows pretty fast.