### PR TITLE
Add Search tests

### DIFF
--- a/public/js/test/mochitest/.eslintrc
+++ b/public/js/test/mochitest/.eslintrc
@@ -52,6 +52,7 @@
     "invokeInTab": false,
     "findSource": false,
     "findElement": false,
+    "findElementWithSelector": false,
     "findAllElements": false,
     "openNewTabAndToolbox": false,
     "selectSource": false,
@@ -68,6 +69,7 @@
     "isVisibleWithin": false,
     "clickElement": false,
     "togglePauseOnExceptions": false,
+    "type": false,
     "pressKey": false,
     "EXAMPLE_URL": false
   }

--- a/public/js/test/mochitest/browser.ini
+++ b/public/js/test/mochitest/browser.ini
@@ -48,5 +48,6 @@ support-files =
 [browser_dbg-navigation.js]
 [browser_dbg-pretty-print.js]
 [browser_dbg-pretty-print-paused.js]
+[browser_dbg-searching.js]
 [browser_dbg-sourcemaps.js]
 [browser_dbg-sourcemaps-bogus.js]

--- a/public/js/test/mochitest/browser_dbg-searching.js
+++ b/public/js/test/mochitest/browser_dbg-searching.js
@@ -1,0 +1,27 @@
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
+
+// Testing source search
+add_task(function* () {
+  const dbg = yield initDebugger("doc-script-switching.html");
+
+  pressKey(dbg, "sourceSearch");
+  findElementWithSelector(dbg, "input").focus();
+  type(dbg, "sw");
+  pressKey(dbg, "Enter");
+
+  yield waitForDispatch(dbg, "LOAD_SOURCE_TEXT");
+  let source = dbg.selectors.getSelectedSource(dbg.getState());
+  ok(source.get("url").match(/switching-01/), "first source is selected");
+
+  // 2. arrow keys and check to see if source is selected
+  pressKey(dbg, "sourceSearch");
+  findElementWithSelector(dbg, "input").focus();
+  type(dbg, "sw");
+  pressKey(dbg, "Down");
+  pressKey(dbg, "Enter");
+
+  yield waitForDispatch(dbg, "LOAD_SOURCE_TEXT");
+  source = dbg.selectors.getSelectedSource(dbg.getState());
+  ok(source.get("url").match(/switching-02/), "second source is selected");
+});

--- a/public/js/test/mochitest/head.js
+++ b/public/js/test/mochitest/head.js
@@ -523,7 +523,13 @@ function invokeInTab(fnc) {
 }
 
 const isLinux = Services.appinfo.OS === "Linux";
+const cmdOrCtrl = isLinux ? { ctrlKey: true } : { metaKey: true };
 const keyMappings = {
+  sourceSearch: { code: "p", modifiers: cmdOrCtrl},
+  fileSearch: { code: "f", modifiers: cmdOrCtrl},
+  "Enter": { code: "VK_RETURN" },
+  "Up": { code: "VK_UP" },
+  "Down": { code: "VK_DOWN" },
   pauseKey: { code: "VK_F8" },
   resumeKey: { code: "VK_F8" },
   stepOverKey: { code: "VK_F10" },
@@ -542,12 +548,19 @@ const keyMappings = {
  */
 function pressKey(dbg, keyName) {
   let keyEvent = keyMappings[keyName];
+
   const { code, modifiers } = keyEvent;
   return EventUtils.synthesizeKey(
     code,
     modifiers || {},
     dbg.win
   );
+}
+
+function type(dbg, string) {
+  string.split("").forEach(char => {
+    EventUtils.synthesizeKey(char, {}, dbg.win);
+  });
 }
 
 function isVisibleWithin(outerEl, innerEl) {
@@ -592,6 +605,10 @@ function getSelector(elementName, ...args) {
 
 function findElement(dbg, elementName, ...args) {
   const selector = getSelector(elementName, ...args);
+  return findElementWithSelector(dbg, selector);
+}
+
+function findElementWithSelector(dbg, selector) {
   return dbg.win.document.querySelector(selector);
 }
 


### PR DESCRIPTION
Associated Issue: #1067 

### Summary of Changes

* Adds some mochi tests for source search. I'd like to add some unit tests later as most of this is more suited for that

* I tried really hard to get file search tests in, but for whatever reason I kept opening the content search bar and not the editor search bar. 

here's a small patch for the file search tests
```js
// Testing file search
add_task(function* () {
  const dbg = yield initDebugger("doc-script-switching.html");
  yield selectSource(dbg, "switching-01");

  // window.dbg = dbg;
  // yield pauseTest();
  const el = findElementWithSelector(dbg, ".CodeMirror-line").focus();
  console.log("el", el);
  pressKey(dbg, "fileSearch");
  type(dbg, "fun");
  debugger;
});
```


