### PR TITLE
use flex to clean up search, fix overflow issue with close button

### DIFF
--- a/public/js/components/CloseButton.css
+++ b/public/js/components/CloseButton.css
@@ -27,9 +27,9 @@
 }
 
 .close-btn-big {
-  position: absolute;
-  top: 12px;
-  right: 10px;
+  padding: 13px;
+  width: 40px;
+  height: 40px;
 }
 
 .close-btn-big path {
@@ -38,15 +38,18 @@
 
 .close-btn-big .close {
   cursor: pointer;
-  display: inline;
+  display: inline-block;
   padding: 2px;
   text-align: center;
-  line-height: 5px;
   transition: all 0.25s easeinout;
+  line-height: 100%;
+  width: 16px;
+  height: 16px;
 }
 
 .close-btn-big .close svg {
   width: 9px;
+  height: 9px;
 }
 
 .close-btn-big .close:hover {

--- a/public/js/components/EditorSearchBar.css
+++ b/public/js/components/EditorSearchBar.css
@@ -6,13 +6,14 @@
   display: flex;
 }
 
-.search-bar svg {
-  width: 16px;
-}
-
 .search-bar i {
   display: block;
   padding: 13px 0 0 13px;
+  width: 40px;
+}
+
+.search-bar i svg {
+  width: 16px;
 }
 
 .search-bar input {
@@ -22,14 +23,17 @@
   background-color: var(--theme-body-background);
   color: var(--theme-comment);
   width: calc(100% - 38px);
-  padding-left: 10px;
-  display: flex;
-  padding-right: 100px;
   flex: 1;
 }
 
 .search-bar .magnifying-glass {
   background-color: var(--theme-body-background);
+  width: 40px;
+}
+
+.search-bar .magnifying-glass path,
+.search-bar .magnifying-glass ellipse {
+  stroke: var(--theme-splitter-color);
 }
 
 .search-bar input::placeholder {

--- a/public/js/components/SourceSearch.css
+++ b/public/js/components/SourceSearch.css
@@ -18,3 +18,11 @@
 .search-container .autocomplete {
   flex: 1;
 }
+
+.searchinput-container {
+  display: flex;
+}
+
+.searchinput-container .close-btn-big {
+  border-bottom: 1px solid var(--theme-splitter-color);
+}


### PR DESCRIPTION
Associated Issue: n/a

### Summary of Changes

* standardize the large close button for use in both source and file search
* move toward flex based model for both source and file search

### Testing

* [x] passes `npm test`
* [x] passes `npm run lint`

### Screenshots/Videos (OPTIONAL)

Here's the original problem I was seeing in Firefox

<img width="637" alt="screen shot 2016-11-09 at 2 15 11 pm" src="https://cloud.githubusercontent.com/assets/2134/20166113/759bdaea-a6c7-11e6-83df-ccd16a65f7b4.png">

And now we see this for results

<img width="635" alt="screen shot 2016-11-09 at 10 00 35 pm" src="https://cloud.githubusercontent.com/assets/2134/20166180/e9315e58-a6c7-11e6-92d9-b5ce1c1c5dda.png">

And this for empty states

<img width="655" alt="screen shot 2016-11-09 at 3 15 45 pm" src="https://cloud.githubusercontent.com/assets/2134/20166123/889b6174-a6c7-11e6-8110-32d94d5c93bf.png">

<img width="653" alt="screen shot 2016-11-09 at 3 16 00 pm" src="https://cloud.githubusercontent.com/assets/2134/20166124/8b2da136-a6c7-11e6-81fe-a77a74cca3f4.png">

Padding and spacing could use some additional followup PRs but this is a nice improvement from before and works on Chrome as well.
