### PR TITLE
Fix fresh NPM install

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "co": "=4.6.0",
     "css-loader": "^0.25.0",
     "devtools-config": "^0.0.3",
-    "devtools-local-toolbox": "^0.0.3",
+    "devtools-local-toolbox": "^0.0.5",
     "devtools-modules": "^0.0.3",
     "devtools-network-request": "^0.0.3",
     "devtools-sham-modules": "^0.0.3",

--- a/packages/devtools-local-toolbox/package.json
+++ b/packages/devtools-local-toolbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "devtools-local-toolbox",
-  "version": "0.0.3",
+  "version": "0.0.5",
   "license": "MPL-2.0",
   "repository": {
     "type": "git",
@@ -47,6 +47,7 @@
     "ws": "^1.0.1"
   },
   "files": [
-    "public/js"
+    "public/js",
+    "bin"
   ]
 }


### PR DESCRIPTION
We were seeing a couple of issues recently related git cloning and installing the project. #936 #954 #946

This fixes (i hope) the last issue, where `npm install devtools-local-toolbox` failed due to bin not being exported.

Here's a quick summary for those interested. NPM 3 runs the top level lifecycle hooks after installing dependencies [here](https://github.com/npm/npm/blob/master/lib/install.js#L263). This requires us to a) publish packages, b) have these packages be installable. 

For the record, yarn runs preinstall before installing dependencies [here](https://github.com/yarnpkg/yarn/blob/master/src/cli/commands/install.js#L709). Yarn's code is also significantly easier to follow if you ask me :)

