### PR TITLE
update the hidden source tabs on resize of the window

### DIFF
--- a/src/components/SourceTabs.js
+++ b/src/components/SourceTabs.js
@@ -16,6 +16,7 @@ const CloseButton = require("./CloseButton");
 const Svg = require("./utils/Svg");
 const Dropdown = React.createFactory(require("./Dropdown"));
 const { showMenu, buildMenu } = require("../utils/menu");
+const { debounce } = require("lodash");
 
 require("./SourceTabs.css");
 require("./Dropdown.css");
@@ -82,8 +83,19 @@ const SourceTabs = React.createClass({
 
   componentDidUpdate(prevProps) {
     if (!(prevProps === this.props)) {
-      this.updateHiddenSourceTabs(this.props.sourceTabs);
+      this.updateHiddenSourceTabs();
     }
+  },
+
+  componentDidMount() {
+    this.updateHiddenSourceTabs();
+    this.onResize = debounce(this.updateHiddenSourceTabs);
+    window.addEventListener("resize", this.onResize, false);
+  },
+
+  componentDidDismount() {
+    window.removeEventListener("resize", this.onResize);
+    this.onResize = null;
   },
 
   onTabContextMenu(event, tab) {
@@ -177,11 +189,12 @@ const SourceTabs = React.createClass({
    * Updates the hiddenSourceTabs state, by
    * finding the source tabs who have wrapped and are not on the top row.
    */
-  updateHiddenSourceTabs(sourceTabs) {
+  updateHiddenSourceTabs() {
     if (!this.refs.sourceTabs) {
       return;
     }
 
+    const sourceTabs = this.props.sourceTabs;
     const sourceTabEls = this.refs.sourceTabs.children;
     const hiddenSourceTabs = getHiddenTabs(sourceTabs, sourceTabEls);
 

--- a/src/components/SourceTabs.js
+++ b/src/components/SourceTabs.js
@@ -89,13 +89,11 @@ const SourceTabs = React.createClass({
 
   componentDidMount() {
     this.updateHiddenSourceTabs();
-    this.onResize = debounce(this.updateHiddenSourceTabs);
     window.addEventListener("resize", this.onResize, false);
   },
 
   componentDidDismount() {
     window.removeEventListener("resize", this.onResize);
-    this.onResize = null;
   },
 
   onTabContextMenu(event, tab) {
@@ -184,6 +182,10 @@ const SourceTabs = React.createClass({
 
     showMenu(e, buildMenu(items));
   },
+
+  onResize: debounce(function() {
+    this.updateHiddenSourceTabs();
+  }),
 
   /*
    * Updates the hiddenSourceTabs state, by


### PR DESCRIPTION
Associated Issue: Closes #1254

### Summary of Changes

* create a debounced onResize method to attach to the window resize call
  * Fun fact: Chrome sends endless resize events while the window is changing while Firefox sends a single event after a resize is finished.

### Test Plan

Tell us a little a bit about how you tested your patch.

Example test plan:

- [x] Resize window with multiple tabs and see the overflow option appear

