### PR TITLE
update devtools-local-toolbox for inspector integration

### DIFF
--- a/packages/devtools-local-toolbox/bin/development-server.js
+++ b/packages/devtools-local-toolbox/bin/development-server.js
@@ -90,7 +90,9 @@ function startDevServer(devConfig, webpackConfig) {
   // setup app
   const app = express();
   app.use(express.static("assets/build"));
-  app.get("/", serveRoot);
+  if (!getValue("development.customIndex")) {
+    app.get("/", serveRoot);
+  }
   app.get("/get", handleNetworkRequest);
   const serverPort = getValue("development.serverPort");
   app.listen(serverPort, "0.0.0.0", onRequest);

--- a/packages/devtools-local-toolbox/package.json
+++ b/packages/devtools-local-toolbox/package.json
@@ -55,7 +55,6 @@
     "extract-text-webpack-plugin": "^1.0.1",
     "immutable": "^3.7.6",
     "json-loader": "^0.5.4",
-    "lodash": "^4.13.1",
     "minimist": "^1.2.0",
     "mustache": "^2.2.1",
     "react": "=0.14.7",

--- a/packages/devtools-local-toolbox/webpack.config.js
+++ b/packages/devtools-local-toolbox/webpack.config.js
@@ -5,7 +5,6 @@ const path = require("path");
 const webpack = require("webpack");
 const ExtractTextPlugin = require("extract-text-webpack-plugin");
 const { isDevelopment, isFirefoxPanel, getValue } = require("devtools-config");
-const merge = require("lodash/merge");
 const NODE_ENV = process.env.NODE_ENV || "development";
 const TARGET = process.env.TARGET || "local";
 
@@ -18,37 +17,38 @@ module.exports = (webpackConfig, envConfig) => {
   webpackConfig.context = path.resolve(__dirname, "src");
   webpackConfig.devtool = "source-map";
 
-  webpackConfig.resolve = merge({
-    alias: {
-      "devtools/client/shared/vendor/react": "react",
-      "devtools/client/shared/vendor/react-dom": "react-dom"
-    }
-  }, webpackConfig.resolve);
-
-  webpackConfig.module = {
-    loaders: [
-    { test: /\.json$/,
-      loader: "json" },
-    { test: /\.js$/,
-      exclude: request => {
-        return request.match(/(node_modules|bower_components|fs)/)
-               && !request.match(/devtools-local-toolbox\/src/);
-      },
-      loaders: [
-        "babel?" +
-          defaultBabelPlugins.map(p => "plugins[]=" + p) +
-          "&ignore=src/lib"
-      ],
-      isJavaScriptLoader: true
+  webpackConfig.module = webpackConfig.module || {};
+  webpackConfig.module.loaders = webpackConfig.module.loaders || [];
+  webpackConfig.module.loaders.push({
+    test: /\.json$/,
+    loader: "json"
+  });
+  webpackConfig.module.loaders.push({
+    test: /\.js$/,
+    exclude: request => {
+      let excluded = request.match(/(node_modules|bower_components|fs)/);
+      if (webpackConfig.babelExcludes) {
+        // If the tool defines an additional exclude regexp for Babel.
+        excluded = excluded || request.match(webpackConfig.babelExcludes);
+      }
+      return excluded && !request.match(/devtools-local-toolbox\/src/);
     },
-    { test: /\.svg$/,
-      exclude: /lkdjlskdjslkdjsdlk/,
-      loader: "svg-inline" }
-    ]
-  };
+    loaders: [
+      "babel?" +
+        defaultBabelPlugins.map(p => "plugins[]=" + p) +
+        "&ignore=src/lib"
+    ],
+    isJavaScriptLoader: true
+  });
+  webpackConfig.module.loaders.push({
+    test: /\.svg$/,
+    exclude: /lkdjlskdjslkdjsdlk/,
+    loader: "svg-inline"
+  });
 
   const ignoreRegexes = [/^fs$/];
-  webpackConfig.externals = [];
+  webpackConfig.externals = webpackConfig.externals || [];
+
   function externalsTest(context, request, callback) {
     let mod = request;
 
@@ -61,7 +61,8 @@ module.exports = (webpackConfig, envConfig) => {
   }
   webpackConfig.externals.push(externalsTest);
 
-  webpackConfig.plugins = [
+  webpackConfig.plugins = webpackConfig.plugins || [];
+  webpackConfig.plugins.push(
     new webpack.DefinePlugin({
       "process.env": {
         NODE_ENV: JSON.stringify(NODE_ENV),
@@ -69,7 +70,7 @@ module.exports = (webpackConfig, envConfig) => {
       },
       "DebuggerConfig": JSON.stringify(envConfig)
     })
-  ];
+  );
 
   if (isDevelopment()) {
     webpackConfig.module.loaders.push({

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,10 +13,17 @@ function buildConfig(envConfig) {
               path.join(projectPath, "utils/pretty-print-worker.js")
     },
 
-  output: {
-    path: path.join(__dirname, "assets/build"),
-    filename: "[name].js",
-    publicPath: "/assets/build"
+    output: {
+      path: path.join(__dirname, "assets/build"),
+      filename: "[name].js",
+      publicPath: "/assets/build"
+    },
+
+    resolve: {
+      alias: {
+        "devtools/client/shared/vendor/react": "react",
+        "devtools/client/shared/vendor/react-dom": "react-dom",
+      }
     }
   }
 


### PR DESCRIPTION
This PR is the outcome of the integration work between devtools-local-toolbox and the inspector. 

The corresponding bugzilla entry is https://bugzilla.mozilla.org/show_bug.cgi?id=1291049 , which contains patches to apply on mc, and that should be compatible with the changes proposed in this PR.

### Summary of Changes

* add a development.customIndex configuration value in order to disable the default route serving index.html
* allow webpack-config to merge plugins, externals and module loaders
* allow tools to define a custom regexp to exclude requests from being transpiled by babel (babelExcludes in the tool's webpackConfig)

@jasonLaster can you have a look and let me know what you think?

