### PR TITLE
update flowconfig, use shared Source type

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -3,7 +3,3 @@
 .*node_modules/fbjs.*
 .*node_modules/npm.*
 .*firefox/.*
-
-[options]
-module.name_mapper='^Services$' -> '<PROJECT_ROOT>/public/js/lib/devtools/client/shared/shim/Services.js'
-module.name_mapper='^devtools/\(.+$\)' -> '<PROJECT_ROOT>/public/js/lib/devtools/\1.js'

--- a/public/js/utils/source.js
+++ b/public/js/utils/source.js
@@ -32,8 +32,7 @@ function isJavaScript(url: string, contentType: string = ""): boolean {
          contentType.includes("javascript");
 }
 
-// TODO: This should use a shared Source type
-function isPretty(source: {url: string}): boolean {
+function isPretty(source: Source): boolean {
   return source.url ? /formatted$/.test(source.url) : false;
 }
 


### PR DESCRIPTION
Associated Issue: #942

### Summary of Changes

* remove the options section from the flowconfig
* use the shared Source type, remove TODO

### Testing

* [x] passes `npm test`
* [x] passes `npm run lint`
