### PR TITLE
Fix the dev server config loading issue

### DIFF
--- a/packages/devtools-local-toolbox/bin/development-server.js
+++ b/packages/devtools-local-toolbox/bin/development-server.js
@@ -52,7 +52,7 @@ function httpGet(url, onResponse) {
 const app = express();
 
 // Webpack middleware
-const webpackConfig = require("../webpack.config");
+const webpackConfig = require("../../../webpack.config");
 const compiler = webpack(webpackConfig);
 
 app.use(webpackDevMiddleware(compiler, {


### PR DESCRIPTION
Associated Issue: #936 (sort of)

### Summary of Changes

* while `npm install` still fails when run without `npm run preinstall` first, this fixes a config error by loading the right file. There may still be more work to do to get the issue closed and further documentation to write to improve things in regards to the mono-repo workflow, but this should at least get things working for most.

### Testing

* [x] passes `npm test`
* [x] passes `npm run lint`