### PR TITLE
Extract command bar

### DIFF
--- a/src/actions/pause.js
+++ b/src/actions/pause.js
@@ -3,7 +3,8 @@ const constants = require("../constants");
 const { selectSource } = require("./sources");
 const { PROMISE } = require("../utils/redux/middleware/promise");
 
-const { getExpressions, getSelectedFrame } = require("../selectors");
+const { getExpressions, getSelectedFrame,
+        getPause } = require("../selectors");
 const { updateFrameLocations } = require("../utils/pause");
 
 import type { Pause, Frame, Expression, Grip } from "../types";
@@ -104,7 +105,11 @@ function command({ type }: CommandType) {
  * @returns {Function} {@link command}
  */
 function stepIn() {
-  return command({ type: "stepIn" });
+  return ({ dispatch, getState }: ThunkArgs) => {
+    if (getPause(getState())) {
+      return dispatch(command({ type: "stepIn" }));
+    }
+  };
 }
 
 /**
@@ -114,7 +119,11 @@ function stepIn() {
  * @returns {Function} {@link command}
  */
 function stepOver() {
-  return command({ type: "stepOver" });
+  return ({ dispatch, getState }: ThunkArgs) => {
+    if (getPause(getState())) {
+      return dispatch(command({ type: "stepOver" }));
+    }
+  };
 }
 
 /**
@@ -124,7 +133,11 @@ function stepOver() {
  * @returns {Function} {@link command}
  */
 function stepOut() {
-  return command({ type: "stepOut" });
+  return ({ dispatch, getState }: ThunkArgs) => {
+    if (getPause(getState())) {
+      return dispatch(command({ type: "stepOut" }));
+    }
+  };
 }
 
 /**
@@ -134,7 +147,11 @@ function stepOut() {
  * @returns {Function} {@link command}
  */
 function resume() {
-  return command({ type: "resume" });
+  return ({ dispatch, getState }: ThunkArgs) => {
+    if (getPause(getState())) {
+      return dispatch(command({ type: "resume" }));
+    }
+  };
 }
 
 /**

--- a/src/components/CommandBar.css
+++ b/src/components/CommandBar.css
@@ -1,0 +1,69 @@
+.right-sidebar .command-bar {
+  border-bottom: 1px solid var(--theme-splitter-color);
+}
+
+.command-bar {
+  height: 30px;
+}
+
+html:not([dir="rtl"]) .command-bar {
+  padding: 8px 5px 10px 1px;
+}
+
+html[dir="rtl"] .command-bar {
+  padding: 8px 1px 10px 5px;
+}
+
+.command-bar > span {
+  cursor: pointer;
+  width: 16px;
+  height: 17px;
+  display: inline-block;
+  text-align: center;
+  transition: all 0.25s ease;
+}
+
+:root.theme-dark .command-bar > span {
+  fill: var(--theme-body-color);
+}
+
+:root.theme-dark .command-bar > span:hover {
+  fill: var(--theme-selection-color);
+}
+
+html:not([dir="rtl"]) .command-bar > span {
+  margin-right: 0.7em;
+}
+
+html[dir="rtl"] .command-bar > span {
+  margin-left: 0.7em;
+}
+
+.command-bar > span.disabled {
+  opacity: 0.3;
+  cursor: default;
+}
+
+html:not([dir="rtl"]) .command-bar .stepOut {
+  margin-right: 2em;
+}
+
+html[dir="rtl"] .command-bar .stepOut {
+  margin-left: 2em;
+}
+
+.command-bar .subSettings {
+  float: right;
+}
+
+.command-bar .toggleBreakpoints.breakpoints-disabled path {
+  stroke: var(--theme-highlight-blue);
+}
+
+.command-bar span.pause-exceptions.uncaught {
+  stroke: var(--theme-highlight-purple);
+}
+
+.command-bar span.pause-exceptions.all {
+  stroke: var(--theme-highlight-blue);
+}

--- a/src/components/CommandBar.js
+++ b/src/components/CommandBar.js
@@ -1,0 +1,185 @@
+const React = require("react");
+const { DOM: dom, PropTypes } = React;
+const { connect } = require("react-redux");
+const { bindActionCreators } = require("redux");
+const { getPause, getIsWaitingOnBreak, getBreakpointsDisabled,
+        getShouldPauseOnExceptions, getShouldIgnoreCaughtExceptions,
+        getBreakpoints, getBreakpointsLoading
+      } = require("../selectors");
+const Svg = require("./utils/Svg");
+const ImPropTypes = require("react-immutable-proptypes");
+
+const { Services: { appinfo }} = require("devtools-modules");
+
+const shiftKey = appinfo.OS === "Darwin" ? "\u21E7" : "Shift+";
+const ctrlKey = appinfo.OS === "Linux" ? "Ctrl+" : "";
+
+const actions = require("../actions");
+require("./CommandBar.css");
+
+function debugBtn(onClick, type, className, tooltip) {
+  className = `${type} ${className}`;
+  return dom.span(
+    { onClick, className, key: type },
+    Svg(type, { title: tooltip })
+  );
+}
+
+const CommandBar = React.createClass({
+  propTypes: {
+    sources: PropTypes.object,
+    selectedSource: PropTypes.object,
+    resume: PropTypes.func,
+    stepIn: PropTypes.func,
+    stepOut: PropTypes.func,
+    stepOver: PropTypes.func,
+    toggleAllBreakpoints: PropTypes.func,
+    breakOnNext: PropTypes.func,
+    pause: ImPropTypes.map,
+    pauseOnExceptions: PropTypes.func,
+    shouldPauseOnExceptions: PropTypes.bool,
+    shouldIgnoreCaughtExceptions: PropTypes.bool,
+    breakpoints: ImPropTypes.map,
+    isWaitingOnBreak: PropTypes.bool,
+    breakpointsDisabled: PropTypes.bool,
+    breakpointsLoading: PropTypes.bool,
+  },
+
+  contextTypes: {
+    shortcuts: PropTypes.object
+  },
+
+  displayName: "CommandBar",
+
+  componentWillUnmount() {
+    const shortcuts = this.context.shortcuts;
+    shortcuts.off("F8", this.props.resume);
+    shortcuts.off("F10", this.props.stepOver);
+    shortcuts.off(`${ctrlKey}F11`, this.props.stepIn);
+    shortcuts.off(`${ctrlKey}Shift+F11`, this.props.stepOut);
+  },
+
+  componentDidMount() {
+    const shortcuts = this.context.shortcuts;
+    shortcuts.on("F8", this.props.resume);
+    shortcuts.on("F10", this.props.stepOver);
+    shortcuts.on(`${ctrlKey}F11`, this.props.stepIn);
+    shortcuts.on(`${ctrlKey}Shift+F11`, this.props.stepOut);
+  },
+
+  renderStepButtons() {
+    const className = this.props.pause ? "active" : "disabled";
+    return [
+      debugBtn(this.props.stepOver, "stepOver", className,
+        L10N.getStr("stepOverTooltip")
+      ),
+      debugBtn(this.props.stepIn, "stepIn", className,
+        L10N.getFormatStr("stepInTooltip", ctrlKey)
+      ),
+      debugBtn(this.props.stepOut, "stepOut", className,
+        L10N.getFormatStr("stepOutTooltip", ctrlKey + shiftKey)
+      )
+    ];
+  },
+
+  renderPauseButton() {
+    const { pause, breakOnNext, isWaitingOnBreak } = this.props;
+
+    if (pause) {
+      return debugBtn(this.props.resume, "resume", "active",
+        L10N.getStr("resumeButtonTooltip")
+      );
+    }
+
+    if (isWaitingOnBreak) {
+      return debugBtn(null, "pause", "disabled",
+        L10N.getStr("pausePendingButtonTooltip")
+      );
+    }
+
+    return debugBtn(breakOnNext, "pause", "active",
+      L10N.getStr("pauseButtonTooltip")
+    );
+  },
+
+  /*
+   * The pause on exception button has three states in this order:
+   *  1. don't pause on exceptions      [false, false]
+   *  2. pause on uncaught exceptions   [true, true]
+   *  3. pause on all exceptions        [true, false]
+  */
+  renderPauseOnExceptions() {
+    const { shouldPauseOnExceptions, shouldIgnoreCaughtExceptions,
+            pauseOnExceptions } = this.props;
+
+    if (!shouldPauseOnExceptions && !shouldIgnoreCaughtExceptions) {
+      return debugBtn(
+        () => pauseOnExceptions(true, true),
+        "pause-exceptions",
+        "enabled",
+        L10N.getStr("ignoreExceptions")
+      );
+    }
+
+    if (shouldPauseOnExceptions && shouldIgnoreCaughtExceptions) {
+      return debugBtn(
+        () => pauseOnExceptions(true, false),
+        "pause-exceptions",
+        "uncaught enabled",
+        L10N.getStr("pauseOnUncaughtExceptions")
+      );
+    }
+
+    return debugBtn(
+      () => pauseOnExceptions(false, false),
+      "pause-exceptions",
+      "all enabled",
+      L10N.getStr("pauseOnExceptions")
+    );
+  },
+
+  renderDisableBreakpoints() {
+    const { toggleAllBreakpoints, breakpoints,
+            breakpointsDisabled, breakpointsLoading } = this.props;
+
+    if (breakpoints.size == 0 || breakpointsLoading) {
+      return debugBtn(
+        null, "toggleBreakpoints", "disabled", "Disable Breakpoints"
+      );
+    }
+
+    return debugBtn(
+      () => toggleAllBreakpoints(!breakpointsDisabled),
+      "toggleBreakpoints",
+      breakpointsDisabled ? "breakpoints-disabled" : "",
+      "Disable Breakpoints"
+    );
+  },
+
+  render() {
+    return (
+      dom.div(
+        { className: "command-bar" },
+        this.renderPauseButton(),
+        this.renderStepButtons(),
+        this.renderDisableBreakpoints(),
+        this.renderPauseOnExceptions()
+      )
+    );
+  }
+});
+
+module.exports = connect(
+  state => {
+    return {
+      pause: getPause(state),
+      isWaitingOnBreak: getIsWaitingOnBreak(state),
+      shouldPauseOnExceptions: getShouldPauseOnExceptions(state),
+      shouldIgnoreCaughtExceptions: getShouldIgnoreCaughtExceptions(state),
+      breakpointsDisabled: getBreakpointsDisabled(state),
+      breakpoints: getBreakpoints(state),
+      breakpointsLoading: getBreakpointsLoading(state),
+    };
+  },
+  dispatch => bindActionCreators(actions, dispatch)
+)(CommandBar);

--- a/src/components/RightSidebar.css
+++ b/src/components/RightSidebar.css
@@ -15,64 +15,6 @@
   overflow-x: hidden;
 }
 
-.right-sidebar .command-bar {
-  border-bottom: 1px solid var(--theme-splitter-color);
-}
-
-.command-bar {
-  height: 30px;
-}
-
-html:not([dir="rtl"]) .command-bar {
-  padding: 8px 5px 10px 1px;
-}
-
-html[dir="rtl"] .command-bar {
-  padding: 8px 1px 10px 5px;
-}
-
-.command-bar > span {
-  cursor: pointer;
-  width: 16px;
-  height: 17px;
-  display: inline-block;
-  text-align: center;
-  transition: all 0.25s ease;
-}
-
-:root.theme-dark .command-bar > span {
-  fill: var(--theme-body-color);
-}
-
-:root.theme-dark .command-bar > span:hover {
-  fill: var(--theme-selection-color);
-}
-
-html:not([dir="rtl"]) .command-bar > span {
-  margin-right: 0.7em;
-}
-
-html[dir="rtl"] .command-bar > span {
-  margin-left: 0.7em;
-}
-
-.command-bar > span.disabled {
-  opacity: 0.3;
-  cursor: default;
-}
-
-html:not([dir="rtl"]) .command-bar .stepOut {
-  margin-right: 2em;
-}
-
-html[dir="rtl"] .command-bar .stepOut {
-  margin-left: 2em;
-}
-
-.command-bar .subSettings {
-  float: right;
-}
-
 .pane {
   color: var(--theme-body-color);
 }
@@ -83,16 +25,4 @@ html[dir="rtl"] .command-bar .stepOut {
   padding: 0.5em;
   -moz-user-select: none;
   user-select: none;
-}
-
-.toggleBreakpoints.breakpoints-disabled path {
-  stroke: var(--theme-highlight-blue);
-}
-
-span.pause-exceptions.uncaught {
-  stroke: var(--theme-highlight-purple);
-}
-
-span.pause-exceptions.all {
-  stroke: var(--theme-highlight-blue);
 }

--- a/src/components/RightSidebar.js
+++ b/src/components/RightSidebar.js
@@ -2,17 +2,8 @@ const React = require("react");
 const { DOM: dom, PropTypes } = React;
 const { connect } = require("react-redux");
 const { bindActionCreators } = require("redux");
-const { getPause, getIsWaitingOnBreak, getBreakpointsDisabled,
-        getShouldPauseOnExceptions, getShouldIgnoreCaughtExceptions,
-        getBreakpoints, getBreakpointsLoading
-      } = require("../selectors");
 const { isEnabled } = require("devtools-config");
 const Svg = require("./utils/Svg");
-const ImPropTypes = require("react-immutable-proptypes");
-
-const { Services: { appinfo }} = require("devtools-modules");
-const shiftKey = appinfo.OS === "Darwin" ? "\u21E7" : "Shift+";
-const ctrlKey = appinfo.OS === "Linux" ? "Ctrl+" : "";
 
 const actions = require("../actions");
 const Breakpoints = React.createFactory(require("./Breakpoints"));
@@ -20,6 +11,7 @@ const Expressions = React.createFactory(require("./Expressions"));
 const Scopes = React.createFactory(require("./Scopes"));
 const Frames = React.createFactory(require("./Frames"));
 const Accordion = React.createFactory(require("./Accordion"));
+const CommandBar = React.createFactory(require("./CommandBar"));
 require("./RightSidebar.css");
 
 function debugBtn(onClick, type, className, tooltip) {
@@ -32,22 +24,6 @@ function debugBtn(onClick, type, className, tooltip) {
 
 const RightSidebar = React.createClass({
   propTypes: {
-    sources: PropTypes.object,
-    selectedSource: PropTypes.object,
-    resume: PropTypes.func,
-    stepIn: PropTypes.func,
-    stepOut: PropTypes.func,
-    stepOver: PropTypes.func,
-    toggleAllBreakpoints: PropTypes.func,
-    breakOnNext: PropTypes.func,
-    pause: ImPropTypes.map,
-    pauseOnExceptions: PropTypes.func,
-    shouldPauseOnExceptions: PropTypes.bool,
-    shouldIgnoreCaughtExceptions: PropTypes.bool,
-    breakpoints: ImPropTypes.map,
-    isWaitingOnBreak: PropTypes.bool,
-    breakpointsDisabled: PropTypes.bool,
-    breakpointsLoading: PropTypes.bool,
     evaluateExpressions: PropTypes.func,
   },
 
@@ -63,142 +39,29 @@ const RightSidebar = React.createClass({
     };
   },
 
-  resume() {
-    if (this.props.pause) {
-      this.props.resume();
-    } else if (!this.props.isWaitingOnBreak) {
-      this.props.breakOnNext();
-    }
-  },
-
-  stepOver() {
-    if (!this.props.pause) {
-      return;
-    }
-    this.props.stepOver();
-  },
-
-  stepIn() {
-    if (!this.props.pause) {
-      return;
-    }
-    this.props.stepIn();
-  },
-
-  stepOut() {
-    if (!this.props.pause) {
-      return;
-    }
-    this.props.stepOut();
-  },
-
-  componentWillUnmount() {
-    const shortcuts = this.context.shortcuts;
-    shortcuts.off("F8", this.resume);
-    shortcuts.off("F10", this.stepOver);
-    shortcuts.off(`${ctrlKey}F11`, this.stepIn);
-    shortcuts.off(`${ctrlKey}Shift+F11`, this.stepOut);
-  },
-
-  componentDidMount() {
-    const shortcuts = this.context.shortcuts;
-    shortcuts.on("F8", this.resume);
-    shortcuts.on("F10", this.stepOver);
-    shortcuts.on(`${ctrlKey}F11`, this.stepIn);
-    shortcuts.on(`${ctrlKey}Shift+F11`, this.stepOut);
-  },
-
-  renderStepButtons() {
-    const className = this.props.pause ? "active" : "disabled";
+  watchExpressionHeaderButtons() {
+    const { expressionInputVisibility } = this.state;
     return [
-      debugBtn(this.stepOver, "stepOver", className,
-        L10N.getStr("stepOverTooltip")
-      ),
-      debugBtn(this.stepIn, "stepIn", className,
-        L10N.getFormatStr("stepInTooltip", ctrlKey)
-      ),
-      debugBtn(this.stepOut, "stepOut", className,
-        L10N.getFormatStr("stepOutTooltip", ctrlKey + shiftKey)
-      )
+      debugBtn(
+        evt => {
+          evt.stopPropagation();
+          this.props.evaluateExpressions();
+        }, "domain",
+        "accordion-button", "Refresh"),
+      debugBtn(
+        evt => {
+          evt.stopPropagation();
+          this.setState({
+            expressionInputVisibility: !expressionInputVisibility
+          });
+        }, "file",
+        "accordion-button", "Add Watch Expression")
     ];
-  },
-
-  renderPauseButton() {
-    const { pause, breakOnNext, isWaitingOnBreak } = this.props;
-
-    if (pause) {
-      return debugBtn(this.resume, "resume", "active",
-        L10N.getStr("resumeButtonTooltip")
-      );
-    }
-
-    if (isWaitingOnBreak) {
-      return debugBtn(null, "pause", "disabled",
-        L10N.getStr("pausePendingButtonTooltip")
-      );
-    }
-
-    return debugBtn(breakOnNext, "pause", "active",
-      L10N.getStr("pauseButtonTooltip")
-    );
-  },
-
-  /*
-   * The pause on exception button has three states in this order:
-   *  1. don't pause on exceptions      [false, false]
-   *  2. pause on uncaught exceptions   [true, true]
-   *  3. pause on all exceptions        [true, false]
-  */
-  renderPauseOnExceptions() {
-    const { shouldPauseOnExceptions, shouldIgnoreCaughtExceptions,
-            pauseOnExceptions } = this.props;
-
-    if (!shouldPauseOnExceptions && !shouldIgnoreCaughtExceptions) {
-      return debugBtn(
-        () => pauseOnExceptions(true, true),
-        "pause-exceptions",
-        "enabled",
-        L10N.getStr("ignoreExceptions")
-      );
-    }
-
-    if (shouldPauseOnExceptions && shouldIgnoreCaughtExceptions) {
-      return debugBtn(
-        () => pauseOnExceptions(true, false),
-        "pause-exceptions",
-        "uncaught enabled",
-        L10N.getStr("pauseOnUncaughtExceptions")
-      );
-    }
-
-    return debugBtn(
-      () => pauseOnExceptions(false, false),
-      "pause-exceptions",
-      "all enabled",
-      L10N.getStr("pauseOnExceptions")
-    );
-  },
-
-  renderDisableBreakpoints() {
-    const { toggleAllBreakpoints, breakpoints,
-            breakpointsDisabled, breakpointsLoading } = this.props;
-
-    if (breakpoints.size == 0 || breakpointsLoading) {
-      return debugBtn(
-        null, "toggleBreakpoints", "disabled", "Disable Breakpoints"
-      );
-    }
-
-    return debugBtn(
-      () => toggleAllBreakpoints(!breakpointsDisabled),
-      "toggleBreakpoints",
-      breakpointsDisabled ? "breakpoints-disabled" : "",
-      "Disable Breakpoints"
-    );
   },
 
   getItems() {
     const { expressionInputVisibility } = this.state;
+
     const items = [
       { header: L10N.getStr("breakpoints.header"),
         component: Breakpoints,
@@ -210,22 +73,7 @@ const RightSidebar = React.createClass({
     ];
     if (isEnabled("watchExpressions")) {
       items.unshift({ header: L10N.getStr("watchExpressions.header"),
-        buttons: [
-          debugBtn(
-            evt => {
-              evt.stopPropagation();
-              this.props.evaluateExpressions();
-            }, "domain",
-            "accordion-button", "Refresh"),
-          debugBtn(
-            evt => {
-              evt.stopPropagation();
-              this.setState({
-                expressionInputVisibility: !expressionInputVisibility
-              });
-            }, "file",
-            "accordion-button", "Add Watch Expression")
-        ],
+        buttons: this.watchExpressionHeaderButtons(),
         component: Expressions,
         componentProps: { expressionInputVisibility },
         opened: true
@@ -239,34 +87,16 @@ const RightSidebar = React.createClass({
       dom.div(
         { className: "right-sidebar",
           style: { overflowX: "hidden" }},
-        dom.div(
-          { className: "command-bar" },
-          this.renderPauseButton(),
-          this.renderStepButtons(),
-          this.renderDisableBreakpoints(),
-          this.renderPauseOnExceptions()
-        ),
-
+        CommandBar(),
         Accordion({
           items: this.getItems()
         })
       )
     );
   }
-
 });
 
 module.exports = connect(
-  state => {
-    return {
-      pause: getPause(state),
-      isWaitingOnBreak: getIsWaitingOnBreak(state),
-      shouldPauseOnExceptions: getShouldPauseOnExceptions(state),
-      shouldIgnoreCaughtExceptions: getShouldIgnoreCaughtExceptions(state),
-      breakpointsDisabled: getBreakpointsDisabled(state),
-      breakpoints: getBreakpoints(state),
-      breakpointsLoading: getBreakpointsLoading(state),
-    };
-  },
+  () => ({}),
   dispatch => bindActionCreators(actions, dispatch)
 )(RightSidebar);


### PR DESCRIPTION
Associated Issue: #1266

### Summary of Changes

* Extracts Command Bar so that it can be re-used in the vertical layout
* cleans up the watch expression buttons so that it is more clear what is going on

### Test Plan

- [x] test wait on break
- [x] test step in, step out, step over
- [x] test toggle all breakpoints
- [x] test pause on caught and uncaught exceptions


### Screenshots/Videos 

![](http://g.recordit.co/O0BWUTq2Qb.gif)