### PR TITLE
Fix `networkRequest` is not a function error in chrome client

### DIFF
--- a/public/js/clients/chrome.js
+++ b/public/js/clients/chrome.js
@@ -4,7 +4,7 @@ const { connect } = require("../lib/chrome-remote-debug-protocol");
 const defer = require("../utils/defer");
 const { Tab } = require("../types");
 const { isEnabled, getValue } = require("../feature");
-const { networkRequest } = require("../utils/networkRequest");
+const networkRequest = require("../utils/networkRequest");
 const { setupCommands, clientCommands } = require("./chrome/commands");
 const { setupEvents, clientEvents, pageEvents } = require("./chrome/events");
 


### PR DESCRIPTION
Associated Issue: #855 
### Summary of Changes

* change the require call to get the whole export instead of attempting to destructure which caused the error

### Testing

* [x] passes `npm test`
* [x] passes `npm run lint`
