### PR TITLE
Adding copy source URL to context menu for editor, frames, and source

### DIFF
--- a/assets/locales/debugger.properties
+++ b/assets/locales/debugger.properties
@@ -14,6 +14,14 @@
 # that collapses the left and right panes in the debugger UI.
 collapsePanes=Collapse panes
 
+# LOCALIZATION NOTE (copySourceUrl): This is the text that appears in the
+# context menu to copy the source URL of file open.
+copySourceUrl=Copy Source Url
+
+# LOCALIZATION NOTE (copySourceUrl): This is the text that appears in the
+# context menu to copy the source URL of file open.
+copySourceUrl.key=X
+
 # LOCALIZATION NOTE (expandPanes): This is the tooltip for the button
 # that expands the left and right panes in the debugger UI.
 expandPanes=Expand panes

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -123,11 +123,14 @@ const Editor = React.createClass({
   },
 
   async onContextMenu(cm, event) {
+    const revealInTreeLabel = L10N.getStr("sourceTabs.revealInTree");
+    const revealInTreeKey = L10N.getStr("sourceTabs.revealInTree.key");
+
     if (event.target.classList.contains("CodeMirror-linenumber")) {
       return this.onGutterContextMenu(event);
     }
 
-    const { selectedLocation } = this.props;
+    const { selectedLocation, showSource } = this.props;
 
     event.stopPropagation();
     event.preventDefault();
@@ -189,11 +192,12 @@ const Editor = React.createClass({
 
     const showSourceMenuItem = {
       id: "node-menu-show-source",
-      label: "Show source",
-      accesskey: "s",
+      label: revealInTreeLabel,
+      accesskey: revealInTreeKey,
       disabled: false,
-      click: () => showSource(tab)
+      click: () => showSource(source.get("id"))
     };
+    menuOptions.push(showSourceMenuItem);
 
     showMenu(event, menuOptions);
 

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -31,6 +31,7 @@ const { isFirefox } = require("devtools-config");
 const { showMenu } = require("../shared/menu");
 const { isEnabled } = require("devtools-config");
 const { isOriginalId, hasMappedSource } = require("../../utils/source-map");
+const { copyToTheClipboard } = require("../../utils/clipboard");
 
 require("./Editor.css");
 
@@ -133,6 +134,15 @@ const Editor = React.createClass({
 
     const isMapped = await hasMappedSource(selectedLocation);
 
+    const source = this.props.selectedSource;
+    const copySourceUrl = {
+      id: "node-menu-copy-source",
+      label: "Copy Source URL",
+      accesskey: "X",
+      disabled: false,
+      click: () => copyToTheClipboard(source.get("url"))
+    };
+
     const { line, ch } = this.editor.codeMirror.coordsChar({
       left: event.clientX,
       top: event.clientY
@@ -173,7 +183,20 @@ const Editor = React.createClass({
       menuOptions.push(watchExpressionLabel);
     }
 
+    if (isEnabled("copySource")) {
+      menuOptions.push(copySourceUrl);
+    }
+
+    const showSourceMenuItem = {
+      id: "node-menu-show-source",
+      label: "Show source",
+      accesskey: "s",
+      disabled: false,
+      click: () => showSource(tab)
+    };
+
     showMenu(event, menuOptions);
+
   },
 
   onGutterContextMenu(event) {

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -123,6 +123,8 @@ const Editor = React.createClass({
   },
 
   async onContextMenu(cm, event) {
+    const copySourceUrlLabel = L10N.getStr("copySourceUrl");
+    const copySourceUrlKey = L10N.getStr("copySourceUrl.key");
     const revealInTreeLabel = L10N.getStr("sourceTabs.revealInTree");
     const revealInTreeKey = L10N.getStr("sourceTabs.revealInTree.key");
 
@@ -140,8 +142,8 @@ const Editor = React.createClass({
     const source = this.props.selectedSource;
     const copySourceUrl = {
       id: "node-menu-copy-source",
-      label: "Copy Source URL",
-      accesskey: "X",
+      label: copySourceUrlLabel,
+      accesskey: copySourceUrlKey,
       disabled: false,
       click: () => copyToTheClipboard(source.get("url"))
     };

--- a/src/components/SecondaryPanes/Frames.js
+++ b/src/components/SecondaryPanes/Frames.js
@@ -42,7 +42,7 @@ function renderFrameLocation({ source, location }: Frame) {
 const Frames = createClass({
   propTypes: {
     frames: ImPropTypes.list,
-    selectedFrame: PropTypes.object,
+    selectedFrame: PropTypes.object.isRequired,
     selectFrame: PropTypes.func.isRequired
   },
 
@@ -66,14 +66,13 @@ const Frames = createClass({
     });
   },
 
-  onContextMenu(event, frame) {
+  onContextMenu(event: SyntheticKeyboardEvent, frame: Frame) {
     event.stopPropagation();
     event.preventDefault();
 
-    const source = frame.source;
-
     const menuOptions = [];
 
+    const source = frame.source;
     if (source) {
       const copySourceUrl = {
         id: "node-menu-copy-source",
@@ -108,10 +107,8 @@ const Frames = createClass({
     );
   },
 
-  onMouseDown(e, frame, selectedFrame) {
-    if (e.nativeEvent.which == 3 
-        && selectedFrame
-        && selectedFrame.id != frame.id) {
+  onMouseDown(e: SyntheticKeyboardEvent, frame: Frame, selectedFrame: Frame) {
+    if (e.nativeEvent.which == 3 && selectedFrame.id != frame.id) {
       return;
     }
     this.props.selectFrame(frame);

--- a/src/components/SecondaryPanes/Frames.js
+++ b/src/components/SecondaryPanes/Frames.js
@@ -67,6 +67,9 @@ const Frames = createClass({
   },
 
   onContextMenu(event: SyntheticKeyboardEvent, frame: Frame) {
+    const copySourceUrlLabel = L10N.getStr("copySourceUrl");
+    const copySourceUrlKey = L10N.getStr("copySourceUrl.key");
+    
     event.stopPropagation();
     event.preventDefault();
 
@@ -76,8 +79,8 @@ const Frames = createClass({
     if (source) {
       const copySourceUrl = {
         id: "node-menu-copy-source",
-        label: "Copy Source URL",
-        accesskey: "X",
+        label: copySourceUrlLabel,
+        accesskey: copySourceUrlKey,
         disabled: false,
         click: () => copyToTheClipboard(source.url)
       };

--- a/src/components/SecondaryPanes/Frames.js
+++ b/src/components/SecondaryPanes/Frames.js
@@ -71,20 +71,24 @@ const Frames = createClass({
     event.preventDefault();
 
     const source = frame.source;
-    const copySourceUrl = {
-      id: "node-menu-copy-source",
-      label: "Copy Source URL",
-      accesskey: "X",
-      disabled: false,
-      click: () => copyToTheClipboard(source.url)
-    };
 
-    let items = [];
-    if (isEnabled("copySource")) {
-      items.push(copySourceUrl);
+    const menuOptions = [];
+
+    if (source) {
+      const copySourceUrl = {
+        id: "node-menu-copy-source",
+        label: "Copy Source URL",
+        accesskey: "X",
+        disabled: false,
+        click: () => copyToTheClipboard(source.url)
+      };
+
+      if (isEnabled("copySource")) {
+        menuOptions.push(copySourceUrl);
+      }      
     }
 
-    showMenu(event, items);
+    showMenu(event, menuOptions);
   },
 
   renderFrame(frame: Frame) {
@@ -105,7 +109,9 @@ const Frames = createClass({
   },
 
   onMouseDown(e, frame, selectedFrame) {
-    if (e.nativeEvent.which == 3 && selectedFrame.id != frame.id) {
+    if (e.nativeEvent.which == 3 
+        && selectedFrame
+        && selectedFrame.id != frame.id) {
       return;
     }
     this.props.selectFrame(frame);

--- a/src/components/SourcesTree.js
+++ b/src/components/SourcesTree.js
@@ -124,7 +124,7 @@ let SourcesTree = React.createClass({
   onContextMenu(event, item) {
     const copySourceUrlLabel = L10N.getStr("copySourceUrl");
     const copySourceUrlKey = L10N.getStr("copySourceUrl.key");
-    
+
     event.stopPropagation();
     event.preventDefault();
 

--- a/src/components/SourcesTree.js
+++ b/src/components/SourcesTree.js
@@ -122,6 +122,9 @@ let SourcesTree = React.createClass({
   },
 
   onContextMenu(event, item) {
+    const copySourceUrlLabel = L10N.getStr("copySourceUrl");
+    const copySourceUrlKey = L10N.getStr("copySourceUrl.key");
+    
     event.stopPropagation();
     event.preventDefault();
 
@@ -131,8 +134,8 @@ let SourcesTree = React.createClass({
       const source = item.contents.get("url");
       const copySourceUrl = {
         id: "node-menu-copy-source",
-        label: "Copy Source URL",
-        accesskey: "X",
+        label: copySourceUrlLabel,
+        accesskey: copySourceUrlKey,
         disabled: false,
         click: () => copyToTheClipboard(source)
       };

--- a/src/components/SourcesTree.js
+++ b/src/components/SourcesTree.js
@@ -8,12 +8,14 @@ const { Set } = require("immutable");
 const { isEnabled } = require("devtools-config");
 const { getShownSource, getSelectedSource } = require("../selectors");
 const {
-  nodeHasChildren, createParentMap, addToTree,
+  nodeHasChildren, createParentMap, isDirectory, addToTree,
   collapseTree, createTree, getDirectories
 } = require("../utils/sources-tree.js");
 const ManagedTree = React.createFactory(require("./shared/ManagedTree"));
 const actions = require("../actions");
 const Svg = require("./shared/Svg");
+const { showMenu } = require("./shared/menu");
+const { copyToTheClipboard } = require("../utils/clipboard");
 const { throttle } = require("../utils/utils");
 
 let SourcesTree = React.createClass({
@@ -119,6 +121,31 @@ let SourcesTree = React.createClass({
     return Svg("folder");
   },
 
+  onContextMenu(event, item) {
+    event.stopPropagation();
+    event.preventDefault();
+
+    if (!isDirectory(item)) {
+      const source = item.contents.get("url");
+      const copySourceUrl = {
+        id: "node-menu-copy-source",
+        label: "Copy Source URL",
+        accesskey: "X",
+        disabled: false,
+        click: () => copyToTheClipboard(source)
+      };
+
+      if (isEnabled("copySource")) {
+        menuOptions.push(copySourceUrl);
+      }      
+    }
+
+    const menuOptions = [];
+
+    showMenu(event, menuOptions);
+
+  },
+
   renderItem(item, depth, focused, _, expanded, { setExpanded }) {
     const arrow = Svg(
       "arrow",
@@ -143,7 +170,8 @@ let SourcesTree = React.createClass({
         style: { [paddingDir]: `${depth * 15}px` },
         key: item.path,
         onClick: () => this.selectItem(item),
-        onDoubleClick: e => setExpanded(item, !expanded)
+        onDoubleClick: e => setExpanded(item, !expanded),
+        onContextMenu: (e) => this.onContextMenu(e, item)
       },
       dom.div(null, arrow, icon, item.name)
     );

--- a/src/components/SourcesTree.js
+++ b/src/components/SourcesTree.js
@@ -125,6 +125,8 @@ let SourcesTree = React.createClass({
     event.stopPropagation();
     event.preventDefault();
 
+    const menuOptions = [];
+
     if (!isDirectory(item)) {
       const source = item.contents.get("url");
       const copySourceUrl = {
@@ -139,8 +141,6 @@ let SourcesTree = React.createClass({
         menuOptions.push(copySourceUrl);
       }
     }
-
-    const menuOptions = [];
 
     showMenu(event, menuOptions);
   },

--- a/src/components/SourcesTree.js
+++ b/src/components/SourcesTree.js
@@ -137,13 +137,12 @@ let SourcesTree = React.createClass({
 
       if (isEnabled("copySource")) {
         menuOptions.push(copySourceUrl);
-      }      
+      }
     }
 
     const menuOptions = [];
 
     showMenu(event, menuOptions);
-
   },
 
   renderItem(item, depth, focused, _, expanded, { setExpanded }) {

--- a/src/strings.json
+++ b/src/strings.json
@@ -77,5 +77,7 @@
   "whyPaused.debugCommand": "Paused on debugged function",
   "whyPaused.other": "Debugger paused",
   "collapsePanes": "Collapse panes",
-  "expandPanes": "Expand panes"
+  "expandPanes": "Expand panes",
+  "copySourceUrl": "Copy Source Url",
+  "copySourceUrl.key": "Copy Source Url"
 }

--- a/src/utils/clipboard.js
+++ b/src/utils/clipboard.js
@@ -1,0 +1,16 @@
+/**
+ * Clipboard function taken from
+ * https://dxr.mozilla.org/mozilla-central/source/devtools/shared/platform/content/clipboard.js
+ */
+function copyToTheClipboard(string) {
+  let doCopy = function(e) {
+    e.clipboardData.setData("text/plain", string);
+    e.preventDefault();
+  };
+
+  document.addEventListener("copy", doCopy);
+  document.execCommand("copy", false, null);
+  document.removeEventListener("copy", doCopy);
+}
+
+module.exports = { copyToTheClipboard };

--- a/src/utils/sources-tree.js
+++ b/src/utils/sources-tree.js
@@ -152,7 +152,7 @@ function getURL(sourceUrl: string): { path: string, group: string } {
  * @memberof utils/sources-tree
  * @static
  */
-function isDirectory(url: string) {
+function isDirectory(url: Object) {
   const parts = url.path.split("/").filter(p => p !== "");
 
   return (parts.length === 0 ||

--- a/src/utils/sources-tree.js
+++ b/src/utils/sources-tree.js
@@ -152,6 +152,17 @@ function getURL(sourceUrl: string): { path: string, group: string } {
  * @memberof utils/sources-tree
  * @static
  */
+function isDirectory(url: string) {
+  const parts = url.path.split("/").filter(p => p !== "");
+  
+  return (parts.length === 0 ||
+                 parts[parts.length - 1].indexOf(".") === -1);
+}
+
+/**
+ * @memberof utils/sources-tree
+ * @static
+ */
 function addToTree(tree: any, source: TmpSource) {
   const url = getURL(source.get("url"));
 
@@ -165,8 +176,7 @@ function addToTree(tree: any, source: TmpSource) {
   url.path = decodeURIComponent(url.path);
 
   const parts = url.path.split("/").filter(p => p !== "");
-  const isDir = (parts.length === 0 ||
-                 parts[parts.length - 1].indexOf(".") === -1);
+  const isDir = isDirectory(url);
   parts.unshift(url.group);
 
   let path = "";
@@ -332,6 +342,7 @@ module.exports = {
   createNode,
   nodeHasChildren,
   createParentMap,
+  isDirectory,
   addToTree,
   collapseTree,
   createTree,

--- a/src/utils/sources-tree.js
+++ b/src/utils/sources-tree.js
@@ -154,7 +154,7 @@ function getURL(sourceUrl: string): { path: string, group: string } {
  */
 function isDirectory(url: string) {
   const parts = url.path.split("/").filter(p => p !== "");
-  
+
   return (parts.length === 0 ||
                  parts[parts.length - 1].indexOf(".") === -1);
 }


### PR DESCRIPTION
… tree

Associated Issue: #1490

### Summary of Changes

Added the ability to copy source URL to:

* Editor.js
* Frames.js
* SourceTree.js

### Test Plan

Opened to-do MVC app and tested across different options.

- Right clicked editor, copied source.
- Right clicked stack frame, copied source.
- Right clicked left source tree, copied source.

### Screenshots/Videos (OPTIONAL)
