### PR TITLE
Run unit tests on prepush

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "firefox": "node bin/firefox-driver --start",
     "mochitests-watch": "MOCHITESTS=true TARGET=firefox-panel webpack --watch",
     "build-docs": "documentation build --format html --shallow  --document-exported --output docs/reference/ public/js/actions/ public/js/test/mochitest/head.js",
-    "prepush": "npm run lint",
+    "prepush": "npm run lint; npm run test",
     "build-storybook": "build-storybook"
   },
   "engineStrict": true,

--- a/public/js/utils/sources-tree.js
+++ b/public/js/utils/sources-tree.js
@@ -102,7 +102,7 @@ function getURL(source: TmpSource): { path: string, group: string } {
 function addToTree(tree: any, source: TmpSource) {
   const url = getURL(source);
 
-  if (IGNORED_URLS.includes(url) ||
+  if (IGNORED_URLS.indexOf(url) != -1 ||
       !source.get("url") ||
       isPretty(source.toJS())) {
     return;


### PR DESCRIPTION
### Summary of Changes

* adds `npm run test` to the `prepush` script
* replaces `[].includes` with `_.includes` in sources-tree because node < 6 does not support `[].includes`. As a side-note, we run the unit tests on CI with node 6.3, so we don't run into this issue there.
