### PR TITLE
Simplify initDebugger mochitest helper

### DIFF
--- a/public/js/test/mochitest/browser_dbg-breaking.js
+++ b/public/js/test/mochitest/browser_dbg-breaking.js
@@ -4,7 +4,7 @@
 // Tests the breakpoints are hit in various situations.
 
 add_task(function* () {
-  const dbg = yield initDebugger("doc-scripts.html", "scripts.html");
+  const dbg = yield initDebugger("doc-scripts.html");
   const { selectors: { getSelectedSource }, getState } = dbg;
 
   // Make sure we can set a top-level breakpoint and it will be hit on

--- a/public/js/test/mochitest/browser_dbg-call-stack.js
+++ b/public/js/test/mochitest/browser_dbg-call-stack.js
@@ -16,10 +16,7 @@ function isFrameSelected(dbg, index, title) {
 }
 
 add_task(function* () {
-  const dbg = yield initDebugger(
-    "doc-script-switching.html",
-    "script-switching-01.js"
-  );
+  const dbg = yield initDebugger("doc-script-switching.html");
 
   toggleCallStack(dbg);
 

--- a/public/js/test/mochitest/browser_dbg-debugger-buttons.js
+++ b/public/js/test/mochitest/browser_dbg-debugger-buttons.js
@@ -25,10 +25,7 @@ function clickStepOut(dbg) {
  *  5. stepUp at the end of a function
  */
 add_task(function* () {
-  const dbg = yield initDebugger(
-    "doc-debugger-statements.html",
-    "debugger-statements.html"
-  );
+  const dbg = yield initDebugger("doc-debugger-statements.html");
 
   yield reload(dbg);
   yield waitForPaused(dbg);

--- a/public/js/test/mochitest/browser_dbg-editor-gutter.js
+++ b/public/js/test/mochitest/browser_dbg-editor-gutter.js
@@ -22,7 +22,7 @@ function assertEditorBreakpoint(dbg, line, shouldExist) {
 }
 
 add_task(function* () {
-  const dbg = yield initDebugger("doc-scripts.html", "simple1.js");
+  const dbg = yield initDebugger("doc-scripts.html");
   const { selectors: { getBreakpoints, getBreakpoint }, getState } = dbg;
   const source = findSource(dbg, "simple1.js");
 

--- a/public/js/test/mochitest/browser_dbg-editor-highlight.js
+++ b/public/js/test/mochitest/browser_dbg-editor-highlight.js
@@ -34,7 +34,6 @@ add_task(function* () {
 
   // Test jumping to a line in a source that exists but hasn't been
   // loaded yet.
-  yield waitForSources(dbg, "simple1.js");
   selectSource(dbg, "simple1.js", 6);
 
   // Make sure the source is in the loading state, wait for it to be

--- a/public/js/test/mochitest/browser_dbg-editor-mode.js
+++ b/public/js/test/mochitest/browser_dbg-editor-mode.js
@@ -4,10 +4,7 @@
 // Tests that the editor sets the correct mode for different file
 // types
 add_task(function* () {
-  const dbg = yield initDebugger(
-    "doc-scripts.html",
-    "simple1.js", "doc-scripts.html"
-  );
+  const dbg = yield initDebugger("doc-scripts.html");
 
   yield selectSource(dbg, "simple1.js");
   is(dbg.win.cm.getOption("mode").name, "javascript", "Mode is correct");

--- a/public/js/test/mochitest/browser_dbg-editor-select.js
+++ b/public/js/test/mochitest/browser_dbg-editor-select.js
@@ -17,10 +17,7 @@ add_task(function* () {
   // fix a frequent failure allow a longer timeout.
   requestLongerTimeout(2);
 
-  const dbg = yield initDebugger(
-    "doc-scripts.html",
-    "simple1.js", "simple2.js", "long.js"
-  );
+  const dbg = yield initDebugger("doc-scripts.html");
   const { selectors: { getSelectedSource }, getState } = dbg;
   const simple1 = findSource(dbg, "simple1.js");
   const simple2 = findSource(dbg, "simple2.js");

--- a/public/js/test/mochitest/browser_dbg-iframes.js
+++ b/public/js/test/mochitest/browser_dbg-iframes.js
@@ -7,7 +7,7 @@
  *  2. pause in the iframe
  */
 add_task(function* () {
-  const dbg = yield initDebugger("doc-iframes.html", "iframes.html");
+  const dbg = yield initDebugger("doc-iframes.html");
 
   // test pausing in the main thread
   yield reload(dbg);

--- a/public/js/test/mochitest/browser_dbg-pause-exceptions.js
+++ b/public/js/test/mochitest/browser_dbg-pause-exceptions.js
@@ -17,7 +17,7 @@ function caughtException() {
   4. skip a caught error
 */
 add_task(function* () {
-  const dbg = yield initDebugger("doc-exceptions.html", "exceptions.js");
+  const dbg = yield initDebugger("doc-exceptions.html");
 
   // test skipping an uncaught exception
   yield togglePauseOnExceptions(dbg, false, false);

--- a/public/js/test/mochitest/browser_dbg_keyboard-shortcuts.js
+++ b/public/js/test/mochitest/browser_dbg_keyboard-shortcuts.js
@@ -26,10 +26,7 @@ function pressStepOut(dbg) {
 }
 
 add_task(function*() {
-  const dbg = yield initDebugger(
-    "doc-debugger-statements.html",
-    "debugger-statements.html"
-  );
+  const dbg = yield initDebugger("doc-debugger-statements.html");
 
   yield reload(dbg);
   yield waitForPaused(dbg);

--- a/public/js/test/mochitest/head.js
+++ b/public/js/test/mochitest/head.js
@@ -300,9 +300,7 @@ function createDebuggerContext(toolbox) {
 function initDebugger(url, ...sources) {
   return Task.spawn(function* () {
     const toolbox = yield openNewTabAndToolbox(EXAMPLE_URL + url, "jsdebugger");
-    const dbg = createDebuggerContext(toolbox);
-    yield waitForSources(dbg, ...sources);
-    return dbg;
+    return createDebuggerContext(toolbox);
   });
 };
 


### PR DESCRIPTION
Now that the toolbox doesn't signal that the debugger is ready until all sources exist, we don't need to wait for specific sources any more. There were some tests that were listing them unnecessarily; you *only* needed to pass them to `initDebugger` if you explicitly used them afterwards. If you call `waitForPaused` first and wait for it to pause, you don't need to list the source; you're not using it until it exists anyway.

But this is a little simpler. We cannot simplify `navigate` or `reload` because that is another API entirely, and only signifies that the page is changing. There we will need a way to know when it is "completed", and you specify that by giving it any sources you need afterwards. Again, you do *not* need to list anything if you do not *directly* use a source. If you're waiting for a `LOAD_SOURCE_TEXT` action, or a paused state, you don't need to pass anything.