### PR TITLE
Add screencast docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,18 +12,12 @@ We respect your time and want to help you make the most of it as you learn more 
   * [Reporting Bugs](#reporting-bugs-bug)
   * [Suggesting Enhancements](#suggesting-enhancements-new)
   * [Writing Documentation](#writing-documentation-book)
+  * [Share what you know](#share-what-you-know)
   * [Writing Code](#writing-code-computer)
     * [Your First Code Contribution](#your-first-code-contribution)
     * [Coding Standards](#coding-standards)
     * [Pull Requests](#pull-requests)
-    * [Hot Reloading](#hot-reloading-fire)
-    * [Logging](#logging)
-  * [Tests](#tests)
-    * [Unit Tests](#unit-tests)
-    * [Integration Tests](#integration-tests)
-    * [Linting](#linting)
-  * [Configuration](#configuration)
-    * [Create a local config file](#create-a-local-config-file)
+    * [Local Development](#local-development-computer)
   * [Issues and Pull Request labels](#issues-and-pull-requests)
   * [Project Overview](#project-overview)
     * [debugger.html](#debuggerhtml)
@@ -53,6 +47,13 @@ We are actively investigating ways of support enhancement requests in the projec
 ### Writing Documentation :book:
 
 Documentation is as important as code and we need your help to maintain clear and usable documentation.  If you find an error in here or other project documentation please [file an issue](https://github.com/devtools-html/debugger.html/issues/new) and tag it with the label [docs](https://github.com/devtools-html/debugger.html/labels/docs).
+
+### Share what you know
+
+Give a talk or write a blog post and help others get started. Very few developers know that the debugger is a web app. It's a lot of fun to hear the amazing tools others want to build once they learn that they can!
+
+We'd be happy to link to it here. It could go a long way towards helping a newcomer get started!
+
 
 ### Writing Code :computer:
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ debugger.html is a hackable debugger for modern times, built from the ground up 
 
 Here's the *quick setup*, if you're getting started, we recommend the detailed [getting started][getting-started] instructions.
 
-
 ```bash
 npm i -g yarn@0.16.1
 git clone git@github.com:devtools-html/debugger.html.git
@@ -28,6 +27,12 @@ cd debugger.html
 yarn start
 ```
 
+After the debugger is setup, you can:
+
+* practice [debugging the debugger][first-activity]
+* claim an [up for grabs][up-for-grabs] issues
+* read the [app overview][app-overview] or [contributing][contributing] guidelines
+* watch a debugger [screencast][getting-started-screencast]
 
 ### Getting Involved
 
@@ -53,6 +58,10 @@ We're all on Mozilla's IRC in the [#devtools-html][irc-devtools-html] channel on
 
 [getting-started]:./docs/getting-setup.md
 [contributing]:./CONTRIBUTING.md
+[getting-started-screencast]:/docs/videos#getting-started
+[up-for-grabs]:https://github.com/devtools-html/debugger.html/issues?q=is%3Aissue+is%3Aopen+label%3A%22up+for+grabs%22
+[app-overview]:./docs/debugger.html-react-redux-overview.md
+[first-activity]:./docs/debugging-the-debugger.md
 
 [irc-devtools-html]:irc://irc.mozilla.org/devtools-html
 

--- a/docs/debugger-html-react-redux-overview.md
+++ b/docs/debugger-html-react-redux-overview.md
@@ -101,6 +101,7 @@ SourcesTree encapsulates ManagedTree.
 
 ![](https://docs.google.com/drawings/d/1dOCy4BePfX77ky3yUTlZRnAeeFIIi4UAJcYaYmYvUcY/pub?w=960&h=720)
 [Click here to Edit](https://docs.google.com/drawings/d/1dOCy4BePfX77ky3yUTlZRnAeeFIIi4UAJcYaYmYvUcY/edit?usp=sharing)
+
 ##Source editor/file search
 
 The center portion of the application displays either the source editor or a file search entry box. If the editor is displayed rendering is handled by three main components and one dynamic component.

--- a/docs/debugging-the-debugger.md
+++ b/docs/debugging-the-debugger.md
@@ -83,7 +83,7 @@ Please let us know if we're missing something zen  [here][getting-started-issue]
 
 Now that you've internalized the debugger philosophy, it's time to start putting this wisdom to use.
 
-**Share what you know** Give a talk in school, work, or a local meetup. I'm willing to bet your audience will not know the debugger is a web app!
+**Share what you know** Give a talk in school, work, or a local meetup. I'm willing to bet your audience will not know the debugger is a web app! Write a blog post. We'd be happy to link to it here and it could go a really long way towards helping a newcomer grok the philosophy.
 
 - here are @amitzur's [slides][amit-slides] from his [talk][amit-tweet]
 

--- a/docs/getting-setup.md
+++ b/docs/getting-setup.md
@@ -32,7 +32,7 @@ In this step, we'll open Firefox. [Chrome](#starting-chrome) and [Node](#startin
 yarn run firefox
 ```
 
-After Firefox is open, it's nice to go to a page you want to debug. I recommend, TodoMVC http://todomvc.com/examples/vanillajs/.
+After Firefox is open, go to a page you want to debug. I recommend, TodoMVC http://todomvc.com/examples/vanillajs/.
 
 *Why am I opening Firefox from the terminal?*  
 The firefox command opens firefox with special permissions that enable remote debugging.
@@ -45,7 +45,7 @@ You can either try to run it [manually](#starting-firefox) or comment on the [is
 
 ### Step 4. Start the Debugger
 
-Now that Firefox is open, lets start the development server. In a new terminal tab, run these commands:
+Now that Firefox is open, lets start the [development server][dev-server]. In a new terminal tab, run these commands:
 
 ```bash
 cd debugger.html
@@ -61,7 +61,7 @@ Go to `localhost:8000` in any browser to view the Debugger. If everything worked
 
 ### Next Steps
 
-Go [here](./debugging-the-debugger.md) if you want to start debugging the debugger!
+Try this [first activity][first-activity] if you want to start debugging the debugger!
 
 ## Appendix
 
@@ -168,3 +168,5 @@ C:\Program Files (x86)\Mozilla Firefox\firefox.exe -start-debugger-server 6080 -
 [windows-issue]:https://github.com/devtools-html/debugger.html/issues/1248
 [yarn-issue]:https://github.com/devtools-html/debugger.html/issues/1216
 [yarn]:https://yarnpkg.com
+[dev-server]:../packages/devtools-local-toolbox/README.md#dev-server
+[first-activity]:./debugging-the-debugger.md

--- a/docs/videos.md
+++ b/docs/videos.md
@@ -1,0 +1,31 @@
+## Debugger Screencasts
+
+**Goals:**
+* Help newcomers get started
+* Give a visual flavor of how the Debugger works
+* Show how some of the React + Redux concepts come together to create the Debugger
+* Introduce you to the team. The Debugger is a fun project and we don't take ourselves too seriously!
+
+### Getting Started
+This [video](https://youtu.be/9bQ0a3pnBZk) walks through the [getting setup][getting-setup] steps:
+1. starting the [dev server][dev-server]  
+2. starting chrome and firefox  
+3. launching the debugger  
+4. and then jumps in to [debugger inception][first-activity] because it's too cool not to!
+
+
+###  Event Listeners part 1
+
+This [video](https://youtu.be/VOwn1U7K2qg) gives an overview of [event listeners][event-listeners], a new feature we're working on that lists the event handlers on the page. After that, we jump in and make each event listener link to where the handler is defined.
+
+
+### Event Listeners part 2
+
+This [video](https://youtu.be/NoMryxkNPk0) adds additional functionality to event listeners, such as a checkbox that enables and disables breakpoints for that listener and a close button that removes the breakpoint entirely. Along the way, fetch breakpoints, refactor the component, and squash lots of bugs as they emerge.
+
+
+
+[getting setup]:./getting-setup.md
+[dev-server]:../packages/devtools-local-toolbox/README.md#dev-server
+[first-activity]:./debugging-the-debugger.md
+[event-listeners]:http://github.com/devtools-html/debugger.html/issues/1232


### PR DESCRIPTION
Associated Issue: #582

I had a chance to record some screencasts the other day.  I found the process enjoyable, so instead of just creating one getting started video I created a couple extra feature videos as well.

### Summary of Changes

* PR is blocked by actually uploading screencasts and linking to them
* Added a videos section
* Linked to Jason's overview
* Fixed some contributing TOC links
* Added a contributing sharing section

### Test Plan

- [x] test links
- [x] test videos


