### PR TITLE
callstack and scope panes open on pause

### DIFF
--- a/src/components/Accordion.js
+++ b/src/components/Accordion.js
@@ -19,11 +19,10 @@ const Accordion = React.createClass({
   },
 
   componentWillReceiveProps: function(nextProps) {
-    const opened = [...this.state.opened];
-    const newOpened = opened.map((isOpen, i) => {
-      const shouldOpen = this.props.items[i].shouldOpen;
+    const newOpened = this.state.opened.map((isOpen, i) => {
+      const { shouldOpen } = nextProps.items[i];
 
-      return isOpen ? isOpen : shouldOpen && shouldOpen();
+      return isOpen || (shouldOpen && shouldOpen());
     });
 
     this.setState({ opened: newOpened });

--- a/src/components/Accordion.js
+++ b/src/components/Accordion.js
@@ -18,6 +18,17 @@ const Accordion = React.createClass({
       created: [] };
   },
 
+  componentWillReceiveProps: function(nextProps) {
+    const opened = [...this.state.opened];
+    const newOpened = opened.map((isOpen, i) => {
+      const shouldOpen = this.props.items[i].shouldOpen;
+
+      return isOpen ? isOpen : shouldOpen && shouldOpen();
+    });
+
+    this.setState({ opened: newOpened });
+  },
+
   handleHeaderClick: function(i) {
     const opened = [...this.state.opened];
     const created = [...this.state.created];

--- a/src/components/RightSidebar.js
+++ b/src/components/RightSidebar.js
@@ -4,6 +4,9 @@ const { connect } = require("react-redux");
 const { bindActionCreators } = require("redux");
 const { isEnabled } = require("devtools-config");
 const Svg = require("./utils/Svg");
+const ImPropTypes = require("react-immutable-proptypes");
+
+const { getPause } = require("../selectors");
 
 const actions = require("../actions");
 const WhyPaused = React.createFactory(require("./WhyPaused"));
@@ -31,6 +34,7 @@ function debugBtn(onClick, type, className, tooltip) {
 const RightSidebar = React.createClass({
   propTypes: {
     evaluateExpressions: PropTypes.func,
+    pauseData: ImPropTypes.map
   },
 
   contextTypes: {
@@ -75,15 +79,18 @@ const RightSidebar = React.createClass({
 
   getItems() {
     const { expressionInputVisibility } = this.state;
+    const isPaused = () => !!this.props.pauseData;
 
     const items = [
       { header: L10N.getStr("breakpoints.header"),
         component: Breakpoints,
         opened: true },
       { header: L10N.getStr("callStack.header"),
-        component: Frames },
+        component: Frames,
+        shouldOpen: isPaused },
       { header: L10N.getStr("scopes.header"),
-        component: Scopes }
+        component: Scopes,
+        shouldOpen: isPaused },
     ];
 
     if (isEnabled("eventListeners")) {
@@ -121,6 +128,8 @@ const RightSidebar = React.createClass({
 });
 
 module.exports = connect(
-  () => ({}),
+  state => ({
+    pauseData: getPause(state)
+  }),
   dispatch => bindActionCreators(actions, dispatch)
 )(RightSidebar);

--- a/src/components/Scopes.js
+++ b/src/components/Scopes.js
@@ -45,10 +45,11 @@ function getSpecialVariables(pauseInfo, path) {
   }
 
   if (returned) {
+    const value = returned.toJS ? returned.toJS() : returned;
     vars.push({
       name: "<return>",
       path: `${path}/<return>`,
-      contents: { value: returned.toJS() }
+      contents: { value }
     });
   }
 


### PR DESCRIPTION
Associated Issue: #1280 

Right Sidebar gets the pause data from the state, and the Accordion items now have a shouldOpen prop. Just like @jasonLaster suggested.