### PR TITLE
Add mochitest for source tree (fixes #648)

### DIFF
--- a/public/js/test/mochitest/.eslintrc
+++ b/public/js/test/mochitest/.eslintrc
@@ -74,6 +74,7 @@
     "togglePauseOnExceptions": false,
     "type": false,
     "pressKey": false,
-    "EXAMPLE_URL": false
+    "EXAMPLE_URL": false,
+    "waitUntil": false
   }
 }

--- a/public/js/test/mochitest/browser.ini
+++ b/public/js/test/mochitest/browser.ini
@@ -17,12 +17,14 @@ support-files =
   examples/doc-minified.html
   examples/doc-sourcemaps.html
   examples/doc-sourcemap-bogus.html
+  examples/doc-sources.html
   examples/bogus-map.js
   examples/entry.js
   examples/exceptions.js
-  examples/math.min.js
-  examples/opts.js
   examples/long.js
+  examples/math.min.js
+  examples/nested/nested-source.js
+  examples/opts.js
   examples/output.js
   examples/simple1.js
   examples/simple2.js
@@ -53,3 +55,4 @@ support-files =
 [browser_dbg-searching.js]
 [browser_dbg-sourcemaps.js]
 [browser_dbg-sourcemaps-bogus.js]
+[browser_dbg-sources.js]

--- a/public/js/test/mochitest/browser_dbg-sources.js
+++ b/public/js/test/mochitest/browser_dbg-sources.js
@@ -1,0 +1,58 @@
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
+
+// Tests that the source tree works.
+
+function* waitForSourceCount(dbg, i) {
+  // We are forced to wait until the DOM nodes appear because the
+  // source tree batches its rendering.
+  yield waitUntil(() => {
+    return findAllElements(dbg, "sourceNodes").length === i;
+  });
+}
+
+add_task(function* () {
+  const dbg = yield initDebugger("doc-sources.html");
+  const { selectors: { getSelectedSource }, getState } = dbg;
+
+  // Expand nodes and make sure more sources appear.
+  is(findAllElements(dbg, "sourceNodes").length, 2);
+
+  clickElement(dbg, "sourceArrow", 2);
+  is(findAllElements(dbg, "sourceNodes").length, 7);
+
+  clickElement(dbg, "sourceArrow", 3);
+  is(findAllElements(dbg, "sourceNodes").length, 8);
+
+  // Select a source.
+  ok(!findElementWithSelector(dbg, ".sources-list .focused"),
+     "Source is not focused");
+  const selected = waitForDispatch(dbg, "SELECT_SOURCE");
+  clickElement(dbg, "sourceNode", 4);
+  yield selected;
+  ok(findElementWithSelector(dbg, ".sources-list .focused"),
+     "Source is focused");
+  ok(getSelectedSource(getState()).get("url").includes("nested-source.js"),
+     "The right source is selected");
+
+  // Make sure new sources appear in the list.
+  ContentTask.spawn(gBrowser.selectedBrowser, null, function() {
+    const script = content.document.createElement("script");
+    script.src = "math.min.js";
+    content.document.body.appendChild(script);
+  });
+
+  yield waitForSourceCount(dbg, 9);
+  is(findElement(dbg, "sourceNode", 7).querySelector("span").innerText,
+     "math.min.js",
+     "The dynamic script exists");
+
+  // Make sure named eval sources appear in the list.
+  ContentTask.spawn(gBrowser.selectedBrowser, null, function() {
+    content.eval("window.evaledFunc = function() {} //# sourceURL=evaled.js");
+  });
+  yield waitForSourceCount(dbg, 11);
+  is(findElement(dbg, "sourceNode", 2).querySelector("span").innerText,
+     "evaled.js",
+     "The eval script exists");
+});

--- a/public/js/test/mochitest/examples/doc-sources.html
+++ b/public/js/test/mochitest/examples/doc-sources.html
@@ -1,0 +1,23 @@
+<!-- Any copyright is dedicated to the Public Domain.
+     http://creativecommons.org/publicdomain/zero/1.0/ -->
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8"/>
+    <title>Debugger test page</title>
+  </head>
+ 
+  <body>
+    <script src="simple1.js"></script>
+    <script src="simple2.js"></script>
+    <script src="long.js"></script>
+    <script>
+      // This inline script allows this HTML page to show up as a
+      // source. It also needs to introduce a new global variable so
+      // it's not immediately garbage collected.
+      function inline_script() { var x = 5; }
+    </script>
+    <script src="nested/nested-source.js"></script>
+    <script src="nested/deeper/deeper-source.js"></script>
+  </body>
+</html>

--- a/public/js/test/mochitest/examples/nested/nested-source.js
+++ b/public/js/test/mochitest/examples/nested/nested-source.js
@@ -1,0 +1,3 @@
+function computeSomething() {
+  return 1;
+}

--- a/public/js/test/mochitest/head.js
+++ b/public/js/test/mochitest/head.js
@@ -594,7 +594,10 @@ const selectors = {
   stepIn: ".stepIn.active",
   toggleBreakpoints: ".toggleBreakpoints",
   prettyPrintButton: ".prettyPrint",
-  sourceFooter: ".source-footer"
+  sourceFooter: ".source-footer",
+  sourceNode: i => `.sources-list .tree-node:nth-child(${i})`,
+  sourceNodes: ".sources-list .tree-node",
+  sourceArrow: i => `.sources-list .tree-node:nth-child(${i}) .arrow`,
 };
 
 function getSelector(elementName, ...args) {


### PR DESCRIPTION
Been trying to do this for a while, sorry. Kept getting distracted, and took a while to decide the right way to do this. This covers the core cases from the previous mochitests. This doesn't test the specific nesting, but we have a lot of unit tests for that kind of stuff.