### PR TITLE
Disable selections for the autocomplete result list.

### DIFF
--- a/public/js/components/Autocomplete.css
+++ b/public/js/components/Autocomplete.css
@@ -4,6 +4,11 @@
   padding: 20px;
 }
 
+.autocomplete .results * {
+  -moz-user-select: none;
+  user-select: none;
+}
+
 .autocomplete ul {
   list-style: none;
   width: 100%;


### PR DESCRIPTION
Associated Issue: N/A

### Summary of Changes

* disable selection for the autocomplete result list

I had forgotten to include this in the previous PR and we didn't remember it in the issue either.

### Testing

* [x] passes `npm test`
* [x] passes `npm run lint`
