### PR TITLE
Remove isTesting

### DIFF
--- a/packages/devtools-config/src/feature.js
+++ b/packages/devtools-config/src/feature.js
@@ -1,8 +1,6 @@
 const pick = require("lodash/get");
 let config;
 
-const flag = require("./test-flag");
-
 /**
  * Gets a config value for a given key
  * e.g "chrome.webSocketPort"
@@ -21,10 +19,6 @@ function isDevelopment() {
     return process.env.NODE_ENV === "development";
   }
   return process.env.NODE_ENV !== "production";
-}
-
-function isTesting() {
-  return flag.testing;
 }
 
 function isFirefoxPanel() {
@@ -51,7 +45,6 @@ module.exports = {
   isEnabled,
   getValue,
   isDevelopment,
-  isTesting,
   isFirefoxPanel,
   isApplication,
   isFirefox,

--- a/packages/devtools-local-toolbox/src/utils/debug.js
+++ b/packages/devtools-local-toolbox/src/utils/debug.js
@@ -1,7 +1,7 @@
-const { isDevelopment, isTesting } = require("devtools-config");
+const { isDevelopment } = require("devtools-config");
 
 function debugGlobal(field, value) {
-  if (isDevelopment() || isTesting()) {
+  if (isDevelopment()) {
     window[field] = value;
   }
 }

--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -9,7 +9,6 @@ const SourceEditor = require("../utils/source-editor");
 const SourceFooter = createFactory(require("./SourceFooter"));
 const EditorSearchBar = createFactory(require("./EditorSearchBar"));
 const { renderConditionalPanel } = require("./EditorConditionalPanel");
-const { debugGlobal } = require("devtools-local-toolbox");
 const {
   getSourceText, getBreakpointsForSource,
   getSelectedLocation, getSelectedFrame,
@@ -371,7 +370,7 @@ const Editor = React.createClass({
     ));
 
     resizeBreakpointGutter(this.editor.codeMirror);
-    debugGlobal("cm", this.editor.codeMirror);
+    window.cm = this.editor.codeMirror;
 
     if (this.props.sourceText) {
       this.setText(this.props.sourceText.get("text"));


### PR DESCRIPTION
This PR drops the `isTesting` query in `feature.js`.

I'm opening this PR outside of the source map discussion because it is easier to have separate conversations. 

Benefits:
* it removes the need for `devtools-config` to require `./test-flag` which adds a `devtoolsRequire` in the panel
* it simplifies `debugGlobal`, which makes the `window.cm` more explicit. (this is a good thing)
* it lets the `devtools-config` be used in workers

Drawbacks:
* we might want to check whether we're in a testing mode down the road.  
* `window.cm` is now always a global. I don't think this is a big deal, it's a smell to use a global in that way and unlikely that another tool will reach into the panel and invoke a code mirror method.
