### PR TITLE
move source search out of app into a separate component [WIP]

### DIFF
--- a/public/js/components/SourceSearch.css
+++ b/public/js/components/SourceSearch.css
@@ -1,0 +1,26 @@
+/* vim:set ts=2 sw=2 sts=2 et: */
+
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+.search-container {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  z-index: 200;
+  background-color: var(--theme-search-overlays-semitransparent);
+}
+
+.search-container .autocomplete {
+  flex: 1;
+}
+
+.search-container .close-button {
+  width: 16px;
+  margin-top: 25px;
+  margin-right: 20px;
+}

--- a/public/js/components/SourceSearch.js
+++ b/public/js/components/SourceSearch.js
@@ -1,0 +1,100 @@
+const React = require("react");
+const { DOM: dom, PropTypes, createFactory } = React;
+const { connect } = require("react-redux");
+const { bindActionCreators } = require("redux");
+const actions = require("../actions");
+const { getSources, getSelectedSource } = require("../selectors");
+const { endTruncateStr } = require("../utils/utils");
+const { parse: parseURL } = require("url");
+
+require("./SourceSearch.css");
+
+const Svg = require("./utils/Svg");
+const Autocomplete = createFactory(require("./Autocomplete"));
+
+function searchResults(sources) {
+  function getSourcePath(source) {
+    const { path } = parseURL(source.get("url"));
+    return endTruncateStr(path, 50);
+  }
+
+  return sources.valueSeq()
+    .filter(source => source.get("url"))
+    .map(source => ({
+      value: getSourcePath(source),
+      title: getSourcePath(source).split("/").pop(),
+      subtitle: getSourcePath(source),
+      id: source.get("id")
+    }))
+    .toJS();
+}
+
+const Search = React.createClass({
+  propTypes: {
+    sources: PropTypes.object,
+    selectSource: PropTypes.func,
+    selectedSource: PropTypes.object
+  },
+
+  contextTypes: {
+    shortcuts: PropTypes.object
+  },
+
+  displayName: "Search",
+
+  getInitialState() {
+    return {
+      searchOn: false
+    };
+  },
+
+  componentWillUnmount() {
+    const shortcuts = this.context.shortcuts;
+    shortcuts.off("CmdOrCtrl+P", this.toggle);
+    shortcuts.off("Escape", this.onEscape);
+  },
+
+  componentDidMount() {
+    const shortcuts = this.context.shortcuts;
+    shortcuts.on("CmdOrCtrl+P", this.toggle);
+    shortcuts.on("Escape", this.onEscape);
+  },
+
+  toggle(key, e) {
+    e.preventDefault();
+    this.setState({ searchOn: !this.state.searchOn });
+  },
+
+  onEscape(shortcut, e) {
+    if (this.state.searchOn) {
+      e.preventDefault();
+      this.setState({ searchOn: false });
+    }
+  },
+
+  close() {
+    this.setState({ searchOn: false });
+  },
+
+  render() {
+    return this.state.searchOn ?
+      dom.div({ className: "search-container" },
+      Autocomplete({
+        selectItem: result => {
+          this.props.selectSource(result.id);
+          this.setState({ searchOn: false });
+        },
+        items: searchResults(this.props.sources)
+      }),
+      dom.div({ className: "close-button" },
+      Svg("close", { onClick: this.close }))
+    ) : null;
+  }
+
+});
+
+module.exports = connect(
+  state => ({ sources: getSources(state),
+              selectedSource: getSelectedSource(state) }),
+  dispatch => bindActionCreators(actions, dispatch)
+)(Search);


### PR DESCRIPTION
Associated Issue: none

### Summary of Changes

* Move Source Search to its own component
  * I'd appreciate any review on this initial part
* [in progress] I'm working on saving the last thing you searched for in the input
  * For example, you search for `inc` and select the first item, it turns out to be wrong, so you search again but now you have to enter your search terms all over again.  I would like to re-run the last search but leave the text selected so you can easily start typing something else.
* [in progress] allow for tabbing to the next item when the search results are open

### Testing

* [x] passes `npm test`
* [x] passes `npm run lint`

### Screenshots/Videos (OPTIONAL)

Not yet.
