### PR TITLE
fix local-toolbox error when chrome.debug is false

### DIFF
--- a/packages/devtools-local-toolbox/src/clients/chrome.js
+++ b/packages/devtools-local-toolbox/src/clients/chrome.js
@@ -16,7 +16,7 @@ Array.prototype.peekLast = function() {
 
 let connection;
 
-function createTabs(tabs, {type, clientType}) {
+function createTabs(tabs, {type, clientType} = {}) {
   return tabs
     .filter(tab => {
       return tab.type == type;


### PR DESCRIPTION
@jasonLaster 
Found a small issue introduced by #1295 while verifying #1323. 

When `chrome.debug` is false createTabs is called with a single argument `createTabs([])`. Added a default value. Would be fine with updating the different call sites as well, let me know if you want me to change it.  