### PR TITLE
Fix pretty-printing & enable it

### DIFF
--- a/packages/devtools-config/configs/development.json
+++ b/packages/devtools-config/configs/development.json
@@ -9,7 +9,7 @@
   "features": {
     "tabs": true,
     "sourceMaps": true,
-    "prettyPrint": false,
+    "prettyPrint": true,
     "watchExpressions": false,
     "search": true
   },

--- a/packages/devtools-config/configs/firefox-panel.json
+++ b/packages/devtools-config/configs/firefox-panel.json
@@ -5,6 +5,7 @@
   "clientLogging": false,
   "features": {
     "tabs": true,
-    "sourceMaps": true
+    "sourceMaps": true,
+    "prettyPrint": true
   }
 }

--- a/public/js/components/SourceFooter.js
+++ b/public/js/components/SourceFooter.js
@@ -9,7 +9,7 @@ const { getSelectedSource, getSourceText, getPrettySource } = require("../select
 const Svg = require("./utils/Svg");
 const ImPropTypes = require("react-immutable-proptypes");
 const classnames = require("classnames");
-const { isOriginalId, originalToGeneratedId } = require("../utils/source-map");
+const { isOriginalId } = require("../utils/source-map");
 const { isPretty } = require("../utils/source");
 const { find, findNext, findPrev } = require("../utils/source-search");
 
@@ -49,18 +49,7 @@ const SourceFooter = React.createClass({
   },
 
   onClickPrettyPrint() {
-    const { selectedSource, togglePrettyPrint,
-            selectSource, prettySource } = this.props;
-
-    if (isPretty(selectedSource.toJS())) {
-      return selectSource(originalToGeneratedId(selectedSource.get("id")));
-    }
-
-    if (selectedSource.get("isPrettyPrinted")) {
-      return selectSource(prettySource.get("id"));
-    }
-
-    togglePrettyPrint(selectedSource.get("id"));
+    this.props.togglePrettyPrint(this.props.selectedSource.get("id"));
   },
 
   prettyPrintButton() {

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -35,8 +35,6 @@ window.actions = {
   selectSourceURL: actions.selectSourceURL
 };
 
-const sourceMap = require("./utils/source-map");
-
 function unmountRoot() {
   const mount = document.querySelector("#mount");
   ReactDOM.unmountComponentAtNode(mount);
@@ -45,6 +43,9 @@ function unmountRoot() {
 if (isDevelopment()) {
   bootstrap(React, ReactDOM, App, actions, store);
 } else if (isFirefoxPanel()) {
+  const sourceMap = require("./utils/source-map");
+  const prettyPrint = require("./utils/pretty-print");
+
   module.exports = {
     bootstrap: ({ threadClient, tabTarget }) => {
       firefox.setThreadClient(threadClient);
@@ -55,6 +56,7 @@ if (isDevelopment()) {
     destroy: () => {
       unmountRoot();
       sourceMap.destroyWorker();
+      prettyPrint.destoryWorker();
     },
     store: store,
     actions: actions,

--- a/public/js/reducers/sources.js
+++ b/public/js/reducers/sources.js
@@ -77,14 +77,6 @@ function update(state = State(), action: Action) : Record<SourcesState> {
       break;
 
     case "TOGGLE_PRETTY_PRINT":
-      if (action.status === "done") {
-        return _updateText(state, action)
-          .setIn(
-            ["sources", action.source.id, "isPrettyPrinted"],
-            action.value.isPrettyPrinted
-          );
-      }
-
       return _updateText(state, action);
 
     case "NAVIGATE":

--- a/public/js/utils/pretty-print-worker.js
+++ b/public/js/utils/pretty-print-worker.js
@@ -1,10 +1,5 @@
 const prettyFast = require("pretty-fast");
-
-self.onmessage = function(msg) {
-  let { code, mappings } = prettyPrint(msg.data);
-  mappings = invertMappings(mappings);
-  self.postMessage({ code, mappings });
-};
+const assert = require("./assert");
 
 function prettyPrint({ url, indent, source }) {
   try {
@@ -41,3 +36,18 @@ function invertMappings(mappings) {
     return mapping;
   });
 }
+
+self.onmessage = function(msg) {
+  const { id, args } = msg.data;
+  assert(msg.data.method === "prettyPrint",
+        "Method must be `prettyPrint`");
+
+  try {
+    let { code, mappings } = prettyPrint(args[0]);
+    self.postMessage({ id, response: {
+      code, mappings: invertMappings(mappings)
+    }});
+  } catch (e) {
+    self.postMessage({ id, error: e });
+  }
+};

--- a/public/js/utils/pretty-print.js
+++ b/public/js/utils/pretty-print.js
@@ -1,0 +1,36 @@
+const { getValue } = require("devtools-config");
+const { workerTask } = require("./utils");
+const { isJavaScript } = require("./source");
+const assert = require("./assert");
+
+let prettyPrintWorker = new Worker(
+  getValue("baseWorkerURL") + "pretty-print-worker.js"
+);
+
+function destroyWorker() {
+  prettyPrintWorker.terminate();
+  prettyPrintWorker = null;
+}
+
+const _prettyPrint = workerTask(prettyPrintWorker, "prettyPrint");
+
+async function prettyPrint({ source, sourceText, url }) {
+  const contentType = sourceText ? sourceText.contentType : null;
+  const indent = 2;
+
+  assert(
+    isJavaScript(source.url, contentType),
+    "Can't prettify non-javascript files."
+  );
+
+  return await _prettyPrint({
+    url,
+    indent,
+    source: sourceText.text
+  });
+}
+
+module.exports = {
+  prettyPrint,
+  destroyWorker
+};

--- a/public/js/utils/source-map-worker.js
+++ b/public/js/utils/source-map-worker.js
@@ -208,8 +208,9 @@ self.onmessage = function(msg) {
   const response = publicInterface[method].apply(undefined, args);
   if (response instanceof Promise) {
     response.then(val => self.postMessage({ id, response: val }),
-                  err => self.postMessage({ id, response: err }));
+                  err => self.postMessage({ id, error: err }));
   } else {
     self.postMessage({ id, response });
   }
 };
+


### PR DESCRIPTION
This is a simple implementation of pretty-printing.

I intentionally simplified some of the logic. We should take this in steps, because there are some very weird situations with pretty-printing: if you pretty-print a generated source that has a sourcemap, do you "replace" its sourcemap? That would make sense, but then what happens to the old "original" source? In the old debugger this is temporary, and un-pretty-printing it would restore the old sourcemap. Various things like that.

Right now this only allows pretty-printing an unsourcemapped source. If it has a sourcemap, it replaces it.

Because sourcemaps work, all breakpoint/stepping/etc related things should "just work".