### PR TITLE
[POC] show the reason why the debugger is paused

### DIFF
--- a/configs/development.json
+++ b/configs/development.json
@@ -11,7 +11,8 @@
   },
   "features": {
     "watchExpressions": false,
-    "editorSearch": false
+    "editorSearch": false,
+    "whyPaused": false
   },
   "chrome": {
     "debug": true,

--- a/src/components/RightSidebar.js
+++ b/src/components/RightSidebar.js
@@ -6,6 +6,7 @@ const { isEnabled } = require("devtools-config");
 const Svg = require("./utils/Svg");
 
 const actions = require("../actions");
+const WhyPaused = React.createFactory(require("./WhyPaused"));
 const Breakpoints = React.createFactory(require("./Breakpoints"));
 const Expressions = React.createFactory(require("./Expressions"));
 const Scopes = React.createFactory(require("./Scopes"));
@@ -88,6 +89,7 @@ const RightSidebar = React.createClass({
         { className: "right-sidebar",
           style: { overflowX: "hidden" }},
         CommandBar(),
+        WhyPaused(),
         Accordion({
           items: this.getItems()
         })

--- a/src/components/RightSidebar.js
+++ b/src/components/RightSidebar.js
@@ -89,7 +89,7 @@ const RightSidebar = React.createClass({
         { className: "right-sidebar",
           style: { overflowX: "hidden" }},
         CommandBar(),
-        WhyPaused(),
+        isEnabled("whyPaused") ? WhyPaused() : null,
         Accordion({
           items: this.getItems()
         })

--- a/src/components/WhyPaused.css
+++ b/src/components/WhyPaused.css
@@ -1,0 +1,7 @@
+
+.why-paused {
+  background-color: lemonchiffon;
+  color: var(--theme-highlight-blue);
+  padding: 8px 6px;
+  white-space: normal;
+}

--- a/src/components/WhyPaused.js
+++ b/src/components/WhyPaused.js
@@ -1,0 +1,50 @@
+const React = require("react");
+const { bindActionCreators } = require("redux");
+const { connect } = require("react-redux");
+const ImPropTypes = require("react-immutable-proptypes");
+const actions = require("../actions");
+const { getPause } = require("../selectors");
+const { DOM: dom } = React;
+
+require("./WhyPaused.css");
+
+function getPauseReason(pauseInfo) {
+  if (!pauseInfo) {
+    return null;
+  }
+
+  let reasonType = pauseInfo.getIn(["why"]).get("type");
+  if (!reasons[reasonType]) {
+    console.log("reasonType", reasonType);
+  }
+  return reasons[reasonType];
+}
+
+const reasons = {
+  "debuggerStatement": "Paused on a debugger; statement in the source code",
+  "breakpoint": "Paused on a breakpoint"
+};
+
+const WhyPaused = React.createClass({
+  propTypes: {
+    pauseInfo: ImPropTypes.map
+  },
+
+  displayName: "WhyPaused",
+
+  render() {
+    const { pauseInfo } = this.props;
+    const reason = getPauseReason(pauseInfo);
+
+    return pauseInfo ?
+      dom.div({ className: "pane why-paused" }, reason)
+      : null;
+  }
+});
+
+module.exports = connect(
+  state => ({
+    pauseInfo: getPause(state)
+  }),
+  dispatch => bindActionCreators(actions, dispatch)
+)(WhyPaused);

--- a/src/components/WhyPaused.js
+++ b/src/components/WhyPaused.js
@@ -6,24 +6,9 @@ const actions = require("../actions");
 const { getPause } = require("../selectors");
 const { DOM: dom } = React;
 
+const { getPauseReason } = require("../utils/pause");
+
 require("./WhyPaused.css");
-
-function getPauseReason(pauseInfo) {
-  if (!pauseInfo) {
-    return null;
-  }
-
-  let reasonType = pauseInfo.getIn(["why"]).get("type");
-  if (!reasons[reasonType]) {
-    console.log("reasonType", reasonType);
-  }
-  return reasons[reasonType];
-}
-
-const reasons = {
-  "debuggerStatement": "Paused on a debugger; statement in the source code",
-  "breakpoint": "Paused on a breakpoint"
-};
 
 const WhyPaused = React.createClass({
   propTypes: {

--- a/src/components/WhyPaused.js
+++ b/src/components/WhyPaused.js
@@ -36,7 +36,7 @@ const WhyPaused = React.createClass({
     const { pauseInfo } = this.props;
     const reason = getPauseReason(pauseInfo);
 
-    return pauseInfo ?
+    return reason ?
       dom.div({ className: "pane why-paused" }, reason)
       : null;
   }

--- a/src/types.js
+++ b/src/types.js
@@ -11,7 +11,8 @@ export type Why = {
 
 export type Pause = {
   frames: Frame[],
-  why: Why
+  why: Why,
+  getIn: (string[]) => any
 }
 
 export type Expression = {

--- a/src/utils/pause.js
+++ b/src/utils/pause.js
@@ -19,6 +19,24 @@ function updateFrameLocations(frames: FrameType[]): Promise<FrameType[]> {
   );
 }
 
+const reasons = {
+  "debuggerStatement": "Paused on a debugger; statement in the source code",
+  "breakpoint": "Paused on a breakpoint"
+};
+
+function getPauseReason(pauseInfo) {
+  if (!pauseInfo) {
+    return null;
+  }
+
+  let reasonType = pauseInfo.getIn(["why"]).get("type");
+  if (!reasons[reasonType]) {
+    console.log("reasonType", reasonType);
+  }
+  return reasons[reasonType];
+}
+
 module.exports = {
-  updateFrameLocations
+  updateFrameLocations,
+  getPauseReason
 };

--- a/src/utils/pause.js
+++ b/src/utils/pause.js
@@ -2,7 +2,7 @@
 const { Frame } = require("../tcomb-types");
 const { getOriginalLocation } = require("./source-map");
 
-import type { Frame as FrameType } from "../types";
+import type { Pause, Frame as FrameType } from "../types";
 
 function updateFrameLocations(frames: FrameType[]): Promise<FrameType[]> {
   if (!frames) {
@@ -24,7 +24,7 @@ const reasons = {
   "breakpoint": "Paused on a breakpoint"
 };
 
-function getPauseReason(pauseInfo) {
+function getPauseReason(pauseInfo: Pause): string | null {
   if (!pauseInfo) {
     return null;
   }


### PR DESCRIPTION
Just a proof of concept for now, if anyone wants to take this further feel free to pick this up.  I think we want input from @helenvholmes first.  I'm not sure the sidebar is actually a good location, the way it pushes everything down doesn't seem like the best design.  A good path forward could be to move the logic out of the component and into a util function such that we can try a couple different variants of the components.

### Summary of Changes

* Create a new component that displays why the debugger is paused

### Test Plan

Tell us a little a bit about how you tested your patch.

Example test plan:

- [x] Pause on breakpoint
- [x] Pause on debugger statement
- [x] Turn off feature flag (no element rendered)
- [x] Turn on feature flag (element rendered)
- [ ] Pause on exception
- [ ] Pause on ...

### Screenshots/Videos

![screen shot 2016-11-29 at 8 02 50 am](https://cloud.githubusercontent.com/assets/2134/20717583/c4392264-b60a-11e6-9194-3bca0aeb26c5.png)

![screen shot 2016-11-29 at 8 02 46 am](https://cloud.githubusercontent.com/assets/2134/20717587/c89fda32-b60a-11e6-95af-31b7fbec1a51.png)
