### PR TITLE
enable the why paused feature

### DIFF
--- a/assets/locales/debugger.properties
+++ b/assets/locales/debugger.properties
@@ -430,3 +430,26 @@ variablesViewMissingArgs=(unavailable)
 anonymousSourcesLabel=Anonymous Sources
 
 experimental=This is an experimental feature
+
+# LOCALIZATION NOTE (whyPaused.debuggerStatement): The text that is displayed
+# in a info block explaining how the debugger is currently paused due to a `debugger`
+# statement in the code
+whyPaused.debuggerStatement=Paused on debugger statement
+
+# LOCALIZATION NOTE (whyPaused.breakpoint): The text that is displayed
+# in a info block explaining how the debugger is currently paused on a breakpoint
+whyPaused.breakpoint=Paused on breakpoint
+
+# LOCALIZATION NOTE (whyPaused.exception): The text that is displayed
+# in a info block explaining how the debugger is currently paused on an exception
+whyPaused.exception=Paused on exception
+
+# LOCALIZATION NOTE (whyPaused.resumeLimit): The text that is displayed
+# in a info block explaining how the debugger is currently paused while stepping
+# in or out of the stack
+whyPaused.resumeLimit=Paused while stepping
+
+# LOCALIZATION NOTE (whyPaused.pauseOnDOMEvents): The text that is displayed
+# in a info block explaining how the debugger is currently paused on an event
+# listener breakpoint set
+whyPaused.pauseOnDOMEvents=Paused on event listener

--- a/configs/development.json
+++ b/configs/development.json
@@ -14,7 +14,6 @@
     "copySource": false,
     "showSource": false,
     "editorSearch": false,
-    "whyPaused": false,
     "verticalLayout": false,
     "eventListeners": false
   },

--- a/src/components/RightSidebar.js
+++ b/src/components/RightSidebar.js
@@ -118,7 +118,7 @@ const RightSidebar = React.createClass({
         { className: "right-sidebar",
           style: { overflowX: "hidden" }},
         CommandBar(),
-        isEnabled("whyPaused") ? WhyPaused() : null,
+        WhyPaused(),
         Accordion({
           items: this.getItems()
         })

--- a/src/components/WhyPaused.css
+++ b/src/components/WhyPaused.css
@@ -2,6 +2,6 @@
 .why-paused {
   background-color: lemonchiffon;
   color: var(--theme-highlight-blue);
-  padding: 8px 6px;
+  padding: 10px 10px 10px 20px;
   white-space: normal;
 }

--- a/src/components/WhyPaused.js
+++ b/src/components/WhyPaused.js
@@ -22,7 +22,7 @@ const WhyPaused = React.createClass({
     const reason = getPauseReason(pauseInfo);
 
     return reason ?
-      dom.div({ className: "pane why-paused" }, reason)
+      dom.div({ className: "pane why-paused" }, L10N.getStr(reason))
       : null;
   }
 });

--- a/src/strings.json
+++ b/src/strings.json
@@ -46,5 +46,10 @@
   "sourceTabs.closeOtherTabs": "Close others",
   "sourceTabs.closeTabsToRight": "Close tabs to the right",
   "sourceTabs.closeAllTabs": "Close all tabs",
-  "loadingText": "Loading\u2026"
+  "loadingText": "Loading\u2026",
+  "whyPaused.debuggerStatement": "Paused on debugger statement",
+  "whyPaused.breakpoint": "Paused on breakpoint",
+  "whyPaused.exception": "Paused on exception",
+  "whyPaused.resumeLimit": "Paused while stepping",
+  "whyPaused.pauseOnDOMEvents": "Paused on event listener"
 }

--- a/src/utils/pause.js
+++ b/src/utils/pause.js
@@ -19,9 +19,16 @@ function updateFrameLocations(frames: FrameType[]): Promise<FrameType[]> {
   );
 }
 
+// Map protocol pause "why" reason to a valid L10N key
+// These are the known unhandled reasons:
+// "breakpointConditionThrown", "clientEvaluated"
+// "interrupted", "attached"
 const reasons = {
-  "debuggerStatement": "Paused on a debugger; statement in the source code",
-  "breakpoint": "Paused on a breakpoint"
+  "debuggerStatement": "whyPaused.debuggerStatement",
+  "breakpoint": "whyPaused.breakpoint",
+  "exception": "whyPaused.exception",
+  "resumeLimit": "whyPaused.resumeLimit",
+  "pauseOnDOMEvents": "whyPaused.pauseOnDOMEvents"
 };
 
 function getPauseReason(pauseInfo: Pause): string | null {
@@ -31,7 +38,7 @@ function getPauseReason(pauseInfo: Pause): string | null {
 
   let reasonType = pauseInfo.getIn(["why"]).get("type");
   if (!reasons[reasonType]) {
-    console.log("reasonType", reasonType);
+    console.log("Please file an issue: reasonType=", reasonType);
   }
   return reasons[reasonType];
 }


### PR DESCRIPTION
Associated Issue: #1345 

### Summary of Changes

* enable the "why paused" feature by default
* use L10N for all strings

### Test Plan

- [x] Trigger breakpoint
- [x] Trigger exception
- [x] Trigger stepping after pausing
- [x] Trigger debugger statement

### Screenshots/Videos (OPTIONAL)

![debugger statement](https://cloud.githubusercontent.com/assets/2134/21415928/681a6176-c7c3-11e6-8eaa-433fd4f588c3.png)

![exception](https://cloud.githubusercontent.com/assets/2134/21415916/5769ba8e-c7c3-11e6-8e94-da0b446b9482.png)

![stepping](https://cloud.githubusercontent.com/assets/2134/21415917/5ec6a422-c7c3-11e6-89b9-a9006507ac24.png)

![breakpoint](https://cloud.githubusercontent.com/assets/2134/21415971/b2752d96-c7c3-11e6-8fc5-51c39d61e609.png)
