### PR TITLE
Fix Cmd+F with selected text issue

### DIFF
--- a/src/components/EditorSearchBar.js
+++ b/src/components/EditorSearchBar.js
@@ -81,11 +81,7 @@ const EditorSearchBar = React.createClass({
                           && hasLoaded;
 
     if (doneLoading || changedFiles) {
-      const query = this.state.query;
-      const count = countMatches(query, sourceText.get("text"));
-      // eslint-disable-next-line react/no-did-update-set-state
-      this.setState({ count: count, index: 0 });
-      this.search(query);
+      this.doSearch(this.state.query);
     }
   },
 
@@ -113,6 +109,7 @@ const EditorSearchBar = React.createClass({
     if (this.state.enabled) {
       const selection = this.props.editor.codeMirror.getSelection();
       this.setSearchValue(selection);
+      this.doSearch(selection);
       this.selectSearchInput();
     }
   },
@@ -136,12 +133,16 @@ const EditorSearchBar = React.createClass({
     return findDOMNode(this).querySelector("input");
   },
 
-  onChange(e) {
+  doSearch(query) {
     const sourceText = this.props.sourceText;
-    const query = e.target.value;
     const count = countMatches(query, sourceText.get("text"));
+    // eslint-disable-next-line react/no-did-update-set-state
     this.setState({ query, count, index: 0 });
     this.search(query);
+  },
+
+  onChange(e) {
+    this.doSearch(e.target.value);
   },
 
   traverseResultsPrev(e) {


### PR DESCRIPTION
Associated Issue: #1568

### Summary of Changes

* Move reoccurring code into doSearch
* Call from multiple places

### Test Plan

- [x] Open a source
- [x] Select text
- [x] Cmd+F
- [x] Hit enter
- [x] It should move to the next result
### Screenshots/Videos
![cmd f_sel_text](https://cloud.githubusercontent.com/assets/792924/21582405/106a6cda-d04e-11e6-88fb-bdfb970a6cf3.gif)

