### PR TITLE
Show optimized out variables in object inspector

### DIFF
--- a/src/components/ObjectInspector.css
+++ b/src/components/ObjectInspector.css
@@ -23,3 +23,7 @@ html .arrow.expanded svg {
 .arrow.hidden {
   visibility: hidden;
 }
+
+.object-node .unavailable {
+  color: var(--theme-body-color-inactive);
+}

--- a/src/components/ObjectInspector.js
+++ b/src/components/ObjectInspector.js
@@ -38,6 +38,15 @@ function nodeHasChildren(item) {
   return Array.isArray(item.contents);
 }
 
+function nodeIsOptimizedOut(item) {
+  return !nodeHasChildren(item) && item.contents.value.optimizedOut === true;
+}
+
+function nodeIsMissingArguments(item) {
+  return !nodeHasChildren(item) &&
+    item.contents.value.missingArguments === true;
+}
+
 function nodeHasProperties(item) {
   return !nodeHasChildren(item) && item.contents.value.type === "object";
 }
@@ -132,13 +141,17 @@ const ObjectInspector = React.createClass({
 
   renderItem(item, depth, focused, _, expanded, { setExpanded }) {
     let objectValue;
-    if (nodeHasProperties(item) || nodeIsPrimitive(item)) {
+    if (nodeIsOptimizedOut(item)) {
+      objectValue = dom.span({ className: "unavailable" }, "(optimized away)");
+    } else if (nodeIsMissingArguments(item)) {
+      objectValue = dom.span({ className: "unavailable" }, "(unavailable)");
+    } else if (nodeHasProperties(item) || nodeIsPrimitive(item)) {
       const object = item.contents.value;
       objectValue = Rep({ object, mode: "tiny" });
     }
 
     return dom.div(
-      { className: classnames("node", { focused }),
+      { className: classnames("node object-node", { focused }),
         style: { marginLeft: depth * 15 },
         onClick: e => {
           e.stopPropagation();

--- a/src/components/Scopes.js
+++ b/src/components/Scopes.js
@@ -21,9 +21,6 @@ function getBindingVariables(bindings, parentName) {
   const variables = toPairs(bindings.variables);
 
   return args.concat(variables)
-    .filter(binding => (
-      !(binding[1].value.missingArguments || binding[1].value.optimizedOut)
-    ))
     .map(binding => ({
       name: binding[0],
       path: `${parentName}/${binding[0]}`,


### PR DESCRIPTION
I had most of this done before break but didn't get it finished. This is actually pretty simple. It will show variables and arguments that have been optimized out with a special message:

<img width="315" alt="screen shot 2016-11-28 at 11 39 50 am" src="https://cloud.githubusercontent.com/assets/17031/20677109/05634d06-b560-11e6-827e-cafd007db9ba.png">
