### PR TITLE
Escape EditorSearchBar queries before using as RegExp

### DIFF
--- a/public/js/components/EditorSearchBar.js
+++ b/public/js/components/EditorSearchBar.js
@@ -4,12 +4,12 @@ const { findDOMNode } = require("react-dom");
 const Svg = require("./utils/Svg");
 const { find, findNext, findPrev } = require("../utils/source-search");
 const classnames = require("classnames");
-const debounce = require("lodash").debounce;
+const { debounce, escapeRegExp } = require("lodash");
 
 require("./EditorSearchBar.css");
 
 function countMatches(query, text) {
-  const re = new RegExp(query, "g");
+  const re = new RegExp(escapeRegExp(query), "g");
   const match = text.match(re);
   return match ? match.length : 0;
 }


### PR DESCRIPTION
Associated Issue: #1092 

### Summary of Changes

* Runs `escapeRegExp` on `query` passed to `countMatches`. Searching for something like `val(` would previously throw an error for an unterminated parenthetical in a regular expression.

### Testing

* [x] passes `npm test`
* [x] passes `npm run lint`