### PR TITLE
Fix #1011, #999: Fix call stack and accordion headers' colors in dark theme

### DIFF
--- a/public/js/components/Accordion.css
+++ b/public/js/components/Accordion.css
@@ -20,7 +20,7 @@
 }
 
 .accordion ._header:hover {
-  background-color: var(--theme-selection-color);
+  background-color: var(--theme-search-overlays-semitransparent);
 }
 
 .accordion ._header:hover svg {

--- a/public/js/components/Frames.css
+++ b/public/js/components/Frames.css
@@ -36,7 +36,7 @@
 .frames ul li.selected,
 .frames ul li.selected .location {
   background-color: var(--theme-selection-background);
-  color: var(--theme-body-background);
+  color: white;
 }
 
 .show-more {
@@ -48,5 +48,5 @@
 }
 
 .show-more:hover {
-  background-color: var(--theme-selection-color);
+  background-color: var(--theme-search-overlays-semitransparent);
 }


### PR DESCRIPTION
Associated Issues: #1011, #999

### Summary of Changes

* Changes accordion header hovers in dark theme
* Changes selected state color in call stack, in dark theme, to white
* Changes hover state on "Expand rows" in dark theme

### Testing

* [x] passes `npm test`
* [x] passes `npm run lint`

### Screenshots/Videos

Light theme:
<img width="342" alt="screen shot 2016-10-31 at 2 04 44 pm" src="https://cloud.githubusercontent.com/assets/1720093/19865695/b197468e-9f73-11e6-9768-f5c02b6e7d0e.png">

Dark theme, call stack hover state:
<img width="343" alt="screen shot 2016-10-31 at 2 07 18 pm" src="https://cloud.githubusercontent.com/assets/1720093/19865711/bd6f0834-9f73-11e6-9c1c-8ceabd2a7c36.png">

Dark theme, selected stack:
<img width="346" alt="screen shot 2016-10-31 at 2 07 23 pm" src="https://cloud.githubusercontent.com/assets/1720093/19865720/c7a1fdc0-9f73-11e6-979e-2fad55b2ebca.png">
