### PR TITLE
Disable breakpoint sliding on sourcemapped sources

### DIFF
--- a/public/js/actions/breakpoints.js
+++ b/public/js/actions/breakpoints.js
@@ -13,7 +13,7 @@ const { PROMISE } = require("../utils/redux/middleware/promise");
 const { getBreakpoint, getBreakpoints } = require("../selectors");
 
 const {
-  getOriginalLocation, getGeneratedLocation
+  getOriginalLocation, getGeneratedLocation, isOriginalId
 } = require("../utils/source-map");
 
 import type { Location } from "./types";
@@ -75,7 +75,8 @@ function addBreakpoint(location: Location,
         location = await getGeneratedLocation(bp.location, getState());
         let { id, actualLocation } = await client.setBreakpoint(
           location,
-          bp.condition
+          bp.condition,
+          isOriginalId(bp.location.sourceId)
         );
 
         actualLocation = await getOriginalLocation(actualLocation);

--- a/public/js/clients/firefox/commands.js
+++ b/public/js/clients/firefox/commands.js
@@ -46,13 +46,14 @@ function sourceContents(sourceId) {
   return sourceClient.source();
 }
 
-function setBreakpoint(location, condition) {
+function setBreakpoint(location, condition, noSliding) {
   const sourceClient = threadClient.source({ actor: location.sourceId });
 
   return sourceClient.setBreakpoint({
     line: location.line,
     column: location.column,
-    condition: condition
+    condition,
+    noSliding
   }).then(([res, bpClient]) => {
     bpClients[bpClient.actor] = bpClient;
 

--- a/public/js/lib/devtools-sham/shared/client/main.js
+++ b/public/js/lib/devtools-sham/shared/client/main.js
@@ -2925,7 +2925,7 @@ SourceClient.prototype = {
    * @param function aOnResponse
    *        Called with the thread's response.
    */
-  setBreakpoint: function ({ line, column, condition }, aOnResponse = noop) {
+  setBreakpoint: function ({ line, column, condition, noSliding }, aOnResponse = noop) {
     // A helper function that sets the breakpoint.
     let doSetBreakpoint = aCallback => {
       let root = this._client.mainRoot;
@@ -2938,7 +2938,8 @@ SourceClient.prototype = {
         to: this.actor,
         type: "setBreakpoint",
         location: location,
-        condition: condition
+        condition: condition,
+        noSliding: noSliding
       };
 
       // Backwards compatibility: send the breakpoint request to the


### PR DESCRIPTION
After [this bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1305079) lands, we'll have the ability to turn off breakpoint sliding when setting breakpoints. We want to do this when setting breakpoint on sourcemapped sources (this is how the old debugger behaved) because sliding is a "nice to have" but ridiculously infuriating when it goes wrong (see [bug 1230345](https://bugzilla.mozilla.org/show_bug.cgi?id=1230345)). And sliding is almost always wrong with sourcemaps.

This is because the engine does sliding on the generated source, and then we'll sourcemap the final location back. But who knows where that maps to. I've seen cases in Firefox/Chrome where the breakpoint literally slides **up**.

We can't merge this until that bug lands, but that should be tomorrow.