### PR TITLE
Windows env fix

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,7 +116,7 @@ $ /Applications/Firefox.app/Contents/MacOS/firefox-bin --start-debugger-server 6
 **Windows:**
 
 ```
-C:\Program Files (x86)\Mozilla Firefox\firefox.exe -start-debugger-server 6080 -P development
+C:\Program Files (x86)\Mozilla Firefox\firefox.exe -start-debugging-server 6080 -P development
 ```
 
 > If this command doesn't work for your OS or Firefox version see the other [Firefox commands for running in a debuggable state](./docs/remotely-debuggable-browsers.md#firefox)

--- a/bin/firefox-driver.js
+++ b/bin/firefox-driver.js
@@ -22,7 +22,7 @@ const useWebSocket = args.websocket;
 function binaryArgs() {
   return [
     (!isWindows ? "-" : "") +
-    "-start-debugger-server=" +
+    "--start-debugging-server=" +
     (useWebSocket ? "ws:6080" : "6080")
   ];
 }


### PR DESCRIPTION
Associated Issue: #1248

### Summary of Changes

*edited firefox-driver.js to run 'yarn start firefox'

### Test Plan

Tell us a little a bit about how you tested your patch.

Example test plan:

*Navigate to debugger.html folder from command prompt from windows
*Execute "yarn start firefox" to start the server
*Open browser and go to localhost:8000

Output: debugger.html is up and running

### Screenshots/Videos (OPTIONAL)

yarn start firefox vs yarn run firefox

![yarn2](https://cloud.githubusercontent.com/assets/3799600/20604688/b4e8699e-b28d-11e6-97c3-450795dd7228.JPG)
