### PR TITLE
Apply the fix from #759 to the splitbox splitter as it had regressed.

### DIFF
--- a/public/js/lib/devtools/client/shared/components/splitter/SplitBox.css
+++ b/public/js/lib/devtools/client/shared/components/splitter/SplitBox.css
@@ -73,6 +73,16 @@
   cursor: ns-resize;
 }
 
+.split-box .splitter .splitter-handle {
+  cursor: ew-resize;
+  position: absolute;
+  top: 0;
+  left: -4px;
+  width: 8px;
+  height: 100%;
+  z-index: 5;
+}
+
 .split-box.disabled {
   pointer-events: none;
 }

--- a/public/js/lib/devtools/client/shared/components/splitter/SplitBox.js
+++ b/public/js/lib/devtools/client/shared/components/splitter/SplitBox.js
@@ -199,13 +199,14 @@ const SplitBox = React.createClass({
             style: leftPanelStyle },
             startPanel
           ) : null,
+        dom.div({ className: "splitter" },
         Draggable({
-          className: "splitter",
+          className: "splitter-handle",
           style: splitterStyle,
           onStart: this.onStartMove,
           onStop: this.onStopMove,
           onMove: this.onMove
-        }),
+        })),
         endPanel ?
           dom.div({
             className: endPanelControl ? "controlled" : "uncontrolled",


### PR DESCRIPTION
Associated Issue: #825 

### Summary of Changes

* make the `Draggable` have an invisible wider click target

### Testing

* [x] passes `npm test`
* [x] passes `npm run lint`

### Screenshots/Videos (OPTIONAL)

