### PR TITLE
changes because of eslint issues that npm run lint was reporting

### DIFF
--- a/public/js/components/Accordion.js
+++ b/public/js/components/Accordion.js
@@ -15,7 +15,7 @@ const Accordion = React.createClass({
 
   getInitialState: function() {
     return { opened: this.props.items.map(item => item.opened),
-             created: [] };
+      created: [] };
   },
 
   handleHeaderClick: function(i) {
@@ -51,7 +51,7 @@ const Accordion = React.createClass({
       (created[i] || opened[i]) ?
         div(
           { className: "_content",
-              style: { display: opened[i] ? "block" : "none" }
+            style: { display: opened[i] ? "block" : "none" }
           },
           React.createElement(item.component, item.componentProps || {})
         ) :

--- a/public/js/components/App.js
+++ b/public/js/components/App.js
@@ -84,7 +84,7 @@ App.childContextTypes = {
 
 module.exports = connect(
   state => ({ sources: getSources(state),
-              selectedSource: getSelectedSource(state),
-            }),
+    selectedSource: getSelectedSource(state),
+  }),
   dispatch => bindActionCreators(actions, dispatch)
 )(App);

--- a/public/js/components/Expressions.js
+++ b/public/js/components/Expressions.js
@@ -107,7 +107,7 @@ const Expressions = React.createClass({
   renderExpressionContainer(expression) {
     return dom.div(
       { className: "expression-container",
-      key: expression.id + expression.input },
+        key: expression.id + expression.input },
       expression.updating ?
         this.renderExpressionUpdating(expression) :
         this.renderExpression(expression)

--- a/public/js/components/RightSidebar.js
+++ b/public/js/components/RightSidebar.js
@@ -192,13 +192,13 @@ const RightSidebar = React.createClass({
 
   getItems() {
     const items = [
-    { header: L10N.getStr("breakpoints.header"),
-      component: Breakpoints,
-      opened: true },
-    { header: L10N.getStr("callStack.header"),
-      component: Frames },
-    { header: L10N.getStr("scopes.header"),
-      component: Scopes }
+      { header: L10N.getStr("breakpoints.header"),
+        component: Breakpoints,
+        opened: true },
+      { header: L10N.getStr("callStack.header"),
+        component: Frames },
+      { header: L10N.getStr("scopes.header"),
+        component: Scopes }
     ];
     if (isEnabled("watchExpressions")) {
       items.unshift({ header: L10N.getStr("watchExpressions.header"),

--- a/public/js/components/SourceSearch.js
+++ b/public/js/components/SourceSearch.js
@@ -93,8 +93,8 @@ const Search = React.createClass({
 
 module.exports = connect(
   state => ({ sources: getSources(state),
-              selectedSource: getSelectedSource(state),
-              searchOn: getFileSearchState(state)
-            }),
+    selectedSource: getSelectedSource(state),
+    searchOn: getFileSearchState(state)
+  }),
   dispatch => bindActionCreators(actions, dispatch)
 )(Search);

--- a/public/js/components/Sources.js
+++ b/public/js/components/Sources.js
@@ -36,6 +36,6 @@ const Sources = React.createClass({
 
 module.exports = connect(
   state => ({ selectedSource: getSelectedSource(state),
-              sources: getSources(state) }),
+    sources: getSources(state) }),
   dispatch => bindActionCreators(actions, dispatch)
 )(Sources);

--- a/public/js/components/SourcesTree.js
+++ b/public/js/components/SourcesTree.js
@@ -65,8 +65,8 @@ let SourcesTree = React.createClass({
           : this.state.sourceTree;
 
     this.setState({ uncollapsedTree,
-                    sourceTree,
-                    parentMap: createParentMap(sourceTree) });
+      sourceTree,
+      parentMap: createParentMap(sourceTree) });
   },
 
   focusItem(item) {

--- a/public/js/components/utils/ManagedTree.js
+++ b/public/js/components/utils/ManagedTree.js
@@ -9,7 +9,7 @@ let ManagedTree = React.createClass({
 
   getInitialState() {
     return { expanded: new Set(),
-             focusedItem: null };
+      focusedItem: null };
   },
 
   setExpanded(item, isExpanded) {

--- a/public/js/utils/sources-tree.js
+++ b/public/js/utils/sources-tree.js
@@ -260,9 +260,9 @@ function createTree(sources: any) {
   const sourceTree = collapseTree(uncollapsedTree);
 
   return { uncollapsedTree,
-           sourceTree,
-           parentMap: createParentMap(sourceTree),
-           focusedItem: null };
+    sourceTree,
+    parentMap: createParentMap(sourceTree),
+    focusedItem: null };
 }
 
 module.exports = {


### PR DESCRIPTION
Associated Issue: #999 

### Summary of Changes

* made changes to indentation because npm run lint was reporting these as errors

### Testing

* [X] passes `npm test`
* [X] passes `npm run lint`

### Screenshots/Videos (OPTIONAL)

@jasonLaster here's that separate PR you were requesting. I made a new branch from my master fork and npm run lint, getting the same indentation errors that I referenced in issue #999. For the record I'm running the packages `linter-eslint version 8.0.0` `linter version 1.11.18`  and `editorconfig version 2.0.1` in Atom on an Ubuntu VM. I did not touch any of settings in those packages, so that could be why `npm run lint` reported those errors in the first place. 

Let me know what questions you have. 