### PR TITLE
Change debugger context menu styles to be closer to native OSX styling.

### DIFF
--- a/public/js/components/App.css
+++ b/public/js/components/App.css
@@ -6,7 +6,7 @@
 
 :root.theme-light,
 :root .theme-light {
-  --theme-search-overlays-semitransparent: rgba(221, 225, 228, 0.66);
+  --theme-search-overlays-semitransparent: rgba(190, 190, 190, 0.8);
   --theme-faded-tab-color: #7e7e7e;
 }
 

--- a/public/js/components/App.css
+++ b/public/js/components/App.css
@@ -6,7 +6,7 @@
 
 :root.theme-light,
 :root .theme-light {
-  --theme-search-overlays-semitransparent: rgba(190, 190, 190, 0.8);
+  --theme-search-overlays-semitransparent: rgba(221, 225, 228, 0.66);
   --theme-faded-tab-color: #7e7e7e;
 }
 

--- a/public/js/components/menu.css
+++ b/public/js/components/menu.css
@@ -7,7 +7,7 @@ menupopup {
   background: #f2f2f2;
   border-radius: 5px;
   color: #585858;
-  box-shadow: 0 0 4px 0 rgba(190, 190, 190, 0.8);;
+  box-shadow: 0 0 4px 0 rgba(190, 190, 190, 0.8);
   min-width: 130px;
 }
 

--- a/public/js/components/menu.css
+++ b/public/js/components/menu.css
@@ -4,21 +4,23 @@ menupopup {
   background: white;
   border: 1px solid #cccccc;
   padding: 5px 0;
-  background: #fbfbfb;
+  background: #f2f2f2;
   border-radius: 5px;
   color: #585858;
-  box-shadow: 0 4px 4px 0 var(--theme-search-overlays-semitransparent);
+  box-shadow: 0 0 4px 0 var(--theme-search-overlays-semitransparent);
   min-width: 130px;
 }
 
 menuitem {
   display: block;
-  padding: 0 10px;
+  padding: 0 20px;
   line-height: 20px;
+  font-weight: 500;
+  font-size: 13px;
 }
 
 menuitem:hover {
-  background: #4a9afb;
+  background: #3780fb;
   color: white;
   cursor: pointer;
 }

--- a/public/js/components/menu.css
+++ b/public/js/components/menu.css
@@ -7,7 +7,7 @@ menupopup {
   background: #f2f2f2;
   border-radius: 5px;
   color: #585858;
-  box-shadow: 0 0 4px 0 var(--theme-search-overlays-semitransparent);
+  box-shadow: 0 0 4px 0 rgba(190, 190, 190, 0.8);;
   min-width: 130px;
 }
 


### PR DESCRIPTION
Associated Issue: #1102 

@jasonLaster 

### Summary of Changes
* Changed the background color of the context menu, drop shadow color, and `menuitem` hover color.
* Changed the padding of the `menuitem` class.
* Changed the font sizing for the context menu.

### Testing

* [x] passes `npm test`
* [x] passes `npm run lint`

### Screenshots/Videos
![screen shot 2016-11-08 at 6 57 33 pm](https://cloud.githubusercontent.com/assets/5490167/20122382/3aca0c8a-a5e5-11e6-99ef-d61c36572265.png)


