### PR TITLE
fix clientType null when calling makeThunkArgs

### DIFF
--- a/packages/devtools-local-toolbox/package.json
+++ b/packages/devtools-local-toolbox/package.json
@@ -66,6 +66,7 @@
     "react-redux": "4.4.5",
     "redux": "3.5.2",
     "serve-index": "^1.8.0",
+    "single-module-instance-webpack-plugin": "0.0.4",
     "style-loader": "^0.13.1",
     "svg-inline-loader": "^0.7.1",
     "tcomb": "^3.1.0",

--- a/packages/devtools-local-toolbox/webpack.config.js
+++ b/packages/devtools-local-toolbox/webpack.config.js
@@ -3,6 +3,7 @@ require("babel-register");
 
 const path = require("path");
 const webpack = require("webpack");
+const SingleModuleInstancePlugin = require("single-module-instance-webpack-plugin");
 const ExtractTextPlugin = require("extract-text-webpack-plugin");
 const { isDevelopment, isFirefoxPanel, getValue } = require("devtools-config");
 const NODE_ENV = process.env.NODE_ENV || "development";
@@ -71,6 +72,8 @@ module.exports = (webpackConfig, envConfig) => {
       "DebuggerConfig": JSON.stringify(envConfig)
     })
   );
+
+  webpackConfig.plugins.push(new SingleModuleInstancePlugin());
 
   if (isDevelopment()) {
     webpackConfig.module.loaders.push({


### PR DESCRIPTION
This PR should fix adding breakpoints when debugging Chrome.

The devtools-client-adapters required in main.js (used to get {firefox, getClient}) was generating a separate instance from the one required in devtools-local-toolbox.

This first adapters instance was never properly initialized with a call to startDebugging, so when calling getClient in 
```javascript
const createStore = configureStore({
  log: getValue("logging.actions"),
  makeThunkArgs: (args, state) => {
    return Object.assign({}, args, { client: getClient(state) });
  }
});
```

the clientType was always null and defaulting to the firefox client. For now I just forwarded the necessary exports from devtools-client-adapters to devtools-local-toolbox, so that we only ever create one instance of the adapters.

cc @jasonLaster 