### PR TITLE
Upgrade Event Listeners redux backend

### DIFF
--- a/packages/devtools-client-adapters/src/firefox/commands.js
+++ b/packages/devtools-client-adapters/src/firefox/commands.js
@@ -144,7 +144,22 @@ function disablePrettyPrint(sourceId) {
   return sourceClient.disablePrettyPrint();
 }
 
+function interrupt() {
+  return threadClient.interrupt();
+}
+
+function eventListeners() {
+  return threadClient.eventListeners();
+}
+
+function pauseGrip(func) {
+  return threadClient.pauseGrip(func);
+}
+
 const clientCommands = {
+  interrupt,
+  eventListeners,
+  pauseGrip,
   resume,
   stepIn,
   stepOut,

--- a/packages/devtools-client-adapters/src/firefox/events.js
+++ b/packages/devtools-client-adapters/src/firefox/events.js
@@ -1,4 +1,5 @@
 const { createFrame, createSource } = require("./create");
+const { isEnabled } = require("devtools-config");
 
 const CALL_STACK_PAGE_SIZE = 1000;
 
@@ -36,6 +37,10 @@ function resumed(_, packet) {
 
 function newSource(_, { source }) {
   actions.newSource(createSource(source));
+
+  if (isEnabled("eventListeners")) {
+    actions.fetchEventListeners();
+  }
 }
 
 const clientEvents = {

--- a/src/reducers/event-listeners.js
+++ b/src/reducers/event-listeners.js
@@ -14,7 +14,7 @@ function update(state = initialState, action, emit) {
   switch (action.type) {
     case constants.UPDATE_EVENT_BREAKPOINTS:
       state.activeEventNames = action.eventNames;
-      emit("activeEventNames", state.activeEventNames);
+      // emit("activeEventNames", state.activeEventNames);
       break;
     case constants.FETCH_EVENT_LISTENERS:
       if (action.status === "begin") {
@@ -22,7 +22,6 @@ function update(state = initialState, action, emit) {
       } else if (action.status === "done") {
         state.fetchingListeners = false;
         state.listeners = action.listeners;
-        emit("event-listeners", state.listeners);
       }
       break;
     case constants.NAVIGATE:
@@ -32,4 +31,11 @@ function update(state = initialState, action, emit) {
   return state;
 }
 
-module.exports = update;
+function getEventListeners(state) {
+  return state.listeners;
+}
+
+module.exports = {
+  update,
+  getEventListeners
+};

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -10,7 +10,7 @@ const pause = require("./pause");
 const ui = require("./ui");
 
 module.exports = {
-  eventListeners,
+  eventListeners: eventListeners.update,
   sources: sources.update,
   breakpoints: breakpoints.update,
   pause: pause.update,

--- a/src/selectors.js
+++ b/src/selectors.js
@@ -3,6 +3,7 @@
 const sources = require("./reducers/sources");
 const pause = require("./reducers/pause");
 const breakpoints = require("./reducers/breakpoints");
+const eventListeners = require("./reducers/event-listeners");
 const ui = require("./reducers/ui");
 
 /**
@@ -35,6 +36,8 @@ module.exports = {
   getShouldIgnoreCaughtExceptions: pause.getShouldIgnoreCaughtExceptions,
   getFrames: pause.getFrames,
   getSelectedFrame: pause.getSelectedFrame,
+
+  getEventListeners: eventListeners.getEventListeners,
 
   getFileSearchState: ui.getFileSearchState
 };

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -10,34 +10,6 @@
  * @module utils/utils
  */
 
-const co = require("co");
-
-/**
- * @memberof utils/utils
- * @static
- */
-function asPaused(client: any, func: any) {
-  if (client.state != "paused") {
-    return co(function* () {
-      yield client.interrupt();
-      let result;
-
-      try {
-        result = yield func();
-      } catch (e) {
-        // Try to put the debugger back in a working state by resuming
-        // it
-        yield client.resume();
-        throw e;
-      }
-
-      yield client.resume();
-      return result;
-    });
-  }
-  return func();
-}
-
 /**
  * @memberof utils/utils
  * @static
@@ -225,7 +197,6 @@ function throttle(func: any, ms: number) {
 }
 
 module.exports = {
-  asPaused,
   handleError,
   promisify,
   truncateStr,


### PR DESCRIPTION
### Summary of Changes

* upgrades event listener reducer
* upgrades event listener action for fetching event listeners
* adds a call for fetching events in newSource behind a flag
* moves asPaused over to eventListners

### Test Plan

- [ ] make sure it doesn't break anything when flagged off
- [ ] make sure `appStore.getState().eventListeners.listeners` has state

