### PR TITLE
remove flow coverage rport

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "expect.js": "^0.3.1",
     "firefox-profile": "^0.4.0",
     "flow-bin": "^0.36.0",
-    "flow-coverage-report": "^0.2.0",
     "fuzzaldrin-plus": "^0.4.1",
     "geckodriver": "^1.2.0",
     "glob": "^7.0.3",


### PR DESCRIPTION
I tracked down the issue with React updating to 15.3 and found that


`react-dom` has an index.js file with just a `module.exports = require('react/lib/reactDOM)`, which our single-module-plugin turns into `module.exports = require()` and fails to load react dom.

The easy fix is to the flow coverage report so that we don't load react 15.3 and we can fix single module plugin in january

https://github.com/devtools-html/devtools-core/issues/23