### PR TITLE
move toward 24px toolbar

### DIFF
--- a/src/components/CommandBar.css
+++ b/src/components/CommandBar.css
@@ -3,14 +3,14 @@
 }
 
 .command-bar {
-  height: 30px;
-  padding: 8px 5px;
+  height: 24px;
+  padding: 4px;
 }
 
 .command-bar > span {
   cursor: pointer;
   width: 16px;
-  height: 17px;
+  height: 16px;
   display: inline-block;
   text-align: center;
   transition: all 0.25s ease;

--- a/src/components/Dropdown.css
+++ b/src/components/Dropdown.css
@@ -12,8 +12,8 @@
 
 .dropdown-button {
   position: absolute;
-  right: 20px;
-  top: 3px;
+  right: 24px;
+  top: 0px;
   font-size: 16px;
   color: var(--theme-body-color);
   cursor: pointer;

--- a/src/components/Editor.css
+++ b/src/components/Editor.css
@@ -110,9 +110,9 @@ html[dir="rtl"] .editor-mount {
   width: calc(100% - 1px);
 
   /* Offsetting it by 30px for the sources-header area */
-  height: calc(100% - 30px);
+  height: calc(100% - 24px);
   position: absolute;
-  top: 30px;
+  top: 24px;
   left: 0;
   padding: 50px 0;
   text-align: center;

--- a/src/components/SourceTabs.css
+++ b/src/components/SourceTabs.css
@@ -1,6 +1,6 @@
 .source-header {
   border-bottom: 1px solid var(--theme-splitter-color);
-  height: 30px;
+  height: 24px;
   flex: 1;
 }
 
@@ -21,11 +21,12 @@
   height: 14px;
   display: inline-block;
   position: relative;
-  top: 4px;
-  margin: 4px;
+  top: 2px;
+  margin: 2px 6px;
   margin-inline-start: 30px;
   line-height: 0;
   fill: var(--theme-comment);
+  cursor: pointer;
 }
 
 .source-tab {
@@ -34,8 +35,8 @@
   border: 1px solid var(--theme-splitter-color);
   border-top-left-radius: 2px;
   border-top-right-radius: 2px;
-  height: 24px;
-  line-height: 20px;
+  height: 22px;
+  line-height: 18px;
   display: inline-block;
   position: relative;
   transition: all 0.25s ease;
@@ -49,7 +50,7 @@
   padding-inline-start: 12px;
   padding-inline-end: 20px;
 
-  margin-top: 6px;
+  margin-top: 2px;
   margin-inline-start: 8px;
 }
 
@@ -120,6 +121,7 @@
   width: 16px;
   height: 16px;
   margin: 0 4px;
+  cursor: pointer;
 }
 
 .toggle-button-start svg,
@@ -132,12 +134,12 @@
 }
 
 .toggle-button-start {
-  top: 7px;
+  top: 3px;
   left: 0;
 }
 
 .toggle-button-end {
-  top: 7px;
+  top: 3px;
   right: 0;
 }
 

--- a/src/components/Sources.css
+++ b/src/components/Sources.css
@@ -11,11 +11,11 @@
 }
 
 .sources-header {
-  height: 30px;
+  height: 24px;
   border-bottom: 1px solid var(--theme-splitter-color);
   padding-top: 0px;
   padding-bottom: 0px;
-  line-height: 30px;
+  line-height: 24px;
   font-size: 1.2em;
   display: flex;
   align-items: baseline;


### PR DESCRIPTION
Associated Issue: #1536 

### Summary of Changes

* Change from 30px to 24px across CSS files

### Test Plan

- [x] Command-P opens at the correct position
- [x] Toolbar buttons are vertically lined up correctly
- [ ] Tab overflow works out correctly

### Screenshots/Videos (OPTIONAL)

Finding some issues with the tab overflow, otherwise this seems to work fairly well.

<img width="368" alt="screen shot 2016-12-27 at 1 31 26 pm" src="https://cloud.githubusercontent.com/assets/2134/21508836/ce163fa8-cc38-11e6-8df6-0279e0c9cb68.png">
