### PR TITLE
Update sources overflow button for consistent styling

### DIFF
--- a/public/js/components/Dropdown.js
+++ b/public/js/components/Dropdown.js
@@ -37,7 +37,7 @@ const Dropdown = React.createClass({
         className: "subsettings",
         onClick: this.toggleDropdown
       },
-      dom.img({ src: "images/subSettings.svg" })
+      "»"
     );
   },
 


### PR DESCRIPTION
Associated Issue: #1015 

### Summary of Changes

* Replace the existing sources overflow button with the guillemet »

### Testing

* [x] passes `npm test`
* [x] passes `npm run lint`

### Screenshots/Videos (OPTIONAL)

**Before:**
<img width="371" alt="screen shot 2016-10-27 at 12 01 42 am" src="https://cloud.githubusercontent.com/assets/8756983/19755087/a3116ab6-9bd8-11e6-8d6d-ad04add5ecc8.png">

**After:**
<img width="410" alt="screen shot 2016-10-26 at 11 34 26 pm" src="https://cloud.githubusercontent.com/assets/8756983/19755082/9a7793f8-9bd8-11e6-9513-b7c453d9634b.png">