### PR TITLE
look for the yarn-error.log file relative to the build directory

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -39,7 +39,7 @@ dependencies:
 
 general:
   artifacts:
-    - ./yarn-error.log
+    - "yarn-error.log"
 
 experimental:
   notify:


### PR DESCRIPTION
We need to remove the `./` to save files relative to the build directory.  See: https://circleci.com/docs/configuration/#artifacts