### PR TITLE
switch test plan template to completed checkboxes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -11,10 +11,10 @@ Tell us a little a bit about how you tested your patch.
 
 Example test plan:
 
-- [ ] Command-P opens the panel
-- [ ] Clicking “+” opens the panel
-- [ ] Clicking a source navigates to the source
-- [ ] Clicking "x" closes the panel
+- [x] Command-P opens the panel
+- [x] Clicking “+” opens the panel
+- [x] Clicking a source navigates to the source
+- [x] Clicking "x" closes the panel
 
 Here's the Debugger's Testing doc
 https://docs.google.com/document/d/1oBMRxV8A2ag2t22YsQOxTdEv0mXKzIg0tggJjRkU1S0/edit#.


### PR DESCRIPTION
We're currently suggesting that people file test plans with incomplete checkboxes, which I believe is the opposite thing we want :)

@clarkbw mind taking a look?
