### PR TITLE
Prevent source header info from wrapping

### DIFF
--- a/public/js/components/Sources.css
+++ b/public/js/components/Sources.css
@@ -8,17 +8,19 @@
 .sources-header {
   height: 30px;
   border-bottom: 1px solid var(--theme-splitter-color);
-  padding-left: 10px;
+  padding: 0 10px;
   line-height: 30px;
   font-size: 1.2em;
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
 }
 
 .sources-header-info {
   font-size: 0.7em;
   color: var(--theme-comment-alt);
   font-weight: lighter;
-  padding-right: 10px;
-  float: right;
+  white-space: nowrap;
 }
 
 .sources-list {


### PR DESCRIPTION
This prevents the keyboard shortcut label in the source header from wrapping and overflowing on the list of sources below it when the sidebar is small.

With this simple CSS change, resizing the sidebar now looks like this:

![sidebar](https://cloud.githubusercontent.com/assets/1152698/18827612/0f88acc6-83d4-11e6-8482-7360f3275b73.gif)
