### PR TITLE
[Watch Expressions] Adjust header buttons height so that the header i…

### DIFF
--- a/assets/images/refresh.svg
+++ b/assets/images/refresh.svg
@@ -1,7 +1,7 @@
 <!-- This Source Code Form is subject to the terms of the Mozilla Public
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
-<svg width="16" height="16" viewBox="2 2 40 40" xmlns="http://www.w3.org/2000/svg">
+<svg width="16" height="16" viewBox="4 4 40 40" xmlns="http://www.w3.org/2000/svg">
   <path d="M35.3 12.7c-2.89-2.9-6.88-4.7-11.3-4.7-8.84 0-15.98 7.16-15.98 16s7.14 16 15.98 16c7.45 0 13.69-5.1 15.46-12h-4.16c-1.65 4.66-6.07 8-11.3 8-6.63 0-12-5.37-12-12s5.37-12 12-12c3.31 0 6.28 1.38 8.45 3.55l-6.45 6.45h14v-14l-4.7 4.7z"/>
   <path d="M0 0h48v48h-48z" fill="none"/>
 </svg>

--- a/src/components/Accordion.css
+++ b/src/components/Accordion.css
@@ -38,7 +38,9 @@
 }
 
 .accordion ._header .header-buttons {
+  display: flex;
   margin-left: auto;
+  padding-right: 5px;
 }
 
 .accordion .header-buttons .add-button {

--- a/src/components/RightSidebar.js
+++ b/src/components/RightSidebar.js
@@ -52,18 +52,16 @@ const RightSidebar = React.createClass({
   watchExpressionHeaderButtons() {
     const { expressionInputVisibility } = this.state;
     return [
-      dom.button({
-        onClick: evt => {
+      debugBtn(
+        evt => {
           evt.stopPropagation();
           this.setState({
             expressionInputVisibility: !expressionInputVisibility
           });
         },
-        key: "add-button",
-        className: "add-button",
-        title: L10N.getStr("watchExpressions.addButton")
-      },
-        "+"
+        "plus",
+        "add-button",
+        L10N.getStr("watchExpressions.addButton")
       ),
       debugBtn(
         evt => {


### PR DESCRIPTION
Fixes #1524

- The icons were aligned vertically at the bottom, adding flex layout implicitly set align-items to flex-start which is the same as for the bar title/header.
- I changed the plus button from the text "+" to svg for consistency (the plus .svg icon is used for new debugger tabs too)
- The svg's viewBox still seems to be slightly off but I might be wrong...
Result:
![screenshot_2016-12-26_14-03-52](https://cloud.githubusercontent.com/assets/4202539/21483130/5b0d54ec-cb75-11e6-9f51-192edf723603.png)
