### PR TITLE
js/components/Editor.js: Focus on breakpoint input

### DIFF
--- a/public/js/components/Editor.js
+++ b/public/js/components/Editor.js
@@ -111,11 +111,14 @@ const Editor = React.createClass({
       }
     };
 
-    const panel = renderConditionalPanel({
-      condition, closePanel, setBreakpoint
-    });
+    const panel = this.editor.codeMirror.addLineWidget(
+      line,
+      renderConditionalPanel({ condition, closePanel, setBreakpoint })
+    );
 
-    this.cbPanels[line] = this.editor.codeMirror.addLineWidget(line, panel);
+    // Focus on the breakpoint input when it opens.
+    panel.node.querySelector("input").focus();
+    this.cbPanels[line] = panel;
   },
 
   isCbPanelOpen() {


### PR DESCRIPTION
Associated Issue: #1096

### Summary of Changes

* Trigger focus when the breakpoint input field appears.

### Testing

* [x] passes `npm test`
* [x] passes `npm run lint`

### Screenshots/Videos

<img width="625" alt="screen shot 2016-11-06 at 5 00 09 pm" src="https://cloud.githubusercontent.com/assets/81969/20042132/8017d4e2-a442-11e6-9573-48563c99d058.png">

Thank you for the diff! That really helps a lot for me to understand the code.
