### PR TITLE
Consistently return Seq from getFrames

### DIFF
--- a/public/js/components/Frames.js
+++ b/public/js/components/Frames.js
@@ -29,7 +29,7 @@ function renderFrameLocation(frame) {
 
 const Frames = React.createClass({
   propTypes: {
-    frames: ImPropTypes.list.isRequired,
+    frames: ImPropTypes.list,
     selectedFrame: PropTypes.object,
     selectFrame: PropTypes.func.isRequired
   },
@@ -66,6 +66,9 @@ const Frames = React.createClass({
 
   renderFrames() {
     let { frames } = this.props;
+    if (!frames) {
+      return null;
+    }
 
     const numFramesToShow = this.state.showAllFrames
       ? frames.size : NUM_FRAMES_SHOWN;
@@ -92,7 +95,7 @@ const Frames = React.createClass({
   render() {
     const { frames } = this.props;
 
-    if (frames.size === 0) {
+    if (!frames) {
       return div(
         { className: "pane frames" },
         div(
@@ -110,15 +113,20 @@ const Frames = React.createClass({
   }
 });
 
+function getAndProcessFrames(state) {
+  const frames = getFrames(state);
+  if (!frames) {
+    return null;
+  }
+  return frames.filter(frame => getSource(state, frame.location.sourceId))
+               .map(frame => Object.assign({}, frame, {
+                 source: getSource(state, frame.location.sourceId).toJS()
+               }));
+}
+
 module.exports = connect(
   state => ({
-    frames: getFrames(state)
-      .filter(frame => getSource(state, frame.location.sourceId))
-      .map(frame => {
-        return Object.assign({}, frame, {
-          source: getSource(state, frame.location.sourceId).toJS()
-        });
-      }),
+    frames: getAndProcessFrames(state),
     selectedFrame: getSelectedFrame(state)
   }),
   dispatch => bindActionCreators(actions, dispatch)

--- a/public/js/components/Frames.js
+++ b/public/js/components/Frames.js
@@ -92,7 +92,7 @@ const Frames = React.createClass({
   render() {
     const { frames } = this.props;
 
-    if (frames.length === 0) {
+    if (frames.size === 0) {
       return div(
         { className: "pane frames" },
         div(

--- a/public/js/reducers/pause.js
+++ b/public/js/reducers/pause.js
@@ -137,7 +137,9 @@ function getShouldIgnoreCaughtExceptions(state) {
 }
 
 function getFrames(state) {
-  return state.pause.get("frames") || [];
+  // frames should always be an Immutable Seq
+  // Return an empty Seq if the state is null
+  return state.pause.get("frames") || fromJS([]);
 }
 
 function getSelectedFrame(state) {

--- a/public/js/reducers/pause.js
+++ b/public/js/reducers/pause.js
@@ -137,9 +137,7 @@ function getShouldIgnoreCaughtExceptions(state) {
 }
 
 function getFrames(state) {
-  // frames should always be an Immutable Seq
-  // Return an empty Seq if the state is null
-  return state.pause.get("frames") || fromJS([]);
+  return state.pause.get("frames");
 }
 
 function getSelectedFrame(state) {

--- a/public/js/utils/pause.js
+++ b/public/js/utils/pause.js
@@ -2,6 +2,9 @@ const { Frame } = require("../tcomb-types");
 const { getOriginalLocation } = require("./source-map");
 
 function updateFrameLocations(frames) {
+  if (!frames) {
+    return Promise.resolve(frames);
+  }
   return Promise.all(
     frames.map(frame => {
       return getOriginalLocation(frame.location).then(loc => {


### PR DESCRIPTION
Associated Issue: #1056 

### Summary of Changes

* Consistently passes `frames` as type `Seq`, even when there are 0 frames. 

Previously, 0 frames would be stored in state as `null` and returned from the selector as `[]`. This confusion between whether `frames` is an `Array` with a `length` or a `Seq` with a `size` was part of what caused the bug resulting in #1056. https://github.com/devtools-html/debugger.html/pull/1083 fixed the buggy behavior but it left the type inconsistency, so this PR corrects that.

### Testing

* [x] passes `npm test`
* [x] passes `npm run lint`

