### PR TITLE
Vertical Rhythm, #700

### DIFF
--- a/public/js/components/Accordion.css
+++ b/public/js/components/Accordion.css
@@ -28,5 +28,6 @@
 }
 
 .accordion ._content {
-  border-bottom: 1px solid var(--theme-splitter-color);;
+  border-bottom: 1px solid var(--theme-splitter-color);
+  font-size: 12px;
 }

--- a/public/js/components/Breakpoints.css
+++ b/public/js/components/Breakpoints.css
@@ -3,9 +3,13 @@
   font-size: 12px;
   color: var(--theme-content-color1);
   margin: 0.25em 0;
-  padding: 0.25em 0;
+  padding: 0.25em 1px 0 0;
   line-height: 1em;
   position: relative;
+}
+
+.breakpoints-list .breakpoint:last-of-type {
+  padding-bottom: 0.45em;
 }
 
 .breakpoints-list .breakpoint.paused {
@@ -24,6 +28,8 @@
 
 .breakpoints-list .breakpoint-label {
   display: inline-block;
+  padding-left: 2px;
+  padding-bottom: 4px;
 }
 
 .breakpoints-list .pause-indicator {
@@ -33,7 +39,7 @@
 
 .breakpoint-snippet {
   color: var(--theme-comment);
-  padding-left: 20px;
+  padding-left: 22px;
 }
 
 .breakpoint .close-btn {

--- a/public/js/components/Frames.css
+++ b/public/js/components/Frames.css
@@ -7,7 +7,7 @@
 
 .frames ul li {
   cursor: pointer;
-  padding: 10px;
+  padding: 7px 10px 7px 21px;
   clear: both;
   overflow: hidden;
 }

--- a/public/js/components/RightSidebar.css
+++ b/public/js/components/RightSidebar.css
@@ -16,7 +16,7 @@
 
 .command-bar {
   height: 30px;
-  padding: 8px 5px 10px 17px;
+  padding: 8px 5px 10px 1px;
 }
 
 .command-bar > span {

--- a/public/js/components/SourceFooter.css
+++ b/public/js/components/SourceFooter.css
@@ -5,7 +5,7 @@
   position: absolute;
   bottom: 0;
   left: 0;
-  right: 0;
+  right: 1px;
   opacity: 1;
   z-index: 100;
 }

--- a/public/js/components/Sources.css
+++ b/public/js/components/Sources.css
@@ -17,7 +17,7 @@
 }
 
 .sources-header-info {
-  font-size: 0.7em;
+  font-size: 12px;
   color: var(--theme-comment-alt);
   font-weight: lighter;
   white-space: nowrap;


### PR DESCRIPTION
Associated Issue: #700 

### Summary of Changes
Very small updates to the right sidebar so everything is left-aligned, including:

* Aligning debugger actions with accordion
* Aligning breakpoints and frames with their accordion headers
* Using @jasonLaster's self-proclaimed ugly hack to fix the splitter not extending to bottom of right pane
* Declaration of ```12px``` to fix the ```<message-box>``` styling issue in which right-pane elements sometimes appeared 1px larger than their headers

### Testing

* [x] passes `npm test`
* [x] passes `npm run lint`

### Screenshots/Videos
![screen shot 2016-10-04 at 3 46 27 pm](https://cloud.githubusercontent.com/assets/1720093/19089768/bc03f89a-8a49-11e6-95b4-fe3c640cd8de.png)

One thing this PR _doesn't_ do (but I think it would be nice if it did) is change the event scopes to no longer be bolded (but it seemed like that was library code from FF that I didn't want to touch).