### PR TITLE
Fix missing import of `Svg` in `SourceTabs.js`.

### DIFF
--- a/public/js/components/SourceTabs.js
+++ b/public/js/components/SourceTabs.js
@@ -9,6 +9,7 @@ const classnames = require("classnames");
 const actions = require("../actions");
 const { isEnabled } = require("../feature");
 const CloseButton = require("./CloseButton");
+const Svg = require("./utils/Svg");
 
 require("./SourceTabs.css");
 require("./Dropdown.css");


### PR DESCRIPTION
Associated Issue: N/A

### Summary of Changes

* fix a missing import caused by a bad rebase.

### Testing

* [x] passes `npm test`
* [x] passes `npm run lint`
