### PR TITLE
Make development server work for node v5

### DIFF
--- a/packages/devtools-local-toolbox/bin/development-server.js
+++ b/packages/devtools-local-toolbox/bin/development-server.js
@@ -24,8 +24,9 @@ checkNode(">=5.0.0", function(_, opts) {
   }
 });
 
-const { getValue, isDevelopment } = require("devtools-config");
-const {registerConfig} = require("../../devtools-config/registerConfig");
+const getValue = require("devtools-config").getValue;
+const isDevelopment = require("devtools-config").isDevelopment;
+const registerConfig = require("../../devtools-config/registerConfig").registerConfig;
 registerConfig();
 
 


### PR DESCRIPTION
Associated Issue: no known associated issue number 🙃

### Summary of Changes

* Changes the ```const { foo } = require(..)``` syntax to ```const foo = require(...).foo``` in ```development-server.js```

### Testing

* [ ] passes `npm test` — note: not passing, because I'm on node v5:

```bash
> debugger.html@0.0.5 test /Users/hholmes/code/debugger.html
> node public/js/test/node-unit-tests.js

/Users/hholmes/code/debugger.html/public/js/test/node-unit-tests.js:11
const { registerConfig } = require("../../../packages/devtools-config/registerConfig");
      ^

SyntaxError: Unexpected token {
```

* [x] passes `npm run lint`

### Screenshots/Videos: N/A