### PR TITLE
Fix source tree leak

### DIFF
--- a/src/components/SourcesTree.js
+++ b/src/components/SourcesTree.js
@@ -121,8 +121,10 @@ let SourcesTree = React.createClass({
 
   render: function() {
     const { focusedItem, sourceTree, parentMap } = this.state;
+    const isEmpty = sourceTree.contents.length === 0;
 
     const tree = ManagedTree({
+      key: isEmpty ? "empty" : "full",
       getParent: item => {
         return parentMap.get(item);
       },

--- a/src/components/utils/ManagedTree.js
+++ b/src/components/utils/ManagedTree.js
@@ -8,8 +8,10 @@ let ManagedTree = React.createClass({
   displayName: "ManagedTree",
 
   getInitialState() {
-    return { expanded: new Set(),
-      focusedItem: null };
+    return {
+      expanded: new Set(),
+      focusedItem: null
+    };
   },
 
   setExpanded(item, isExpanded) {


### PR DESCRIPTION
@gregtatum found a pretty serious memory leak. The problem is that the tree component keeps a reference to all items has seen ([here](https://github.com/devtools-html/debugger.html/blob/master/packages/devtools-sham-modules/client/shared/components/tree.js#L203)), so if you keep the same tree around forever and keep adding items, it will continually grow.

Usually the tree is used once and disposed of, like the object inspector. But the source tree is mounted once and used forever, so sources keep building up. Somehow it looks like there's a 1.6MB string being retained per item, which is crazy... I don't understand why it's so big, but making sure the tree releases sources fixes the leak at least.

We achieve this simply be forcing a re-mount of the source tree if it becomes empty. This means across page refreshes we will render a fresh tree and all previous state will be lost.