### PR TITLE
change path for windows in firefox driver

### DIFF
--- a/bin/firefox-driver.js
+++ b/bin/firefox-driver.js
@@ -19,6 +19,12 @@ const shouldStart = args.start;
 const isTests = args.tests;
 const useWebSocket = args.websocket;
 
+if (isWindows) {
+  // https://github.com/devtools-html/debugger.html/pull/1309
+  var path = require('path');
+  process.env.PATH = `${path.resolve(__dirname, '../node_modules/geckodriver')};${process.env.PATH}`;
+}
+
 function binaryArgs() {
   return [
     (!isWindows ? "-" : "") +


### PR DESCRIPTION
Associated Issue: #1309 

### Summary of Changes

* prepended the `../node_modules/geckodriver` path for a windows machine so it can successfully find the `geckodriver.exe` 
* Note that using `../node_modules/geckodriver/bin` does not find the `.exe` version which is why I used the parent directory

### Test Plan

Tell us a little a bit about how you tested your patch.

Example test plan:

- [x] yarn run firefox

fixes #1309