### PR TITLE
Show "no results" label and sad face for no results

### DIFF
--- a/public/images/Svg.js
+++ b/public/images/Svg.js
@@ -22,7 +22,8 @@ const svg = {
   "stepOut": require("./stepOut.svg"),
   "stepOver": require("./stepOver.svg"),
   "subSettings": require("./subSettings.svg"),
-  "worker": require("./worker.svg")
+  "worker": require("./worker.svg"),
+  "sad-face": require("./sad-face.svg")
 };
 
 module.exports = function(name, props) { // eslint-disable-line

--- a/public/images/sad-face.svg
+++ b/public/images/sad-face.svg
@@ -1,0 +1,9 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="#D92215">
+  <path d="M8 14.5c-3.6 0-6.5-2.9-6.5-6.5S4.4 1.5 8 1.5s6.5 2.9 6.5 6.5-2.9 6.5-6.5 6.5zm0-12C5 2.5 2.5 5 2.5 8S5 13.5 8 13.5 13.5 11 13.5 8 11 2.5 8 2.5z"/>
+  <circle cx="5" cy="6" r="1" transform="translate(1 1)"/>
+  <circle cx="9" cy="6" r="1" transform="translate(1 1)"/>
+  <path d="M5.5 11c-.1 0-.2 0-.3-.1-.2-.1-.3-.4-.1-.7C6 9 7 8.5 8.1 8.5c1.7.1 2.8 1.7 2.8 1.8.2.2.1.5-.1.7-.2.1-.6 0-.7-.2 0 0-.9-1.3-2-1.3-.7 0-1.4.4-2.1 1.3-.2.2-.4.2-.5.2z"/>
+</svg>

--- a/public/js/components/EditorSearchBar.js
+++ b/public/js/components/EditorSearchBar.js
@@ -114,14 +114,29 @@ const EditorSearchBar = React.createClass({
   renderSummary() {
     const { count, index, query } = this.state;
 
-    if (count == 0 || query.trim() == "") {
+    if (query.trim() == "") {
       return dom.div({});
+    } else if (count == 0) {
+      return dom.div(
+          { className: "summary" },
+          "no results"
+          );
     }
 
     return dom.div(
       { className: "summary" },
       `${index + 1} of ${count} results`
     );
+  },
+
+  renderSvg() {
+    const { count, query } = this.state;
+
+    if (count == 0 && query.trim() != "") {
+      return Svg("sad-face");
+    }
+
+    return Svg("magnifying-glass");
   },
 
   render() {
@@ -133,7 +148,7 @@ const EditorSearchBar = React.createClass({
 
     return dom.div(
       { className: "search-bar" },
-      Svg("magnifying-glass"),
+      this.renderSvg(),
       dom.input({
         className: classnames({
           empty: count == 0


### PR DESCRIPTION
Associated Issue: #967 

### Summary of Changes

* When code search returns 0 results, this PR shows a "no results" summary and changes from magnifying glass to sad smiley.
* Also I added an extra check for query, to see if it's empty. If it is empty, we don't show a sad smiley. Would like to hear your thoughts on this, since this was not mentioned in the issue. Hope you guys don't mind about this :)

### Testing

* [ x] passes `npm test`
* [ x] passes `npm run lint`

### Screenshots/Videos (OPTIONAL)

<img width="1227" alt="screen shot 2016-10-22 at 20 35 44" src="https://cloud.githubusercontent.com/assets/5848935/19620272/5dab54e4-9897-11e6-8130-2ec0a474eee7.png">

<img width="1229" alt="screen shot 2016-10-22 at 20 34 47" src="https://cloud.githubusercontent.com/assets/5848935/19620276/83c41f4e-9897-11e6-95fc-5efe9cfe9966.png">

<img width="1199" alt="screen shot 2016-10-22 at 20 34 54" src="https://cloud.githubusercontent.com/assets/5848935/19620275/7ddae6c6-9897-11e6-9b9a-e0faf7a01fd9.png">


