### PR TITLE
Fix scopes

### DIFF
--- a/packages/devtools-local-toolbox/webpack.config.devtools.js
+++ b/packages/devtools-local-toolbox/webpack.config.devtools.js
@@ -21,15 +21,22 @@ const nativeMapping = {
 };
 
 let packagesPath = path.join(__dirname, "../");
+let projectPath = path.join(__dirname, "../../");
 
 module.exports = webpackConfig => {
   webpackConfig.output.library = "Debugger";
 
   if (process.env.MOCHITESTS) {
-    webpackConfig.output.path = path.join(__dirname, "firefox/devtools/client/debugger/new");
+    webpackConfig.output.path = path.join(
+      projectPath,
+      "firefox/devtools/client/debugger/new"
+    );
   }
 
-  webpackConfig.resolve.alias["devtools-network-request"] = path.resolve(packagesPath, "devtools-network-request/privilegedNetworkRequest");
+  webpackConfig.resolve.alias["devtools-network-request"] = path.resolve(
+     packagesPath,
+     "devtools-network-request/privilegedNetworkRequest"
+  );
 
   function externalsTest(context, request, callback) {
     let mod = request;

--- a/packages/devtools-modules/index.js
+++ b/packages/devtools-modules/index.js
@@ -1,9 +1,9 @@
 const Services = require("./client/shared/shim/Services").Services;
-const SplitBox = require("./client/shared/components/splitter/SplitBox")
+const SplitBox = require("./client/shared/components/splitter/SplitBox");
 // const SplitBoxCSS = require("./client/shared/components/splitter/SplitBox.css")
-const rep = require("./client/shared/components/reps/rep");
+const rep = require("./client/shared/components/reps/rep").Rep;
 // const repCSS = require("./client/shared/components/reps/reps.css");
-const Grip = require("./client/shared/components/reps/grip");
+const Grip = require("./client/shared/components/reps/grip").Grip;
 
 module.exports = {
   Services,
@@ -12,4 +12,4 @@ module.exports = {
   rep,
   // repCSS,
   Grip
-}
+};

--- a/public/js/test/mochitest/.eslintrc
+++ b/public/js/test/mochitest/.eslintrc
@@ -64,6 +64,7 @@
     "removeBreakpoint": false,
     "addBreakpoint": false,
     "toggleCallStack": false,
+    "toggleScopes": false,
     "isVisibleWithin": false,
     "clickElement": false,
     "togglePauseOnExceptions": false,

--- a/public/js/test/mochitest/browser.ini
+++ b/public/js/test/mochitest/browser.ini
@@ -27,6 +27,7 @@ support-files =
 [browser_dbg-breaking.js]
 [browser_dbg-breaking-from-console.js]
 [browser_dbg-call-stack.js]
+[browser_dbg-scopes.js]
 [browser_dbg-chrome-create.js]
 [browser_dbg-chrome-debugging.js]
 [browser_dbg-console.js]

--- a/public/js/test/mochitest/browser_dbg-scopes.js
+++ b/public/js/test/mochitest/browser_dbg-scopes.js
@@ -1,0 +1,27 @@
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
+
+function toggleNode(dbg, index) {
+  clickElement(dbg, "scopeNode", index);
+}
+
+function getLabel(dbg, index) {
+  return findElement(dbg, "scopeNode", index).innerText;
+}
+
+add_task(function* () {
+  const dbg = yield initDebugger("doc-script-switching.html");
+
+  toggleScopes(dbg);
+
+  invokeInTab("firstCall");
+  yield waitForPaused(dbg);
+
+  toggleNode(dbg, 1);
+  toggleNode(dbg, 2);
+
+  yield waitForDispatch(dbg, "LOAD_OBJECT_PROPERTIES");
+
+  is(getLabel(dbg, 1), "secondCall");
+  is(getLabel(dbg, 2), "<this>");
+});

--- a/public/js/test/mochitest/head.js
+++ b/public/js/test/mochitest/head.js
@@ -558,6 +558,8 @@ function isVisibleWithin(outerEl, innerEl) {
 
 const selectors = {
   callStackHeader: ".call-stack-pane ._header",
+  scopesHeader: ".scopes-pane ._header",
+  scopeNode: i => `.scopes-list .tree-node:nth-child(${i}) .object-label`,
   frame: index => `.frames ul li:nth-child(${index})`,
   gutter: i => `.CodeMirror-code *:nth-child(${i}) .CodeMirror-linenumber`,
   pauseOnExceptions: ".pause-exceptions",
@@ -623,4 +625,8 @@ function clickElement(dbg, elementName, ...args) {
  */
 function toggleCallStack(dbg) {
   return findElement(dbg, "callStackHeader").click();
+}
+
+function toggleScopes(dbg) {
+  return findElement(dbg, "scopesHeader").click();
 }


### PR DESCRIPTION
This fixes an issue I was seeing expanding the scope pane. It also adds some tests to ensure that the Scopes and object properties load correctly. We likely want some other integration style tests where [getScopes](https://github.com/devtools-html/debugger.html/blob/master/public/js/components/Scopes.js#L75) is concerned.