### PR TITLE
Make `selectedFrame` prop of Frames not required

### DIFF
--- a/public/js/components/Frames.js
+++ b/public/js/components/Frames.js
@@ -42,7 +42,7 @@ function renderFrame(frame, selectedFrame, selectFrame) {
 const Frames = React.createClass({
   propTypes: {
     frames: ImPropTypes.list.isRequired,
-    selectedFrame: PropTypes.object.isRequired,
+    selectedFrame: PropTypes.object,
     selectFrame: PropTypes.func.isRequired
   },
 


### PR DESCRIPTION
I didn't know this, but prop warnings actually fail on try, which is kinda cool. I think it's an accident; I think the test harness catches it just because it has the word "failed" in the warning message.

Anyway, on the last push to try, it was failing because of this. `selectedFrame` isn't required; we render the frames component without any frames.