### PR TITLE
Fix source search filter

### DIFF
--- a/public/js/components/SourceSearch.js
+++ b/public/js/components/SourceSearch.js
@@ -23,7 +23,7 @@ function searchResults(sources) {
   }
 
   return sources.valueSeq()
-    .filter(source => !isPretty(source.toJS() || source.get("url")))
+    .filter(source => !isPretty(source.toJS()) && source.get("url"))
     .map(source => ({
       value: getSourcePath(source),
       title: getSourcePath(source).split("/").pop(),


### PR DESCRIPTION
Fixes #1044 - so that both pretty sources and sources w/o a url are excluded

as a side note - I was surprised to learn while debugging this that in the backbone example jquery and underscore have new source events with the introduction type Function and scriptSource. Didn't expect that...

@jacobjzhang mind double checking my fix here. 