### PR TITLE
Refactor some functions in Frames.js, add Flow types

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -8,3 +8,4 @@
 
 [libs]
 ./packages/devtools-config/flow-interface.js
+./public/js/global-types.js

--- a/packages/devtools-local-toolbox/src/index.js
+++ b/packages/devtools-local-toolbox/src/index.js
@@ -6,6 +6,7 @@ const { Provider } = require("react-redux");
 const { DevToolsUtils, AppConstants } = require("devtools-sham-modules");
 const { injectGlobals, debugGlobal } = require("./utils/debug");
 const { setConfig, isEnabled, getValue, isDevelopment } = require("devtools-config");
+const L10N = require("./utils/L10N");
 
 setConfig(DebuggerConfig);
 
@@ -29,8 +30,6 @@ if (process.env.TARGET !== "firefox-panel") {
     case "firebug": require("./lib/themes/firebug-theme.css"); break;
   }
   document.body.parentNode.classList.add(`theme-${theme}`);
-
-  window.L10N = require("./utils/L10N");
 }
 
 function initApp() {
@@ -122,5 +121,6 @@ module.exports = {
   bootstrap,
   renderRoot,
   debugGlobal,
-  client
+  client,
+  L10N
 };

--- a/public/js/global-types.js
+++ b/public/js/global-types.js
@@ -1,0 +1,1 @@
+declare var L10N: any;

--- a/src/main.js
+++ b/src/main.js
@@ -1,10 +1,12 @@
+// @flow
+
 const React = require("react");
 const { bindActionCreators, combineReducers } = require("redux");
 const ReactDOM = require("react-dom");
 
 const {
   client: { getClient, firefox },
-  renderRoot, bootstrap
+  renderRoot, bootstrap, L10N
 } = require("devtools-local-toolbox");
 
 const { getValue, isFirefoxPanel } = require("devtools-config");
@@ -28,7 +30,8 @@ const store = createStore(combineReducers(reducers));
 const actions = bindActionCreators(require("./actions"), store.dispatch);
 
 if (!isFirefoxPanel()) {
-  L10N.setBundle(require("./strings.json"));
+  window.L10N = L10N;
+  window.L10N.setBundle(require("./strings.json"));
 }
 
 window.appStore = store;
@@ -50,7 +53,7 @@ if (isFirefoxPanel()) {
   const prettyPrint = require("./utils/pretty-print");
 
   module.exports = {
-    bootstrap: ({ threadClient, tabTarget, toolbox, L10N }) => {
+    bootstrap: ({ threadClient, tabTarget, toolbox, L10N }: any) => {
       // TODO (jlast) remove when the panel has L10N
       if (L10N) {
         window.L10N = L10N;

--- a/src/types.js
+++ b/src/types.js
@@ -55,3 +55,42 @@ export type SourceText = {
   text: string,
   contentType: string
 };
+
+/**
+ * Scope
+ * @memberof types
+ * @static
+ */
+export type Scope = {
+  actor: string,
+  parent: Scope,
+  bindings: {
+    // FIXME Define these types more clearly
+    arguments: Array<Object>,
+    variables: Object
+  },
+  function: {
+    actor: string,
+    class: string,
+    displayName: string,
+    location: Location,
+    // FIXME Define this type more clearly
+    parameterNames: Array<Object>
+  },
+  type: string
+}
+
+/**
+ * Frame
+ * @memberof types
+ * @static
+ */
+export type Frame = {
+   id: string,
+   displayName: string,
+   location: Location,
+   source: Source,
+   scope: Scope,
+   // FIXME Define this type more clearly
+   this: Object
+ }


### PR DESCRIPTION
### Summary of Changes

* Refactor some functions in Frames.js to be more type-safe and less coupled to `this.props`
* Add Flow type-checking to Frames.js

### Testing

* [x] passes `npm test`
* [x] passes `npm run lint`

### Additional Notes

Flow doesn't like `L10N` being a global. I had to redeclare it at the top of the file in order to get Flow to cooperate.

I feel like `L10N` ought to be `require`d just like everything else, especially if we need to do that in every file that we add Flow to.
