### PR TITLE
Adjust the editor height for when the code search is visible so the scrollbar doesn't sit under the footer

### DIFF
--- a/public/js/components/Editor.css
+++ b/public/js/components/Editor.css
@@ -43,10 +43,6 @@ html[dir="rtl"] .editor-mount {
   opacity: 0.3;
 }
 
-.search-bar ~ .editor-mount {
-  height: calc(100% - 56px);
-}
-
 .CodeMirror {
   width: 100%;
   height: 100%;
@@ -56,6 +52,10 @@ html[dir="rtl"] .editor-mount {
   width: 100%;
   height: calc(100% - 32px);
   background-color: var(--theme-body-background);
+}
+
+.search-bar ~ .editor-mount {
+  height: calc(100% - 72px);
 }
 
 .CodeMirror-linenumber {


### PR DESCRIPTION
Associated Issue: N/A

### Summary of Changes

* adjust the height of the editor to properly account for source footer, move rule down file to cascade properly

### Testing

* [x] passes `npm test`
* [x] passes `npm run lint`

### Screenshots/Videos (OPTIONAL)

#### Before

![screenshot_20161025_142148](https://cloud.githubusercontent.com/assets/580982/19702796/69f4fc68-9abe-11e6-8a4a-8016585b8ed3.png)


#### After

![screenshot_20161025_142057](https://cloud.githubusercontent.com/assets/580982/19702747/4804a87e-9abe-11e6-84be-c24e363c58b7.png)
![screenshot_20161025_142102](https://cloud.githubusercontent.com/assets/580982/19702748/4804f270-9abe-11e6-8aaa-238d438c1e49.png)
