### PR TITLE
Switch "Office Hours" to "Community Call"

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ We strive for collaboration with [mutual respect for each other][contributing]. 
 
 We're all on Mozilla's IRC in the [#devtools-html][irc-devtools-html] channel on irc.mozilla.org.
 
-* **Open Office Hours** Every Tuesday, Thursday at 3pm EST. [Event](https://calendar.google.com/calendar/render#eventpage_6%7Ceid-MzBtZHBhNm5jcW44dXR0dm1yajliOWQzamNfMjAxNjExMjJUMjAwMDAwWiBodWtoZG9rbzNuMm5oNzZiZGw2dWUya2pqb0Bn-1-0-)
+* **Community Call** Every Tuesday, Thursday at 3pm EST. [Event](https://calendar.google.com/calendar/render#eventpage_6%7Ceid-MzBtZHBhNm5jcW44dXR0dm1yajliOWQzamNfMjAxNjExMjJUMjAwMDAwWiBodWtoZG9rbzNuMm5oNzZiZGw2dWUya2pqb0Bn-1-0-)
 * **DevTools Call** Every Tuesday at 12pm EST. [info](https://wiki.mozilla.org/DevTools)
 
 ### License


### PR DESCRIPTION
I've been thinking for the past month that office hours is not the best name for the call for a couple reasons:

1) it's actually very vague. Most people ask me what it is
2) it creates an employee / volunteer distinction. Office hours is like seeing the professor and has office in the title. In fact that is the opposite of what we're trying to do here. We are all working on the project together and the call is about discussing goals, plans, etc

Why "Community Call"?
- it communicates that it is open to everyone

Other ideas?

CC @clarkbw, @bomsy, @wldcordeiro 