### PR TITLE
Autocomplete.css: wrap title and subtitle in smaller views

### DIFF
--- a/public/js/components/Autocomplete.css
+++ b/public/js/components/Autocomplete.css
@@ -35,11 +35,13 @@
 
 .autocomplete li .title {
   line-height: 1.5em;
+  word-break: break-all;
 }
 
 .autocomplete li .subtitle {
   line-height: 1.5em;
   color: grey;
+  word-break: break-all;
 }
 
 .autocomplete input {


### PR DESCRIPTION
Associated Issue: #1071

### Summary of Changes

* Add the word-break property which is supported everywhere.

### Testing

* [x] passes `npm test`
* [x] passes `npm run lint`

### Screenshots/Videos

https://v.usetapes.com/a79pIE1ONH

