### PR TITLE
Rework source tree and editor layout for vertical debugger layout

### DIFF
--- a/src/components/App.css
+++ b/src/components/App.css
@@ -38,7 +38,7 @@ body {
   height: 100%;
 }
 
-.center-pane {
+.editor-pane {
   display: flex;
   position: relative;
   flex: 1;


### PR DESCRIPTION
Associated Issue: #1358 

### Summary of Changes

* Refactor the `App` component to have two distinct render functions for vertical and horizontal layouts to simplify rendering the right layouts.
* Move the editor and source tree into a sibling start pane for the vertical `Splitbox`

Note: the `endPane` of the vertical layout will be broken but will be addressed in a separate PR for issue #1359 

Note 2: the collapse buttons will also be fixed in their own PR for issue #1537 

### Test Plan

- [ ] Open the debugger
- [ ] Resize to 700 or less pixels
- [ ] Observe that the editor and source tabs render as the top section of a vertical `Splitbox`


### Screenshots/Videos

![screenshot_20161222_210748](https://cloud.githubusercontent.com/assets/580982/21446960/b73c5616-c88a-11e6-86aa-675d25fa7465.png)

