### PR TITLE
Fix "revealing and focusing the non selected source"

### DIFF
--- a/configs/development.json
+++ b/configs/development.json
@@ -12,7 +12,7 @@
     "watchExpressions": false,
     "chromeScopes": false,
     "copySource": false,
-    "showSource": true,
+    "showSource": false,
     "editorSearch": false,
     "whyPaused": false,
     "verticalLayout": false,

--- a/configs/development.json
+++ b/configs/development.json
@@ -12,7 +12,7 @@
     "watchExpressions": false,
     "chromeScopes": false,
     "copySource": false,
-    "showSource": false,
+    "showSource": true,
     "editorSearch": false,
     "whyPaused": false,
     "verticalLayout": false,

--- a/src/components/SourcesTree.js
+++ b/src/components/SourcesTree.js
@@ -50,6 +50,7 @@ let SourcesTree = React.createClass({
         this.state.sourceTree
       );
 
+      this.selectItem(listItems[0]);
       return this.setState({ listItems });
     }
 


### PR DESCRIPTION
Associated Issue:
When we reveal on a non selected source, the file is shown correctly in `Sources`, but the non selected source is not focused and shown in the editor.

![den4ygazjk](https://cloud.githubusercontent.com/assets/4562118/21334613/abb06ccc-c693-11e6-82a9-5d50668e991c.gif)
(GIF provided by @jasonLaster )

### Summary of Changes

* Revealing and focusing the non selected source
