### PR TITLE
Cleanup editor re-search work

### DIFF
--- a/src/components/EditorSearchBar.js
+++ b/src/components/EditorSearchBar.js
@@ -70,15 +70,15 @@ const EditorSearchBar = React.createClass({
 
     if (sourceText && sourceText.get("text") &&
       ((selectedSource != prevProps.selectedSource) ||
-      this.shouldLoad)) {
+      this.context.shouldLoad)) {
       const query = this.state.query;
       const count = countMatches(query, sourceText.get("text"));
       // eslint-disable-next-line react/no-did-update-set-state
       this.setState({ count: count, index: 0 });
-      this.shouldLoad = false;
+      this.context.shouldLoad = false;
       this.search(query);
     } else if (selectedSource != prevProps.selectedSource) {
-      this.shouldLoad = true;
+      this.context.shouldLoad = true;
     }
   },
 

--- a/src/components/EditorSearchBar.js
+++ b/src/components/EditorSearchBar.js
@@ -61,14 +61,16 @@ const EditorSearchBar = React.createClass({
   },
 
   componentDidUpdate(prevProps) {
-    const { sourceText, selectedSource } = this.props;
-
     if (this.searchInput()) {
       this.searchInput().focus();
     }
+  },
+
+  componentWillReceiveProps(nextProps) {
+    const { sourceText, selectedSource } = this.props;
 
     if (sourceText && sourceText.get("text") &&
-      selectedSource != prevProps.selectedSource) {
+      selectedSource != nextProps.selectedSource) {
       const query = this.state.query;
       const count = countMatches(query, sourceText.get("text"));
       this.setState({ count: count, index: 0 });

--- a/src/components/EditorSearchBar.js
+++ b/src/components/EditorSearchBar.js
@@ -37,7 +37,8 @@ const EditorSearchBar = React.createClass({
   },
 
   contextTypes: {
-    shortcuts: PropTypes.object
+    shortcuts: PropTypes.object,
+    shouldLoad: PropTypes.object
   },
 
   componentWillUnmount() {
@@ -61,20 +62,23 @@ const EditorSearchBar = React.createClass({
   },
 
   componentDidUpdate(prevProps) {
+    const { sourceText, selectedSource } = this.props;
+
     if (this.searchInput()) {
       this.searchInput().focus();
     }
-  },
-
-  componentWillReceiveProps(nextProps) {
-    const { sourceText, selectedSource } = this.props;
 
     if (sourceText && sourceText.get("text") &&
-      selectedSource != nextProps.selectedSource) {
+      ((selectedSource != prevProps.selectedSource) ||
+      this.context.shouldLoad)) {
       const query = this.state.query;
       const count = countMatches(query, sourceText.get("text"));
+      // eslint-disable-next-line react/no-did-update-set-state
       this.setState({ count: count, index: 0 });
+      this.context.shouldLoad = 0;
       this.search(query);
+    } else if (selectedSource != prevProps.selectedSource) {
+      this.context.shouldLoad = 1;
     }
   },
 

--- a/src/components/EditorSearchBar.js
+++ b/src/components/EditorSearchBar.js
@@ -37,8 +37,7 @@ const EditorSearchBar = React.createClass({
   },
 
   contextTypes: {
-    shortcuts: PropTypes.object,
-    shouldLoad: PropTypes.object
+    shortcuts: PropTypes.object
   },
 
   componentWillUnmount() {
@@ -68,17 +67,20 @@ const EditorSearchBar = React.createClass({
       this.searchInput().focus();
     }
 
-    if (sourceText && sourceText.get("text") &&
-      ((selectedSource != prevProps.selectedSource) ||
-      this.context.shouldLoad)) {
+    const hasLoaded = sourceText && !sourceText.get("loading");
+    const wasLoading = prevProps.sourceText
+                        && prevProps.sourceText.get("loading");
+
+    const doneLoading = wasLoading && hasLoaded;
+    const changedFiles = selectedSource != prevProps.selectedSource
+                          && hasLoaded;
+
+    if (doneLoading || changedFiles) {
       const query = this.state.query;
       const count = countMatches(query, sourceText.get("text"));
       // eslint-disable-next-line react/no-did-update-set-state
       this.setState({ count: count, index: 0 });
-      this.context.shouldLoad = false;
       this.search(query);
-    } else if (selectedSource != prevProps.selectedSource) {
-      this.context.shouldLoad = true;
     }
   },
 
@@ -186,7 +188,7 @@ const EditorSearchBar = React.createClass({
   search: debounce(function(query) {
     const sourceText = this.props.sourceText;
 
-    if (!sourceText.get("text")) {
+    if (!sourceText || !sourceText.get("text")) {
       return;
     }
 

--- a/src/components/EditorSearchBar.js
+++ b/src/components/EditorSearchBar.js
@@ -70,15 +70,15 @@ const EditorSearchBar = React.createClass({
 
     if (sourceText && sourceText.get("text") &&
       ((selectedSource != prevProps.selectedSource) ||
-      this.context.shouldLoad)) {
+      this.shouldLoad)) {
       const query = this.state.query;
       const count = countMatches(query, sourceText.get("text"));
       // eslint-disable-next-line react/no-did-update-set-state
       this.setState({ count: count, index: 0 });
-      this.context.shouldLoad = 0;
+      this.shouldLoad = false;
       this.search(query);
     } else if (selectedSource != prevProps.selectedSource) {
-      this.context.shouldLoad = 1;
+      this.shouldLoad = true;
     }
   },
 


### PR DESCRIPTION
#1321

Calling `setState()` inside `componentDidUpdate()` may create an infinite loop if there is no break condition for state (http://stackoverflow.com/questions/30528348/setstate-inside-of-componentdidupdate); therefore, I moved the code for re-search to `componentWillReceiveProps()`. 