### PR TITLE
Fix flow statements

### DIFF
--- a/packages/devtools-config/src/feature.js
+++ b/packages/devtools-config/src/feature.js
@@ -7,11 +7,11 @@ const flag = require("./test-flag");
  * Gets a config value for a given key
  * e.g "chrome.webSocketPort"
  */
-function getValue(key: string) {
+function getValue(key) {
   return pick(config, key);
 }
 
-function isEnabled(key: string) {
+function isEnabled(key) {
   return config.features[key];
 }
 
@@ -35,7 +35,7 @@ function isFirefox() {
   return /firefox/i.test(navigator.userAgent);
 }
 
-function setConfig(value: Object) {
+function setConfig(value) {
   config = value;
 }
 

--- a/public/js/utils/assert.js
+++ b/public/js/utils/assert.js
@@ -1,3 +1,5 @@
+// @flow
+
 function assert(condition: boolean, message: string) {
   if (!condition) {
     throw new Error("Assertion failure: " + message);


### PR DESCRIPTION
The last Flow PR introduced two issues:
1. types to feature.js which broke `npm test` and `npm start`. I'm not sure how CI passed
2. it left out a `// @flow` comment
