### PR TITLE
Remove max tab width

### DIFF
--- a/public/js/components/SourceTabs.css
+++ b/public/js/components/SourceTabs.css
@@ -46,10 +46,7 @@
   position: relative;
   transition: all 0.25s ease;
   min-width: 40px;
-  max-width: 132px;
   overflow: hidden;
-  word-wrap: break-word;
-  word-break: break-word;
 }
 
 html:not([dir="rtl"]) .source-tab {


### PR DESCRIPTION
There's no reason we should have a max tab width in my opinion. The current CSS is broken, leading to this when it's too wide:

<img width="228" alt="screen shot 2016-10-28 at 5 25 30 pm" src="https://cloud.githubusercontent.com/assets/17031/19822925/f969043a-9d33-11e6-9488-8e55e1ad5f88.png">

For now let's just remove this. We can think of how to solve this better later.