### PR TITLE
Extract `log` into its own module to make `utils` avoid config dependency

### DIFF
--- a/public/js/utils/log.js
+++ b/public/js/utils/log.js
@@ -1,0 +1,11 @@
+const { isDevelopment } = require("../feature");
+
+function log() {
+  if (!isDevelopment()) {
+    return;
+  }
+
+  console.log.apply(console, ["[log]", ...arguments]);
+}
+
+module.exports = log;

--- a/public/js/utils/utils.js
+++ b/public/js/utils/utils.js
@@ -6,7 +6,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 const co = require("co");
-const { isDevelopment } = require("../feature");
 
 function asPaused(client: any, func: any) {
   if (client.state != "paused") {
@@ -160,14 +159,6 @@ function compose(...funcs: any) {
   };
 }
 
-function log() {
-  if (!isDevelopment()) {
-    return;
-  }
-
-  console.log.apply(console, ["[log]", ...arguments]);
-}
-
 function updateObj<T>(obj: T, fields: $Shape<T>) : T {
   return Object.assign({}, obj, fields);
 }
@@ -197,7 +188,6 @@ module.exports = {
   toObject,
   mapObject,
   compose,
-  log,
   updateObj,
   throttle
 };


### PR DESCRIPTION
The `devtoolsRequire` problem in the source map worker was caused by #860 because it loads the `utils` file in `source.js` now, which tries to load in our config system... You can't load the config system in the worker, nothing is set up. The only thing that needs the config system in `utils` is the log function, so I extracted it out. I looked through our codebase and couldn't even find any uses of it though.

Not sure if there's a better solution.