### PR TITLE
Add theme coloring to the input field for file search

### DIFF
--- a/public/js/components/Autocomplete.css
+++ b/public/js/components/Autocomplete.css
@@ -45,12 +45,18 @@
 .autocomplete input {
   width: 100%;
   border: none;
+  background-color: var(--theme-body-background);
+  color: var(--theme-comment);
   border-bottom: 1px solid var(--theme-splitter-color);
   outline: none;
   line-height: 30px;
   font-size: 14px;
   height: 40px;
   padding-left: 30px;
+}
+
+.autocomplete input::placeholder {
+  color: var(--theme-body-color-inactive);
 }
 
 .autocomplete .magnifying-glass svg {


### PR DESCRIPTION
Associated Issue: #780 

### Summary of Changes

* add color vars for backgrounds/colors to make the input match theme style.

### Testing

* [x] passes `npm test`
* [x] passes `npm run lint`

### Screenshots/Videos (OPTIONAL)

![screenshot_20161025_134632](https://cloud.githubusercontent.com/assets/580982/19701649/78fead08-9ab9-11e6-8287-2c178b214053.png)
