### PR TITLE
Ignore whitespaces

### DIFF
--- a/public/js/utils/source-search.js
+++ b/public/js/utils/source-search.js
@@ -34,6 +34,10 @@ function getSearchCursor(cm, query, pos) {
     typeof query == "string" && query == query.toLowerCase());
 }
 
+function ignoreWhiteSpace(str) {
+  return /^\s{0,2}$/.test(str) ? "(?!\s*.*)" : str;
+}
+
 /**
  * This returns a mode object used by CoeMirror's addOverlay function
  * to parse and style tokens in the file.
@@ -46,7 +50,7 @@ function getSearchCursor(cm, query, pos) {
  * @static
  */
 function searchOverlay(query) {
-  query = new RegExp(escapeRegExp(query === "" ? "(?!\s*.*)" : query), "g");
+  query = new RegExp(escapeRegExp(ignoreWhiteSpace(query)), "g");
   return {
     token: function(stream) {
       query.lastIndex = stream.pos;

--- a/public/js/utils/source-search.js
+++ b/public/js/utils/source-search.js
@@ -34,6 +34,12 @@ function getSearchCursor(cm, query, pos) {
     typeof query == "string" && query == query.toLowerCase());
 }
 
+/**
+ * Ignore doing outline matches for less than 3 whitespaces
+ *
+ * @memberof utils/source-search
+ * @static
+ */
 function ignoreWhiteSpace(str) {
   return /^\s{0,2}$/.test(str) ? "(?!\s*.*)" : str;
 }


### PR DESCRIPTION
Associated Issue: #1101

### Summary of Changes

* Add regexp to ignore doing matching on whitespaces below 3

### Testing

* [x] passes `npm test`
* [x] passes `npm run lint`

### Screenshots/Videos
![whitespace-gif](https://cloud.githubusercontent.com/assets/792924/20031895/157e6414-a377-11e6-8d1d-4090d196cbcc.gif)

