### PR TITLE
[L10N] Fix hardcoded strings

### DIFF
--- a/assets/locales/debugger.properties
+++ b/assets/locales/debugger.properties
@@ -230,6 +230,9 @@ scopes.notAvailable=Scopes Unavailable
 # for when the debugger is not paused.
 scopes.notPaused=Not Paused
 
+# LOCALIZATION NOTE (scopes.block): Scopes right sidebar block subheading
+scopes.block=Block
+
 # LOCALIZATION NOTE (sources.header): Sources left sidebar header
 sources.header=Sources
 

--- a/src/components/Scopes.js
+++ b/src/components/Scopes.js
@@ -97,7 +97,7 @@ function getScopes(pauseInfo, selectedFrame) {
       if (type === "function") {
         title = scope.function.displayName || "(anonymous)";
       } else {
-        title = "Block";
+        title = L10N.getStr("scopes.block");
       }
 
       let vars = getBindingVariables(bindings, title);

--- a/src/strings.json
+++ b/src/strings.json
@@ -12,6 +12,7 @@
   "editor.addConditionalBreakpoint": "Add Conditional Breakpoint",
   "scopes.header": "Scopes",
   "scopes.notAvailable": "Scopes Unavailable",
+  "scopes.block":"Block",
   "scopes.notPaused": "Not Paused",
   "sources.header": "Sources",
   "sources.search": "%S to search",


### PR DESCRIPTION
Associated Issue: #<1143>

### Summary of Changes

*Replaced a hardcoded string using L10N strings from debugger.properties 

### Testing

* [29 ] passes `npm test`
* [ ] passes `npm run lint`
 
My First merge request to this project! I was unable to run `npm run lint on my system so couldn't update the number of passes.

