### PR TITLE
Fix #1571 - Fix first tab being a pixel off

### DIFF
--- a/src/components/SourceTabs.css
+++ b/src/components/SourceTabs.css
@@ -16,7 +16,7 @@
 .source-tabs {
   max-width: calc(100% - 80px);
   float: left;
-  margin-left: 20px;
+  margin-left: 21px;
 }
 
 .source-header .new-tab-btn {


### PR DESCRIPTION
<img width="211" alt="tab-lineup" src="https://cloud.githubusercontent.com/assets/46655/21552906/7108fd30-cdca-11e6-95a0-4c6a4aadaf1f.png">
