### PR TITLE
Style search bar in dark mode

### DIFF
--- a/src/components/EditorSearchBar.css
+++ b/src/components/EditorSearchBar.css
@@ -1,7 +1,7 @@
 .search-bar {
   width: calc(100% - 1px);
   height: 40px;
-  background: white;
+  background-color: var(--theme-body-background);
   border-bottom: 1px solid var(--theme-splitter-color);
   display: flex;
 }


### PR DESCRIPTION
Fixes this atrocity. 

![screen shot 2016-11-14 at 9 45 16 am](https://cloud.githubusercontent.com/assets/254562/20268982/4d229aaa-aa4f-11e6-8ddb-1a9f0c2a3318.png)

Looks fine in light mode.