### PR TITLE
remove `babel` dependency since it's moved to `babel-cli`

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
   },
   "devDependencies": {
     "amd-loader": "0.0.5",
-    "babel": "^6.5.2",
     "babel-cli": "^6.7.5",
     "babel-core": "^6.17.0",
     "babel-eslint": "^6.1.2",


### PR DESCRIPTION
the `babel` package in 6.x currently doesn't do anything, so you should be seeing the deprecation message from `babel` (noticed this from seeing https://github.com/yarnpkg/yarn/issues/638)

```
warning babel@6.5.2: Babel's CLI commands have been moved from the babel package to the babel-cli package
```

As an aside I don't `babel-preset-es2015` or `babel-preset-stage-0` being used atm? (and maybe give 
https://github.com/babel/babel-preset-env a shot)