### PR TITLE
Allow frames to be focus-able

### DIFF
--- a/public/js/components/Frames.css
+++ b/public/js/components/Frames.css
@@ -11,6 +11,12 @@
   overflow: hidden;
 }
 
+/* Style the focused call frame like so:
+.frames ul li:focus {
+  border: 3px solid red;
+}
+*/
+
 .frames ul li * {
   -moz-user-select: none;
   user-select: none;

--- a/public/js/components/Frames.js
+++ b/public/js/components/Frames.js
@@ -33,7 +33,9 @@ function renderFrame(frame, selectedFrame, selectFrame) {
   return dom.li(
     { key: frame.id,
       className: `frame ${selectedClass}`,
-      onClick: () => selectFrame(frame) },
+      onMouseDown: () => selectFrame(frame),
+      tabIndex: 0
+    },
     renderFrameTitle(frame),
     renderFrameLocation(frame)
   );

--- a/public/js/test/mochitest/browser_dbg-call-stack.js
+++ b/public/js/test/mochitest/browser_dbg-call-stack.js
@@ -1,12 +1,9 @@
 /* Any copyright is dedicated to the Public Domain.
  * http://creativecommons.org/publicdomain/zero/1.0/ */
-function findFrame(dbg, index) {
-  return findElement(dbg, "frame", index);
-}
 
 // checks to see if the frame is selected and the title is correct
 function isFrameSelected(dbg, index, title) {
-  const $frame = findFrame(dbg, index);
+  const $frame = findElement(dbg, "frame", index);
   const frame = dbg.selectors.getSelectedFrame(dbg.getState());
 
   const elSelected = $frame.classList.contains("selected");
@@ -25,6 +22,6 @@ add_task(function* () {
 
   ok(isFrameSelected(dbg, 1, "secondCall"), "the first frame is selected");
 
-  findFrame(dbg, 2).click();
+  clickElement(dbg, "frame", 2);
   ok(isFrameSelected(dbg, 2, "firstCall"), "the second frame is selected");
 });


### PR DESCRIPTION
Helen was asking how to detect when a frame is "focused", and I discovered that all we have to do is add a "tabindex" to it to allow it to be focus-able. This is allows us to style it with `li:focus` and everything just works. When you click on a frame, it'll be a bold blue, but when you click away it'll change to a more subtle color.

We should able to use this technique in the tree component as well. Right now it uses a hidden button to allow each item to be focus-able, but it just needs a `tabindex` property to work.

I also had to change the click event to `mouseDown` because that's when the element gets focused. Otherwise it's too easy for a call frame to be "focused" but not "selected", just by pressing the mouse down on a frame but the moving the cursor outside of it. Previously this would not select it. Now, the focused and selected properties are always in sync.