### PR TITLE
Disable custom code search because of bugs

### DIFF
--- a/packages/devtools-config/configs/development.json
+++ b/packages/devtools-config/configs/development.json
@@ -11,7 +11,8 @@
     "tabs": true,
     "sourceMaps": true,
     "prettyPrint": true,
-    "watchExpressions": false
+    "watchExpressions": false,
+    "editorSearch": false
   },
   "chrome": {
     "debug": true,

--- a/public/js/components/Editor.js
+++ b/public/js/components/Editor.js
@@ -277,7 +277,7 @@ const Editor = React.createClass({
     });
 
     // disables the default search shortcuts
-    this.editor._initShortcuts = () => {};
+    // this.editor._initShortcuts = () => {};
 
     this.editor.appendToLocalElement(
       ReactDOM.findDOMNode(this).querySelector(".editor-mount")

--- a/public/js/components/Editor.js
+++ b/public/js/components/Editor.js
@@ -23,6 +23,7 @@ const { getDocument, setDocument } = require("../utils/source-documents");
 const { shouldShowFooter } = require("../utils/editor");
 const { isFirefox } = require("devtools-config");
 const { showMenu } = require("../utils/menu");
+const { isEnabled } = require("devtools-config");
 
 require("./Editor.css");
 
@@ -277,7 +278,9 @@ const Editor = React.createClass({
     });
 
     // disables the default search shortcuts
-    // this.editor._initShortcuts = () => {};
+    if (isEnabled("editorSearch")) {
+      this.editor._initShortcuts = () => {};
+    }
 
     this.editor.appendToLocalElement(
       ReactDOM.findDOMNode(this).querySelector(".editor-mount")

--- a/public/js/components/EditorSearchBar.js
+++ b/public/js/components/EditorSearchBar.js
@@ -38,15 +38,15 @@ const EditorSearchBar = React.createClass({
   },
 
   componentWillUnmount() {
-    const shortcuts = this.context.shortcuts;
-    shortcuts.off("CmdOrCtrl+F", this.toggleSearch);
-    shortcuts.off("Escape", this.onEscape);
+    // const shortcuts = this.context.shortcuts;
+    // shortcuts.off("CmdOrCtrl+F", this.toggleSearch);
+    // shortcuts.off("Escape", this.onEscape);
   },
 
   componentDidMount() {
-    const shortcuts = this.context.shortcuts;
-    shortcuts.on("CmdOrCtrl+F", this.toggleSearch);
-    shortcuts.on("Escape", this.onEscape);
+    // const shortcuts = this.context.shortcuts;
+    // shortcuts.on("CmdOrCtrl+F", this.toggleSearch);
+    // shortcuts.on("Escape", this.onEscape);
   },
 
   componentWillReceiveProps() {

--- a/public/js/components/EditorSearchBar.js
+++ b/public/js/components/EditorSearchBar.js
@@ -6,6 +6,7 @@ const { find, findNext, findPrev } = require("../utils/source-search");
 const classnames = require("classnames");
 const { debounce, escapeRegExp } = require("lodash");
 const CloseButton = require("./CloseButton");
+const { isEnabled } = require("devtools-config");
 
 require("./EditorSearchBar.css");
 
@@ -38,15 +39,19 @@ const EditorSearchBar = React.createClass({
   },
 
   componentWillUnmount() {
-    // const shortcuts = this.context.shortcuts;
-    // shortcuts.off("CmdOrCtrl+F", this.toggleSearch);
-    // shortcuts.off("Escape", this.onEscape);
+    const shortcuts = this.context.shortcuts;
+    if (isEnabled("editorSearch")) {
+      shortcuts.off("CmdOrCtrl+F", this.toggleSearch);
+      shortcuts.off("Escape", this.onEscape);
+    }
   },
 
   componentDidMount() {
-    // const shortcuts = this.context.shortcuts;
-    // shortcuts.on("CmdOrCtrl+F", this.toggleSearch);
-    // shortcuts.on("Escape", this.onEscape);
+    const shortcuts = this.context.shortcuts;
+    if (isEnabled("editorSearch")) {
+      shortcuts.on("CmdOrCtrl+F", this.toggleSearch);
+      shortcuts.on("Escape", this.onEscape);
+    }
   },
 
   componentWillReceiveProps() {


### PR DESCRIPTION
The custom code search we have is far too buggy for us to enable it in dev edition. This PR disables it and Cmd+F will bring up the default code search in the devtools codemirror which works well.

Watch this movie: http://jlongster.com/s/editor-bugs.mp4

In that movie, I found the following bugs:

* Cmd-g and Cmd-shift-g don't work, an extremely command shortcut for find next and prev
* At 20s, the text isn't highlighted when you open it (happens if you click in the editor before opening it)
* The worst one, at 47s, is that you can still see the old file search somehow when clicking away from the search bar (if it's open) and either pressing escape or cmd+f (can't remember which one). Now pressing cmd+f again open the custom search bar and there are TWO open. Hilariousness ensues.

It's way too late to fix this and too risky. Let's just use the default one which works well.