### PR TITLE
Add conditional breakpoints

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -2,6 +2,7 @@
 .*node_modules/cjson.*
 .*node_modules/fbjs.*
 .*node_modules/npm.*
+.*node_modules/config-chain.*
 .*firefox/.*
 
 [options]

--- a/packages/devtools-config/configs/development.json
+++ b/packages/devtools-config/configs/development.json
@@ -11,7 +11,8 @@
     "sourceMaps": true,
     "prettyPrint": true,
     "watchExpressions": false,
-    "search": true
+    "search": true,
+    "conditionalBreakpoints": true
   },
   "chrome": {
     "debug": true,

--- a/packages/devtools-sham-modules/shared/client/main.js
+++ b/packages/devtools-sham-modules/shared/client/main.js
@@ -3070,7 +3070,7 @@ BreakpointClient.prototype = {
   /**
    * Set the condition of this breakpoint
    */
-  setCondition: function(gThreadClient, aCondition) {
+  setCondition: function(gThreadClient, aCondition, noSliding) {
     let root = this._client.mainRoot;
     let deferred = promise.defer();
 
@@ -3078,7 +3078,8 @@ BreakpointClient.prototype = {
       let info = {
         line: this.location.line,
         column: this.location.column,
-        condition: aCondition
+        condition: aCondition,
+        noSliding
       };
 
       // Remove the current breakpoint and add a new one with the

--- a/public/js/actions/breakpoints.js
+++ b/public/js/actions/breakpoints.js
@@ -180,28 +180,29 @@ function toggleAllBreakpoints(shouldDisableBreakpoints: Boolean) {
  *        The condition to set on the breakpoint
  */
 function setBreakpointCondition(location: Location, condition: string) {
-  throw new Error("not implemented");
+  return ({ dispatch, getState, client }: ThunkArgs) => {
+    const bp = getBreakpoint(getState(), location);
+    if (!bp) {
+      throw new Error("Breakpoint does not exist at the specified location");
+    }
+    if (bp.loading) {
+      // TODO(jwl): when this function is called, make sure the action
+      // creator waits for the breakpoint to exist
+      throw new Error("breakpoint must be saved");
+    }
 
-  // return ({ dispatch, getState, client }) => {
-  //   const bp = getBreakpoint(getState(), location);
-  //   if (!bp) {
-  //     throw new Error("Breakpoint does not exist at the specified location");
-  //   }
-  //   if (bp.get("loading")) {
-  //     // TODO(jwl): when this function is called, make sure the action
-  //     // creator waits for the breakpoint to exist
-  //     throw new Error("breakpoint must be saved");
-  //   }
-
-  //   return dispatch({
-  //     type: constants.SET_BREAKPOINT_CONDITION,
-  //     breakpoint: bp,
-  //     condition: condition,
-  //     [PROMISE]: Task.spawn(function* () {
-  //       yield client.setBreakpointCondition(bp.get("id"), condition);
-  //     })
-  //   });
-  // };
+    return dispatch({
+      type: constants.SET_BREAKPOINT_CONDITION,
+      breakpoint: bp,
+      condition: condition,
+      [PROMISE]: client.setBreakpointCondition(
+        bp.id,
+        location,
+        condition,
+        isOriginalId(bp.location.sourceId)
+      )
+    });
+  };
 }
 
 module.exports = {

--- a/public/js/actions/types.js
+++ b/public/js/actions/types.js
@@ -48,6 +48,12 @@ export type Breakpoint = {
   condition: ?string,
 };
 
+type BreakpointResult = {
+  actualLocation: Location,
+  id: string,
+  text: string
+}
+
 /**
  * Source Text
  *
@@ -66,7 +72,7 @@ type BreakpointAction =
     condition: string,
     status: AsyncStatus,
     error: string,
-    value: { actualLocation: Location, id: string, text: string } }
+    value: BreakpointResult}
   | { type: "REMOVE_BREAKPOINT",
       breakpoint: Breakpoint,
       status: AsyncStatus,
@@ -76,6 +82,7 @@ type BreakpointAction =
       breakpoint: Breakpoint,
       condition: string,
       status: AsyncStatus,
+      value: BreakpointResult,
       error: string }
   | { type: "TOGGLE_BREAKPOINTS",
       shouldDisableBreakpoints: boolean,

--- a/public/js/components/Editor.css
+++ b/public/js/components/Editor.css
@@ -31,6 +31,10 @@
   right: -4px;
 }
 
+.new-breakpoint.has-condition svg {
+  fill: var(--theme-graphs-yellow);
+}
+
 .editor.new-breakpoint.breakpoint-disabled svg {
   opacity: 0.3;
 }
@@ -102,4 +106,25 @@
   z-index: 100;
   -moz-user-select: none;
   user-select: none;
+}
+
+.conditional-breakpoint-panel {
+  border-top: 1px solid var(--theme-gray);
+  border-bottom: 1px solid var(--theme-gray);
+  cursor: initial;
+  margin: 1em 0;
+  position: relative;
+}
+
+.conditional-breakpoint-panel .header {
+  background: var(--theme-toolbar-background);
+  color: var(--theme-body-color);
+  height: 2em;
+  padding: 0 0.5em;
+  line-height: 2em;
+}
+
+.conditional-breakpoint-panel input {
+  margin: 1em;
+  width: calc(100% - 2em);
 }

--- a/public/js/components/EditorBreakpoint.js
+++ b/public/js/components/EditorBreakpoint.js
@@ -29,17 +29,22 @@ const Breakpoint = React.createClass({
   addBreakpoint() {
     const bp = this.props.breakpoint;
     const line = bp.location.line - 1;
+
     this.props.editor.setGutterMarker(
       line,
       "breakpoints",
       makeMarker(bp.disabled)
     );
     this.props.editor.addLineClass(line, "line", "new-breakpoint");
+    if (bp.condition) {
+      this.props.editor.addLineClass(line, "line", "has-condition");
+    }
   },
 
   shouldComponentUpdate(nextProps) {
     return this.props.editor !== nextProps.editor ||
-      this.props.breakpoint.disabled !== nextProps.breakpoint.disabled;
+      this.props.breakpoint.disabled !== nextProps.breakpoint.disabled ||
+      this.props.breakpoint.condition !== nextProps.breakpoint.condition;
   },
 
   componentDidMount() {
@@ -64,6 +69,7 @@ const Breakpoint = React.createClass({
 
     this.props.editor.setGutterMarker(line, "breakpoints", null);
     this.props.editor.removeLineClass(line, "line", "new-breakpoint");
+    this.props.editor.removeLineClass(line, "line", "has-condition");
   },
 
   render() {

--- a/public/js/reducers/breakpoints.js
+++ b/public/js/reducers/breakpoints.js
@@ -142,6 +142,7 @@ function update(state = State(), action: Action) {
       } else if (action.status === "done") {
         const bp = state.breakpoints.get(id);
         return state.setIn(["breakpoints", id], updateObj(bp, {
+          id: action.value.id,
           loading: false
         }));
       } else if (action.status === "error") {


### PR DESCRIPTION
Associated Issue: #101

### Summary of Changes

I paired with Giorgio @ppold on this feature last night. This PR is an initial conditional breakpoints implementation, it satisfies the basic requirements and will be polished in subsequent PRs.

User steps:
* click to add a breakpoint
* cmd+click to edit breakpoint
* add a condition
* enter to save

Next steps:
* clicking on the breakpoint while the panel is open should close the panel and remove the breakpoint
* the panel input should be focused when the panel is opened
* style the panel. Perhaps move the description to input placeholder text (shorten dramatically)
* perhaps add a close button
* perhaps update the breakpoint in the breakpoint list to either show it's a conditional or show the condition. Chrome does not do anything here...

### Screenshots/Videos 

![](http://g.recordit.co/LbZV3IVNOz.gif)