### PR TITLE
cache the mochitest-runner docker image on circleci

### DIFF
--- a/bin/update-docker
+++ b/bin/update-docker
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+DOWNLOADS_PATH=${DOWNLOADS_PATH:-"$HOME/downloads"}
+
+mkdir -p $DOWNLOADS_PATH
+
+if [[ -e $DOWNLOADS_PATH/mochitest-runner.tar ]]; then
+  time docker load -i $DOWNLOADS_PATH/mochitest-runner.tar;
+fi
+
+docker images
+
+time docker pull jlongster/mochitest-runner
+
+docker images
+
+time docker save jlongster/mochitest-runner > $DOWNLOADS_PATH/mochitest-runner.tar

--- a/circle.yml
+++ b/circle.yml
@@ -3,6 +3,10 @@ machine:
     version: 6.3
   services:
     - docker
+  environment:
+    DOWNLOADS_PATH: "$HOME/downloads"
+  post:
+    - mkdir -p $DOWNLOADS_PATH
 
 checkout:
   post:
@@ -32,12 +36,13 @@ test:
 dependencies:
   cache_directories:
     - "~/downloads"
+
   override:
     - npm i -g jasonlaster/lerna
     - lerna bootstrap
     - ./bin/install-chrome
     - ./bin/install-firefox
-    - docker pull jlongster/mochitest-runner
+    - ./bin/update-docker
 experimental:
   notify:
     branches:


### PR DESCRIPTION
Associated Issue: none
### Summary of Changes
- moved docker pull into a new script
- `update-docker` attempts to cache the docker image and reuse the cache on future runs
### Testing
- [x] passes `npm test`
- [x] passes `npm run lint`
  
  GO FASTER
