### PR TITLE
Enable search in the panel

### DIFF
--- a/packages/devtools-config/configs/development.json
+++ b/packages/devtools-config/configs/development.json
@@ -11,8 +11,7 @@
     "tabs": true,
     "sourceMaps": true,
     "prettyPrint": true,
-    "watchExpressions": false,
-    "search": true
+    "watchExpressions": false
   },
   "chrome": {
     "debug": true,

--- a/public/js/components/Editor.js
+++ b/public/js/components/Editor.js
@@ -21,7 +21,7 @@ const Breakpoint = React.createFactory(require("./EditorBreakpoint"));
 
 const { getDocument, setDocument } = require("../utils/source-documents");
 const { shouldShowFooter } = require("../utils/editor");
-const { isEnabled, isFirefox } = require("devtools-config");
+const { isFirefox } = require("devtools-config");
 const { showMenu } = require("../utils/menu");
 
 require("./Editor.css");
@@ -252,7 +252,6 @@ const Editor = React.createClass({
   },
 
   componentDidMount() {
-    const extraKeys = isEnabled("search") ? { "Cmd-F": () => {} } : {};
     this.cbPanels = {};
 
     this.editor = new SourceEditor({
@@ -266,8 +265,11 @@ const Editor = React.createClass({
       enableCodeFolding: false,
       gutters: ["breakpoints"],
       value: " ",
-      extraKeys
+      extraKeys: {}
     });
+
+    // disables the default search shortcuts
+    this.editor._initShortcuts = () => {};
 
     this.editor.appendToLocalElement(
       ReactDOM.findDOMNode(this).querySelector(".editor-mount")

--- a/public/js/components/EditorSearchBar.js
+++ b/public/js/components/EditorSearchBar.js
@@ -2,7 +2,6 @@ const React = require("react");
 const { DOM: dom, PropTypes } = React;
 const { findDOMNode } = require("react-dom");
 const Svg = require("./utils/Svg");
-const { isEnabled } = require("devtools-config");
 const { find, findNext, findPrev } = require("../utils/source-search");
 const classnames = require("classnames");
 const debounce = require("lodash").debounce;
@@ -39,18 +38,14 @@ const EditorSearchBar = React.createClass({
 
   componentWillUnmount() {
     const shortcuts = this.context.shortcuts;
-    if (isEnabled("search")) {
-      shortcuts.off("CmdOrCtrl+F", this.toggleSearch);
-      shortcuts.off("Escape", this.onEscape);
-    }
+    shortcuts.off("CmdOrCtrl+F", this.toggleSearch);
+    shortcuts.off("Escape", this.onEscape);
   },
 
   componentDidMount() {
     const shortcuts = this.context.shortcuts;
-    if (isEnabled("search")) {
-      shortcuts.on("CmdOrCtrl+F", this.toggleSearch);
-      shortcuts.on("Escape", this.onEscape);
-    }
+    shortcuts.on("CmdOrCtrl+F", this.toggleSearch);
+    shortcuts.on("Escape", this.onEscape);
   },
 
   componentDidUpdate() {
@@ -74,7 +69,9 @@ const EditorSearchBar = React.createClass({
 
     if (this.state.enabled) {
       const node = this.searchInput();
-      node.setSelectionRange(0, node.value.length);
+      if (node) {
+        node.setSelectionRange(0, node.value.length);
+      }
     }
   },
 
@@ -147,7 +144,7 @@ const EditorSearchBar = React.createClass({
   },
 
   render() {
-    if (!isEnabled("search") || !this.state.enabled) {
+    if (!this.state.enabled) {
       return dom.div();
     }
 

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -49,11 +49,13 @@ if (isFirefoxPanel()) {
   const prettyPrint = require("./utils/pretty-print");
 
   module.exports = {
-    bootstrap: ({ threadClient, tabTarget, toolbox }) => {
+    bootstrap: ({ threadClient, tabTarget, toolbox, L10N }) => {
       // TODO (jlast) remove when the panel has L10N
-      if (!window.L10N) {
+      if (L10N) {
+        window.L10N = L10N;
+      } else {
         window.L10N = require("../../packages/devtools-local-toolbox/public/js/utils/L10N");
-        L10N.setBundle(require("./strings.json"));
+        window.L10N.setBundle(require("./strings.json"));
       }
 
       firefox.setThreadClient(threadClient);


### PR DESCRIPTION
Associated Issue: #1067 

### Summary of Changes

* enables search, which turns on the new search bar in the panel
* update the L10N bootstrap logic so that it expects L10N to be passed in. Previously, the assumption was that L10N was a global on the window, but that was a bad assumption
* there's an associated m-c change as well that i'll link to soon

### Screenshots/Videos (OPTIONAL)
![](http://g.recordit.co/chXZ2AGFDz.gif)