### PR TITLE
(WIP) fix some issues with watch expressions

### DIFF
--- a/packages/devtools-local-toolbox/public/js/clients/firefox/commands.js
+++ b/packages/devtools-local-toolbox/public/js/clients/firefox/commands.js
@@ -91,11 +91,11 @@ function setBreakpointCondition(breakpointId, location, condition, noSliding) {
     .then(_bpClient => onNewBreakpoint(location, [{}, _bpClient]));
 }
 
-function evaluate(script) {
+function evaluate(script, { frameId }) {
   const deferred = defer();
   tabTarget.activeConsole.evaluateJS(script, (result) => {
     deferred.resolve(result);
-  });
+  }, { frameActor: frameId });
 
   return deferred.promise;
 }


### PR DESCRIPTION
Associated Issue: #916 

### Summary of Changes

I took a look at some of the redux work for watch expressions so that we can scope out the work we want to do to get watch expressions functional. I think this is also blocking #917. 

I found a couple of things:
1. the evaluate call needs the current frame
2. we should not eval when we aren't paused
3. we should evaluate after the store has been updated

there are some other quirks with this work that should be ironed out as well 
- for instance it might try to eval while you type
- and likely some other things as well

### Testing

* [ ] passes `npm test`
* [ ] passes `npm run lint`

### Screenshots/Videos (OPTIONAL)

