### PR TITLE
Add note about current limitations of Node.js as a debugging target

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -136,6 +136,8 @@ $ node --inspect server.js
 
 With node running in _inspect mode_ go to your browser running `localhost:8000` and click **[connect to Node](http://localhost:8000/?ws=localhost:9229/node)**
 
+**Note:** Currently Node.js debugging is limited in some ways, there isn't support for seeing variables or the console, but you can manage breakpoints and navigate code execution (pause, step-in, step-over, etc.) in the debugger across various sources.
+
 ## How Can I Contribute?
 
 Here is a great GitHub guide on [contributing to Open Source](https://guides.github.com/activities/contributing-to-open-source/) to help you get started.


### PR DESCRIPTION
Associated Issue: #764 

### Summary of Changes

* Add note about current limitations of Node.js as a debugging target 

### Testing

* [x] passes `npm test`
* [x] passes `npm run lint`