### PR TITLE
Disable highlight for non-experimental WebAssembly format.

### DIFF
--- a/public/js/components/Editor.js
+++ b/public/js/components/Editor.js
@@ -139,7 +139,7 @@ const Editor = React.createClass({
     if (contentType.includes("javascript")) {
       this.editor.setMode({ name: "javascript" });
     } else if (contentType === "text/wasm") {
-      this.editor.setMode({ name: "wasm" });
+      this.editor.setMode({ name: "text" });
     } else if (sourceText.get("text").match(/^\s*</)) {
       // Use HTML mode for files in which the first non whitespace
       // character is `<` regardless of extension.


### PR DESCRIPTION
Based on the [bug 1308510](https://bugzilla.mozilla.org/show_bug.cgi?id=1308510)

We decide to use non-experimental WebAssembly format in devtools. However formal grammar (and highlight rules) are not defined for it yet. Proposing to disable the wasm mode in the devtools editor.