### PR TITLE
Set collapse/expand cursor to pointer to show it's clickable

### DIFF
--- a/src/components/SourceTabs.css
+++ b/src/components/SourceTabs.css
@@ -124,6 +124,7 @@
   width: 16px;
   height: 16px;
   margin: 0 4px;
+  cursor: pointer;
 }
 
 .toggle-button-start svg,


### PR DESCRIPTION
All other clickable icons have this cursor -- updating to use the same cursor for integrity.