### PR TITLE
#1041: File Search - blinking orange cursor

### DIFF
--- a/public/js/components/EditorSearchBar.js
+++ b/public/js/components/EditorSearchBar.js
@@ -144,14 +144,14 @@ const EditorSearchBar = React.createClass({
       return dom.div();
     }
 
-    const { count } = this.state;
+    const { count, query } = this.state;
 
     return dom.div(
       { className: "search-bar" },
       this.renderSvg(),
       dom.input({
         className: classnames({
-          empty: count == 0
+          empty: count == 0 && query.trim() != ""
         }),
         onChange: this.onChange,
         onKeyUp: this.onKeyUp,


### PR DESCRIPTION
Associated Issue: #1041

### Summary of Changes

* add query const to render method so that we only apply the "empty" className if the query is not empty, thereby only changing the cursor to orange if empty search result and NOT when search input is first visible.

### Testing

* [ X] passes `npm test`
* [ X] passes `npm run lint`

### Screenshots/Videos (OPTIONAL)
![1041-debugger-cursor-searchbar](https://cloud.githubusercontent.com/assets/82321/19840386/bead790a-9eca-11e6-8c0d-a5f09b567010.gif)

