### PR TITLE
Remove borders from inactive tabs

### DIFF
--- a/src/components/SourceTabs.css
+++ b/src/components/SourceTabs.css
@@ -34,9 +34,8 @@
 }
 
 .source-tab {
-  background-color: var(--theme-toolbar-background-alt);
   color: var(--theme-faded-tab-color);
-  border: 1px solid var(--theme-splitter-color);
+  border: 1px solid transparent;
   border-top-left-radius: 2px;
   border-top-right-radius: 2px;
   height: 24px;
@@ -58,13 +57,15 @@
 }
 
 .source-tab:hover {
-  background: var(--theme-toolbar-background);
+  background-color: var(--theme-toolbar-background-alt);
+  border-color: var(--theme-splitter-color);
   cursor: pointer;
 }
 
 .source-tab.active {
   color: var(--theme-body-color);
   background-color: var(--theme-body-background);
+  border-color: var(--theme-splitter-color);
   border-bottom-color: transparent;
 }
 


### PR DESCRIPTION
This is just an idea; I've removed borders from inactive tabs to prevent the weird-ish look of empty space to the right of inactive tabs when the "x" isn't displaying.
<img width="759" alt="tabswithoutborders" src="https://cloud.githubusercontent.com/assets/46655/21528736/4c0e4786-ccfa-11e6-8bee-ce1b467c0432.png">
