### PR TITLE
add README to docs directory

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,13 @@
+## debugger.html docs
+
+[debugger.html react / redux overview](./debugger-html-react-redux-overview.md)
+
+* [Getting Setup](./getting-setup.md)
+* [Local Development](./local-development.md)
+* [Remotely debuggable browsers](./remotely-debuggable-browsers.md)
+* [Feature Flags](./feature-flags.md)
+* [Mochitests](./mochitests.md)
+* [Lerna](./lerna.md)
+* [Debugging the debugger](./debugging-the-debugger.md)
+
+[Reference Documentation](./reference)


### PR DESCRIPTION
### Summary of Changes

* Adds a README file to the docs directory which gives us an index page thanks to [some changes at GitHub](https://github.com/blog/2289-publishing-with-github-pages-now-as-easy-as-1-2-3)

### Test Plan

[x] Checked that it worked at http://clarkbw.github.io/debugger.html/

### Screenshots/Videos (OPTIONAL)

<img width="412" alt="screen shot 2016-12-12 at 5 56 50 am" src="https://cloud.githubusercontent.com/assets/2134/21105863/e1de5d46-c02f-11e6-8bc8-3beb61792811.png">
