### PR TITLE
destroy the node_modules directory cache in circleci

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -35,6 +35,8 @@ dependencies:
     - npm i -g jasonlaster/lerna
     - yarn install
     - ./bin/update-docker
+  post:
+    - rm -rf ~/node_modules
 
 experimental:
   notify:


### PR DESCRIPTION
Associated Issue: #1451 

### Summary of Changes

* delete the node_modules directory before it is cached

### Test Plan

- [x] Create PR
- [x] Expect failure on first CI
- [x] Expect success on CI without cache
- [x] Commit change to master
- [x] Revert change later

This is the recommended way to permanently destroy your `node_modules` cache directory.
https://circleci.com/docs/how-cache-works/
