### PR TITLE
add flow typing to sources actions

### DIFF
--- a/public/js/actions/breakpoints.js
+++ b/public/js/actions/breakpoints.js
@@ -16,20 +16,8 @@ const {
   getOriginalLocation, getGeneratedLocation, isOriginalId
 } = require("../utils/source-map");
 
-import type { Location } from "./types";
+import type { Location, ThunkArgs } from "./types";
 
-/**
- * Argument parameters via Thunk middleware for {@link https://github.com/gaearon/redux-thunk|Redux Thunk}
- *
- * @memberof actions/breakpoints
- * @static
- * @typedef {Object} ThunkArgs
- */
-type ThunkArgs = {
-  dispatch: any,
-  getState: any,
-  client: any
-}
 function _breakpointExists(state, location: Location) {
   const currentBp = getBreakpoint(state, location);
   return currentBp && !currentBp.disabled;

--- a/public/js/actions/types.js
+++ b/public/js/actions/types.js
@@ -10,6 +10,19 @@ export type { Source };
  */
 
 /**
+  * Argument parameters via Thunk middleware for {@link https://github.com/gaearon/redux-thunk|Redux Thunk}
+  *
+  * @memberof actions/breakpoints
+  * @static
+  * @typedef {Object} ThunkArgs
+  */
+export type ThunkArgs = {
+  dispatch: any,
+  getState: any,
+  client: any
+};
+
+/**
  * Tri-state status for async operations
  *
  * Available options are:


### PR DESCRIPTION
Associated Issue: none

### Summary of Changes

* moved `ThunkArgs` into `actions/types` and typed the sources action
* removed the unused `blackbox` function from the sources action module

### Testing

* [x] passes `npm test`
* [x] passes `npm run lint`

