### PR TITLE
Show real URL for tab title, not :formatted URL

### DIFF
--- a/src/actions/sources.js
+++ b/src/actions/sources.js
@@ -197,7 +197,12 @@ function togglePrettyPrint(sourceId: string) {
 
     const url = getPrettySourceURL(source.url);
     const id = generatedToOriginalId(source.id, url);
-    const originalSource = { url, id, isPrettyPrinted: false };
+    const originalSource = {
+      url,
+      id,
+      isPrettyPrinted: false,
+      trueUrl: source.url
+    };
     dispatch({
       type: constants.ADD_SOURCE,
       source: originalSource

--- a/src/components/SourceTabs.js
+++ b/src/components/SourceTabs.js
@@ -200,7 +200,7 @@ const SourceTabs = React.createClass({
         key: source.get("id"),
         onClick: () => selectSource(source.get("id")),
         onContextMenu: (e) => this.onTabContextMenu(e, source.get("id")),
-        title: source.get("url")
+        title: source.get("trueUrl") || source.get("url")
       },
       dom.div({ className: "filename" }, filename),
       CloseButton({ handleClick: onClickClose }));


### PR DESCRIPTION
This is sort of an ugly hack but I'd like to talk about why we're using `:formatted` and a new tab at all.  We could create a function that removes `:formatted` but that's kinda gross.  Let me know what a better route may be.