### PR TITLE
support windows development environment for devtools-local-toolbox

### DIFF
--- a/packages/devtools-local-toolbox/webpack.config.js
+++ b/packages/devtools-local-toolbox/webpack.config.js
@@ -31,7 +31,7 @@ module.exports = (webpackConfig, envConfig) => {
         // If the tool defines an additional exclude regexp for Babel.
         excluded = excluded || request.match(webpackConfig.babelExcludes);
       }
-      return excluded && !request.match(/devtools-local-toolbox\/src/);
+      return excluded && !request.match(/devtools-local-toolbox(\/|\\)src/);
     },
     loaders: [
       "babel?" +


### PR DESCRIPTION
cc @jasonLaster 

I was trying to setup the inspector.html development environment on windows, and it looks like the babel exclude regexp needs to be updated to accept both posix and win32 path styles.

I was looking for a better way to do this than replacing `\/` by `(\/|\\), but didn't find any.