### PR TITLE
Adjust Splitbox initial widths

### DIFF
--- a/public/js/components/App.js
+++ b/public/js/components/App.js
@@ -136,13 +136,13 @@ const App = React.createClass({
                               { "theme-light": !isFirefoxPanel() }) },
       SplitBox({
         style: { width: "100vh" },
-        initialSize: "20%",
+        initialSize: "300px",
         minSize: 10,
         maxSize: "50%",
         splitterSize: 1,
         startPanel: Sources({ sources: this.props.sources }),
         endPanel: SplitBox({
-          initialSize: "25%",
+          initialSize: "300px",
           minSize: 10,
           maxSize: "80%",
           splitterSize: 1,

--- a/public/js/components/App.js
+++ b/public/js/components/App.js
@@ -136,13 +136,13 @@ const App = React.createClass({
                               { "theme-light": !isFirefoxPanel() }) },
       SplitBox({
         style: { width: "100vh" },
-        initialSize: "33%",
+        initialSize: "20%",
         minSize: 10,
         maxSize: "50%",
         splitterSize: 1,
         startPanel: Sources({ sources: this.props.sources }),
         endPanel: SplitBox({
-          initialSize: "50%",
+          initialSize: "25%",
           minSize: 10,
           maxSize: "80%",
           splitterSize: 1,


### PR DESCRIPTION
Associated Issue: #823 

### Summary of Changes

* adjust the initial widths of the sidebars to give the editor more room

### Testing

* [x] passes `npm test`
* [x] passes `npm run lint`

### Screenshots/Videos (OPTIONAL)

#### Before

![screenshot_20160926_190939](https://cloud.githubusercontent.com/assets/580982/18857100/48115c6a-841e-11e6-98e2-864519e3a907.png)

#### After

![screenshot_20160926_211551](https://cloud.githubusercontent.com/assets/580982/18859112/7240d71c-842e-11e6-92b1-30b24de3f699.png)


I tried to make the initial widths work out so that the editor is 60% of the content and the sidebars are 20% a piece.
