### PR TITLE
fadeout non enumerable props in the scope list

### DIFF
--- a/src/components/ObjectInspector.js
+++ b/src/components/ObjectInspector.js
@@ -151,7 +151,13 @@ const ObjectInspector = React.createClass({
     }
 
     return dom.div(
-      { className: classnames("node object-node", { focused }),
+      {
+        className: classnames("node object-node",
+          {
+            focused,
+            "not-enumerable": (!item.contents.enumerable &&
+                               !nodeHasChildren(item))
+          }),
         style: { marginLeft: depth * 15 },
         onClick: e => {
           e.stopPropagation();

--- a/src/components/Scopes.css
+++ b/src/components/Scopes.css
@@ -1,4 +1,8 @@
 
+.object-node.not-enumerable {
+  opacity: 0.6;
+}
+
 .object-label {
   color: var(--theme-highlight-blue);
 }


### PR DESCRIPTION
Associated Issue: #1470

### Summary of Changes

* set `not-enumerable` class on objects which are not enumerable
* create a class in the Scopes.css file to set opacity of not-enumerable class to `0.6` - toyed with several versions and this seemed like the right level.  Open to discussion.

Originally in 1470 I chose just the label and then decided on the whole node (which includes the description like `Object` because it helps the others stand out even more.

### Test Plan

- [x] Pause debugger, open scopes pane to review props

### Screenshots/Videos (OPTIONAL)

Here's a small example:

![screen shot 2016-12-21 at 11 46 10](https://cloud.githubusercontent.com/assets/2134/21403913/ae795b68-c773-11e6-91e9-5962d8d9cebb.png)

And here's what it looks like for the Window:

![scopes](https://cloud.githubusercontent.com/assets/2134/21403898/a864e864-c773-11e6-89cf-6c0904e8631a.png)

