### PR TITLE
(dark theme+light theme) Fix breakpoint gutter color, breakpoint hover color, re-center close button

### DIFF
--- a/public/js/components/Breakpoints.css
+++ b/public/js/components/Breakpoints.css
@@ -10,7 +10,7 @@
   line-height: 1em;
   position: relative;
   border-left: 4px solid transparent;
-
+  transition: all 0.25s ease;
 }
 
 .breakpoints-list .breakpoint:last-of-type {
@@ -29,7 +29,7 @@
 
 .breakpoints-list .breakpoint:hover {
   cursor: pointer;
-  background-color: var(--theme-toolbar-background);
+  background-color: var(--theme-search-overlays-semitransparent);
 }
 
 .breakpoints-list .breakpoint.paused:hover {
@@ -59,7 +59,7 @@
 .breakpoint .close-btn {
   position: absolute;
   right: 6px;
-  top: 6px;
+  top: 12px;
 }
 
 .breakpoint .close {

--- a/public/js/components/Editor.css
+++ b/public/js/components/Editor.css
@@ -64,7 +64,7 @@ html[dir="rtl"] .editor-mount {
 }
 
 /* set the linenumber white when there is a breakpoint */
-.new-breakpoint .CodeMirror-linenumber {
+.new-breakpoint .CodeMirror-gutter-wrapper .CodeMirror-linenumber {
   color: white;
 }
 

--- a/public/js/lib/codemirror-mozilla.css
+++ b/public/js/lib/codemirror-mozilla.css
@@ -14,7 +14,7 @@
   /* --breakpoint-background: url("chrome://devtools/skin/images/breakpoint.svg#dark"); */
   /* --breakpoint-hover-background: url("chrome://devtools/skin/images/breakpoint.svg#dark-hover"); */
   --breakpoint-active-color: rgba(0,255,175,.4);
-  --breakpoint-active-color-hover: rgba(112,191,83,.7);
+  --breakpoint-active-color-hover: rgba(0,255,175,.7);
   /* --breakpoint-conditional-background: url("chrome://devtools/skin/images/breakpoint.svg#dark-conditional"); */
 }
 


### PR DESCRIPTION
Associated Issue: #1010, also follow-up from #1012

### Summary of Changes
As a caveat to these changes: I'm not _in love_ with the hover states in the breakpoints pane. However, I still think they're improvements and I think the work necessary to make them 💫 great 🌟 requires m-c changes that should be done in follow-ups.

* Update ```--breakpoint-active-color-hover``` for dark theme to be ```--breakpoint-active-color``` with slightly more opacity
* Make the hover color for the breakpoints in the sidebar less intense, but _more_ intense in light theme
* Recenter the close button (before it was slightly too close to the top)

### Testing

* [x] passes `npm test`
* [x] passes `npm run lint`

### Screenshots/Videos
Before:
![](https://cloud.githubusercontent.com/assets/580982/19714594/b5e2e9b6-9b0c-11e6-866e-aae57dab1765.png)

After:
![](https://d3vv6lp55qjaqc.cloudfront.net/items/333c1K1t0P433P2J2S3a/Image%202016-10-26%20at%201.20.34%20PM.png?X-CloudApp-Visitor-Id=0815a9945113b1ab2bc6a505622ed862&v=84955b3a)

Before (hover state):
![](https://d3vv6lp55qjaqc.cloudfront.net/items/2E21090q3M1Y0N35241g/Image%202016-10-26%20at%201.19.43%20PM.png?X-CloudApp-Visitor-Id=0815a9945113b1ab2bc6a505622ed862&v=4d96615b)

After (hover state):
![](https://d3vv6lp55qjaqc.cloudfront.net/items/3U3f1f2O1b3b0Y1T1V2H/Image%202016-10-26%20at%201.36.02%20PM.png?X-CloudApp-Visitor-Id=0815a9945113b1ab2bc6a505622ed862&v=d3085a16)

Before (hover state, light theme):
![](https://d3vv6lp55qjaqc.cloudfront.net/items/211s190E2Y2l3o393e32/Image%202016-10-26%20at%201.25.43%20PM.png?X-CloudApp-Visitor-Id=0815a9945113b1ab2bc6a505622ed862&v=959cc2bd)

After (hover state, light theme):
![](https://d3vv6lp55qjaqc.cloudfront.net/items/2W2h3K0C051n1Y32340N/Image%202016-10-26%20at%201.37.54%20PM.png?X-CloudApp-Visitor-Id=0815a9945113b1ab2bc6a505622ed862&v=8eb6710b)