### PR TITLE
debounce the code search with a wait of 250ms

### DIFF
--- a/public/js/components/EditorSearchBar.js
+++ b/public/js/components/EditorSearchBar.js
@@ -116,7 +116,7 @@ const EditorSearchBar = React.createClass({
     const ctx = { ed, cm: ed.codeMirror };
 
     find(ctx, query);
-  }, 250),
+  }, 100),
 
   renderSummary() {
     const { count, index, query } = this.state;

--- a/public/js/components/EditorSearchBar.js
+++ b/public/js/components/EditorSearchBar.js
@@ -5,6 +5,7 @@ const Svg = require("./utils/Svg");
 const { isEnabled } = require("devtools-config");
 const { find, findNext, findPrev } = require("../utils/source-search");
 const classnames = require("classnames");
+const debounce = require("lodash").debounce;
 
 require("./EditorSearchBar.css");
 
@@ -83,12 +84,11 @@ const EditorSearchBar = React.createClass({
 
   onChange(e) {
     const query = e.target.value;
-    const ed = this.props.editor;
-    const ctx = { ed, cm: ed.codeMirror };
 
-    find(ctx, query);
     const count = countMatches(query, this.props.sourceText.get("text"));
     this.setState({ query, count, index: 0 });
+
+    this.search(query);
   },
 
   onKeyUp(e) {
@@ -110,6 +110,13 @@ const EditorSearchBar = React.createClass({
       this.setState({ index: nextIndex });
     }
   },
+
+  search: debounce(function(query) {
+    const ed = this.props.editor;
+    const ctx = { ed, cm: ed.codeMirror };
+
+    find(ctx, query);
+  }, 250),
 
   renderSummary() {
     const { count, index, query } = this.state;


### PR DESCRIPTION
Associated Issue: #968

### Summary of Changes

* Created a new search function which is debounced

### Testing

* [x] passes `npm test`
* [x] passes `npm run lint`

### Screenshots/Videos (OPTIONAL)

![debounce-search](https://cloud.githubusercontent.com/assets/792924/19860595/383d3394-9f81-11e6-9025-4349001b9b85.gif)


