### PR TITLE
Hardcode origin

### DIFF
--- a/configs/application.json
+++ b/configs/application.json
@@ -2,7 +2,6 @@
   "title": "Debugger",
   "environment": "development",
   "baseWorkerURL": "http://localhost:8000/assets/build/",
-  "host": "http://localhost:8000",
   "theme": "light",
   "logging": {
     "client": false,

--- a/configs/development.json
+++ b/configs/development.json
@@ -2,7 +2,6 @@
   "title": "Debugger",
   "environment": "development",
   "baseWorkerURL": "http://localhost:8000/assets/build/",
-  "host": "",
   "theme": "light",
   "logging": {
     "client": false,

--- a/configs/firefox-panel.json
+++ b/configs/firefox-panel.json
@@ -1,7 +1,6 @@
 {
   "environment": "firefox-panel",
   "baseWorkerURL": "resource://devtools/client/debugger/new/",
-  "host": "",
   "logging": false,
   "clientLogging": false
 }

--- a/packages/devtools-config/README.md
+++ b/packages/devtools-config/README.md
@@ -28,8 +28,6 @@ All default config values are in [`config/development.json`](./development.json)
   * `examplesPort` Listen Port used to serve examples
 * `hotReloading` enables [Hot Reloading](../docs/local-development.md#hot-reloading) of CSS and React
 * `baseWorkerURL` Location for where the worker bundles exist
-* `host` Location for where the debugger bundles exist
-
 
 ### Local config
 

--- a/packages/devtools-local-toolbox/src/components/LandingPage.js
+++ b/packages/devtools-local-toolbox/src/components/LandingPage.js
@@ -25,9 +25,9 @@ function firstTimeMessage(title, urlPart) {
 }
 
 function getTabURL(tab, paramName) {
-  const hostURL = getValue("host");
+  const devServerOrigin = location.origin;
   const tabID = tab.get("id");
-  return `${hostURL}?${paramName}=${tabID}`;
+  return `${devServerOrigin}?${paramName}=${tabID}`;
 }
 
 const LandingPage = React.createClass({

--- a/packages/devtools-local-toolbox/src/components/LandingPage.js
+++ b/packages/devtools-local-toolbox/src/components/LandingPage.js
@@ -25,9 +25,8 @@ function firstTimeMessage(title, urlPart) {
 }
 
 function getTabURL(tab, paramName) {
-  const devServerOrigin = location.origin;
   const tabID = tab.get("id");
-  return `${devServerOrigin}?${paramName}=${tabID}`;
+  return `/?${paramName}=${tabID}`;
 }
 
 const LandingPage = React.createClass({

--- a/packages/devtools-network-request/networkRequest.js
+++ b/packages/devtools-network-request/networkRequest.js
@@ -2,9 +2,8 @@
 // replaces a more powerful network request from Firefox that can be
 // configured.
 function networkRequest(url, opts) {
-  const devServerOrigin = location.origin;
   return Promise.race([
-    fetch(`${devServerOrigin}/get?url=${url}`)
+    fetch(`/get?url=${url}`)
       .then(res => {
         if (res.status >= 200 && res.status < 300) {
           return res.text().then(text => ({ content: text }));

--- a/packages/devtools-network-request/networkRequest.js
+++ b/packages/devtools-network-request/networkRequest.js
@@ -1,13 +1,10 @@
-const { getValue } = require("devtools-config");
-
 // opts is ignored because this is only used in local development and
 // replaces a more powerful network request from Firefox that can be
 // configured.
 function networkRequest(url, opts) {
-  const devServerURL = getValue("host");
-
+  const devServerOrigin = location.origin;
   return Promise.race([
-    fetch(`${devServerURL}/get?url=${url}`)
+    fetch(`${devServerOrigin}/get?url=${url}`)
       .then(res => {
         if (res.status >= 200 && res.status < 300) {
           return res.text().then(text => ({ content: text }));


### PR DESCRIPTION
This fixes the issue with loading source maps by hardcoding the dev server origin.

I also updated the app to read directly from "http://localhost:8000" instead of "file://index.html" https://github.com/jasonLaster/debugger.app/commit/aa482bcf83bf1181837ce300995c1fc4f26b1720


* I wrote a book on `devServerOrigin` [here](https://github.com/devtools-html/debugger.html/pull/1346#issuecomment-263962730), which is not needed now
* I filed a PR on removing `isTesting` [here](https://github.com/devtools-html/debugger.html/pull/1362) which i still think is a good idea