### PR TITLE
Call out active breakpoint with border

### DIFF
--- a/public/js/components/Breakpoints.css
+++ b/public/js/components/Breakpoints.css
@@ -9,6 +9,8 @@
   padding: 0.5em 1px;
   line-height: 1em;
   position: relative;
+  border-left: 4px solid transparent;
+
 }
 
 .breakpoints-list .breakpoint:last-of-type {
@@ -16,7 +18,8 @@
 }
 
 .breakpoints-list .breakpoint.paused {
-  background-color: var(--breakpoint-active-color);
+  background-color: var(--theme-toolbar-background-alt);
+  border-color: var(--breakpoint-active-color);
 }
 
 .breakpoints-list .breakpoint.disabled .breakpoint-label {
@@ -30,8 +33,11 @@
 }
 
 .breakpoints-list .breakpoint.paused:hover {
-  cursor: pointer;
-  background-color: var(--breakpoint-active-color-hover);
+  border-color: var(--breakpoint-active-color-hover);
+}
+
+.breakpoints-list .breakpoint-checkbox {
+  margin-left: 0;
 }
 
 .breakpoints-list .breakpoint-label {
@@ -47,7 +53,7 @@
 
 .breakpoint-snippet {
   color: var(--theme-comment);
-  padding-left: 22px;
+  padding-left: 18px;
 }
 
 .breakpoint .close-btn {

--- a/public/js/components/Breakpoints.js
+++ b/public/js/components/Breakpoints.js
@@ -91,6 +91,7 @@ const Breakpoints = React.createClass({
       },
       dom.input({
         type: "checkbox",
+        className: "breakpoint-checkbox",
         checked: !isDisabled,
         onChange: () => this.handleCheckbox(breakpoint)
       }),


### PR DESCRIPTION
Turns out that using a `border` was easier than a `::before` element. Its `height` wasn't cooperating at `100%`, and I wasn't sure if setting something like `height: 95%` would be reliable. A `border`, on the other hand, seems to be rendering correctly.

Associated Issue: #871 

### Summary of Changes
![screen shot 2016-10-10 at 1 51 59 pm](https://cloud.githubusercontent.com/assets/1445834/19245956/e7ccc5f4-8ef1-11e6-9284-db3ed3a07f83.png)


* Resets the background color of `.breakpoint.paused` to its state before 6441b2 
* Adds a transparent `border-left` to `.breakpoint`s, which turns `--breakpoint-active-color` on `.paused`
* Adjusts margins and padding to compensate for the border, including adding a new `.breakpoint-checkbox` class to the `<input>` and removing its `margin-left`

### Testing

* [x] passes `npm test`
* [x] passes `npm run lint`

### Screenshots/Videos
![screen shot 2016-10-10 at 1 51 59 pm](https://cloud.githubusercontent.com/assets/1445834/19245965/f489dd7c-8ef1-11e6-8eb0-c15e3b785d1d.png)
**Hover**
![screen shot 2016-10-10 at 1 52 25 pm](https://cloud.githubusercontent.com/assets/1445834/19245959/ecca82ee-8ef1-11e6-8c3f-27553de275c9.png)


