### PR TITLE
Fix dropdown button size

### DIFF
--- a/public/js/components/Dropdown.css
+++ b/public/js/components/Dropdown.css
@@ -10,6 +10,15 @@
   z-index: 1000;
 }
 
+.dropdown-button {
+  position: absolute;
+  right: 12px;
+  top: 5px;
+  font-size: 16px;
+  color: var(--theme-body-color);
+  cursor: pointer;
+}
+
 .dropdown li {
   transition: all 0.25s ease;
   padding: 2px 10px 10px 5px;

--- a/public/js/components/Dropdown.js
+++ b/public/js/components/Dropdown.js
@@ -34,7 +34,7 @@ const Dropdown = React.createClass({
   renderButton() {
     return dom.span(
       {
-        className: "subsettings",
+        className: "dropdown-button",
         onClick: this.toggleDropdown
       },
       "»"

--- a/public/js/components/SourceTabs.css
+++ b/public/js/components/SourceTabs.css
@@ -102,12 +102,3 @@ html[dir="rtl"] .source-tab .close-btn {
 .source-tab:hover .close {
   display: block;
 }
-
-.source-header .subsettings {
-  position: absolute;
-  right: 12px;
-  top: 5px;
-  width: 12px;
-  height: 12px;
-  color: var(--theme-body-color);
-}

--- a/public/js/components/SourceTabs.js
+++ b/public/js/components/SourceTabs.js
@@ -171,21 +171,6 @@ const SourceTabs = React.createClass({
     }, filename);
   },
 
-  renderSourcesDropdownButton() {
-    const hiddenSourceTabs = this.state.hiddenSourceTabs;
-    if (!hiddenSourceTabs || hiddenSourceTabs.size == 0) {
-      return dom.div({});
-    }
-
-    return dom.span(
-      {
-        className: "subsettings",
-        onClick: this.toggleSourcesDropdown
-      },
-      Svg("subSettings")
-    );
-  },
-
   renderTabs() {
     const sourceTabs = this.props.sourceTabs;
     return dom.div(


### PR DESCRIPTION
This is an emergency fix. I'm trying to push out a bundle update today, but the following UI is broken:

<img width="233" alt="screen shot 2016-11-09 at 1 34 19 pm" src="https://cloud.githubusercontent.com/assets/17031/20151151/252fffb8-a687-11e6-8387-95634c47efb3.png">

The best I can do is at least make the dropdown button the same size as our other icons:

<img width="279" alt="screen shot 2016-11-09 at 2 13 38 pm" src="https://cloud.githubusercontent.com/assets/17031/20151172/32a5d6b8-a687-11e6-9a5a-b8f86dc7753e.png">

The color is different than the new tab button, and the new tab button is not positioned correctly when tabs are hidden. But this is the best I can do for the release.