### PR TITLE
use eslint prefer-template and move from string concatenation

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -228,6 +228,7 @@
     "no-multi-spaces": 2,
     // Disallow use of multiline strings (use template strings instead).
     "no-multi-str": 2,
+    "prefer-template": "error",
     // Disallow multiple empty lines.
     "no-multiple-empty-lines": [2, {"max": 1}],
     // Disallow reassignments of native objects.

--- a/packages/devtools-local-toolbox/src/utils/DevToolsUtils.js
+++ b/packages/devtools-local-toolbox/src/utils/DevToolsUtils.js
@@ -1,7 +1,7 @@
 const assert = require("./assert");
 
 function reportException(who, exception) {
-  let msg = who + " threw an exception: ";
+  let msg = `${who} threw an exception: `;
   console.error(msg, exception);
 }
 

--- a/packages/devtools-local-toolbox/src/utils/assert.js
+++ b/packages/devtools-local-toolbox/src/utils/assert.js
@@ -1,6 +1,6 @@
 function assert(condition, message) {
   if (!condition) {
-    throw new Error("Assertion failure: " + message);
+    throw new Error(`Assertion failure: ${message}`);
   }
 }
 

--- a/packages/devtools-local-toolbox/src/utils/event-emitter.js
+++ b/packages/devtools-local-toolbox/src/utils/event-emitter.js
@@ -114,7 +114,7 @@ EventEmitter.prototype = {
           listener.apply(null, arguments);
         } catch (ex) {
           // Prevent a bad listener from interfering with the others.
-          let msg = ex + ": " + ex.stack;
+          let msg = `${ex}: ${ex.stack}`;
           console.error(msg);
         }
       }

--- a/packages/devtools-local-toolbox/src/utils/utils.js
+++ b/packages/devtools-local-toolbox/src/utils/utils.js
@@ -48,14 +48,14 @@ function promisify(context: any, method: any, ...args: any) {
 
 function truncateStr(str: any, size: any) {
   if (str.length > size) {
-    return str.slice(0, size) + "...";
+    return `${str.slice(0, size)}...`;
   }
   return str;
 }
 
 function endTruncateStr(str: string, size: number) {
   if (str.length > size) {
-    return "..." + str.slice(str.length - size);
+    return `...${str.slice(str.length - size)}`;
   }
   return str;
 }

--- a/src/actions/sources.js
+++ b/src/actions/sources.js
@@ -20,6 +20,7 @@ const {
 } = require("../utils/source-map");
 
 const { prettyPrint } = require("../utils/pretty-print");
+const { getPrettySourceURL } = require("../utils/source");
 
 const constants = require("../constants");
 const { removeDocument } = require("../utils/source-documents");
@@ -194,7 +195,7 @@ function togglePrettyPrint(sourceId: string) {
     assert(isGeneratedId(sourceId),
            "Pretty-printing only allowed on generated sources");
 
-    const url = source.url + ":formatted";
+    const url = getPrettySourceURL(source.url);
     const id = generatedToOriginalId(source.id, url);
     const originalSource = { url, id, isPrettyPrinted: false };
     dispatch({

--- a/src/components/Accordion.js
+++ b/src/components/Accordion.js
@@ -36,7 +36,7 @@ const Accordion = React.createClass({
   renderContainer: function(item, i) {
     const { opened, created } = this.state;
     const containerClassName =
-          item.header.toLowerCase().replace(/\s/g, "-") + "-pane";
+      `${item.header.toLowerCase().replace(/\s/g, "-")}-pane`;
 
     return div(
       { className: containerClassName, key: i },

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -9,6 +9,8 @@ const { getSources, getSelectedSource } = require("../selectors");
 const { KeyShortcuts } = require("devtools-sham-modules");
 const shortcuts = new KeyShortcuts({ window });
 
+const cmd = `${cmdString()}+P`;
+
 require("./App.css");
 require("./menu.css");
 require("./SplitBox.css");
@@ -38,7 +40,7 @@ const App = React.createClass({
   renderWelcomeBox() {
     return dom.div(
       { className: "welcomebox" },
-      L10N.getFormatStr("welcome.search", cmdString() + "+P")
+      L10N.getFormatStr("welcome.search", cmd)
     );
   },
 

--- a/src/components/CloseButton.js
+++ b/src/components/CloseButton.js
@@ -6,7 +6,7 @@ require("./CloseButton.css");
 
 function CloseButton({ handleClick, buttonClass }) {
   return dom.div({
-    className: buttonClass ? "close-btn-" + buttonClass : "close-btn",
+    className: buttonClass ? `close-btn-${buttonClass}` : "close-btn",
     onClick: handleClick
   },
     Svg("close"));

--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -51,7 +51,7 @@ function resizeBreakpointGutter(editor) {
   const gutters = editor.display.gutters;
   const lineNumbers = gutters.querySelector(".CodeMirror-linenumbers");
   const breakpoints = gutters.querySelector(".breakpoints");
-  breakpoints.style.width = lineNumbers.clientWidth + "px";
+  breakpoints.style.width = `${lineNumbers.clientWidth}px`;
 }
 
 const Editor = React.createClass({

--- a/src/components/ObjectInspector.js
+++ b/src/components/ObjectInspector.js
@@ -82,14 +82,14 @@ const ObjectInspector = React.createClass({
       // for now by making sure we have a value.
       return "value" in ownProperties[name];
     }).map(name => {
-      return createNode(name, parentPath + "/" + name, ownProperties[name]);
+      return createNode(name, `${parentPath}/${name}`, ownProperties[name]);
     });
 
     // Add the prototype if it exists and is not null
     if (prototype && prototype.type !== "null") {
       nodes.push(createNode(
         "__proto__",
-        parentPath + "/__proto__",
+        `${parentPath}/__proto__`,
         { value: prototype }
       ));
     }

--- a/src/components/Scopes.js
+++ b/src/components/Scopes.js
@@ -26,7 +26,7 @@ function getBindingVariables(bindings, parentName) {
     ))
     .map(binding => ({
       name: binding[0],
-      path: parentName + "/" + binding[0],
+      path: `${parentName}/${binding[0]}`,
       contents: binding[1]
     }));
 }
@@ -42,7 +42,7 @@ function getSpecialVariables(pauseInfo, path) {
 
     vars.push({
       name: "<exception>",
-      path: path + "/<exception>",
+      path: `${path}/<exception>`,
       contents: { value: thrown }
     });
   }
@@ -50,7 +50,7 @@ function getSpecialVariables(pauseInfo, path) {
   if (returned) {
     vars.push({
       name: "<return>",
-      path: path + "/<return>",
+      path: `${path}/<return>`,
       contents: { value: returned.toJS() }
     });
   }
@@ -67,7 +67,7 @@ function getThisVariable(frame, path) {
 
   return {
     name: "<this>",
-    path: path + "/<this>",
+    path: `${path}/<this>`,
     contents: { value: this_ }
   };
 }

--- a/src/components/Sources.js
+++ b/src/components/Sources.js
@@ -10,6 +10,8 @@ const { getSelectedSource, getSources } = require("../selectors");
 
 require("./Sources.css");
 
+const cmd = `${cmdString()}+P`;
+
 const Sources = React.createClass({
   propTypes: {
     sources: ImPropTypes.map.isRequired,
@@ -26,7 +28,7 @@ const Sources = React.createClass({
       dom.div({ className: "sources-header" },
         L10N.getStr("sources.header"),
         dom.span({ className: "sources-header-info" },
-          L10N.getFormatStr("sources.search", cmdString() + "+P")
+          L10N.getFormatStr("sources.search", cmd)
         )
       ),
       SourcesTree({ sources, selectSource })

--- a/src/components/SourcesTree.js
+++ b/src/components/SourcesTree.js
@@ -110,7 +110,7 @@ let SourcesTree = React.createClass({
     return dom.div(
       {
         className: classnames("node", { focused }),
-        style: { paddingLeft: depth * 15 + "px" },
+        style: { paddingLeft: `${depth * 15}px` },
         key: item.path,
         onClick: () => this.selectItem(item),
         onDoubleClick: e => setExpanded(item, !expanded)

--- a/src/reducers/breakpoints.js
+++ b/src/reducers/breakpoints.js
@@ -45,7 +45,7 @@ function locationMoved(location, newLocation) {
 }
 
 function makeLocationId(location: Location) {
-  return location.sourceId + ":" + location.line.toString();
+  return `${location.sourceId}:${location.line.toString()}`;
 }
 
 function update(state = State(), action: Action) {

--- a/src/reducers/sources.js
+++ b/src/reducers/sources.js
@@ -11,6 +11,7 @@
 const fromJS = require("../utils/fromJS");
 const I = require("immutable");
 const makeRecord = require("../utils/makeRecord");
+const { getPrettySourceURL } = require("../utils/source");
 
 import type { Source, Location } from "../types";
 import type { Action } from "../actions/types";
@@ -251,7 +252,7 @@ function getPrettySource(state: OuterState, id: string) {
     return;
   }
 
-  return getSourceByURL(state, source.get("url") + ":formatted");
+  return getSourceByURL(state, getPrettySourceURL(source.get("url")));
 }
 
 module.exports = {

--- a/src/utils/DevToolsUtils.js
+++ b/src/utils/DevToolsUtils.js
@@ -1,7 +1,7 @@
 const assert = require("./assert");
 
 function reportException(who, exception) {
-  let msg = who + " threw an exception: ";
+  let msg = `${who} threw an exception: `;
   console.error(msg, exception);
 }
 

--- a/src/utils/assert.js
+++ b/src/utils/assert.js
@@ -2,7 +2,7 @@
 
 function assert(condition: boolean, message: string) {
   if (!condition) {
-    throw new Error("Assertion failure: " + message);
+    throw new Error(`Assertion failure: ${message}`);
   }
 }
 

--- a/src/utils/menu.js
+++ b/src/utils/menu.js
@@ -23,8 +23,8 @@ function createPopup(doc) {
   mask.onclick = () => popup.hidePopup();
 
   popup.openPopupAtScreen = function(clientX, clientY) {
-    this.style.setProperty("left", clientX + "px");
-    this.style.setProperty("top", clientY + "px");
+    this.style.setProperty("left", `${clientX}px`);
+    this.style.setProperty("top", `${clientY}px`);
     mask = document.querySelector("#contextmenu-mask");
     window.onwheel = preventDefault;
     mask.classList.add("show");

--- a/src/utils/path.js
+++ b/src/utils/path.js
@@ -18,7 +18,7 @@ function isAbsolute(str: string) {
 }
 
 function join(base: string, dir: string) {
-  return base + "/" + dir;
+  return `${base}/${dir}`;
 }
 
 module.exports = {

--- a/src/utils/pretty-print-worker.js
+++ b/src/utils/pretty-print-worker.js
@@ -13,7 +13,7 @@ function prettyPrint({ url, indent, source }) {
       mappings: prettified.map._mappings
     };
   } catch (e) {
-    return new Error(e.message + "\n" + e.stack);
+    return new Error(`${e.message}\n${e.stack}`);
   }
 }
 

--- a/src/utils/pretty-print.js
+++ b/src/utils/pretty-print.js
@@ -4,7 +4,7 @@ const { isJavaScript } = require("./source");
 const assert = require("./assert");
 
 let prettyPrintWorker = new Worker(
-  getValue("baseWorkerURL") + "pretty-print-worker.js"
+  `${getValue("baseWorkerURL")}pretty-print-worker.js`
 );
 
 function destroyWorker() {

--- a/src/utils/source-map-util.js
+++ b/src/utils/source-map-util.js
@@ -8,7 +8,7 @@ function originalToGeneratedId(originalId: string) {
 }
 
 function generatedToOriginalId(generatedId: string, url: string) {
-  return generatedId + "/originalSource-" + md5(url);
+  return `${generatedId}/originalSource-${md5(url)}`;
 }
 
 function isOriginalId(id: string) {

--- a/src/utils/source-map-worker.js
+++ b/src/utils/source-map-worker.js
@@ -52,7 +52,7 @@ function _resolveSourceMapURL(source: Source) {
   }
   // Otherwise, it's a relative path and should be resolved relative
   // to the source.
-  return path.dirname(url) + "/" + sourceMapURL;
+  return `${path.dirname(url)}/${sourceMapURL}`;
 }
 
 /**

--- a/src/utils/source-map.js
+++ b/src/utils/source-map.js
@@ -16,7 +16,7 @@ function restartWorker() {
     sourceMapWorker.terminate();
   }
   sourceMapWorker = new Worker(
-    getValue("baseWorkerURL") + "source-map-worker.js"
+    `${getValue("baseWorkerURL")}source-map-worker.js`
   );
 
   sourceMapWorker.postMessage({ id: 0, method: "enableSourceMaps" });

--- a/src/utils/source.js
+++ b/src/utils/source.js
@@ -52,6 +52,14 @@ function isPretty(source: Source): boolean {
 }
 
 /**
+ * @memberof utils/source
+ * @static
+ */
+function getPrettySourceURL(url: string): string {
+  return `${url}:formatted`;
+}
+
+/**
  * Show a source url's filename.
  * If the source does not have a url, use the source id.
  *
@@ -72,5 +80,6 @@ function getFilename(source: Source) {
 module.exports = {
   isJavaScript,
   isPretty,
+  getPrettySourceURL,
   getFilename
 };

--- a/src/utils/sources-tree.js
+++ b/src/utils/sources-tree.js
@@ -122,7 +122,7 @@ function getURL(source: TmpSource): { path: string, group: string } {
 
   return merge(def, {
     path: path,
-    group: protocol ? protocol + "//" : ""
+    group: protocol ? `${protocol}//` : ""
   });
 }
 
@@ -171,14 +171,14 @@ function addToTree(tree: any, source: TmpSource) {
     } else {
       // No node with this name exists, so insert a new one in the
       // place that is alphabetically sorted.
-      const node = createNode(part, path + "/" + part, []);
+      const node = createNode(part, `${path}/${part}`, []);
       const where = index === -1 ? children.length : index;
       children.splice(where, 0, node);
       subtree = children[where];
     }
 
     // Keep track of the children so we can tag each node with them.
-    path = path + "/" + part;
+    path = `${path}/${part}`;
   }
 
   // Overwrite the contents of the final node to store the source

--- a/src/utils/test-head.js
+++ b/src/utils/test-head.js
@@ -41,7 +41,7 @@ function commonLog(msg: string, data: any = {}) {
 function makeSource(name: string, props: any = {}) {
   return Object.assign({
     id: name,
-    url: "http://example.com/test/" + name
+    url: `http://example.com/test/${name}`
   }, props);
 }
 

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -69,7 +69,7 @@ function promisify(context: any, method: any, ...args: any) {
  */
 function truncateStr(str: any, size: any) {
   if (str.length > size) {
-    return str.slice(0, size) + "...";
+    return `${str.slice(0, size)}...`;
   }
   return str;
 }
@@ -80,7 +80,7 @@ function truncateStr(str: any, size: any) {
  */
 function endTruncateStr(str: any, size: any) {
   if (str.length > size) {
-    return "..." + str.slice(str.length - size);
+    return `...${str.slice(str.length - size)}`;
   }
   return str;
 }


### PR DESCRIPTION
Associated Issue: n/a

In general template performance is about the same to slightly better, however I believe they are much more readable than string concatenation.  With the given eslint rule we can make the code base more consistent overall.

NOTE: This is one of this diff where I need lots of eyes because tiny changes in white space can really make a difference here.  I combed over it all carefully but I don't want to introduce errors here.

### Summary of Changes

* add `prefer-template` to the eslint rules
* move all instances of string concatenation to string templates

### Test Plan

Ran tests, played with the debugger in both todomvc and increment
