### PR TITLE
Add an example of a large file

### DIFF
--- a/src/test/examples/large-files.html
+++ b/src/test/examples/large-files.html
@@ -1,0 +1,13 @@
+<html>
+  <head>
+    <title>Large Files</title>
+
+    <!--  5mb JS file-->
+    <script src="https://rawgit.com/jasonLaster/20e76123b0c1f1e3584261c7f0c7d60f/raw/1177fc5d37804663dd20b389f468c2150fac8eaf/5mb.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
+  </head>
+
+  <body>
+  </body>
+
+</html>


### PR DESCRIPTION
Associated Issue: #1377 

### Summary of Changes

* @jnachtigall pointed out that large files can be slow in windows.
* this creates an example others can use with some large files. we can go bigger later too
