### PR TITLE
Fix #994: Fix tab colors in dark theme

### DIFF
--- a/packages/devtools-local-toolbox/public/js/lib/themes/variables.css
+++ b/packages/devtools-local-toolbox/public/js/lib/themes/variables.css
@@ -20,7 +20,6 @@
   --theme-contrast-background: #e6b064;
 
   --theme-tab-toolbar-background: #fcfcfc;
-  --theme-faded-tab-color: #7E7E7E;
   --theme-toolbar-background: #fcfcfc;
   --theme-toolbar-background-alt: #f5f5f5;
   --theme-selection-background: #4c9ed9;
@@ -83,7 +82,6 @@
   --theme-contrast-background: #ffb35b;
 
   --theme-tab-toolbar-background: #272b35;
-  --theme-faded-tab-color: #333945;
   --theme-toolbar-background: #272b35;
   --theme-toolbar-background-alt: #2F343E;
   --theme-selection-background: #5675B9;

--- a/public/js/components/App.css
+++ b/public/js/components/App.css
@@ -7,6 +7,12 @@
 :root.theme-light,
 :root .theme-light {
   --theme-search-overlays-semitransparent: rgba(221, 225, 228, 0.66);
+  --theme-faded-tab-color: #7e7e7e;
+}
+
+:root.theme-dark,
+:root .theme-dark {
+  --theme-faded-tab-color: #6e7d8c;
 }
 
 * {


### PR DESCRIPTION
Associated Issue: #994

### Summary of Changes

* Changes the ```theme-faded-tab-color``` in dark theme to a slightly lighter color
* Moves the tab variables out of ```variables.css``` into ```App.css```, as there's no corresponding m-c commit to add that variable

### Testing

* [x] passes `npm test`
* [x] passes `npm run lint`

### Screenshots/Videos
<img width="293" alt="screen shot 2016-10-31 at 4 29 54 pm" src="https://cloud.githubusercontent.com/assets/1720093/19870526/4e0370ac-9f87-11e6-9358-fca973e71e5f.png">
