### PR TITLE
handle about: urls in the source search fixes #866

### DIFF
--- a/packages/devtools-local-toolbox/public/js/utils/utils.js
+++ b/packages/devtools-local-toolbox/public/js/utils/utils.js
@@ -53,7 +53,7 @@ function truncateStr(str: any, size: any) {
   return str;
 }
 
-function endTruncateStr(str: any, size: any) {
+function endTruncateStr(str: string, size: number) {
   if (str.length > size) {
     return "..." + str.slice(str.length - size);
   }

--- a/public/js/components/SourceSearch.js
+++ b/public/js/components/SourceSearch.js
@@ -18,8 +18,9 @@ const Autocomplete = createFactory(require("./Autocomplete"));
 
 function searchResults(sources) {
   function getSourcePath(source) {
-    const { path } = parseURL(source.get("url"));
-    return endTruncateStr(path, 50);
+    const { path, href } = parseURL(source.get("url"));
+    // for URLs like "about:home" the path is null so we pass the full href
+    return endTruncateStr((path || href), 50);
   }
 
   return sources.valueSeq()


### PR DESCRIPTION
Associated Issue: #866

### Summary of Changes

* passes in the full URL when there is no path


### Testing

* [x] passes `npm test`
* [x] passes `npm run lint`

When a URL like about:home is passed to the URL module it doesn't return a path.  The path is returned on all other parses even if you are missing the protocol.

```
> url.parse("about:home")
Url {
  protocol: 'about:',
  slashes: null,
  auth: null,
  host: 'home',
  port: null,
  hostname: 'home',
  hash: null,
  search: null,
  query: null,
  pathname: null,
  path: null,
  href: 'about:home' }
```

