### PR TITLE
override escape shortcut in codemirror to fix split console toggle

### DIFF
--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -336,7 +336,10 @@ const Editor = React.createClass({
       enableCodeFolding: false,
       gutters: ["breakpoints"],
       value: " ",
-      extraKeys: {}
+      extraKeys: {
+        // Override code mirror keymap to avoid conflicts with split console.
+        Esc: false
+      }
     });
 
     // disables the default search shortcuts
@@ -369,6 +372,17 @@ const Editor = React.createClass({
     shortcuts.on("CmdOrCtrl+Shift+B", () => this.showConditionalPanel(
       getCursorLine(this.editor.codeMirror)
     ));
+    // The default Esc command is overridden in the CodeMirror keymap to allow
+    // the Esc keypress event to be catched by the toolbox and trigger the
+    // split console. Restore it here, but preventDefault if and only if there
+    // is a multiselection.
+    shortcuts.on("Esc", (key, e) => {
+      let cm = this.editor.codeMirror;
+      if (cm.listSelections().length > 1) {
+        cm.execCommand("singleSelection");
+        e.preventDefault();
+      }
+    });
 
     resizeBreakpointGutter(this.editor.codeMirror);
     debugGlobal("cm", this.editor.codeMirror);

--- a/src/test/mochitest/browser_dbg-console.js
+++ b/src/test/mochitest/browser_dbg-console.js
@@ -13,7 +13,7 @@ function getSplitConsole(dbg) {
   }
 
   if (!toolbox.splitConsole) {
-    EventUtils.synthesizeKey("VK_ESCAPE", {}, win);
+    pressKey(dbg, "Escape");
   }
 
   return new Promise(resolve => {
@@ -29,6 +29,14 @@ add_task(function* () {
   Services.prefs.setBoolPref("devtools.toolbox.splitconsoleEnabled", true);
   const dbg = yield initDebugger("doc-script-switching.html");
 
+  yield selectSource(dbg, "switching-01");
+
+  // open the console
   yield getSplitConsole(dbg);
   ok(dbg.toolbox.splitConsole, "Split console is shown.");
+
+  // close the console
+  clickElement(dbg, "codeMirror");
+  pressKey(dbg, "Escape");
+  ok(!dbg.toolbox.splitConsole, "Split console is hidden.");
 });

--- a/src/test/mochitest/head.js
+++ b/src/test/mochitest/head.js
@@ -534,6 +534,7 @@ const keyMappings = {
   "Enter": { code: "VK_RETURN" },
   "Up": { code: "VK_UP" },
   "Down": { code: "VK_DOWN" },
+  "Escape": { code: "VK_ESCAPE" },
   pauseKey: { code: "VK_F8" },
   resumeKey: { code: "VK_F8" },
   stepOverKey: { code: "VK_F10" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -6627,4 +6627,3 @@ zip-stream@^1.1.0:
     compress-commons "^1.1.0"
     lodash "^4.8.0"
     readable-stream "^2.0.0"
-


### PR DESCRIPTION
Associated Issue: #1404 

### Summary of Changes

* remove default codemirror shortcut for escape (which was calling the singleSelection command)
* add a custom key shortcut for escape that calls the singleSelection command if necessary, but doesn't if singleSelection would have no impact.

### Test Plan

I tested this in a tab only and not in a panel, just trying to check that I could catch the keypress event when using the escape key while the focus is in the codemirror editor.

- [x] add a listener on keypress on the window `window.addEventListener("keypress", function (e) {console.log("keypress", e)})`
- [x] open a script in the debugger editor
- [x] press escape
- [x] check the keypress event is logged

(I wanted to add a dedicated testcase but I can't get firefox to build for now for some reason ...)
