### PR TITLE
#1460 Polish: Full row highlighting for sources

### DIFF
--- a/src/components/Sources.css
+++ b/src/components/Sources.css
@@ -65,7 +65,7 @@
   cursor: pointer;
 }
 
-.tree .node:hover {
+.tree-node:hover {
   background: var(--theme-tab-toolbar-background);
 }
 


### PR DESCRIPTION
Tree rows will be completely highlighted instead of just their labels, per "[#1]" in #1460:

<img src="https://camo.githubusercontent.com/d990d5ac52f3abd113f70dcff0cb17b75198e884/687474703a2f2f672e7265636f726469742e636f2f42717250356d5a7434392e676966">