### PR TITLE
Disable mochitests on linux32 debug

### DIFF
--- a/public/js/test/mochitest/browser.ini
+++ b/public/js/test/mochitest/browser.ini
@@ -1,6 +1,7 @@
 [DEFAULT]
 tags = devtools
 subsuite = devtools
+skip-if = (os == 'linux' && debug && bits == 32)
 support-files =
   head.js
   !/devtools/client/commandline/test/helpers.js


### PR DESCRIPTION
This change happened on mozilla-central but should have happened here. Linux32 debug is unable to run out tests, as its so slow even the smallest debugger test because intermittent because it runs so slowly. We ran into this on the old debugger and disabled those as well, so this isn't specific to the new debugger. We're still running the tests on linue32 opt, and linux64 debug and opt.