### PR TITLE
end truncate only subtitle and pass the full value to the HTML title

### DIFF
--- a/src/components/Autocomplete.js
+++ b/src/components/Autocomplete.js
@@ -94,6 +94,7 @@ const Autocomplete = React.createClass({
       {
         onClick: () => this.props.selectItem(result),
         key: result.value,
+        title: result.value,
         className: classnames({
           selected: index === this.state.selectedIndex
         })

--- a/src/components/SourceSearch.js
+++ b/src/components/SourceSearch.js
@@ -20,7 +20,7 @@ function searchResults(sources) {
   function getSourcePath(source) {
     const { path, href } = parseURL(source.get("url"));
     // for URLs like "about:home" the path is null so we pass the full href
-    return endTruncateStr((path || href), 50);
+    return (path || href);
   }
 
   return sources.valueSeq()
@@ -28,7 +28,7 @@ function searchResults(sources) {
     .map(source => ({
       value: getSourcePath(source),
       title: getSourcePath(source).split("/").pop(),
-      subtitle: getSourcePath(source),
+      subtitle: endTruncateStr(getSourcePath(source)),
       id: source.get("id")
     }))
     .toJS();

--- a/src/components/SourceSearch.js
+++ b/src/components/SourceSearch.js
@@ -28,7 +28,7 @@ function searchResults(sources) {
     .map(source => ({
       value: getSourcePath(source),
       title: getSourcePath(source).split("/").pop(),
-      subtitle: endTruncateStr(getSourcePath(source)),
+      subtitle: endTruncateStr(getSourcePath(source), 50),
       id: source.get("id")
     }))
     .toJS();


### PR DESCRIPTION
Associated Issue: #1426 

### Summary of Changes

* only truncate the subtitle

For now I am passing the full path around such that we can have it in the title and I'm only truncating the subtitle, the path shown below the file match name.  I was going to use CSS but this actually seems simpler if the `endTruncateStr` function was doing a decent job before.

### Test Plan

- [x] Loaded up some fake sources with long names
- [x] Searched with `cmd+P` and selected some results

### Screenshots/Videos (OPTIONAL)
