### PR TITLE
Isolate the CSS var --theme-search-overlays-semitransparent so it's available in the toolbox

### DIFF
--- a/public/js/components/App.css
+++ b/public/js/components/App.css
@@ -4,6 +4,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+:root.theme-light,
+:root .theme-light {
+  --theme-search-overlays-semitransparent: rgba(221, 225, 228, 0.66);
+}
+
 * {
   box-sizing: border-box;
 }

--- a/public/js/lib/themes/variables.css
+++ b/public/js/lib/themes/variables.css
@@ -25,7 +25,6 @@
   --theme-toolbar-background-alt: #f5f5f5;
   --theme-selection-background: #4c9ed9;
   --theme-selection-background-semitransparent: rgba(76, 158, 217, 0.15);
-  --theme-search-overlays-semitransparent: rgba(221, 225, 228, 0.66);
   --theme-selection-color: #f5f7fa;
   --theme-splitter-color: #dde1e4;
   --theme-comment: #696969;


### PR DESCRIPTION
The transparent overlay of the search box isn't working in the Firefox panel on master because this CSS var doesn't exist in the themes, we added it. We shouldn't added anything to `variables.css` that's also not added on mozilla-central.