### PR TITLE
(WIP) File search style outline matches

### DIFF
--- a/packages/devtools-local-toolbox/src/lib/themes/dark-theme.css
+++ b/packages/devtools-local-toolbox/src/lib/themes/dark-theme.css
@@ -212,7 +212,7 @@ body {
 }
 
 .cm-s-mozilla .CodeMirror-selected { /* selected text (unfocused) */
-  background: rgb(176, 176, 176);
+  background: rgb(255, 255, 0);
 }
 
 .cm-s-mozilla .CodeMirror-activeline-background { /* selected color with alpha */

--- a/packages/devtools-local-toolbox/src/lib/themes/light-theme.css
+++ b/packages/devtools-local-toolbox/src/lib/themes/light-theme.css
@@ -214,7 +214,7 @@ body {
 }
 
 .cm-s-mozilla .CodeMirror-selected { /* selected text (unfocused) */
-  background: rgb(176, 176, 176);
+  background: rgb(255, 255, 0);
 }
 
 .cm-s-mozilla .CodeMirror-activeline-background { /* selected color with alpha */

--- a/src/lib/codemirror-mozilla.css
+++ b/src/lib/codemirror-mozilla.css
@@ -129,7 +129,7 @@ selector in floating-scrollbar-light.css across all platforms. */
   background: none;
   outline-width: 1px;
   outline-style: solid;
-  outline-color: var(--theme-comment);
+  outline-color: var(--theme-comment-alt);
 }
 
 /* CodeMirror dialogs styling */


### PR DESCRIPTION
Associated Issue: #1111

### Summary of Changes

* Change selected match to yellow
* Lighten the match outlines

### Test Plan

- [ ] Ctrl + F to see the search matches

### Screenshots

![debugger-file-search](https://cloud.githubusercontent.com/assets/2848472/20470087/3c9b2070-af73-11e6-83bc-552f4ccad8d0.png)

![debugger-file-search-dark](https://cloud.githubusercontent.com/assets/2848472/20470134/9969dc56-af73-11e6-880b-36987b13002c.png)