### PR TITLE
Disable search key

### DIFF
--- a/public/js/components/Editor.js
+++ b/public/js/components/Editor.js
@@ -17,6 +17,7 @@ const actions = require("../actions");
 const Breakpoint = React.createFactory(require("./EditorBreakpoint"));
 
 const { getDocument, setDocument } = require("../utils/source-documents");
+const { isEnabled } = require("../feature");
 
 require("./Editor.css");
 
@@ -144,6 +145,8 @@ const Editor = React.createClass({
   },
 
   componentDidMount() {
+    const extraKeys = isEnabled("search") ? { "Cmd-F": () => {} } : {};
+
     this.editor = new SourceEditor({
       mode: "javascript",
       readOnly: true,
@@ -154,7 +157,8 @@ const Editor = React.createClass({
       showAnnotationRuler: true,
       enableCodeFolding: false,
       gutters: ["breakpoints"],
-      value: " "
+      value: " ",
+      extraKeys
     });
 
     this.editor.appendToLocalElement(

--- a/public/js/components/SourceFooter.js
+++ b/public/js/components/SourceFooter.js
@@ -116,12 +116,16 @@ const SourceFooter = React.createClass({
 
     this.keyShortcutsEnabled = true;
     const shortcuts = this.context.shortcuts;
-    shortcuts.on("Cmd+f", this.focusSearch);
+    if (isEnabled("search")) {
+      shortcuts.on("Cmd+f", this.focusSearch);
+    }
   },
 
   componentWillUnmount() {
     const shortcuts = this.context.shortcuts;
-    shortcuts.off("Cmd+f", this.focusSearch);
+    if (isEnabled("search")) {
+      shortcuts.off("Cmd+f", this.focusSearch);
+    }
   },
 
   componentDidUpdate() {


### PR DESCRIPTION
Fixes: #869

### Summary of Changes

Disables the keyboard shortcut that triggered the search UI in the firefox panel.

