### PR TITLE
Polish RTL

### DIFF
--- a/public/js/components/Editor.css
+++ b/public/js/components/Editor.css
@@ -16,6 +16,10 @@
   left: 0px;
 }
 
+html[dir="rtl"] .editor-mount {
+  direction: ltr;
+}
+
 .editor-wrapper .breakpoints {
   position: absolute;
   top: 0;

--- a/public/js/components/ObjectInspector.css
+++ b/public/js/components/ObjectInspector.css
@@ -1,13 +1,22 @@
 .arrow svg {
   fill: var(--theme-splitter-color);
-  margin-right: 5px;
   margin-top: 3px;
-  transform: rotate(-90deg);
   transition: transform 0.25s ease;
   width: 10px;
 }
 
-.arrow.expanded svg {
+html:not([dir="rtl"]) .arrow svg {
+  margin-right: 5px;
+  transform: rotate(-90deg);
+}
+
+html[dir="rtl"] .arrow svg {
+  margin-left: 5px;
+  transform: rotate(90deg);
+}
+
+/* TODO (Amit): html is just for specificity. keep it like this? */
+html .arrow.expanded svg {
   transform: rotate(0deg);
 }
 

--- a/public/js/components/RightSidebar.css
+++ b/public/js/components/RightSidebar.css
@@ -21,12 +21,18 @@
 
 .command-bar {
   height: 30px;
+}
+
+html:not([dir="rtl"]) .command-bar {
   padding: 8px 5px 10px 1px;
+}
+
+html[dir="rtl"] .command-bar {
+  padding: 8px 1px 10px 5px;
 }
 
 .command-bar > span {
   cursor: pointer;
-  margin-right: 0.7em;
   width: 16px;
   height: 17px;
   display: inline-block;
@@ -34,13 +40,25 @@
   transition: opacity 200ms;
 }
 
+html:not([dir="rtl"]) .command-bar > span {
+  margin-right: 0.7em;
+}
+
+html[dir="rtl"] .command-bar > span {
+  margin-left: 0.7em;
+}
+
 .command-bar > span.disabled {
   opacity: 0.3;
   cursor: default;
 }
 
-.command-bar .stepOut {
+html:not([dir="rtl"]) .command-bar .stepOut {
   margin-right: 2em;
+}
+
+html[dir="rtl"] .command-bar .stepOut {
+  margin-left: 2em;
 }
 
 .command-bar .subSettings {

--- a/public/js/components/SourceFooter.css
+++ b/public/js/components/SourceFooter.css
@@ -12,8 +12,12 @@
   user-select: none;
 }
 
-.source-footer .command-bar {
+html:not([dir="rtl"]) .source-footer .command-bar {
   float: right;
+}
+
+html[dir="rtl"] .source-footer .command-bar {
+  float: left;
 }
 
 .source-footer .command-bar * {
@@ -23,12 +27,19 @@
 
 .command-bar > span {
   cursor: pointer;
-  margin-right: 0.7em;
   width: 1em;
   height: 1.1em;
   display: inline-block;
   text-align: center;
   transition: opacity 200ms;
+}
+
+html:not([dir="rtl"]) .command-bar > span {
+  margin-right: 0.7em;
+}
+
+html[dir="rtl"] .command-bar > span {
+  margin-left: 0.7em;
 }
 
 .source-footer .prettyPrint.pretty {

--- a/public/js/components/SourceTabs.css
+++ b/public/js/components/SourceTabs.css
@@ -20,14 +20,22 @@
   border: 1px solid var(--theme-splitter-color);
   border-top-left-radius: 2px;
   border-top-right-radius: 2px;
-  padding: 2px 20px 2px 12px;
   height: 23px;
   line-height: 20px;
-  margin: 6px 0 0 8px;
   display: inline-block;
   border-bottom: none;
   position: relative;
   transition: all 0.25s ease;
+}
+
+html:not([dir="rtl"]) .source-tab {
+  padding: 2px 20px 2px 12px;
+  margin: 6px 0 0 8px;
+}
+
+html[dir="rtl"] .source-tab {
+  padding: 2px 12px 2px 20px;
+  margin: 6px 8px 0 0;
 }
 
 .source-tab:hover {
@@ -51,8 +59,15 @@
 
 .source-tab .close-btn {
   position: absolute;
-  right: 4px;
   top: 3px;
+}
+
+html:not([dir="rtl"]) .source-tab .close-btn {
+  right: 4px;
+}
+
+html[dir="rtl"] .source-tab .close-btn {
+  left: 4px;
 }
 
 .source-tab .close {

--- a/public/js/components/Sources.css
+++ b/public/js/components/Sources.css
@@ -13,7 +13,8 @@
 .sources-header {
   height: 30px;
   border-bottom: 1px solid var(--theme-splitter-color);
-  padding: 0 10px;
+  padding-top: 0px;
+  padding-bottom: 0px;
   line-height: 30px;
   font-size: 1.2em;
   display: flex;
@@ -23,6 +24,14 @@
   user-select: none;
 }
 
+html:not([dir="rtl"]) .sources-header {
+  padding-left: 10px;
+}
+
+html[dir="rtl"] .sources-header {
+  padding-right: 10px;
+}
+
 .sources-header-info {
   font-size: 12px;
   color: var(--theme-comment-alt);
@@ -30,44 +39,20 @@
   white-space: nowrap;
 }
 
+html:not([dir="rtl"]) .sources-header-info {
+  padding-right: 10px;
+  float: right;
+}
+
+html[dir="rtl"] .sources-header-info {
+  padding-left: 10px;
+  float: left;
+}
+
 .sources-list {
   flex: 1;
   display: flex;
   overflow: hidden;
-}
-
-ul.sources-list {
-  list-style: none;
-  margin: 20px 0;
-  padding: 0;
-  padding-left: 10px;
-  flex: 1;
-  white-space: nowrap;
-}
-
-.sources-list ul {
-  list-style: none;
-  margin: 0.5em 0;
-  padding: 0;
-}
-
-.sources-list .source-item {
-  list-style: none;
-  white-space: nowrap;
-}
-
-.sources-list .label {
-  font-size: 1em;
-  padding-left: 10px;
-  color: var(--theme-comment);
-}
-
-.sources-list .source-item.selected {
-  background-color: var(--theme-selection-background);
-}
-
-.sources-list .source-item.selected .label {
-  color: var(--theme-selection-color);
 }
 
 .arrow,
@@ -95,12 +80,24 @@ ul.sources-list {
 .folder svg,
 .worker svg {
   width: 15px;
-  margin-right: 5px;
 }
 
 .file svg {
   width: 13px;
+}
+
+html:not([dir="rtl"]) .file svg,
+html:not([dir="rtl"]) .domain svg,
+html:not([dir="rtl"]) .folder svg,
+html:not([dir="rtl"]) .worker svg {
   margin-right: 5px;
+}
+
+html[dir="rtl"] .file svg,
+html[dir="rtl"] .domain svg,
+html[dir="rtl"] .folder svg,
+html[dir="rtl"] .worker svg {
+  margin-left: 5px;
 }
 
 .tree {

--- a/public/js/components/utils/ManagedTree.css
+++ b/public/js/components/utils/ManagedTree.css
@@ -24,8 +24,12 @@
   background-color: var(--theme-selection-background);
 }
 
-.tree .node > div {
+html:not([dir="rtl"]) .tree .node > div {
   margin-left: 10px;
+}
+
+html[dir="rtl"] .tree .node > div {
+  margin-right: 10px;
 }
 
 .tree .node.focused svg {


### PR DESCRIPTION
Associated Issue: #867 

### Summary of Changes

1. I chose to use html[dir="rtl"] as an indicator for RTL. The :dir pseudo-class is only supported in Firefox, so I wasn't sure if it's a good choice. I have a feeling you're going to tell me to go with :dir :-)

2. I explicitly separated directional properties to html:not([dir="rtl"]) for (a) declarative style (b) avoid property reset under the RTL rule. I felt it was too verbose, but better than the alternative.
e.g. 
```
.some-class {
  width: 10px;
  margin-left: 8px;
}
```
becomes:
```
.some-class {
  width: 10px;
}

html:not([dir="rtl"]) .some-class {
  margin-left: 8px;
}

html[dir="rtl"] .some-class {
  margin-right: 8px;
}
```

3. I want to raise my concern about the ability to maintain this. Maybe unit test coverage can help, but I would suggest some automatic generation of RTL css through annotations or something. Or, I would question the RTL requirement altogether.

4. ObjectInspector.css : `.arrow.expanded` rule needed attention due to specificity issue. I didn't like the solution (see TODO).

5. `.commad-bar` rules exist in both RightSidebar.css and SourceFooter.css

6. Sources.css had some seemingly unused styles around UL and .source-item so I removed them.

7. The icons with class name file/domain/folder/worker all have the same rules. I suggest adding a class ("icon?") to consolidate. I can do this, just didn't want it to be part of this pull request and also wanted to know your opinion.

8. `.source-footer` is visually over the splitter on the right side. Not sure if this is intentional, but changing to right:2px fixes it.

9. "⌘+P to search" : currently doesn't render well. When introducing string translations, I suggest placing the "⌘+P" in a separate span with direction:ltr

10. Still need work: breakpoint, call stack, scopes.

11. Sources tree indentation: need to change paddingLeft to paddingRight in SourcesTree.js:113. I didn't know what would be your preferred way to detect RTL in js, but I didn't want to do what SplitBox does: `win.getComputedStyle(doc.documentElement).direction`.

### Testing

* [x] passes `npm test`
* [x] passes `npm run lint`
