### PR TITLE
Update flow-bin to 0.35

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "expect.js": "^0.3.1",
     "extract-text-webpack-plugin": "^1.0.1",
     "firefox-profile": "^0.4.0",
-    "flow-bin": "^0.34.0",
+    "flow-bin": "^0.35.0",
     "flow-coverage-report": "^0.2.0",
     "geckodriver": "^1.2.0",
     "glob": "^7.0.3",

--- a/packages/devtools-local-toolbox/src/utils/utils.js
+++ b/packages/devtools-local-toolbox/src/utils/utils.js
@@ -159,7 +159,7 @@ function compose(...funcs: any) {
   };
 }
 
-function updateObj<T>(obj: T, fields: $Shape<T>) : T {
+function updateObj<T: Object>(obj: T, fields: $Shape<T>) : T {
   return Object.assign({}, obj, fields);
 }
 

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -203,7 +203,7 @@ function compose(...funcs: any) {
  * @memberof utils/utils
  * @static
  */
-function updateObj<T>(obj: T, fields: $Shape<T>) : T {
+function updateObj<T: Object>(obj: T, fields: $Shape<T>) : T {
   return Object.assign({}, obj, fields);
 }
 


### PR DESCRIPTION
This is another version of #1170 with small fixes to make it work. It didn't have anything to do with the record types, it just needed some more specific subtyping.