### PR TITLE
Add prefs for the callstack and the scopes panes

### DIFF
--- a/bin/run-mochitests-docker
+++ b/bin/run-mochitests-docker
@@ -14,4 +14,4 @@ docker run -it \
   -e "DISPLAY=unix$DISPLAY" \
   --ipc host \
   jlongster/mochitest-runner \
-  /bin/bash -c "export SHELL=/bin/bash; touch devtools/client/debugger/new/test/mochitest/browser.ini && ./mach mochitest --subsuite devtools devtools/client/debugger/new/test/mochitest/"
+  /bin/bash -c "export SHELL=/bin/bash; touch devtools/client/debugger/new/test/mochitest/browser.ini && ./mach build && ./mach mochitest --subsuite devtools devtools/client/debugger/new/test/mochitest/"

--- a/src/components/Accordion.js
+++ b/src/components/Accordion.js
@@ -40,6 +40,10 @@ const Accordion = React.createClass({
       item.onOpened();
     }
 
+    if (item.onToggle) {
+      item.onToggle(opened[i]);
+    }
+
     this.setState({ opened, created });
   },
 

--- a/src/components/SecondaryPanes.js
+++ b/src/components/SecondaryPanes.js
@@ -9,6 +9,7 @@ const ImPropTypes = require("react-immutable-proptypes");
 const { getPause, getBreakpoints,
         getBreakpointsDisabled, getBreakpointsLoading
       } = require("../selectors");
+const { prefs } = require("../utils/prefs");
 
 const actions = require("../actions");
 const WhyPaused = React.createFactory(require("./WhyPaused"));
@@ -96,6 +97,10 @@ const SecondaryPanes = React.createClass({
     const scopesContent = this.props.horizontal ? {
       header: L10N.getStr("scopes.header"),
       component: Scopes,
+      opened: prefs.scopesVisible,
+      onToggle: opened => {
+        prefs.scopesVisible = opened;
+      },
       shouldOpen: isPaused
     } : null;
 
@@ -106,6 +111,10 @@ const SecondaryPanes = React.createClass({
         opened: true },
       { header: L10N.getStr("callStack.header"),
         component: Frames,
+        opened: prefs.callStackVisible,
+        onToggle: opened => {
+          prefs.callStackVisible = opened;
+        },
         shouldOpen: isPaused },
       scopesContent
     ];

--- a/src/utils/prefs.js
+++ b/src/utils/prefs.js
@@ -6,12 +6,16 @@ if (isDevelopment()) {
   pref("devtools.debugger.client-source-maps-enabled", true);
   pref("devtools.debugger.pause-on-exceptions", false);
   pref("devtools.debugger.ignore-caught-exceptions", false);
+  pref("devtools.debugger.call-stack-visible", false);
+  pref("devtools.debugger.scopes-visible", false);
 }
 
 const prefs = new PrefsHelper("devtools", {
   clientSourceMapsEnabled: ["Bool", "debugger.client-source-maps-enabled"],
   pauseOnExceptions: ["Bool", "debugger.pause-on-exceptions"],
   ignoreCaughtExceptions: ["Bool", "debugger.ignore-caught-exceptions"],
+  callStackVisible: ["Bool", "debugger.call-stack-visible"],
+  scopesVisible: ["Bool", "debugger.scopes-visible"]
 });
 
 module.exports = { prefs };


### PR DESCRIPTION
Associated Issue: #960

### Summary of Changes

* Add new prefs for callstack and scopes
* Pass in the pref name as properties to the accordion
* When the user clicks the accordion update the pref accordingly
* Check the pref value when new props are passed to the accordion.

#### Note:
If the user does not interact with the accordion explicitly (clicking). The current behaviour is maintained else the user's pref takes precedence.

### Test Plan

- [x] Click the callstack panel to expand / collapse
- [x] Reload the debugger
- [x] Check to make sure the state is maintained

### Screenshots/Videos
![accordion_prefs](https://cloud.githubusercontent.com/assets/792924/21483301/a3536758-cb77-11e6-887b-a630d3555e68.gif)
