### PR TITLE
547 toggle breakpoint preserve state  rework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ build
 node_modules
 config/local.json
 npm-debug.log
+lerna-debug.log
 .idea/
 .vscode/
 /firefox

--- a/packages/devtools-local-toolbox/public/js/clients/chrome/commands.js
+++ b/packages/devtools-local-toolbox/public/js/clients/chrome/commands.js
@@ -75,6 +75,11 @@ function removeBreakpoint(breakpointId) {
   });
 }
 
+function toggleAllBreakpoints(shouldDisableBreakpoints, breakpoints) {
+  return debuggerAgent.setBreakpointsActive(!shouldDisableBreakpoints)
+  .then(() => []);
+}
+
 function evaluate(script) {
   return runtimeAgent.evaluate(script, (_, result) => {
     return result;
@@ -102,6 +107,7 @@ const clientCommands = {
   sourceContents,
   setBreakpoint,
   removeBreakpoint,
+  toggleAllBreakpoints,
   evaluate,
   debuggeeCommand,
   navigate

--- a/public/js/actions/types.js
+++ b/public/js/actions/types.js
@@ -45,7 +45,7 @@ export type Breakpoint = {
   loading: boolean,
   disabled: boolean,
   text: string,
-  condition: ?string
+  condition: ?string,
 };
 
 /**
@@ -76,7 +76,12 @@ type BreakpointAction =
       breakpoint: Breakpoint,
       condition: string,
       status: AsyncStatus,
-      error: string };
+      error: string }
+  | { type: "TOGGLE_BREAKPOINTS",
+      shouldDisableBreakpoints: boolean,
+      status: AsyncStatus,
+      error: string,
+      value: any };
 
 type SourceAction =
   { type: "ADD_SOURCE", source: Source }

--- a/public/js/reducers/breakpoints.js
+++ b/public/js/reducers/breakpoints.js
@@ -110,6 +110,19 @@ function update(state = State(), action: Action) {
       if (action.status === "start") {
         return state.set(
           "breakpointsDisabled", action.shouldDisableBreakpoints);
+      } else if (action.status === "done") {
+        return action.value.reduce((updatedState, bp) => {
+          const locationId = makeLocationId(bp.actualLocation);
+          const breakpoint = updatedState.breakpoints.get(locationId);
+          const bpId = bp.id;
+
+          return updatedState.setIn(["breakpoints", locationId],
+            updateObj(breakpoint, {
+              disabled: action.shouldDisableBreakpoints,
+              id: bpId
+            })
+          );
+        }, state);
       }
       break;
     }

--- a/public/js/reducers/breakpoints.js
+++ b/public/js/reducers/breakpoints.js
@@ -107,24 +107,7 @@ function update(state = State(), action: Action) {
     }
 
     case "TOGGLE_BREAKPOINTS": {
-      if (action.status === "start") {
-        return state.set(
-          "breakpointsDisabled", action.shouldDisableBreakpoints);
-      } else if (action.status === "done") {
-        return action.value.reduce((updatedState, bp) => {
-          const locationId = makeLocationId(bp.actualLocation);
-          const breakpoint = updatedState.breakpoints.get(locationId);
-          const bpId = bp.id;
-
-          return updatedState.setIn(["breakpoints", locationId],
-            updateObj(breakpoint, {
-              disabled: action.shouldDisableBreakpoints,
-              id: bpId
-            })
-          );
-        }, state);
-      }
-      break;
+      return toggleBreakpoints(state, action);
     }
 
     case "SET_BREAKPOINT_CONDITION": {
@@ -149,6 +132,26 @@ function update(state = State(), action: Action) {
     }}
 
   return state;
+}
+
+function toggleBreakpoints(state: any, action: any) {
+  if (action.status === "start") {
+    return state.set(
+      "breakpointsDisabled", action.shouldDisableBreakpoints);
+  } else if (action.status === "done") {
+    return action.value.reduce((updatedState, bp) => {
+      const locationId = makeLocationId(bp.actualLocation);
+      const breakpoint = updatedState.breakpoints.get(locationId);
+      const bpId = bp.id;
+
+      return updatedState.setIn(["breakpoints", locationId],
+        updateObj(breakpoint, {
+          disabled: action.shouldDisableBreakpoints,
+          id: bpId
+        })
+      );
+    }, state);
+  }
 }
 
 // Selectors

--- a/public/js/reducers/breakpoints.js
+++ b/public/js/reducers/breakpoints.js
@@ -107,7 +107,27 @@ function update(state = State(), action: Action) {
     }
 
     case "TOGGLE_BREAKPOINTS": {
-      return toggleBreakpoints(state, action);
+      if (action.status === "start") {
+        return state.set(
+          "breakpointsDisabled", action.shouldDisableBreakpoints
+        );
+      } else if (action.status === "done") {
+        const shouldDisable = action.shouldDisableBreakpoints;
+
+        return action.value.reduce((updatedState, bp) => {
+          const locationId = makeLocationId(bp.actualLocation);
+          const breakpoint = updatedState.breakpoints.get(locationId);
+
+          return updatedState.setIn(
+            ["breakpoints", locationId],
+            updateObj(breakpoint, {
+              disabled: shouldDisable,
+              id: bp.id
+            })
+          );
+        }, state);
+      }
+      break;
     }
 
     case "SET_BREAKPOINT_CONDITION": {
@@ -132,26 +152,6 @@ function update(state = State(), action: Action) {
     }}
 
   return state;
-}
-
-function toggleBreakpoints(state: any, action: any) {
-  if (action.status === "start") {
-    return state.set(
-      "breakpointsDisabled", action.shouldDisableBreakpoints);
-  } else if (action.status === "done") {
-    return action.value.reduce((updatedState, bp) => {
-      const locationId = makeLocationId(bp.actualLocation);
-      const breakpoint = updatedState.breakpoints.get(locationId);
-      const bpId = bp.id;
-
-      return updatedState.setIn(["breakpoints", locationId],
-        updateObj(breakpoint, {
-          disabled: action.shouldDisableBreakpoints,
-          id: bpId
-        })
-      );
-    }, state);
-  }
 }
 
 // Selectors

--- a/public/js/types.js
+++ b/public/js/types.js
@@ -36,7 +36,8 @@ const Breakpoint = t.struct({
 
 const BreakpointResult = t.struct({
   id: t.String,
-  actualLocation: Location
+  actualLocation: Location,
+  condition: t.union([t.String, t.Nil])
 });
 
 const Frame = t.struct({


### PR DESCRIPTION
Associated Issue: #547

### Summary of Changes

* Implement the toggleAllBreakpoint feature for Firefox and Chrome
* Minor changes on `actions/breakpoints.js`
* Rework of the Firefox `commands.js` file to keep disabled breakpoints in memory, used when enabling all breakpoints again

### Testing

* [x] passes `npm test`
* [x] passes `npm run lint`

### Screenshots/Videos (OPTIONAL)
