### PR TITLE
Toggle "Disable Breakpoints" tooltip to "Enable Breakpoints". Fixes #…

### DIFF
--- a/assets/locales/debugger.properties
+++ b/assets/locales/debugger.properties
@@ -172,6 +172,14 @@ breakpoints.header=Breakpoints
 # no breakpoints present
 breakpoints.none=No Breakpoints
 
+# LOCALIZATION NOTE (breakpoints.enable): The text that may appear as a tooltip
+# when hovering over the 'disable breakpoints' switch button in right sidebar
+breakpoints.enable=Enable Breakpoints
+
+# LOCALIZATION NOTE (breakpoints.disable): The text that may appear as a tooltip
+# when hovering over the 'disable breakpoints' switch button in right sidebar
+breakpoints.disable=Disable Breakpoints
+
 # LOCALIZATION NOTE (callStack.header): Call Stack right sidebar pane header.
 callStack.header=Call Stack
 

--- a/src/components/CommandBar.js
+++ b/src/components/CommandBar.js
@@ -213,7 +213,7 @@ const CommandBar = React.createClass({
       () => toggleAllBreakpoints(!breakpointsDisabled),
       "toggleBreakpoints",
       breakpointsDisabled ? "breakpoints-disabled" : "",
-      "Disable Breakpoints"
+      breakpointsDisabled ? "Enable Breakpoints" : "Disable Breakpoints"
     );
   },
 

--- a/src/components/CommandBar.js
+++ b/src/components/CommandBar.js
@@ -204,16 +204,16 @@ const CommandBar = React.createClass({
             breakpointsDisabled, breakpointsLoading } = this.props;
 
     if (breakpoints.size == 0 || breakpointsLoading) {
-      return debugBtn(
-        null, "toggleBreakpoints", "disabled", "Disable Breakpoints"
-      );
+      return debugBtn(null, "toggleBreakpoints", "disabled",
+        L10N.getStr("breakpoints.disable"));
     }
 
     return debugBtn(
       () => toggleAllBreakpoints(!breakpointsDisabled),
       "toggleBreakpoints",
       breakpointsDisabled ? "breakpoints-disabled" : "",
-      breakpointsDisabled ? "Enable Breakpoints" : "Disable Breakpoints"
+      breakpointsDisabled ? L10N.getStr("breakpoints.enable") :
+        L10N.getStr("breakpoints.disable")
     );
   },
 

--- a/src/reducers/breakpoints.js
+++ b/src/reducers/breakpoints.js
@@ -49,7 +49,7 @@ function makeLocationId(location: Location) {
 }
 
 function allBreakpointsDisabled(state) {
-  return state.breakpoints.filter(x => !x.disabled).size <= 0;
+  return state.breakpoints.every(x => x.disabled);
 }
 
 function update(state = State(), action: Action) {

--- a/src/strings.json
+++ b/src/strings.json
@@ -1,6 +1,8 @@
 {
   "breakpoints.header": "Breakpoints",
   "breakpoints.none": "No Breakpoints",
+  "breakpoints.enable": "Enable Breakpoints",
+  "breakpoints.disable": "Disable Breakpoints",
   "callStack.header": "Call Stack",
   "callStack.notPaused": "Not Paused",
   "callStack.collapse": "Collapse Rows",


### PR DESCRIPTION
Fixes #1531

It toggles the tooltip text whenever all breakpoints become disabled, either by clicking the button or clicking each breakpoint checkbox individually.
![out](https://cloud.githubusercontent.com/assets/4202539/21483852/25430f94-cb81-11e6-8cb1-2bfaa7deb1b0.gif)

