### PR TITLE
Add install yarn script

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -37,11 +37,12 @@ test:
 
 dependencies:
   pre:
-    - curl -o- -L https://yarnpkg.com/install.sh | bash
   cache_directories:
-    - "~/downloads"
+    - ~/downloads
     - ~/.yarn-cache
+    - ~/.yarn
   override:
+    - npm i -g yarn@0.16.1
     - npm i -g jasonlaster/lerna
     - yarn install
     - ./bin/update-docker


### PR DESCRIPTION
CI is failing when it comes to re-installing yarn. This will keep it
from doing that.