### PR TITLE
Display Window or Global on Window class reps

### DIFF
--- a/public/js/components/Scopes.js
+++ b/public/js/components/Scopes.js
@@ -120,13 +120,11 @@ function getScopes(pauseInfo, selectedFrame) {
         scopes.push({ name: title, path: key, contents: vars });
       }
     } else if (type === "object") {
-      const value = scope.object;
-      // Override preview for Window object
+      let value = scope.object;
+      // If this is the global window scope, mark it as such so that it will
+      // preview Window: Global instead of Window: Window
       if (value.class === "Window") {
-        value.preview = {
-          kind: "Window",
-          isGlobal: true
-        };
+        value = Object.assign({}, scope.object, { isGlobal: true });
       }
       scopes.push({
         name: scope.object.class,

--- a/public/js/components/Scopes.js
+++ b/public/js/components/Scopes.js
@@ -120,10 +120,18 @@ function getScopes(pauseInfo, selectedFrame) {
         scopes.push({ name: title, path: key, contents: vars });
       }
     } else if (type === "object") {
+      const value = scope.object;
+      // Override preview for Window object
+      if (value.class === "Window") {
+        value.preview = {
+          kind: "Window",
+          isGlobal: true
+        };
+      }
       scopes.push({
         name: scope.object.class,
         path: key,
-        contents: { value: scope.object }
+        contents: { value }
       });
     }
   } while (scope = scope.parent); // eslint-disable-line no-cond-assign

--- a/public/js/lib/devtools/client/shared/components/reps/window.js
+++ b/public/js/lib/devtools/client/shared/components/reps/window.js
@@ -37,8 +37,8 @@ define(function (require, exports, module) {
       return "";
     },
 
-    getLocation: function (grip) {
-      return getURLDisplayString(grip.preview.url);
+    getDisplayValue: function (grip) {
+      return grip.preview.isGlobal ? "Global" : "Window";
     },
 
     render: function () {
@@ -48,7 +48,7 @@ define(function (require, exports, module) {
         DOM.span({className: "objectBox objectBox-Window"},
           this.getTitle(grip),
           DOM.span({className: "objectPropValue"},
-            this.getLocation(grip)
+            this.getDisplayValue(grip)
           )
         )
       );

--- a/public/js/lib/devtools/client/shared/components/reps/window.js
+++ b/public/js/lib/devtools/client/shared/components/reps/window.js
@@ -24,6 +24,7 @@ define(function (require, exports, module) {
 
     propTypes: {
       object: React.PropTypes.object.isRequired,
+      mode: React.PropTypes.string
     },
 
     getTitle: function (grip) {
@@ -37,8 +38,16 @@ define(function (require, exports, module) {
       return "";
     },
 
+    getLocation: function (grip) {
+      return getURLDisplayString(grip.preview.url);
+    },
+
     getDisplayValue: function (grip) {
-      return grip.preview.isGlobal ? "Global" : "Window";
+      if (this.props.mode === "tiny") {
+        return grip.isGlobal ? "Global" : "Window";
+      } else {
+        return this.getLocation(grip);
+      }
     },
 
     render: function () {


### PR DESCRIPTION
Associated Issue: #884 

### Summary of Changes

* Window rep will display either `"Window"` or `"Global"` depending on whether its preview has a truthy `isGlobal` property or not
* Top-level Window will override its preview to `{ kind: "Window", isGlobal: true }`

### Notes

This feels like a hack to me, and I'm submitting this PR more to start a discussion than because I'm confident in its ability to fix the issue. I don't understand the code path that renders the reps very well, but this is what I was able to figure out.

The problem that I found is that the top-level Window — the one we want to say `Global` — has a `preview` with `{ kind: "ObjectWithURL" }` rather than `{ kind: "Window" }`. But, apparently, the `view` property in `e` is correctly marked as `{ kind: "Window" }`. I have no idea why it is, or where the `view` property is even coming from, because it's not present in `getBindingVariables`. It seems to be added at some step before the final render, but I wasn't able to track that down.

So that's why I'm not super confident in this fix. It operates under the assumption that if a scope of type `"object"` has a class of `"Window"`, then it must be the global `Window`. I don't know if this is always going to be true. It also doesn't fix the underlying problem of why the global `Window` is being generated with the wrong kind of preview in the first place, which I also wasn't able to track down.

### Testing

* [x] passes `npm test`
* [x] passes `npm run lint`

### Screenshots
![screen shot 2016-10-10 at 2 56 46 pm](https://cloud.githubusercontent.com/assets/1445834/19247622/0f3b0d6e-8efa-11e6-8c55-79260f8c1c4a.png)