### PR TITLE
add more flow typing support to some utils

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -3,3 +3,7 @@
 .*node_modules/fbjs.*
 .*node_modules/npm.*
 .*firefox/.*
+
+[options]
+module.name_mapper='^Services$' -> '<PROJECT_ROOT>/public/js/lib/devtools/client/shared/shim/Services.js'
+module.name_mapper='^devtools/\(.+$\)' -> '<PROJECT_ROOT>/public/js/lib/devtools/\1.js'

--- a/public/js/utils/create-store.js
+++ b/public/js/utils/create-store.js
@@ -1,3 +1,5 @@
+// @flow
+
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
@@ -10,6 +12,13 @@ const { history } = require("./redux/middleware/history");
 const { promise } = require("./redux/middleware/promise");
 const { thunk } = require("./redux/middleware/thunk");
 
+type ReduxStoreOptions = {
+  makeThunkArgs?: Function,
+  history?: boolean,
+  middleware?: Function[],
+  log?: boolean
+};
+
 /**
  * This creates a dispatcher with all the standard middleware in place
  * that all code requires. It can also be optionally configured in
@@ -21,7 +30,7 @@ const { thunk } = require("./redux/middleware/thunk");
  *                   used in tests.
  *        - middleware: array of middleware to be included in the redux store
  */
-const configureStore = (opts = {}) => {
+const configureStore = (opts: ReduxStoreOptions = {}) => {
   const middleware = [
     thunk(opts.makeThunkArgs),
     promise,

--- a/public/js/utils/source.js
+++ b/public/js/utils/source.js
@@ -1,11 +1,9 @@
+// @flow
 
 /**
  * Trims the query part or reference identifier of a url string, if necessary.
- *
- * @param string url - The source url.
- * @return string - The shortened url.
  */
-function trimUrlQuery(url) {
+function trimUrlQuery(url: string): string {
   let length = url.length;
   let q1 = url.indexOf("?");
   let q2 = url.indexOf("&");
@@ -24,13 +22,14 @@ function trimUrlQuery(url) {
  * @return boolean
  *         True if the source is likely javascript.
  */
-function isJavaScript(url, contentType = "") {
+function isJavaScript(url: string, contentType: string = ""): boolean {
   return (url && /\.jsm?$/.test(trimUrlQuery(url))) ||
          contentType.includes("javascript");
 }
 
-function isPretty(source) {
-  return source.url.match(/formatted$/);
+// TODO: This should use a shared Source type
+function isPretty(source: {url: string}): boolean {
+  return /formatted$/.test(source.url);
 }
 
 module.exports = {

--- a/public/js/utils/text.js
+++ b/public/js/utils/text.js
@@ -1,6 +1,8 @@
+// @flow
+
 const { Services } = require("Services");
 
-function cmdString() {
+function cmdString(): string {
   return (Services.appinfo.OS === "Darwin") ? "⌘" : "Ctrl";
 }
 


### PR DESCRIPTION
Associated Issue: n/a

### Summary of Changes

* add two `module.name_mapper` options to the flowconfig that allows for flow to find most of the devtools modules and the Services module shim
* add flow typing support to a couple of utils files
* ended up rewriting the `getURL` function to make it clearer and simpler.  always returns an object now and we check for an empty path before continuing

### Testing

* [x] passes `npm test`
* [x] passes `npm run lint`
* [x] passes `npm run flow`

