### PR TITLE
Fix styling for watch expression buttons.

### DIFF
--- a/src/components/Accordion.css
+++ b/src/components/Accordion.css
@@ -31,3 +31,8 @@
   border-bottom: 1px solid var(--theme-splitter-color);
   font-size: 12px;
 }
+
+.accordion .accordion-button {
+  border: none;
+  background: none;
+}

--- a/src/components/Accordion.js
+++ b/src/components/Accordion.js
@@ -1,7 +1,7 @@
 const React = require("react");
 const { DOM: dom, PropTypes } = React;
 
-const { div, span } = dom;
+const { div } = dom;
 const Svg = require("./utils/Svg");
 
 require("./Accordion.css");
@@ -47,10 +47,7 @@ const Accordion = React.createClass({
         Svg("arrow", { className: opened[i] ? "expanded" : "" }),
         item.header,
         item.buttons ?
-        dom.button({ className: "header-buttons" },
-          item.buttons.map((button, id) => span({ key: id }, button))
-        ) :
-        null
+        dom.span({ className: "header-buttons" }, item.buttons) : null
       ),
 
       (created[i] || opened[i]) ?


### PR DESCRIPTION
Associated Issue: #N/A but somewhat #1304 

### Summary of Changes

* remove default styling from buttons give by browsers

### Test Plan

Tell us a little a bit about how you tested your patch.

Example test plan:

- [x] Open the debugger and see the button styling is removed

### Screenshots/Videos (OPTIONAL)

![screenshot_20161206_175320](https://cloud.githubusercontent.com/assets/580982/20950425/e5751adc-bbdc-11e6-9b02-333e0360b00d.png)

