### PR TITLE
Add `user-select: none` to several parts of the debugger.

### DIFF
--- a/public/js/components/Breakpoints.css
+++ b/public/js/components/Breakpoints.css
@@ -1,8 +1,5 @@
 .breakpoints-list * {
-  -webkit-user-select: none;
   -moz-user-select: none;
-  -ms-user-select: none;
-  -o-user-select: none;
   user-select: none;
 }
 

--- a/public/js/components/Breakpoints.css
+++ b/public/js/components/Breakpoints.css
@@ -1,3 +1,10 @@
+.breakpoints-list * {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  -o-user-select: none;
+  user-select: none;
+}
 
 .breakpoints-list .breakpoint {
   font-size: 12px;

--- a/public/js/components/Editor.css
+++ b/public/js/components/Editor.css
@@ -90,9 +90,6 @@
   background-color: var(--theme-tab-toolbar-background);
   font-weight: lighter;
   z-index: 100;
-  -webkit-user-select: none;
   -moz-user-select: none;
-  -ms-user-select: none;
-  -o-user-select: none;
   user-select: none;
 }

--- a/public/js/components/Editor.css
+++ b/public/js/components/Editor.css
@@ -90,4 +90,9 @@
   background-color: var(--theme-tab-toolbar-background);
   font-weight: lighter;
   z-index: 100;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  -o-user-select: none;
+  user-select: none;
 }

--- a/public/js/components/Frames.css
+++ b/public/js/components/Frames.css
@@ -12,10 +12,7 @@
 }
 
 .frames ul li * {
-  -webkit-user-select: none;
   -moz-user-select: none;
-  -ms-user-select: none;
-  -o-user-select: none;
   user-select: none;
 }
 

--- a/public/js/components/Frames.css
+++ b/public/js/components/Frames.css
@@ -1,4 +1,3 @@
-
 .frames ul {
   list-style: none;
   margin: 0;
@@ -10,6 +9,14 @@
   padding: 7px 10px 7px 21px;
   clear: both;
   overflow: hidden;
+}
+
+.frames ul li * {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  -o-user-select: none;
+  user-select: none;
 }
 
 .frames ul li:nth-of-type(2n) {

--- a/public/js/components/RightSidebar.css
+++ b/public/js/components/RightSidebar.css
@@ -6,10 +6,7 @@
 }
 
 .right-siderbar * {
-  -webkit-user-select: none;
   -moz-user-select: none;
-  -ms-user-select: none;
-  -o-user-select: none;
   user-select: none;
 }
 

--- a/public/js/components/RightSidebar.css
+++ b/public/js/components/RightSidebar.css
@@ -5,6 +5,14 @@
   white-space: nowrap;
 }
 
+.right-siderbar * {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  -o-user-select: none;
+  user-select: none;
+}
+
 .right-sidebar .accordion {
   overflow-y: auto;
   overflow-x: hidden;

--- a/public/js/components/SourceFooter.css
+++ b/public/js/components/SourceFooter.css
@@ -8,10 +8,23 @@
   right: 1px;
   opacity: 1;
   z-index: 100;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  -o-user-select: none;
+  user-select: none;
 }
 
 .source-footer .command-bar {
   float: right;
+}
+
+.source-footer .command-bar * {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  -o-user-select: none;
+  user-select: none;
 }
 
 .command-bar > span {

--- a/public/js/components/SourceFooter.css
+++ b/public/js/components/SourceFooter.css
@@ -8,10 +8,7 @@
   right: 1px;
   opacity: 1;
   z-index: 100;
-  -webkit-user-select: none;
   -moz-user-select: none;
-  -ms-user-select: none;
-  -o-user-select: none;
   user-select: none;
 }
 
@@ -20,10 +17,7 @@
 }
 
 .source-footer .command-bar * {
-  -webkit-user-select: none;
   -moz-user-select: none;
-  -ms-user-select: none;
-  -o-user-select: none;
   user-select: none;
 }
 

--- a/public/js/components/SourceTabs.css
+++ b/public/js/components/SourceTabs.css
@@ -5,10 +5,7 @@
 }
 
 .source-header * {
-  -webkit-user-select: none;
   -moz-user-select: none;
-  -ms-user-select: none;
-  -o-user-select: none;
   user-select: none;
 }
 

--- a/public/js/components/SourceTabs.css
+++ b/public/js/components/SourceTabs.css
@@ -4,6 +4,14 @@
   flex: 1;
 }
 
+.source-header * {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  -o-user-select: none;
+  user-select: none;
+}
+
 .source-tabs {
   width: calc(100% - 30px);
   overflow: hidden;

--- a/public/js/components/Sources.css
+++ b/public/js/components/Sources.css
@@ -6,10 +6,7 @@
 }
 
 .sources-panel * {
-  -webkit-user-select: none;
   -moz-user-select: none;
-  -ms-user-select: none;
-  -o-user-select: none;
   user-select: none;
 }
 
@@ -22,10 +19,7 @@
   display: flex;
   align-items: baseline;
   justify-content: space-between;
-  -webkit-user-select: none;
   -moz-user-select: none;
-  -ms-user-select: none;
-  -o-user-select: none;
   user-select: none;
 }
 

--- a/public/js/components/Sources.css
+++ b/public/js/components/Sources.css
@@ -5,6 +5,14 @@
   overflow: hidden;
 }
 
+.sources-panel * {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  -o-user-select: none;
+  user-select: none;
+}
+
 .sources-header {
   height: 30px;
   border-bottom: 1px solid var(--theme-splitter-color);
@@ -14,6 +22,11 @@
   display: flex;
   align-items: baseline;
   justify-content: space-between;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  -o-user-select: none;
+  user-select: none;
 }
 
 .sources-header-info {


### PR DESCRIPTION
Associated Issue: #841 

### Summary of Changes

* add `user-select: none` to various parts of the debugger so selection/ctrl+a only gets the things we expect (note, bare `user-select` seems to not work so adding the vendor prefixes for full support.)

### Testing

* [x] passes `npm test`
* [x] passes `npm run lint`
