### PR TITLE
Fix for issue#1418 .

### DIFF
--- a/src/actions/tests/sources.js
+++ b/src/actions/tests/sources.js
@@ -83,6 +83,21 @@ describe("sources", () => {
     expect(tabs.getIn([0, "id"])).to.equal("foo.js");
   });
 
+  it("should append a tab for a new source at the end - issue #1418", () => {
+    // See:
+    // https://github.com/devtools-html/debugger.html/issues/1418
+    const { dispatch, getState } = createStore({});
+    dispatch(actions.newSource(makeSource("first_opened.js")));
+    dispatch(actions.selectSource("first_opened.js"));
+    dispatch(actions.newSource(makeSource("second_opened.js")));
+    dispatch(actions.selectSource("second_opened.js"));
+
+    const tabs = getSourceTabs(getState());
+    expect(tabs.size).to.equal(2);
+    expect(tabs.getIn([0, "id"])).to.equal("first_opened.js");
+    expect(tabs.getIn([1, "id"])).to.equal("second_opened.js");
+  });
+
   it("should select previous tab on tab closed", () => {
     const { dispatch, getState } = createStore({});
     dispatch(actions.newSource(makeSource("foo.js")));

--- a/src/reducers/sources.js
+++ b/src/reducers/sources.js
@@ -164,7 +164,7 @@ function updateTabList(state, source, tabIndex) {
     return tabs;
   }
 
-  return tabs.insert(0, source);
+  return tabs.insert(tabs.size, source);
 }
 
 /**


### PR DESCRIPTION
Associated Issue: #1418 

### Summary of Changes

* Made the new tab get appended to the end/right instead of prefixed to the beginning/left.
* Add a new unit test for it.

### Test Plan

I opened a new tab using ctrl+p and saw it got opened at the end.
