### PR TITLE
issue:1248 fix running firefox in debuggable state in windows

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,7 +116,7 @@ $ /Applications/Firefox.app/Contents/MacOS/firefox-bin --start-debugger-server 6
 **Windows:**
 
 ```
-C:\Program Files (x86)\Mozilla Firefox\firefox.exe -start-debugger-server 6080 -P development
+C:\Program Files (x86)\Mozilla Firefox\firefox.exe -start-debugging-server 6080 -P development
 ```
 
 > If this command doesn't work for your OS or Firefox version see the other [Firefox commands for running in a debuggable state](./docs/remotely-debuggable-browsers.md#firefox)


### PR DESCRIPTION
Associated Issue: #1248

### Summary of Changes

*Changed to `--start-debugging-server` from `--start-debugger-server` for windows environment in CONTRIBUTING.md file

### Test Plan

- start debuggable version of firefox browser using `C:\Program Files (x86)\Mozilla Firefox\firefox.exe -start-debugging-server 6080 -P development` on windows 10 
- browser will be launched
- now restart the development server and launch debugger
