### PR TITLE
Install Yarn 0.18.1

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -6,7 +6,7 @@ machine:
   environment:
     DOWNLOADS_PATH: "$HOME/downloads"
     YARN_PATH: "$HOME/.yarn-cache"
-    YARN_VERSION: 0.16.1
+    YARN_VERSION: 0.18.1
     PATH: "${PATH}:${HOME}/.yarn/bin:${HOME}/${CIRCLE_PROJECT_REPONAME}/node_modules/.bin"
   post:
     - mkdir -p $DOWNLOADS_PATH


### PR DESCRIPTION
This gets us back to using the tip of Yarn, which hopefully is more reliable now.