### PR TITLE
[Editor] Fix matched text color

### DIFF
--- a/src/utils/source-search.js
+++ b/src/utils/source-search.js
@@ -80,7 +80,7 @@ function searchOverlay(query) {
 function startSearch(cm, state, query) {
   cm.removeOverlay(state.overlay);
   state.overlay = searchOverlay(query);
-  cm.addOverlay(state.overlay, { opaque: true });
+  cm.addOverlay(state.overlay, { opaque: false });
 }
 
 /**


### PR DESCRIPTION
Associated Issue: #1315 

### Summary of Changes

* Set `opaque` param to `false` on the CodeMirror overlay for matched search terms

### Test Plan
- [x] Enable `editorSearch` in `configs/local.json`
- [x] Open the search panel on a source with Command-F
- [x] Search for something that occurs as a variable name or property name
- [x] The var/prop name should be outlined without changing the text color

### Screenshots/Videos

Before:
![screen shot 2016-11-27 at 1 43 48 pm](https://cloud.githubusercontent.com/assets/1445834/20650893/8f517c40-b4a7-11e6-8ed8-86b9849b1de8.png)
After:
![screen shot 2016-11-27 at 1 37 02 pm](https://cloud.githubusercontent.com/assets/1445834/20650894/92a0353a-b4a7-11e6-9688-67b02b0c5397.png)