### PR TITLE
Call stack collapse frames

### DIFF
--- a/public/js/components/Frames.css
+++ b/public/js/components/Frames.css
@@ -38,3 +38,15 @@
   background-color: var(--theme-selection-background);
   color: var(--theme-body-background);
 }
+
+.show-more {
+  cursor: pointer;
+  text-align: center;
+  padding: 8px 0px;
+  border-top: 1px solid var(--theme-splitter-color);
+  background-color: var(--theme-tab-toolbar-background);
+}
+
+.show-more:hover {
+  background-color: var(--theme-selection-color);
+}

--- a/public/js/components/Frames.js
+++ b/public/js/components/Frames.js
@@ -41,8 +41,8 @@ function renderFrame(frame, selectedFrame, selectFrame) {
 
 const Frames = React.createClass({
   propTypes: {
-    frames: ImPropTypes.map.isRequired,
-    selectedFrame: PropTypes.number.isRequired,
+    frames: ImPropTypes.list.isRequired,
+    selectedFrame: PropTypes.object.isRequired,
     selectFrame: PropTypes.func.isRequired
   },
 
@@ -79,7 +79,7 @@ const Frames = React.createClass({
         }).slice(0, numFramesToShow),
         dom.div({
           className: "show-more",
-          onClick: () => this.toggleFramesDisplay()
+          onClick: this.toggleFramesDisplay
         }, buttonMessage)
       )
     }

--- a/public/js/components/Frames.js
+++ b/public/js/components/Frames.js
@@ -46,6 +46,8 @@ const Frames = React.createClass({
     selectFrame: PropTypes.func.isRequired
   },
 
+  displayName: "Frames",
+
   getInitialState() {
     return { showAllFrames: false };
   },
@@ -58,20 +60,19 @@ const Frames = React.createClass({
 
   render() {
     const { frames, selectedFrame, selectFrame } = this.props;
-    const defaultFramesToShow = 5;
     const numFramesToShow = this.state.showAllFrames ? frames.length : 7;
+    let framesDisplay;
 
     if (frames.length === 0) {
       framesDisplay = div({ className: "pane-info empty" }, "Not Paused");
-
     } else if (frames.length < numFramesToShow) {
       framesDisplay = dom.ul(null, frames.map(frame => {
         return renderFrame(frame, selectedFrame, selectFrame);
-      }))
-      
+      }));
     } else {
       let frameClass = "hideFrames";
-      let buttonMessage = this.state.showAllFrames ? 'Collapse Rows' : 'Expand Rows';
+      let buttonMessage = this.state.showAllFrames ?
+                          "Collapse Rows" : "Expand Rows";
 
       framesDisplay = dom.ul({ className: frameClass },
         frames.map(frame => {
@@ -81,7 +82,7 @@ const Frames = React.createClass({
           className: "show-more",
           onClick: this.toggleFramesDisplay
         }, buttonMessage)
-      )
+      );
     }
 
     return div(
@@ -89,7 +90,7 @@ const Frames = React.createClass({
       framesDisplay
     );
   }
-})
+});
 
 module.exports = connect(
   state => ({


### PR DESCRIPTION
Associated Issue: https://github.com/devtools-html/debugger.html/issues/961

### Summary of Changes

* Changed Frames to a React Class
* Refactored logic to prior to the return
* Logic consists of conditional statement depending on number of frames
* Added expand/collapse rows button

For best testing, use breakpoint on line 52 of todo MVC app with a refresh. Lots of frames there.

### Testing

* [ X ] passes `npm test`
* [x] passes `npm run lint`

### Screenshots/Videos (OPTIONAL)
