### PR TITLE
Prevent breakpoint checkbox from selecting a breakpoint

### DIFF
--- a/public/js/components/Breakpoints.js
+++ b/public/js/components/Breakpoints.js
@@ -93,7 +93,10 @@ const Breakpoints = React.createClass({
         type: "checkbox",
         className: "breakpoint-checkbox",
         checked: !isDisabled,
-        onChange: () => this.handleCheckbox(breakpoint)
+        onChange: () => this.handleCheckbox(breakpoint),
+        // Prevent clicking on the checkbox from triggering the onClick of
+        // the surrounding div
+        onClick: (ev) => ev.stopPropagation()
       }),
       dom.div(
         { className: "breakpoint-label", title: breakpoint.text },


### PR DESCRIPTION
Associated Issue: #940 

### Summary of Changes

* Added an `onClick` to `breakpoint-checkbox` that will only stop propagation of the click to its surrounding div. This allows the `handleCheckbox` to be called without also calling the `selectBreakpoint` call of its parent div.

### Testing

* [x] passes `npm test`
* [x] passes `npm run lint`
