### PR TITLE
Polish tab close button UX

### DIFF
--- a/public/js/components/SourceTabs.css
+++ b/public/js/components/SourceTabs.css
@@ -46,28 +46,27 @@
 
 .source-tab .close-btn {
   position: absolute;
-  right: 7px;
-  top: 7px;
-  width: 9px;
-  height: 9px;
-  padding: 3px;
-  display: none;
+  right: 4px;
+  top: 3px;
 }
 
-.source-tab .close-btn:hover {
+.source-tab .close {
+  display: none;
+  width: 12px;
+  height: 12px;
+  padding: 2px;
+  text-align: center;
+  margin-top: 2px;
+  line-height: 7px;
+}
+
+.source-tab:hover .close {
+  display: block;
+}
+
+.source-tab .close:hover {
   background: var(--theme-selection-background);
   border-radius: 2px;
-}
-
-.source-tab:hover .close-btn {
-  display: inline-block;
-}
-
-.source-tab .close-btn i {
-  font-size: 5px;
-  position: absolute;
-  top: -3px;
-  left: 1px;
 }
 
 .source-header .subsettings {

--- a/public/js/components/SourceTabs.css
+++ b/public/js/components/SourceTabs.css
@@ -47,14 +47,27 @@
 .source-tab .close-btn {
   position: absolute;
   right: 7px;
-  top: 1px;
-  width: 6px;
-  height: 6px;
+  top: 7px;
+  width: 9px;
+  height: 9px;
+  padding: 3px;
   display: none;
 }
 
+.source-tab .close-btn:hover {
+  background: var(--theme-selection-background);
+  border-radius: 2px;
+}
+
 .source-tab:hover .close-btn {
-  display: block;
+  display: inline-block;
+}
+
+.source-tab .close-btn i {
+  font-size: 5px;
+  position: absolute;
+  top: -3px;
+  left: 1px;
 }
 
 .source-header .subsettings {

--- a/public/js/components/SourceTabs.css
+++ b/public/js/components/SourceTabs.css
@@ -57,7 +57,12 @@
   padding: 2px;
   text-align: center;
   margin-top: 2px;
-  line-height: 7px;
+  line-height: 5px;
+  transition: all 0.25s easeinout;
+}
+
+.source-tab:hover svg {
+  width: 6px;
 }
 
 .source-tab:hover .close {
@@ -67,6 +72,10 @@
 .source-tab .close:hover {
   background: var(--theme-selection-background);
   border-radius: 2px;
+}
+
+.source-tab .close:hover path {
+  fill: white;
 }
 
 .source-header .subsettings {

--- a/public/js/components/SourceTabs.css
+++ b/public/js/components/SourceTabs.css
@@ -50,6 +50,11 @@
   top: 1px;
   width: 6px;
   height: 6px;
+  display: none;
+}
+
+.source-tab:hover .close-btn {
+  display: block;
 }
 
 .source-header .subsettings {

--- a/public/js/components/SourceTabs.js
+++ b/public/js/components/SourceTabs.js
@@ -180,13 +180,7 @@ const SourceTabs = React.createClass({
       },
       dom.div({ className: "filename" }, filename),
       dom.div(
-        { onClick: onClickClose },
-        dom.span(
-          { className: "close-btn" },
-          Svg("close")
-        )
-      )
-    );
+        { className: "close-btn", onClick: onClickClose }, Svg("close")));
   },
 
   render() {


### PR DESCRIPTION
Associated Issue: #791

### Summary of Changes

* show the close button only when hovering over tab
* highlight close button when hovering over it

### Testing

* [x] passes `npm test`
* [x] passes `npm run lint`

### Screenshots/Videos

#### Firefox

##### Hovering over tab

![screenshot_20160921_215912](https://cloud.githubusercontent.com/assets/580982/18736699/de5e5f82-8046-11e6-8ee0-c5c2c96fbaac.png)

##### Hovering over button

![screenshot_20160921_215916](https://cloud.githubusercontent.com/assets/580982/18736705/e8e0fbae-8046-11e6-8df2-86007af426f8.png)

#### Chrome

##### Hovering over tab

![screenshot_20160921_215928](https://cloud.githubusercontent.com/assets/580982/18736707/e8f36816-8046-11e6-8f49-9873fad6aaf1.png)

##### Hovering over button

![screenshot_20160921_215933](https://cloud.githubusercontent.com/assets/580982/18736706/e8f2de8c-8046-11e6-8114-654e0078cc88.png)