### PR TITLE
Fix main package eslint script to check package contents as well.

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
+public/build/*
 public/js/lib/tree.js
 public/js/utils/imstruct.js
 public/js/test/examples/**
@@ -5,7 +6,9 @@ public/js/test/integration/**
 public/js/test/unit-sources/**
 public/js/test/mochitest/head.js
 public/js/test/mochitest/examples/**
-webpack.config.js
+webpack.config.*
 
 packages/devtools-modules/**/*.js
 packages/devtools-sham-modules/**/*.js
+bin/
+

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "flow": "flow",
     "lint": "npm run lint-css -s; npm run lint-js -s",
     "lint-css": "stylelint public/js/components/*.css",
-    "lint-js": "eslint public/js",
+    "lint-js": "eslint public/**/*.js packages/**/*.js",
     "lint-fix": "npm run lint-js -- --fix",
     "test": "node public/js/test/node-unit-tests.js",
     "test-all": "npm run test; npm run lint; npm run flow; npm run firefox-unit-test",

--- a/packages/chrome-remote-debugging-protocol/index.js
+++ b/packages/chrome-remote-debugging-protocol/index.js
@@ -1,5 +1,3 @@
-"use strict";
-
 const {
   WebSocketConnection,
   InspectorBackend

--- a/packages/devtools-config/index.js
+++ b/packages/devtools-config/index.js
@@ -1,3 +1,3 @@
-const feature = require("./src/feature")
+const feature = require("./src/feature");
 
-module.exports = feature
+module.exports = feature;

--- a/packages/devtools-config/registerConfig.js
+++ b/packages/devtools-config/registerConfig.js
@@ -8,4 +8,4 @@ function registerConfig() {
 module.exports = {
   getConfig,
   registerConfig
-}
+};

--- a/packages/devtools-config/src/config.js
+++ b/packages/devtools-config/src/config.js
@@ -3,7 +3,7 @@ const _ = require("lodash");
 const fs = require("fs");
 const path = require("path");
 
-const firefoxPanel = require("../configs//firefox-panel.json");
+const firefoxPanel = require("../configs/firefox-panel.json");
 const development = require("../configs/development.json");
 const envConfig = process.env.TARGET === "firefox-panel" ?
    firefoxPanel : development;


### PR DESCRIPTION
Associated Issue: None. Discussed problem directly with @jasonLaster in IRC.

### Summary of Changes

* JS Lint script in `package.json` checks the `packages` js as well as all js files within `public` instead of only direct children.
* Updated `.eslintignore` to ignore new things that aren't needed to be checked with this change.
* Fixed any eslint errors with the current files where appropriate.
* Also updated a file path in `devtools-config` to not have an extra folder slash.

### Testing

* [x] passes `npm test`
* [x] passes `npm run lint`
