### PR TITLE
change path for build-bootstrap.js in chrome-remote-debugging-protoco…

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,7 +67,17 @@ The debugger.html is a web application that makes a [WebSocket](https://develope
 
 First we need to get the web application running.  Within the source code directory, from the command line run these commands.
 
+### Linux or MacOs
+
 * `npm install` - Install dependencies
+* `npm start` - Start development web server
+
+### Windows
+
+It is recommended to use Git Shell which comes with [GitHub Desktop] application to emulate bash on Windows.
+
+* `npm install --ignore-scripts` - Install dependencies
+* `bash ./bin/preinstall` - Run preinstall script manually
 * `npm start` - Start development web server
 
 Then, because `npm start` will remain running, from another terminal window you can open [http://localhost:8000](http://localhost:8000) in your browser or type the following:
@@ -373,3 +383,5 @@ These are the [labels](https://github.com/devtools-html/debugger.html/labels) we
 [labels-firefox]:https://github.com/devtools-html/debugger.html/labels/firefox
 [labels-infrastructure]:https://github.com/devtools-html/debugger.html/labels/infrastructure
 [labels-not-actionable]:https://github.com/devtools-html/debugger.html/labels/not%20actionable
+
+[GitHub Desktop]:https://desktop.github.com/

--- a/README.md
+++ b/README.md
@@ -14,7 +14,18 @@ debugger.html is a hackable debugger for modern times, built from the ground up 
 
 Here are instructions to get the debugger.html application installed and running.
 
+### Linux or MacOs
+
 * `npm install` - Install dependencies
+* `npm start` - Start development web server
+* `open http://localhost:8000` - Open in any modern browser
+
+### Windows
+
+It is recommended to use Git Shell which comes with [GitHub Desktop] application to emulate bash on Windows.
+
+* `npm install --ignore-scripts` - Install dependencies
+* `bash ./bin/preinstall` - Run preinstall script manually
 * `npm start` - Start development web server
 * `open http://localhost:8000` - Open in any modern browser
 
@@ -79,3 +90,5 @@ We're all on Mozilla's IRC in the [#devtools-html][irc-devtools-html] channel on
 [storybook]:./CONTRIBUTING.md#storybook
 
 [irc-devtools-html]:irc://irc.mozilla.org/devtools-html
+
+[GitHub Desktop]:https://desktop.github.com/

--- a/packages/chrome-remote-debugging-protocol/package.json
+++ b/packages/chrome-remote-debugging-protocol/package.json
@@ -4,7 +4,7 @@
   "description": "API for interacting with chrome's remote debugger protocol",
   "main": "index.js",
   "bin": {
-    "chrome-remote-debugging-protocol": "build-bootstrap.js"
+    "chrome-remote-debugging-protocol": "bin/build-bootstrap.js"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
Associated Issue: #1043

### Summary of Changes

* change path for build-bootstrap.js in chrome-remote-debugging-protocol package
* change documentation to correspond with the installation process

### Testing

* [x] passes `npm test`
* [x] passes `npm run lint`

### Screenshots/Videos (OPTIONAL)

Trying to fix the problem with starting debugger.html on Windows.