### PR TITLE
Optimize editor rendering by removing props arg in redux state mapping function

### DIFF
--- a/public/js/components/Editor.js
+++ b/public/js/components/Editor.js
@@ -363,7 +363,7 @@ const Editor = React.createClass({
 });
 
 module.exports = connect(
-  (state, props) => {
+  state => {
     const selectedLocation = getSelectedLocation(state);
     const sourceId = selectedLocation && selectedLocation.sourceId;
     const selectedSource = getSelectedSource(state);


### PR DESCRIPTION
A few things are going on here. For some reason, redux always rerenders a connected component no matter what if you accept the `props` argument. Even if the state you return is the same as before, it'll rerender. We don't use the `props` arg here, so we can just remove it.

For some reason, in React 0.14.7, the editor was rerendering but `componentWillReceiveProps` wasn't being called. We do most of our heavy work in there, so it was skipping it. In React 15, that lifecycle method is always called, which seems like the correct behavior. I haven't been able to reduce this into a simple test case, but let's go ahead and clean this code up which I think will allow us to run against React 15. I'd like to understand this more at some point.