### PR TITLE
Fix #1012: dark theme bg for breakpoint line added

### DIFF
--- a/public/js/lib/codemirror-mozilla.css
+++ b/public/js/lib/codemirror-mozilla.css
@@ -13,7 +13,7 @@
 .theme-dark:root {
   /* --breakpoint-background: url("chrome://devtools/skin/images/breakpoint.svg#dark"); */
   /* --breakpoint-hover-background: url("chrome://devtools/skin/images/breakpoint.svg#dark-hover"); */
-  --breakpoint-active-color: rgba(112,191,83,.4);
+  --breakpoint-active-color: rgba(0,255,175,.4);
   --breakpoint-active-color-hover: rgba(112,191,83,.7);
   /* --breakpoint-conditional-background: url("chrome://devtools/skin/images/breakpoint.svg#dark-conditional"); */
 }


### PR DESCRIPTION
Associated Issue: #1012

### Summary of Changes

* Added background for the breakpoint line in dark theme

### Testing

* [x] passes `npm test`
* [x] passes `npm run lint`

### Screenshots/Videos (OPTIONAL)

Before:
![](https://cloud.githubusercontent.com/assets/580982/19714638/0a8af58a-9b0d-11e6-94be-f8cb11431adf.png)

After:
![](https://d3vv6lp55qjaqc.cloudfront.net/items/2C1S191N210Y3O1S123k/Image%202016-10-26%20at%2011.24.36%20AM.png?X-CloudApp-Visitor-Id=0815a9945113b1ab2bc6a505622ed862&v=38669694)