### PR TITLE
[Source Tree] Don't show empty root. Fixes #1338

### DIFF
--- a/src/utils/sources-tree.js
+++ b/src/utils/sources-tree.js
@@ -135,6 +135,7 @@ function addToTree(tree: any, source: TmpSource) {
 
   if (IGNORED_URLS.indexOf(url) != -1 ||
       !source.get("url") ||
+      !url.group ||
       isPretty(source.toJS())) {
     return;
   }

--- a/src/utils/tests/sources-tree.js
+++ b/src/utils/tests/sources-tree.js
@@ -186,6 +186,32 @@ describe("sources-tree", () => {
     expect(aFileNode.name).to.be("a.js");
   });
 
+  it("excludes javascript: URLs from the tree", () => {
+    const source1 = Map({
+      url: "javascript:alert('Hello World')",
+      actor: "actor1"
+    });
+    const source2 = Map({
+      url: "http://example.com/source1.js",
+      actor: "actor2"
+    });
+    const source3 = Map({
+      url: "javascript:let i = 10; while (i > 0) i--; console.log(i);",
+      actor: "actor3"
+    });
+    const tree = createNode("root", "", []);
+
+    addToTree(tree, source1);
+    addToTree(tree, source2);
+    addToTree(tree, source3);
+
+    let base = tree.contents[0];
+    expect(tree.contents.length).to.be(1);
+
+    let source1Node = base.contents[0];
+    expect(source1Node.name).to.be("source1.js");
+  });
+
   it("can collapse a single source", () => {
     const fullTree = createNode("root", "", []);
     addToTree(fullTree, abcSource);


### PR DESCRIPTION
So the problem appeared whenever there was a **javascript:** URI - because in you getURL switch you do this: 
```
case "javascript:":
      // Ignore `javascript:` URLs for now
      return def;
```

but that just returns `def = { path: "", group: "" };` which is then merged into the tree as an entry with an empty string as its url.

