### PR TITLE
Make sourcemapped location resolve forward instead of back (fixes #1252)

### DIFF
--- a/src/utils/source-map-worker.js
+++ b/src/utils/source-map-worker.js
@@ -143,7 +143,8 @@ async function getGeneratedLocation(location: Location, originalSource: Source)
   const { line, column } = map.generatedPositionFor({
     source: originalSource.url,
     line: location.line,
-    column: location.column == null ? 0 : location.column
+    column: location.column == null ? 0 : location.column,
+    bias: SourceMapConsumer.LEAST_UPPER_BOUND
   });
 
   return {


### PR DESCRIPTION
The problem with sourcemapped breakpoints was that it was searching backwards to find the nearest generated location, which means if there is no mapping for column 0 is would move to the previous line. It's important that we resolve forwards, so it will find the first mapping on the same line (which is a common occurrence, to only map the first piece of code on the line that's indented).
