### PR TITLE
create a downloads cache directory in circleci

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -28,7 +28,10 @@ test:
     - npm run lint-css
     - npm run lint-js
     - npm run flow
+
 dependencies:
+  cache_directories:
+    - "~/downloads"
   override:
     - npm i -g jasonlaster/lerna
     - lerna bootstrap


### PR DESCRIPTION
Associated Issue: n/a

### Summary of Changes

* adds `~/downloads` as a cache directory for circleci (does not use that directory yet)
* change 2

### Testing

* [x] passes `npm test`
* [x] passes `npm run lint`

This PR has really no effect on anything just yet, it creates a custom cache directory.  Which you can learn more about [here](https://circleci.com/docs/how-cache-works/)  I'm working to cache more of what we download in Circle and I believe we are losing the downloads directory because it only exists in my branch.  
Here's the rest of my branch work: https://github.com/clarkbw/debugger.html/tree/fast-circleci