### PR TITLE
Launch Debugger Examples

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "test-all": "npm run test; npm run lint; npm run flow; npm run firefox-unit-test",
     "mocha-server": "node bin/mocha-server.js",
     "firefox-unit-test": "node bin/firefox-driver --test",
-    "firefox": "node bin/firefox-driver --start",
+    "firefox": "node bin/firefox-driver --start --location https://devtools-html.github.io/debugger-examples/",
     "chrome": "node bin/chrome-driver",
     "copy-assets": "node bin/copy-assets",
     "copy-assets-watch": "node bin/copy-assets --watch",


### PR DESCRIPTION
`yarn run firefox` will now open [debugger-examples](https://devtools-html.github.io/debugger-examples/) by default.

![screen shot 2017-01-02 at 9 53 50 am](https://cloud.githubusercontent.com/assets/254562/21591469/523ae624-d0d2-11e6-8710-a33fe48f92d7.png)
