### PR TITLE
Add a fix command to autofix js linting errors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -322,6 +322,12 @@ To test your JS changes run the command:
 $ npm run lint-js
 ```
 
+To automatically fix many errors run the command:
+
+```
+$ npm run lint-fix
+```
+
 #### Storybook
 
 Storybook is our local development and testing utility that allows you to see how an individual component like the breakpoint list view or the call stack view react to any changes to style and code you've made.

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "lint": "npm run lint-css -s; npm run lint-js -s",
     "lint-css": "stylelint public/js/components/*.css",
     "lint-js": "eslint public/js",
+    "lint-fix": "npm run lint-js -- --fix",
     "test": "node public/js/test/node-unit-tests.js",
     "test-all": "npm run test; npm run lint; npm run flow; npm run firefox-unit-test",
     "mocha-server": "node bin/mocha-server.js",


### PR DESCRIPTION
Thought it might be useful after working on https://github.com/devtools-html/debugger.html/pull/1130 and getting a linting error.

### Summary of Changes

Adds a command to run autofix with eslint

`npm run fix`

### Testing

* [x] passes `npm test`
* [x] passes `npm run lint`

### Screenshots/Videos (OPTIONAL)

