### PR TITLE
Fix #1388 - Remove :formatted text from tab tooltip

### DIFF
--- a/src/components/SourceTabs.js
+++ b/src/components/SourceTabs.js
@@ -8,7 +8,7 @@ const {
   getSourceTabs,
   getFileSearchState
 } = require("../selectors");
-const { getFilename } = require("../utils/source");
+const { getFilename, getRawSourceURL } = require("../utils/source");
 const { isEnabled } = require("devtools-config");
 const classnames = require("classnames");
 const actions = require("../actions");
@@ -229,7 +229,7 @@ const SourceTabs = React.createClass({
         key: source.get("id"),
         onClick: () => selectSource(source.get("id")),
         onContextMenu: (e) => this.onTabContextMenu(e, source.get("id")),
-        title: source.get("url")
+        title: getRawSourceURL(source.get("url"))
       },
       dom.div({ className: "filename" }, filename),
       CloseButton({ handleClick: onClickClose }));

--- a/src/utils/source.js
+++ b/src/utils/source.js
@@ -60,6 +60,14 @@ function getPrettySourceURL(url: string): string {
 }
 
 /**
+ * @memberof utils/source
+ * @static
+ */
+function getRawSourceURL(url: string): string {
+  return url.replace(/:formatted$/, "");
+}
+
+/**
  * Show a source url's filename.
  * If the source does not have a url, use the source id.
  *
@@ -81,5 +89,6 @@ module.exports = {
   isJavaScript,
   isPretty,
   getPrettySourceURL,
+  getRawSourceURL,
   getFilename
 };


### PR DESCRIPTION
Associated Issue: #1388

### Summary of Changes

* Removes ":formatted" from tab tooltips

### Test Plan

Tell us a little a bit about how you tested your patch.

- Hover over tab title, view true URL in tooltip

@jasonLaster proposed a different solution in #1388 but this is a fix specific to just this issue -- we can use the new `getRawSourceURL` function as part of #1460 
