### PR TITLE
Wrap the click handler passed to CloseButton

### DIFF
--- a/public/js/components/Autocomplete.js
+++ b/public/js/components/Autocomplete.js
@@ -12,7 +12,7 @@ const Autocomplete = React.createClass({
   propTypes: {
     selectItem: PropTypes.func,
     items: PropTypes.array,
-    handleClose: PropTypes.func,
+    close: PropTypes.func,
     inputValue: PropTypes.string
   },
 
@@ -80,11 +80,11 @@ const Autocomplete = React.createClass({
       if (searchResults.length) {
         this.props.selectItem(searchResults[this.state.selectedIndex]);
       } else {
-        this.props.handleClose(this.state.inputValue);
+        this.props.close(this.state.inputValue);
       }
       e.preventDefault();
     } else if (e.key === "Tab") {
-      this.props.handleClose(this.state.inputValue);
+      this.props.close(this.state.inputValue);
       e.preventDefault();
     }
   },
@@ -161,7 +161,7 @@ const Autocomplete = React.createClass({
       this.renderInput(),
       CloseButton({
         buttonClass: "big",
-        handleClick: this.props.handleClose
+        handleClick: e => this.props.close()
       })),
       this.renderSummary(searchResults),
       this.renderResults(searchResults));

--- a/public/js/components/SourceSearch.js
+++ b/public/js/components/SourceSearch.js
@@ -94,7 +94,7 @@ const Search = React.createClass({
           this.setState({ inputValue: "" });
           this.props.toggleFileSearch(false);
         },
-        handleClose: this.close,
+        close: this.close,
         items: searchResults(this.props.sources),
         inputValue: this.state.inputValue
       })) : null;


### PR DESCRIPTION
Associated Issue: #1173

### Summary of Changes

This commits wraps the handler call in the CloseButton component so that the close
function doesn't receive the event object as an argument

- rename `handleClose` to `close` because it is not a handler anymore
- inline the handler when passing it down from autocomplete to the close button
  `e => close()`

### Testing

* [x] passes `npm test`
* [x] passes `npm run 