### PR TITLE
Fix mochitests after upgrade to React 15

### DIFF
--- a/src/test/mochitest/browser_dbg-sources.js
+++ b/src/test/mochitest/browser_dbg-sources.js
@@ -43,7 +43,7 @@ add_task(function* () {
   });
 
   yield waitForSourceCount(dbg, 9);
-  is(findElement(dbg, "sourceNode", 7).querySelector("span").innerText,
+  is(findElement(dbg, "sourceNode", 7).textContent,
      "math.min.js",
      "The dynamic script exists");
 
@@ -52,7 +52,7 @@ add_task(function* () {
     content.eval("window.evaledFunc = function() {} //# sourceURL=evaled.js");
   });
   yield waitForSourceCount(dbg, 11);
-  is(findElement(dbg, "sourceNode", 2).querySelector("span").innerText,
+  is(findElement(dbg, "sourceNode", 2).textContent,
      "evaled.js",
      "The eval script exists");
 });


### PR DESCRIPTION
devtools in m-c upgraded to React 15.3.2 in bug [1312236](https://bugzilla.mozilla.org/show_bug.cgi?id=1312236). One of the necessary changes was fixing the `browser_dbg-sources.js` mochitest.

This PR introduces the change that's already in m-c also to the `debugger.html` repo.

You'll need to upgrade to React 15.3.2 before merging this. I'm not sure if it's as simple as changing the version number in `package.json` or if more changes are needed.