### PR TITLE
Add separators to the debugger context menu.

### DIFF
--- a/public/js/components/Editor.js
+++ b/public/js/components/Editor.js
@@ -237,6 +237,10 @@ const Editor = React.createClass({
       click: () => this.toggleBreakpoint(line)
     };
 
+    const sep = {
+      type: "separator"
+    };
+
     const conditionalBreakpoint = {
       id: "node-menu-conditional-breakpoint",
       label: cbLabel,
@@ -247,6 +251,7 @@ const Editor = React.createClass({
 
     showMenu(e, [
       toggleBreakpoint,
+      sep,
       conditionalBreakpoint
     ]);
   },

--- a/public/js/components/Editor.js
+++ b/public/js/components/Editor.js
@@ -237,10 +237,6 @@ const Editor = React.createClass({
       click: () => this.toggleBreakpoint(line)
     };
 
-    const sep = {
-      type: "separator"
-    };
-
     const conditionalBreakpoint = {
       id: "node-menu-conditional-breakpoint",
       label: cbLabel,
@@ -251,7 +247,6 @@ const Editor = React.createClass({
 
     showMenu(e, [
       toggleBreakpoint,
-      sep,
       conditionalBreakpoint
     ]);
   },

--- a/public/js/components/menu.css
+++ b/public/js/components/menu.css
@@ -23,6 +23,14 @@ menuitem:hover {
   cursor: pointer;
 }
 
+menuseparator {
+  border-bottom: 1px solid #cacdd3;
+  width: 100%;
+  height: 5px;
+  display: block;
+  margin-bottom: 5px;
+}
+
 #contextmenu-mask.show {
   position: fixed;
   top: 0;


### PR DESCRIPTION
Associated Issue: #1109 

@jasonLaster 

### Summary of Changes
- Added the separator and have it automatically be loaded into context menus.
- Added CSS for the separators in the debugger context menu.

### Screenshots/Videos (OPTIONAL)

![nov-06-2016 15-04-58](https://cloud.githubusercontent.com/assets/5490167/20041116/9cf64388-a432-11e6-88cb-808c4fe09b9a.gif)
