### PR TITLE
changed search bars styling for rtl

### DIFF
--- a/src/components/Autocomplete.css
+++ b/src/components/Autocomplete.css
@@ -10,7 +10,6 @@
 
 .autocomplete .results-summary {
   margin: 10px;
-  direction: ltr;
   text-align: start;
 }
 
@@ -94,7 +93,6 @@
   font-size: 24px;
   padding: 4px;
   word-break: break-all;
-  direction: ltr;
 }
 
 .autocomplete .no-result-msg .sad-face {

--- a/src/components/Autocomplete.css
+++ b/src/components/Autocomplete.css
@@ -10,6 +10,8 @@
 
 .autocomplete .results-summary {
   margin: 10px;
+  direction: ltr;
+  text-align: start;
 }
 
 .autocomplete ul {
@@ -58,7 +60,7 @@
   line-height: 30px;
   font-size: 14px;
   height: 40px;
-  padding-left: 30px;
+  padding-inline-start: 30px;
 }
 
 .autocomplete input::placeholder {
@@ -69,7 +71,7 @@
   width: 16px;
   position: absolute;
   top: 12px;
-  left: 10px;
+  offset-inline-start: 10px;
 }
 
 .autocomplete.focused .magnifying-glass path,
@@ -92,11 +94,12 @@
   font-size: 24px;
   padding: 4px;
   word-break: break-all;
+  direction: ltr;
 }
 
 .autocomplete .no-result-msg .sad-face {
   width: 24px;
-  margin-right: 4px;
+  margin: 0 4px;
   line-height: 0;
   flex-shrink: 0;
 }

--- a/src/components/EditorSearchBar.css
+++ b/src/components/EditorSearchBar.css
@@ -28,7 +28,6 @@
 
 .search-bar .magnifying-glass {
   background-color: var(--theme-body-background);
-  width: 40px;
 }
 
 .search-bar .magnifying-glass path,
@@ -52,5 +51,4 @@
   line-height: 40px;
   padding-right: 10px;
   color: var(--theme-body-color-inactive);
-  direction: ltr;
 }

--- a/src/components/EditorSearchBar.css
+++ b/src/components/EditorSearchBar.css
@@ -8,7 +8,7 @@
 
 .search-bar i {
   display: block;
-  padding: 13px 0 0 13px;
+  padding: 13px;
   width: 40px;
 }
 
@@ -52,4 +52,5 @@
   line-height: 40px;
   padding-right: 10px;
   color: var(--theme-body-color-inactive);
+  direction: ltr;
 }


### PR DESCRIPTION
Associated Issue: #1507

adjusted the styling to support rtl, with the postcss-bidirection thing.

please note that I forced some strings to be ltr-displayed with css, because their text comes from strings.json so I figured they should always be ltr, right?