### PR TITLE
Fix breakpoint arrow and gutter heights

### DIFF
--- a/public/js/components/Editor.css
+++ b/public/js/components/Editor.css
@@ -24,10 +24,11 @@
 
 .editor.new-breakpoint svg {
   fill: var(--theme-selection-background);
-  height: 18px;
+  width: 60px;
+  height: 12px;
   position: absolute;
-  top: 0;
-  right: -8px;
+  top: 1px;
+  right: -4px;
 }
 
 .editor.new-breakpoint.breakpoint-disabled svg {
@@ -41,6 +42,11 @@
   background-color: var(--theme-body-background);
 }
 
+.CodeMirror-linenumber {
+  font-size: 11px;
+  line-height: 15px;
+}
+
 /* set the linenumber white when there is a breakpoint */
 .new-breakpoint .CodeMirror-linenumber {
   color: white;
@@ -49,6 +55,11 @@
 /* move the breakpoint below the linenumber */
 .new-breakpoint .CodeMirror-gutter-elt:last-child {
   z-index: 0;
+}
+
+.editor-wrapper .CodeMirror-line {
+  font-size: 12px;
+  line-height: 15px;
 }
 
 .debug-line .CodeMirror-line {

--- a/public/js/components/Editor.css
+++ b/public/js/components/Editor.css
@@ -25,9 +25,9 @@
 .editor.new-breakpoint svg {
   fill: var(--theme-selection-background);
   width: 60px;
-  height: 12px;
+  height: 14px;
   position: absolute;
-  top: 1px;
+  top: 0px;
   right: -4px;
 }
 
@@ -44,7 +44,7 @@
 
 .CodeMirror-linenumber {
   font-size: 11px;
-  line-height: 15px;
+  line-height: 14px;
 }
 
 /* set the linenumber white when there is a breakpoint */
@@ -58,8 +58,8 @@
 }
 
 .editor-wrapper .CodeMirror-line {
-  font-size: 12px;
-  line-height: 15px;
+  font-size: 11px;
+  line-height: 14px;
 }
 
 .debug-line .CodeMirror-line {

--- a/public/js/components/Editor.css
+++ b/public/js/components/Editor.css
@@ -24,11 +24,10 @@
 
 .editor.new-breakpoint svg {
   fill: var(--theme-selection-background);
-  width: 60px;
-  height: 12px;
+  height: 18px;
   position: absolute;
   top: 0;
-  right: -4px;
+  right: -8px;
 }
 
 .editor.new-breakpoint.breakpoint-disabled svg {
@@ -40,10 +39,6 @@
   width: 100%;
   height: 100%;
   background-color: var(--theme-body-background);
-}
-
-.CodeMirror-linenumber {
-  font-size: 11px;
 }
 
 /* set the linenumber white when there is a breakpoint */


### PR DESCRIPTION
Associated Issue: #875

### Summary of Changes

* Fixed breakpoint gutter height
* Realigned breakpoint arrow svg  

### Testing

* [x] passes `npm run lint-css`

### Screenshots

![debuggerchrome](https://cloud.githubusercontent.com/assets/2848472/19127743/5309801a-8b0e-11e6-8f18-671926223994.jpg)
![debuggerchromebreakpoint](https://cloud.githubusercontent.com/assets/2848472/19127740/53049c9e-8b0e-11e6-9f17-828c1df5d2d7.jpg)
![debuggerfirefox](https://cloud.githubusercontent.com/assets/2848472/19127742/5307f31c-8b0e-11e6-926f-4a62098e8b01.jpg)
![debuggerfirefoxbreakpoint](https://cloud.githubusercontent.com/assets/2848472/19127741/530725e0-8b0e-11e6-81f8-937d82537c02.jpg)

