### PR TITLE
adding a post merge reminder to run yarn install as needed

### DIFF
--- a/bin/post-merge
+++ b/bin/post-merge
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# MIT © Sindre Sorhus - sindresorhus.com
+# via https://gist.github.com/sindresorhus/7996717
+
+changed_files="$(git diff-tree -r --name-only --no-commit-id ORIG_HEAD HEAD)"
+
+check_run() {
+	echo "$changed_files" | grep --quiet "$1" && echo "🎅  $1 changed; RUN: $2"
+}
+
+# In this example it's used to run `yarn install` if yarn.lock changed
+check_run yarn.lock "yarn install"
+
+exit 0;

--- a/package.json
+++ b/package.json
@@ -30,8 +30,9 @@
     "chrome": "node bin/chrome-driver",
     "mochitests-watch": "OUTPUT_PATH=./firefox/devtools/client/debugger/new MOCHITESTS=true TARGET=firefox-panel webpack --watch",
     "build-docs": "documentation build --format html --sort-order alpha --shallow  --document-exported --output docs/reference/ src/types.js src/utils/ src/reducers/ src/actions/ src/test/mochitest/head.js",
+    "flow-coverage": "flow-coverage-report -i 'src/actions/*.js' -i 'src/reducers/*.js' -i 'src/utils/*.js' -t html -t text",
     "prepush": "npm run lint; node src/test/node-unit-tests.js --dots",
-    "flow-coverage": "flow-coverage-report -i 'src/actions/*.js' -i 'src/reducers/*.js' -i 'src/utils/*.js' -t html -t text"
+    "postmerge": "bin/post-merge"
   },
   "dependencies": {
     "codemirror": "^5.1.0",


### PR DESCRIPTION
This looks at the latest changes from when you `git pull` or merge changes into your local branch.  If the `yarn.lock` file is included in those change it will remind you to run `yarn install`.  I decided on just a message instead of automatically running because I felt it was safer to remind people instead of possibly interrupting workflow.

### Summary of Changes

* add a post-merge hook that checks if `yarn.lock` has changed and lets the dev know to run `yarn install`

### Test Plan

- [x] `npm run postmerge`
- [x] `bin/post-merge` while changing the searched for string to something that could be found (NOTE the `post-merge` check is a test in the screenshot below)

### Screenshots/Videos (OPTIONAL)

<img width="586" alt="screen shot 2016-12-20 at 10 19 09 pm" src="https://cloud.githubusercontent.com/assets/2134/21379402/98a70932-c702-11e6-819a-7367c74d873d.png">
