### PR TITLE
Add mocha dot reporter

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "firefox": "node bin/firefox-driver --start",
     "mochitests-watch": "MOCHITESTS=true TARGET=firefox-panel webpack --watch",
     "build-docs": "documentation build --format html --shallow  --document-exported --output docs/reference/ public/js/actions/ public/js/test/mochitest/head.js",
-    "prepush": "npm run lint; npm run test",
+    "prepush": "npm run lint; node public/js/test/node-unit-tests.js --dots",
     "build-storybook": "build-storybook"
   },
   "engineStrict": true,

--- a/public/js/test/node-unit-tests.js
+++ b/public/js/test/node-unit-tests.js
@@ -11,10 +11,11 @@ const setConfig = require("../../../config/feature").setConfig;
 require("amd-loader");
 require("babel-register");
 
-const args = minimist(process.argv.slice(2), {
-  boolean: "ci"
-});
+const args = minimist(process.argv.slice(2),
+{ boolean: ["ci", "dots"] });
+
 const isCI = args.ci;
+const useDots = args.dots;
 
 setConfig(getConfig());
 getConfig().baseWorkerURL = path.join(__dirname, "../../build/");
@@ -52,6 +53,8 @@ const mocha = new Mocha();
 
 if (isCI) {
   mocha.reporter("mocha-circleci-reporter");
+} else if (useDots) {
+  mocha.reporter("dot");
 }
 
 testFiles.forEach(file => mocha.addFile(file));


### PR DESCRIPTION
This switches the default cli mocha reporter to *dot*. The main advantage is that running `git push` will no longer result in a wall of output.


![screen shot 2016-10-06 at 9 24 27 am](https://cloud.githubusercontent.com/assets/254562/19153928/64f96a9a-8ba6-11e6-8a6a-8c999c4a1c8a.png)

