### PR TITLE
try travis for running the mochitests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+sudo: required
+
+language: node_js
+node_js:
+  - "7"
+
+cache:
+  yarn: true
+  directories:
+  - node_modules # NPM packages
+  - $HOME/downloads
+
+services:
+  - docker
+
+before_install:
+  - cp configs/ci.json configs/local.json
+  - ./bin/update-docker
+
+install:
+- yarn install
+
+script:
+  - ./bin/run-mochitests-docker

--- a/circle.yml
+++ b/circle.yml
@@ -21,7 +21,6 @@ test:
     - node src/test/node-unit-tests.js --ci:
         environment:
           MOCHA_FILE: $CIRCLE_TEST_REPORTS/mocha/test-results.xml
-    - ./bin/run-mochitests-docker
     - npm run firefox-unit-test
   post:
     - npm run lint-css
@@ -37,7 +36,6 @@ dependencies:
     - ~/.yarn
   override:
     - yarn install
-    - ./bin/update-docker
 
 general:
   artifacts:


### PR DESCRIPTION
This could be annoying to keep both the circle and travis environments the same, but since travis is running docker I think it might actually work out ok.

### Summary of Changes

* moved the mochitest / docker code over to travis
* removed the mochitests from circle

### Test Plan

- [x] Create PR, see how it goes
