### PR TITLE
Add window.debuggerVersion with version and hash

### DIFF
--- a/packages/devtools-local-toolbox/webpack.config.js
+++ b/packages/devtools-local-toolbox/webpack.config.js
@@ -2,6 +2,7 @@
 require("babel-register");
 
 const path = require("path");
+const {execSync} = require("child_process");
 const webpack = require("webpack");
 const SingleModuleInstancePlugin = require("single-module-instance-webpack-plugin");
 const ExtractTextPlugin = require("extract-text-webpack-plugin");
@@ -63,6 +64,9 @@ module.exports = (webpackConfig, envConfig) => {
   }
   webpackConfig.externals.push(externalsTest);
 
+  const version = require('../../package.json').version;
+  const hash = execSync('git rev-parse --short HEAD').toString().replace('\n', '');
+
   webpackConfig.plugins = webpackConfig.plugins || [];
   webpackConfig.plugins.push(
     new webpack.DefinePlugin({
@@ -70,7 +74,8 @@ module.exports = (webpackConfig, envConfig) => {
         NODE_ENV: JSON.stringify(NODE_ENV),
         TARGET: JSON.stringify(TARGET)
       },
-      "DebuggerConfig": JSON.stringify(envConfig)
+      "DebuggerConfig": JSON.stringify(envConfig),
+      "VERSION": JSON.stringify(`${version}-${hash}`)
     })
   );
 

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,5 @@
 // @flow
+/* global VERSION */
 
 const React = require("react");
 const { bindActionCreators, combineReducers } = require("redux");
@@ -32,6 +33,7 @@ if (!isFirefoxPanel()) {
 }
 
 window.appStore = store;
+window.debuggerVersion = VERSION;
 
 // Expose the bound actions so external things can do things like
 // selecting a source.


### PR DESCRIPTION
Associated Issue: #1396 

### Summary of Changes

* Adds a global variable `window.debuggerVersion` with format `x.y.z-XXXXXXX` where `x.y.z` is the root package.json version, and XXXXXXX is the git HEAD's short sha.

### Test Plan

Example test plan:

- [x] Open the devtools on the devtools, type `debuggerVersion` in the console, should see the version + hash printed.

### Screenshots/Videos

![debuggerversion](https://cloud.githubusercontent.com/assets/657839/21073674/a9be5ab0-bee5-11e6-9bd0-65ec11c67d10.gif)
