### PR TITLE
(dark-theme) Cleanup the scrollbar on chrome

### DIFF
--- a/packages/devtools-local-toolbox/public/js/components/Root.css
+++ b/packages/devtools-local-toolbox/public/js/components/Root.css
@@ -19,3 +19,24 @@ body {
   display: flex;
   height: 100%;
 }
+
+
+::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+  background: transparent;
+}
+
+::-webkit-scrollbar-track {
+  border-radius: 8px;
+  background: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+  border-radius: 8px;
+  background: rgba(113,113,113,0.5);
+}
+
+:root.theme-dark .CodeMirror-scrollbar-filler {
+  background: transparent;
+}


### PR DESCRIPTION
Small fix to make the chrome scrollbars in chrome consistent with the panel

I double checked to make sure the codemirror filler style was okay in the panel.

**Why does this matter?** 
1. having a nice dev environment will make it easier to spot other visual inconsistencies
2. the standalone app will be electron, which will need this cleanup

#### Panel
![](http://g.recordit.co/TpmmPcjEcS.gif)

#### Before
![](http://g.recordit.co/2mUwJ2udzy.gif)

#### After
![](http://g.recordit.co/YLKeo8hTVF.gif)
