### PR TITLE
Vertical layout - add firefox support.

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -64,20 +64,24 @@ const App = React.createClass({
       ? verticalLayoutBreakpoint.matches : true;
 
     return {
-      vertical: vertical
+      vertical
     };
   },
 
   componentDidMount() {
     if (isEnabled("verticalLayout")) {
-      verticalLayoutBreakpoint.onchange = () => this.setState({
-        vertical: verticalLayoutBreakpoint.matches
-      });
+      verticalLayoutBreakpoint.addListener(this.onLayoutChange);
     }
   },
 
   componentWillUnmount() {
-    verticalLayoutBreakpoint.onchange = null;
+    verticalLayoutBreakpoint.removeListener(this.onLayoutChange);
+  },
+
+  onLayoutChange() {
+    this.setState({
+      vertical: verticalLayoutBreakpoint.matches
+    });
   },
 
   render: function() {


### PR DESCRIPTION
Associated Issue: #1357

### Summary of Changes

* replaced non-standard way of adding listener to matchMedia object (`onchange =`) with a standard one (`addListener`)

### Test Plan
- [ ] test in Firefox
- [ ] test in Safari
- [ ] test in Chrome

### Screenshots/Videos
![working on ff and safari](https://cloud.githubusercontent.com/assets/985504/20772587/57732c02-b74e-11e6-9c9e-8982fada4f8c.gif)


