### PR TITLE
Do not overflow "No files matching" message.

### DIFF
--- a/src/components/Autocomplete.css
+++ b/src/components/Autocomplete.css
@@ -98,6 +98,7 @@
   width: 24px;
   margin-right: 4px;
   line-height: 0;
+  flex-shrink: 0;
 }
 
 .autocomplete .no-result-msg .sad-face svg {

--- a/src/components/Autocomplete.css
+++ b/src/components/Autocomplete.css
@@ -90,6 +90,8 @@
   height: 100%;
   color: var(--theme-graphs-full-red);
   font-size: 24px;
+  padding: 4px;
+  word-break: break-all;
 }
 
 .autocomplete .no-result-msg .sad-face {


### PR DESCRIPTION
Associated Issue: #1162

### Summary of Changes

* break long search queries to stop "no files matching" message from overflowing

### Test Plan

Tell us a little a bit about how you tested your patch.

Example test plan:

- [ ] Test if "No files matching" message with a long query does not overflow
- [ ] Test if "No files matching" message with a short query looks the same as before the changes

### Screenshots/Videos

Long query before:
<img width="903" alt="before_long_query" src="https://cloud.githubusercontent.com/assets/985504/20499049/0585f7b4-b030-11e6-925d-e07d48e64f6e.png">

Long query after:
<img width="608" alt="after_long_query" src="https://cloud.githubusercontent.com/assets/985504/20499256/0196bcbe-b031-11e6-96ed-3e5458251745.png">


Short query after:
<img width="793" alt="after_short_query" src="https://cloud.githubusercontent.com/assets/985504/20499061/11e0ee56-b030-11e6-9d95-069b7dd81d84.png">


