### PR TITLE
Allow longer timeout for browser_dbg-editor-select.js

### DIFF
--- a/public/js/test/mochitest/browser_dbg-editor-select.js
+++ b/public/js/test/mochitest/browser_dbg-editor-select.js
@@ -12,6 +12,11 @@ function isElementVisible(dbg, elementName) {
 }
 
 add_task(function* () {
+  // This test runs too slowly on linux debug. I'd like to figure out
+  // which is the slowest part of this and make it run faster, but to
+  // fix a frequent failure allow a longer timeout.
+  requestLongerTimeout(2);
+
   const dbg = yield initDebugger(
     "doc-scripts.html",
     "simple1.js", "simple2.js", "long.js"


### PR DESCRIPTION
This makes me a little sad, but for some reason this test runs for too long on linux debug frequently. Linux debug is a very slow machine, so it's not too surprising, but this test is not huge so I'd like to figure out what is so slow. I'm sure we'll see this in other tests eventually too and hopefully we can cross-check what these tests are doing and find a pattern of something we do a lot. Maybe pausing is slow. I know that currently we convert the whole pause packet to immutable and avoiding that will speed it up a lot, but I'd be surprised if there was *this* big of a perf hit.