### PR TITLE
Align breakpoint-list highlight color with codemirror

### DIFF
--- a/public/js/components/Breakpoints.css
+++ b/public/js/components/Breakpoints.css
@@ -6,8 +6,7 @@
 .breakpoints-list .breakpoint {
   font-size: 12px;
   color: var(--theme-content-color1);
-  margin: 0.25em 0;
-  padding: 0.25em 1px 0 0;
+  padding: 0.5em 1px;
   line-height: 1em;
   position: relative;
 }
@@ -17,7 +16,7 @@
 }
 
 .breakpoints-list .breakpoint.paused {
-  background-color: var(--theme-toolbar-background-alt);
+  background-color: var(--breakpoint-active-color);
 }
 
 .breakpoints-list .breakpoint.disabled .breakpoint-label {
@@ -28,6 +27,11 @@
 .breakpoints-list .breakpoint:hover {
   cursor: pointer;
   background-color: var(--theme-toolbar-background);
+}
+
+.breakpoints-list .breakpoint.paused:hover {
+  cursor: pointer;
+  background-color: var(--breakpoint-active-color-hover);
 }
 
 .breakpoints-list .breakpoint-label {

--- a/public/js/lib/codemirror-mozilla.css
+++ b/public/js/lib/codemirror-mozilla.css
@@ -6,6 +6,7 @@
   /* --breakpoint-background: url("chrome://devtools/skin/images/breakpoint.svg#light"); */
   /* --breakpoint-hover-background: url("chrome://devtools/skin/images/breakpoint.svg#light-hover"); */
   --breakpoint-active-color: rgba(44,187,15,.2);
+  --breakpoint-active-color-hover: rgba(44,187,15,.5);
   /* --breakpoint-conditional-background: url("chrome://devtools/skin/images/breakpoint.svg#light-conditional"); */
 }
 
@@ -13,6 +14,7 @@
   /* --breakpoint-background: url("chrome://devtools/skin/images/breakpoint.svg#dark"); */
   /* --breakpoint-hover-background: url("chrome://devtools/skin/images/breakpoint.svg#dark-hover"); */
   --breakpoint-active-color: rgba(112,191,83,.4);
+  --breakpoint-active-color: rgba(112,191,83,.7);
   /* --breakpoint-conditional-background: url("chrome://devtools/skin/images/breakpoint.svg#dark-conditional"); */
 }
 


### PR DESCRIPTION
Associated Issue: #871 

### Summary of Changes

* `.breakpoints-list .breakpoint.paused` will use `--breakpoint-active-color` to highlight
* Adds `--breakpoint-active-color-hover` variable, and uses this when the user hovers over a `.breakpoints-list .breakpoint.paused`
* Also switches `.breakpoints-list .breakpoint` from using`margin` and `padding` to just `padding` so that the highlight color wraps the entire breakpoint without awkward whitespace

### Testing

* [x] passes `npm test`
* [x] passes `npm run lint`

### Screenshots
#### Before
![screen shot 2016-10-09 at 3 49 17 pm](https://cloud.githubusercontent.com/assets/1445834/19223202/224898d0-8e38-11e6-86a6-225202e61c21.png)
**Awkward whitespace issue is more prominent when we turn the breakpoint blue**
-![screen shot 2016-10-09 at 3 49 09 pm](https://cloud.githubusercontent.com/assets/1445834/19223204/254c4374-8e38-11e6-9519-22e849187d20.png)
#### After
![screen shot 2016-10-09 at 3 50 10 pm](https://cloud.githubusercontent.com/assets/1445834/19223207/42d90ff8-8e38-11e6-86a0-0fae96c4153e.png)
**Hover color**
![screen shot 2016-10-09 at 3 50 25 pm](https://cloud.githubusercontent.com/assets/1445834/19223209/487806e4-8e38-11e6-9cdf-941e3ac36747.png)



