### PR TITLE
Avoid jumping around when clicking on tree items

### DIFF
--- a/packages/devtools-sham-modules/client/shared/components/tree.js
+++ b/packages/devtools-sham-modules/client/shared/components/tree.js
@@ -315,7 +315,7 @@ const Tree = module.exports = createClass({
         onKeyDown: this._onKeyDown,
         onKeyPress: this._preventArrowKeyScrolling,
         onKeyUp: this._preventArrowKeyScrolling,
-        // onScroll: this._onScroll,
+        onScroll: this._onScroll,
         style
       },
       // VirtualScroll({

--- a/src/components/SourcesTree.js
+++ b/src/components/SourcesTree.js
@@ -147,7 +147,7 @@ let SourcesTree = React.createClass({
       },
       getRoots: () => sourceTree.contents,
       getKey: (item, i) => item.path,
-      itemHeight: 30,
+      itemHeight: 18,
       autoExpandDepth: 1,
       autoExpandAll: false,
       onFocus: this.focusItem,


### PR DESCRIPTION
Associated Issue: N/A

### Summary of Changes

* Correct the itemHeight property which is passed to ManagedTree.
* Re-enable the onScroll listener within Tree

The goal of these two changes is to avoid the odd jumpy scrolling behavior in the source tree when clicking on a file while scrolled down in the sources list.

### Test Plan

- Attach the debugger
- Load a page with a large number of sources, and expand them (such as gmail)
- scroll about halfway down, and click on a source item
- Before this patch, the tree would scroll down dramatically, after this patch the tree scrolls an appropriate amount to move the selected item into the viewport.

CC @jasonLaster who helped me figure this out.