### PR TITLE
Fixes layout issues with the sources dropdown

### DIFF
--- a/public/js/components/App.css
+++ b/public/js/components/App.css
@@ -37,6 +37,7 @@ body {
   position: relative;
   flex: 1;
   background-color: var(--theme-tab-toolbar-background);
+  overflow: hidden;
 }
 
 .editor-container {

--- a/public/js/components/Dropdown.css
+++ b/public/js/components/Dropdown.css
@@ -4,10 +4,23 @@
   width: 150px;
   max-height: 300px;
   z-index: 1000;
+  position: absolute;
+  top: 35px;
+  right: 8px;
 }
 
 .dropdown li {
-  padding-left: 10px;
+  padding: 5px 10px;
+  overflow: hidden;
+  height: 30px;
+}
+
+.dropdown li:nth-of-type(2n) {
+  background-color: var(--theme-tab-toolbar-background);
+}
+
+.dropdown li:hover {
+  background-color: var(--theme-toolbar-background);
 }
 
 .dropdown li:hover {
@@ -21,4 +34,14 @@
   font-size: 0.8em;
   margin: 0;
   padding: 0;
+}
+
+.dropdown-mask {
+  position: fixed;
+  width: 100%;
+  height: 100%;
+  background: transparent;
+  z-index: 999;
+  left: 0;
+  top: 0;
 }

--- a/public/js/components/Dropdown.css
+++ b/public/js/components/Dropdown.css
@@ -13,6 +13,7 @@
   padding: 5px 10px;
   overflow: hidden;
   height: 30px;
+  text-overflow: ellipsis;
 }
 
 .dropdown li:nth-of-type(2n) {
@@ -31,7 +32,7 @@
 .dropdown ul {
   list-style: none;
   line-height: 2em;
-  font-size: 0.8em;
+  font-size: 1em;
   margin: 0;
   padding: 0;
 }

--- a/public/js/components/Dropdown.js
+++ b/public/js/components/Dropdown.js
@@ -1,0 +1,62 @@
+const React = require("react");
+const { DOM: dom, PropTypes } = React;
+
+const Dropdown = React.createClass({
+  propTypes: {
+    panel: PropTypes.object
+  },
+
+  displayName: "Dropdown",
+
+  getInitialState() {
+    return {
+      dropdownShown: false
+    };
+  },
+
+  toggleDropdown(e) {
+    this.setState({
+      dropdownShown: !this.state.dropdownShown,
+    });
+  },
+
+  renderPanel() {
+    return dom.div(
+      {
+        className: "dropdown",
+        onClick: this.toggleDropdown,
+        style: { display: (this.state.dropdownShown ? "block" : "none") }
+      },
+      this.props.panel
+    );
+  },
+
+  renderButton() {
+    return dom.span(
+      {
+        className: "subsettings",
+        onClick: this.toggleDropdown
+      },
+      dom.img({ src: "images/subSettings.svg" })
+    );
+  },
+
+  renderMask() {
+    return dom.div({
+      className: "dropdown-mask",
+      onClick: this.toggleDropdown,
+      style: { display: (this.state.dropdownShown ? "block" : "none") }
+    });
+  },
+
+  render() {
+    return dom.div({},
+      this.renderPanel(),
+      this.renderButton(),
+      this.renderMask()
+    );
+  }
+
+});
+
+module.exports = Dropdown;

--- a/public/js/components/SourceTabs.css
+++ b/public/js/components/SourceTabs.css
@@ -83,9 +83,3 @@ html[dir="rtl"] .source-tab .close-btn {
   right: 3px;
   top: 9px;
 }
-
-.sources-dropdown {
-  position: absolute;
-  top: 35px;
-  right: 0px;
-}

--- a/public/js/components/SourceTabs.css
+++ b/public/js/components/SourceTabs.css
@@ -26,6 +26,7 @@
   border-bottom: none;
   position: relative;
   transition: all 0.25s ease;
+  max-width: calc(100% - 68px);
 }
 
 html:not([dir="rtl"]) .source-tab {
@@ -62,6 +63,11 @@ html[dir="rtl"] .source-tab {
   top: 3px;
 }
 
+.source-tab .filename {
+  text-overflow: ellipsis;
+  overflow: hidden;
+}
+
 html:not([dir="rtl"]) .source-tab .close-btn {
   right: 4px;
 }
@@ -80,6 +86,8 @@ html[dir="rtl"] .source-tab .close-btn {
 
 .source-header .subsettings {
   position: absolute;
-  right: 3px;
+  right: 12px;
   top: 9px;
+  width: 12px;
+  height: 12px;
 }

--- a/public/js/components/SourceTabs.js
+++ b/public/js/components/SourceTabs.js
@@ -10,6 +10,7 @@ const actions = require("../actions");
 const { isEnabled } = require("devtools-config");
 const CloseButton = require("./CloseButton");
 const Svg = require("./utils/Svg");
+const Dropdown = React.createFactory(require("./Dropdown"));
 
 require("./SourceTabs.css");
 require("./Dropdown.css");
@@ -34,17 +35,6 @@ function getHiddenTabs(sourceTabs, sourceTabEls) {
   return sourceTabs.filter((tab, index) => {
     return sourceTabEls[index].getBoundingClientRect().top > tabTopOffset;
   });
-}
-
-/*
- * Get the last visible tab index so that we can replace the last
- * tab with the newly selected source.
- */
-function getLastVisibleTabIndex(sourceTabs, sourceTabEls) {
-  const hiddenTabs = getHiddenTabs(sourceTabs, sourceTabEls);
-  const firstHiddenTab = hiddenTabs.first();
-  const firstHiddenTabIndex = sourceTabs.indexOf(firstHiddenTab);
-  return firstHiddenTabIndex - 1;
 }
 
 const SourceTabs = React.createClass({
@@ -91,31 +81,16 @@ const SourceTabs = React.createClass({
     });
   },
 
-  renderSourcesDropdown() {
-    if (!this.state.hiddenSourceTabs) {
-      return dom.div({});
-    }
-
-    return dom.div({
-      className: "sources-dropdown dropdown",
-      ref: "sourcesDropdown",
-      style: { display: (this.state.dropdownShown ? "block" : "none") }
-    },
-      dom.ul({}, this.state.hiddenSourceTabs.map(this.renderDropdownSource))
-    );
-  },
-
   renderDropdownSource(source) {
-    const { selectSource, sourceTabs } = this.props;
+    const { selectSource } = this.props;
     const filename = getFilename(source.toJS());
-    const sourceTabEls = this.refs.sourceTabs.children;
 
     return dom.li({
       key: source.get("id"),
       onClick: () => {
-        const tabIndex = getLastVisibleTabIndex(sourceTabs, sourceTabEls);
+        // const tabIndex = getLastVisibleTabIndex(sourceTabs, sourceTabEls);
+        const tabIndex = 0;
         selectSource(source.get("id"), { tabIndex });
-        this.toggleSourcesDropdown();
       }
     }, filename);
   },
@@ -164,15 +139,28 @@ const SourceTabs = React.createClass({
       CloseButton({ handleClick: onClickClose }));
   },
 
+  renderDropdown() {
+    const hiddenSourceTabs = this.state.hiddenSourceTabs;
+    if (!hiddenSourceTabs || hiddenSourceTabs.size == 0) {
+      return dom.div({});
+    }
+
+    return Dropdown({
+      panel: dom.ul(
+        {},
+        this.state.hiddenSourceTabs.map(this.renderDropdownSource)
+      )
+    });
+  },
+
   render() {
     if (!isEnabled("tabs")) {
       return dom.div({ className: "source-header" });
     }
 
     return dom.div({ className: "source-header" },
-      this.renderSourcesDropdown(),
       this.renderTabs(),
-      this.renderSourcesDropdownButton()
+      this.renderDropdown()
     );
   }
 });

--- a/public/js/reducers/sources.js
+++ b/public/js/reducers/sources.js
@@ -127,8 +127,6 @@ function removeSourceFromTabList(state, id) {
  */
 function updateTabList(state, source, tabIndex) {
   const tabs = state.get("tabs");
-  const selectedSource = getSelectedSource({ sources: state });
-  const selectedSourceIndex = tabs.indexOf(selectedSource);
   const sourceIndex = tabs.indexOf(source);
   const includesSource = !!tabs.find((t) => t.get("id") == source.get("id"));
 
@@ -142,7 +140,7 @@ function updateTabList(state, source, tabIndex) {
     return tabs;
   }
 
-  return tabs.insert(selectedSourceIndex + 1, source);
+  return tabs.insert(0, source);
 }
 
 /**


### PR DESCRIPTION
Fixes some of the styling issues we've seen with the sources dropdown. @wldcordeiro this should address the evil three dots and other related things.

This also pulls in the great work @jacobjzhang did with refactoring the dropdowns.

Some of the styling issues were with:
* the center pane scrolling when a source tab was too big for the header
* a source tab not shrinking to the width of the header
* the subsetting button not adjusting to the width of the header
* the dropdown font height, and text overflowing... this is still not a great dropdown component (even though it is now extracted) there are clipping issues in narrow widths and in general we should probably consider a more mature library, but it gets the job done for now.

![](http://g.recordit.co/WoRqrZGx5r.gif)
