### PR TITLE
Update documentation to refer new contributors to `difficulty:easy` labeled issues

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -167,14 +167,14 @@ If you find an `up for grabs` issue without a difficulty level set as a label or
 
 #### Your First Code Contribution
 
-A good place to start when looking for something to contribute, is looking through the `up-for-grabs` issues. These are actionable issues that no one has laid claim to.
+If you're looking for a good issue, you can look through the `up-for-grabs` issues. These issues should be actionable and well documented.
 
-If this is your first time contributing any code to an open source project take a look through the `difficulty:easy` issues as well, they're typically spec'd out and the steps to completion are laid out more clearly.
-
-Don't be afraid to take issues of `difficulty:medium` or `difficulty:hard` if that's what interests you. You're more than welcome to.
+There are several difficulty levels, *easy*, *medium*, *hard*. We recommend grabbing an *easy* issue, but it's up to you.
 
 * [up-for-grabs][labels-up-for-grabs] - issues that are not assigned to anyone and are available to be worked on.
-* [difficulty:easy][labels-difficulty-easy] - issues which should have clear expectations and a mentor to help you through
+* [difficulty:easy][labels-difficulty-easy] - clear expectations and a mentor to help you through.
+* [difficulty:medium][labels-difficulty-medium] - more complex and may not have as clear expectations.
+* [difficulty:hard][labels-difficulty-hard] - complex and has some open technical questions.
 
 
 To begin your work make sure you follow these steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -167,11 +167,15 @@ If you find an `up for grabs` issue without a difficulty level set as a label or
 
 #### Your First Code Contribution
 
-If this is your first time contributing any code to an open source project take a look through the `difficulty:easy` issues:
+A good place to start when looking for something to contribute, is looking through the `up-for-grabs` issues. These are actionable issues that no one has laid claim to.
 
+If this is your first time contributing any code to an open source project take a look through the `difficulty:easy` issues as well, they're typically spec'd out and the steps to completion are laid out more clearly.
+
+Don't be afraid to take issues of `difficulty:medium` or `difficulty:hard` if that's what interests you. You're more than welcome to.
+
+* [up-for-grabs][labels-up-for-grabs] - issues that are not assigned to anyone and are available to be worked on.
 * [difficulty:easy][labels-difficulty-easy] - issues which should have clear expectations and a mentor to help you through
 
-If you didn't find any issues this time, don't worry.  Take a look at the `up for grabs` issues above and let someone know this is your first time contributing code.
 
 To begin your work make sure you follow these steps:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -167,9 +167,9 @@ If you find an `up for grabs` issue without a difficulty level set as a label or
 
 #### Your First Code Contribution
 
-If this is your first time contributing any code to an open source project take a look through the `first-timers-only` issues:
+If this is your first time contributing any code to an open source project take a look through the `difficulty:easy` issues:
 
-* [first-timers-only][labels-first-timers-only] - issues which should have clear expectations and a mentor to help you through
+* [difficulty:easy][labels-difficulty-easy] - issues which should have clear expectations and a mentor to help you through
 
 If you didn't find any issues this time, don't worry.  Take a look at the `up for grabs` issues above and let someone know this is your first time contributing code.
 
@@ -344,7 +344,6 @@ These are the [labels](https://github.com/devtools-html/debugger.html/labels) we
 | Label name | query:mag_right: | Description |
 | --- | --- | --- |
 | `up-for-grabs` | [search][labels-up-for-grabs] | Good for contributors to work on |
-| `first-timers-only` | [search][labels-first-timers-only] | Good for a first time contribution to open source |
 | `difficulty:easy` | [search][labels-difficulty-easy] | Work that is small changes, updating tests, updating docs, expect very little review |
 | `difficulty:medium` | [search][labels-difficulty-medium] | Work that adapts existing code, adapts existing tests, expect quick review |
 | `difficulty:hard` | [search][labels-difficulty-hard] | Work that requires new tests, new code, and a good understanding of project; expect lots of review |


### PR DESCRIPTION
Associated Issue: #877 

### Summary of Changes

* remove references to the defunct `first-timers-only` label in favor of the `difficulty:easy` label

### Testing

* [x] passes `npm test`
* [x] passes `npm run lint`
