### PR TITLE
Fix breakpoint var name typo on dark mode

### DIFF
--- a/public/js/lib/codemirror-mozilla.css
+++ b/public/js/lib/codemirror-mozilla.css
@@ -14,7 +14,7 @@
   /* --breakpoint-background: url("chrome://devtools/skin/images/breakpoint.svg#dark"); */
   /* --breakpoint-hover-background: url("chrome://devtools/skin/images/breakpoint.svg#dark-hover"); */
   --breakpoint-active-color: rgba(112,191,83,.4);
-  --breakpoint-active-color: rgba(112,191,83,.7);
+  --breakpoint-active-color-hover: rgba(112,191,83,.7);
   /* --breakpoint-conditional-background: url("chrome://devtools/skin/images/breakpoint.svg#dark-conditional"); */
 }
 


### PR DESCRIPTION
Associated issue: #871 

### Summary of Changes

In https://github.com/devtools-html/debugger.html/pull/907 I accidentally overrode `--breakpoint-active-color` in dark mode instead of adding `--breakpoint-active-color-hover`. This fixes the error.

### Testing

* [x] passes `npm test`
* [x] passes `npm run lint`
