### PR TITLE
Hide close items

### DIFF
--- a/public/js/components/SourceTabs.js
+++ b/public/js/components/SourceTabs.js
@@ -15,7 +15,7 @@ const { isEnabled } = require("devtools-config");
 const CloseButton = require("./CloseButton");
 const Svg = require("./utils/Svg");
 const Dropdown = React.createFactory(require("./Dropdown"));
-const { showMenu } = require("../utils/menu");
+const { showMenu, buildMenu } = require("../utils/menu");
 
 require("./SourceTabs.css");
 require("./Dropdown.css");
@@ -125,12 +125,13 @@ const SourceTabs = React.createClass({
       click: () => tabs.forEach(closeTab)
     };
 
-    showMenu(e, [
-      closeTabMenuItem,
-      closeOtherTabsMenuItem,
-      closeTabsToRightMenuItem,
-      closeAllTabsMenuItem
-    ]);
+    showMenu(e, buildMenu([
+      { item: closeTabMenuItem, hide: false },
+      { item: closeOtherTabsMenuItem, hide: () => tabs.size === 1 },
+      { item: closeTabsToRightMenuItem, hide: () => tabs.some((t, i) =>
+        t === tab && (tabs.size - 1) === i) },
+      { item: closeAllTabsMenuItem, hide: false }
+    ]));
   },
 
   /*

--- a/public/js/components/SourceTabs.js
+++ b/public/js/components/SourceTabs.js
@@ -126,11 +126,11 @@ const SourceTabs = React.createClass({
     };
 
     showMenu(e, buildMenu([
-      { item: closeTabMenuItem, hide: false },
-      { item: closeOtherTabsMenuItem, hide: () => tabs.size === 1 },
-      { item: closeTabsToRightMenuItem, hide: () => tabs.some((t, i) =>
-        t === tab && (tabs.size - 1) === i) },
-      { item: closeAllTabsMenuItem, hide: false }
+      { item: closeTabMenuItem },
+      { item: closeOtherTabsMenuItem, hidden: () => tabs.size === 1 },
+      { item: closeTabsToRightMenuItem, hidden: () =>
+         tabs.some((t, i) => t === tab && (tabs.size - 1) === i) },
+      { item: closeAllTabsMenuItem }
     ]));
   },
 

--- a/public/js/components/SourceTabs.js
+++ b/public/js/components/SourceTabs.js
@@ -93,9 +93,9 @@ const SourceTabs = React.createClass({
       accesskey: "O",
       disabled: false,
       click: () => {
-        this.props.sourceTabs.forEach((t) => {
-          if (t.get("id") !== tab) {
-            closeTab(t.get("id"));
+        tabs.forEach((t) => {
+          if (t !== tab) {
+            closeTab(t);
           }
         });
       }
@@ -107,11 +107,11 @@ const SourceTabs = React.createClass({
       accesskey: "R",
       disabled: false,
       click: () => {
-        this.props.sourceTabs.reverse().every((t) => {
-          if (t.get("id") === tab) {
+        tabs.reverse().every((t) => {
+          if (t === tab) {
             return false;
           }
-          closeTab(t.get("id"));
+          closeTab(t);
           return true;
         });
       }

--- a/public/js/utils/menu.js
+++ b/public/js/utils/menu.js
@@ -69,10 +69,10 @@ function showMenu(e, items) {
 }
 
 function buildMenu(items) {
-  return items.map(item => {
-    const remove = typeof item.hide === "function" ? item.hide() : item.hide;
-    return remove ? null : item.item;
-  }).filter((item) => item !== null);
+  return items.map(itm => {
+    const hide = typeof itm.hidden === "function" ? itm.hidden() : itm.hidden;
+    return hide ? null : itm.item;
+  }).filter(itm => itm !== null);
 }
 
 module.exports = {

--- a/public/js/utils/menu.js
+++ b/public/js/utils/menu.js
@@ -68,6 +68,14 @@ function showMenu(e, items) {
   return menu.popup(e.clientX, e.clientY, { doc: document });
 }
 
+function buildMenu(items) {
+  return items.map(item => {
+    const remove = typeof item.hide === "function" ? item.hide() : item.hide;
+    return remove ? null : item.item;
+  }).filter((item) => item !== null);
+}
+
 module.exports = {
-  showMenu
+  showMenu,
+  buildMenu
 };

--- a/public/js/utils/tests/menu.js
+++ b/public/js/utils/tests/menu.js
@@ -1,0 +1,14 @@
+const expect = require("expect.js");
+const { buildMenu } = require("../menu.js");
+
+describe("menu", () => {
+  it("should return an array of visible menu items", () => {
+    let menuItems = [
+      { item: "bla", hidden: false },
+      { item: "foo", hidden: true },
+      { item: "baa", hidden: () => true },
+      { item: "foobar" }
+    ];
+    expect(buildMenu(menuItems)[1]).to.be("foobar");
+  });
+});


### PR DESCRIPTION
Associated Issue: #1139

### Summary of Changes

* Added new buildMenu function and tests
* Use the buildMenu function to generate the list of menuitem that should be visible

### Testing

* [x] passes `npm test`
* [x] passes `npm run lint`

### Screenshots/Videos
![hide-close](https://cloud.githubusercontent.com/assets/792924/20056638/3355197e-a4df-11e6-8a31-f0fdefdebfac.gif)

