### PR TITLE
Remove unecessary CI processes

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -19,16 +19,6 @@ test:
     - node src/test/node-unit-tests.js --ci
     - ./bin/run-mochitests-docker
     - npm run firefox-unit-test
-  pre:
-    - node bin/mocha-server.js:
-        background: true
-    - npm start:
-        background: true
-    - node bin/firefox-driver --start:
-        background: true
-    - /opt/google/chrome/google-chrome --remote-debugging-port=9222 --no-first-run:
-        background: true
-    - sleep 30
   post:
     - npm run lint-css
     - npm run lint-js


### PR DESCRIPTION
We've seen some occasional flakiness due to Circle having a 4GB Ram limit.

Here's an example [fail](https://circleci.com/gh/devtools-html/debugger.html/1817)
Here's a [memory-usage](https://1817-54585418-gh.circle-artifacts.com/0/tmp/memory-usage.txt) overview

This fix removes unused processes from when circle was used and we ran some unit tests in the browser in CI.

We can also limit flow's memory foot print with these four commands:

```
  --sharedmemory-dep-table-pow      The exponent for the size of the shared memory dependency table. The default is 17, implying a size of 2^17 bytes
  --sharedmemory-dirs               Directory in which to store shared memory heap (default: /dev/shm/)
  --sharedmemory-hash-table-pow     The exponent for the size of the shared memory hash table. The default is 19, implying a size of 2^19 bytes
  --sharedmemory-log-level          The logging level for shared memory statistics. 0=none, 1=some
  --sharedmemory-minimum-available  Flow will only use a filesystem for shared memory if it has at least these many bytes available (default: 536870912 - which is 512MB)
``` 

but i wasn't sure which would be best so i let it be