### PR TITLE
use unique context menu ids for each breakpoint menu

### DIFF
--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -249,25 +249,39 @@ const Editor = React.createClass({
   },
 
   showGutterMenu(e, line, bp) {
-    let bpLabel;
-    let cbLabel;
-    let disableBpLabel;
+    let breakpoint, conditional, disabled;
     if (!bp) {
-      bpLabel = L10N.getStr("editor.addBreakpoint");
-      cbLabel = L10N.getStr("editor.addConditionalBreakpoint");
+      breakpoint = {
+        id: "node-menu-add-breakpoint",
+        label: L10N.getStr("editor.addBreakpoint")
+      };
+      conditional = {
+        id: "node-menu-add-conditional-breakpoint",
+        label: L10N.getStr("editor.addConditionalBreakpoint")
+      };
     } else {
-      bpLabel = L10N.getStr("editor.removeBreakpoint");
-      cbLabel = L10N.getStr("editor.editBreakpoint");
+      breakpoint = {
+        id: "node-menu-remove-breakpoint",
+        label: L10N.getStr("editor.removeBreakpoint")
+      };
+      conditional = {
+        id: "node-menu-edit-conditional-breakpoint",
+        label: L10N.getStr("editor.editBreakpoint")
+      };
       if (bp.disabled) {
-        disableBpLabel = L10N.getStr("editor.enableBreakpoint");
+        disabled = {
+          id: "node-menu-enable-breakpoint",
+          label: L10N.getStr("editor.enableBreakpoint")
+        };
       } else {
-        disableBpLabel = L10N.getStr("editor.disableBreakpoint");
+        disabled = {
+          id: "node-menu-disable-breakpoint",
+          label: L10N.getStr("editor.disableBreakpoint")
+        };
       }
     }
 
-    const toggleBreakpoint = {
-      id: "node-menu-breakpoint",
-      label: bpLabel,
+    const toggleBreakpoint = Object.assign({
       accesskey: "B",
       disabled: false,
       click: () => {
@@ -276,15 +290,13 @@ const Editor = React.createClass({
           this.closeConditionalPanel();
         }
       }
-    };
+    }, breakpoint);
 
-    const conditionalBreakpoint = {
-      id: "node-menu-conditional-breakpoint",
-      label: cbLabel,
+    const conditionalBreakpoint = Object.assign({
       accesskey: "C",
       disabled: false,
       click: () => this.showConditionalPanel(line)
-    };
+    }, conditional);
 
     let items = [
       toggleBreakpoint,
@@ -292,13 +304,11 @@ const Editor = React.createClass({
     ];
 
     if (bp) {
-      const disableBreakpoint = {
-        id: "node-menu-disable-breakpoint",
-        label: disableBpLabel,
+      const disableBreakpoint = Object.assign({
         accesskey: "D",
         disabled: false,
         click: () => this.toggleBreakpointDisabledStatus(line)
-      };
+      }, disabled);
       items.push(disableBreakpoint);
     }
 


### PR DESCRIPTION
Associated Issue: #1228 

### Summary of Changes

* Moved to a system of merging objects instead of switching labels to allow for each label to have a different id

### Test Plan

Tell us a little a bit about how you tested your patch.

Example test plan:

- [ ] Trigger context menus and view elements in inspector

### Screenshots/Videos (OPTIONAL)

<img width="720" alt="screen shot 2016-11-22 at 11 58 05 am" src="https://cloud.githubusercontent.com/assets/2134/20539828/5a7f9394-b0ab-11e6-8478-5aa081272b43.png">

<img width="740" alt="screen shot 2016-11-22 at 11 57 43 am" src="https://cloud.githubusercontent.com/assets/2134/20539835/5fadb026-b0ab-11e6-8f11-3c1a522cd508.png">

