### PR TITLE
Fix #1008: Change hardcoded white value in tab overflow

### DIFF
--- a/public/js/components/Dropdown.css
+++ b/public/js/components/Dropdown.css
@@ -1,31 +1,25 @@
 .dropdown {
-  background: white;
+  background: var(--theme-body-background);
   border: 1px solid var(--theme-splitter-color);
-  width: 150px;
+  box-shadow: 0 4px 4px 0 var(--theme-search-overlays-semitransparent);
   max-height: 300px;
-  z-index: 1000;
   position: absolute;
-  top: 35px;
   right: 8px;
+  top: 35px;
+  width: 150px;
+  z-index: 1000;
 }
 
 .dropdown li {
-  padding: 5px 10px;
+  transition: all 0.25s ease;
+  padding: 2px 10px 10px 5px;
   overflow: hidden;
   height: 30px;
   text-overflow: ellipsis;
 }
 
-.dropdown li:nth-of-type(2n) {
-  background-color: var(--theme-tab-toolbar-background);
-}
-
 .dropdown li:hover {
-  background-color: var(--theme-toolbar-background);
-}
-
-.dropdown li:hover {
-  background: var(--theme-tab-toolbar-background);
+  background-color: var(--theme-search-overlays-semitransparent);
   cursor: pointer;
 }
 


### PR DESCRIPTION
Associated Issue: #1008

### Summary of Changes

* Changes hardcoded white background in dark theme theme for the tab overflow
* Adds transitions to background color changes
* Adds drop-shadow on dropdown
* Removes per-```<li>``` background color changes

### Testing

* [x] passes `npm test`
* [x] passes `npm run lint`

### Screenshots/Videos

Before:
<img width="199" alt="screen shot 2016-10-27 at 11 29 53 am" src="https://cloud.githubusercontent.com/assets/1720093/19773752/baf95444-9c38-11e6-8e7c-ddcea87fe6af.png">

After, including hover state:
<img width="202" alt="screen shot 2016-10-27 at 11 28 00 am" src="https://cloud.githubusercontent.com/assets/1720093/19773760/c19f2440-9c38-11e6-9464-8f5933743a5a.png">

After, in light theme, with hover state:
<img width="204" alt="screen shot 2016-10-27 at 11 26 50 am" src="https://cloud.githubusercontent.com/assets/1720093/19773776/cc1f323e-9c38-11e6-8d36-b4f0041e111f.png">
