### PR TITLE
Color the background of code search input to match the theme.

### DIFF
--- a/public/js/components/EditorSearchBar.css
+++ b/public/js/components/EditorSearchBar.css
@@ -19,12 +19,17 @@
   border: none;
   line-height: 30px;
   font-size: 14px;
+  background-color: var(--theme-body-background);
   color: var(--theme-comment);
   width: calc(100% - 38px);
   padding-left: 10px;
   display: flex;
   padding-right: 100px;
   flex: 1;
+}
+
+.search-bar .magnifying-glass {
+  background-color: var(--theme-body-background);
 }
 
 .search-bar input::placeholder {


### PR DESCRIPTION
Associated Issue: #988 (part of)

### Summary of Changes

* add backgrounds to the code search so it matches the theme.

### Testing

* [x] passes `npm test`
* [x] passes `npm run lint`

### Screenshots/Videos (OPTIONAL)

![screenshot_20161025_135358](https://cloud.githubusercontent.com/assets/580982/19701876/828e3a36-9aba-11e6-871e-cbb57029383b.png)
