### PR TITLE
create a context menu for the source tabs with close and close all

### DIFF
--- a/public/debugger.properties
+++ b/public/debugger.properties
@@ -203,6 +203,14 @@ editor.editBreakpoint=Edit Breakpoint
 # menu item for adding a breakpoint condition on a line.
 editor.addConditionalBreakpoint=Add Conditional Breakpoint
 
+# LOCALIZATION NOTE (sourceTabs.closeTab): Editor source tab context menu item
+# for closing the selected tab below the mouse.
+sourceTabs.closeTab=Close tab
+
+# LOCALIZATION NOTE (sourceTabs.closeAllTabs): Editor source tab context menu item
+# for closing all tabs.
+sourceTabs.closeAllTabs=Close all tabs
+
 # LOCALIZATION NOTE (scopes.header): Scopes right sidebar pane header.
 scopes.header=Scopes
 

--- a/public/js/components/SourceTabs.js
+++ b/public/js/components/SourceTabs.js
@@ -15,6 +15,7 @@ const { isEnabled } = require("devtools-config");
 const CloseButton = require("./CloseButton");
 const Svg = require("./utils/Svg");
 const Dropdown = React.createFactory(require("./Dropdown"));
+const { showMenu } = require("../utils/menu");
 
 require("./SourceTabs.css");
 require("./Dropdown.css");
@@ -61,6 +62,39 @@ const SourceTabs = React.createClass({
 
   componentDidUpdate() {
     this.updateHiddenSourceTabs(this.props.sourceTabs);
+  },
+
+  onTabContextMenu(event, tab) {
+    event.preventDefault();
+    this.showContextMenu(event, tab);
+  },
+
+  showContextMenu(e, tab) {
+    const { closeTab } = this.props;
+
+    const closeTabLabel = L10N.getStr("sourceTabs.closeTab");
+    const closeAllTabsLabel = L10N.getStr("sourceTabs.closeAllTabs");
+
+    const closeTabMenuItem = {
+      id: "node-menu-close-tab",
+      label: closeTabLabel,
+      accesskey: "C",
+      disabled: false,
+      click: () => closeTab(tab)
+    };
+
+    const closeAllTabsMenuItem = {
+      id: "node-menu-close-all-tabs",
+      label: closeAllTabsLabel,
+      accesskey: "A",
+      disabled: false,
+      click: () => this.props.sourceTabs.forEach((t) => closeTab(t.get("id")))
+    };
+
+    showMenu(e, [
+      closeTabMenuItem,
+      closeAllTabsMenuItem
+    ]);
   },
 
   /*
@@ -138,6 +172,7 @@ const SourceTabs = React.createClass({
         className: classnames("source-tab", { active }),
         key: source.get("id"),
         onClick: () => selectSource(source.get("id")),
+        onContextMenu: (e) => this.onTabContextMenu(e, source.get("id")),
         title: source.get("url")
       },
       dom.div({ className: "filename" }, filename),

--- a/public/js/strings.json
+++ b/public/js/strings.json
@@ -27,5 +27,7 @@
   "stepOverTooltip": "Step Over (F10)",
   "resumeButtonTooltip": "Click to resume (F8)",
   "pausePendingButtonTooltip": "Waiting for next execution",
-  "pauseButtonTooltip": "Click to pause (F8)"
+  "pauseButtonTooltip": "Click to pause (F8)",
+  "sourceTabs.closeTab": "Close tab",
+  "sourceTabs.closeAllTabs": "Close all tabs"
 }


### PR DESCRIPTION
Associated Issue: I need to learn how to create mochitests so I can write tests for these kinds of things.

### Summary of Changes

* add a context menu to the source tab
* add the close and close all tabs options to the source tab context menu

Note that there is no context menu available from the tab overflow menu.  I actually feel like there could be inline close buttons for closing those tabs in the menu and the "Close All" option can be used from anywhere else.

### Testing

* [x] passes `npm test`
* [x] passes `npm run lint`

### Screenshots/Videos (OPTIONAL)

![tabs context menu](https://cloud.githubusercontent.com/assets/2134/19989556/931cdf20-a1e4-11e6-9378-e78cf350a474.gif)
