### PR TITLE
Fix possible infinite recursion in object inspector by caching based off path (fixes #1120)

### DIFF
--- a/public/js/components/ObjectInspector.js
+++ b/public/js/components/ObjectInspector.js
@@ -114,8 +114,9 @@ const ObjectInspector = React.createClass({
       // because the expanded state depends on instances of nodes
       // being the same across renders. If we didn't do this, each
       // node would be a new instance every render.
-      if (this.actorCache[actor]) {
-        return this.actorCache[actor];
+      const key = item.path;
+      if (this.actorCache[key]) {
+        return this.actorCache[key];
       }
 
       const loadedProps = getObjectProperties(actor);


### PR DESCRIPTION
This took a while to figure out, but the fix is easy. The problem is that if an object has already been rendered, it is cached based off the actor id, and if there is any other place in the tree where it is referenced, it will end up using the cached value. We don't want that, as that will cause the tree's depth-first-search algorithm to go into an infinite loop if there is a circular reference.

By using the path as the key value instead, we force it to recreate a new child array for each instance in the tree, which fixes the infinite recursion.