### PR TITLE
Update eslint to 3.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "co": "=4.6.0",
     "css-loader": "^0.23.1",
     "documentation": "^4.0.0-beta10",
-    "eslint": "^3.0.1",
+    "eslint": "^3.6.0",
     "eslint-plugin-babel": "^3.3.0",
     "eslint-plugin-flowtype": "^2.17.1",
     "eslint-plugin-mozilla": "0.0.3",


### PR DESCRIPTION
We've seen some weird issues with eslint today, and I figured it would be good to be on the latest version to make sure we're not hitting any bugs. I hit a weird bug complaining about the recent flow type changes, and I have no idea why others aren't seeing it. Updating to 3.6.0 made it go away.

