### PR TITLE
evaluate expression when not paused (#1525)

### DIFF
--- a/src/actions/pause.js
+++ b/src/actions/pause.js
@@ -270,12 +270,13 @@ function deleteExpression(expression: Expression) {
  */
 function evaluateExpressions() {
   return async function({ dispatch, getState, client }: ThunkArgs) {
+    const pauseInfo = getPause(getState());
     const selectedFrame = getSelectedFrame(getState());
-    if (!selectedFrame) {
+    if (pauseInfo && !selectedFrame) {
       return;
     }
 
-    const frameId = selectedFrame.id;
+    const frameId = selectedFrame ? selectedFrame.id : null;
 
     for (let expression of getExpressions(getState())) {
       await dispatch({

--- a/src/actions/pause.js
+++ b/src/actions/pause.js
@@ -51,7 +51,7 @@ function paused(pauseInfo: Pause) {
       selectedFrameId: frame.id
     });
 
-    dispatch(evaluateExpressions());
+    dispatch(evaluateExpressions(frame.id));
 
     dispatch(selectSource(frame.location.sourceId,
                           { line: frame.location.line }));
@@ -226,7 +226,9 @@ function addExpression(expression: Expression) {
       id: id,
       input: expression.input
     });
-    dispatch(evaluateExpressions());
+    const selectedFrame = getSelectedFrame(getState());
+    const selectedFrameId = selectedFrame ? selectedFrame.id : null;
+    dispatch(evaluateExpressions(selectedFrameId));
   };
 }
 
@@ -266,24 +268,17 @@ function deleteExpression(expression: Expression) {
 /**
  *
  * @memberof actions/pause
+ * @param {number} selectedFrameId
  * @static
  */
-function evaluateExpressions() {
+function evaluateExpressions(selectedFrameId) {
   return async function({ dispatch, getState, client }: ThunkArgs) {
-    const pauseInfo = getPause(getState());
-    const selectedFrame = getSelectedFrame(getState());
-    if (pauseInfo && !selectedFrame) {
-      return;
-    }
-
-    const frameId = selectedFrame ? selectedFrame.id : null;
-
     for (let expression of getExpressions(getState())) {
       await dispatch({
         type: constants.EVALUATE_EXPRESSION,
         id: expression.id,
         input: expression.input,
-        [PROMISE]: client.evaluate(expression.input, { frameId })
+        [PROMISE]: client.evaluate(expression.input, { selectedFrameId })
       });
     }
   };


### PR DESCRIPTION
Associated Issue: #1525

### Summary of Changes

* When not paused, expressions will be evaluated with global scope
* When paused expressions will be evaluated with selected frame

### Test Plan

- [x] Add an expression, when not paused, should evaluate the expression

### Screenshots/Videos (OPTIONAL)
http://g.recordit.co/smSN9UDFzL.gif