### PR TITLE
Polish the Expressions UI

### DIFF
--- a/src/components/Expressions.css
+++ b/src/components/Expressions.css
@@ -16,6 +16,7 @@
 .input-expression:focus {
   outline-color: var(--theme-selection-background-semitransparent);
   outline-width: 2px;
+  cursor: text;
 }
 
 .expression-container {
@@ -28,7 +29,7 @@
 }
 
 :root.theme-light .expression-container:hover {
-  background-color: var(--theme-selection-color);
+  background-color: var(--theme-tab-toolbar-background);
 }
 
 :root.theme-dark .expression-container:hover {

--- a/src/components/ObjectInspector.js
+++ b/src/components/ObjectInspector.js
@@ -89,11 +89,13 @@ function createNode(name, path, contents) {
 
 const ObjectInspector = React.createClass({
   propTypes: {
+    autoExpandDepth: PropTypes.number,
     name: PropTypes.string,
     desc: PropTypes.object,
     roots: PropTypes.array,
     getObjectProperties: PropTypes.func.isRequired,
-    loadObjectProperties: PropTypes.func.isRequired
+    loadObjectProperties: PropTypes.func.isRequired,
+    onLabelClick: PropTypes.func
   },
 
   displayName: "ObjectInspector",
@@ -104,6 +106,13 @@ const ObjectInspector = React.createClass({
     // being inspected.
     this.actorCache = {};
     return {};
+  },
+
+  getDefaultProps() {
+    return {
+      onLabelClick: () => {},
+      autoExpandDepth: 1
+    };
   },
 
   getChildren(item) {
@@ -175,7 +184,16 @@ const ObjectInspector = React.createClass({
           hidden: nodeIsPrimitive(item)
         })
       }),
-      dom.span({ className: "object-label" }, item.name),
+      dom.span(
+        {
+          className: "object-label",
+          onClick: event => {
+            event.stopPropagation();
+            this.props.onLabelClick(item, { depth, focused, expanded });
+          }
+        },
+        item.name
+      ),
       dom.span({ className: "object-delimiter" },
                objectValue ? ": " : ""),
       dom.span({ className: "object-value" }, objectValue || "")
@@ -183,7 +201,8 @@ const ObjectInspector = React.createClass({
   },
 
   render() {
-    const { name, desc, loadObjectProperties } = this.props;
+    const { name, desc, loadObjectProperties,
+            autoExpandDepth } = this.props;
 
     let roots = this.props.roots;
     if (!roots) {
@@ -197,7 +216,7 @@ const ObjectInspector = React.createClass({
       getRoots: () => roots,
       getKey: item => item.path,
       autoExpand: 0,
-      autoExpandDepth: 1,
+      autoExpandDepth,
       autoExpandAll: false,
       disabledFocus: true,
       onExpand: item => {

--- a/src/components/WhyPaused.js
+++ b/src/components/WhyPaused.js
@@ -21,6 +21,7 @@ const WhyPaused = React.createClass({
     const { pauseInfo } = this.props;
     const reason = getPauseReason(pauseInfo);
 
+    // => here
     return reason ?
       dom.div({ className: "pane why-paused" }, L10N.getStr(reason))
       : null;

--- a/src/reducers/pause.js
+++ b/src/reducers/pause.js
@@ -127,10 +127,15 @@ function update(state = State(), action: Action): Record<PauseState> {
           updating: true });
 
     case constants.DELETE_EXPRESSION:
-      return state.deleteIn(["expressions", action.id]);
+      return deleteExpression(state, action.id);
   }
 
   return state;
+}
+
+function deleteExpression(state, id) {
+  const index = getExpressions({ pause: state }).findKey(e => e.id == id);
+  return state.deleteIn(["expressions", index]);
 }
 
 // Selectors


### PR DESCRIPTION
Associated Issue: #1599

  - [x] Prevent duplicate expressions 
  - [x] Fix editing expressions 
  - [x] Re-evaluate on resume
  - [x] cursor on input should be "text"
  - [x] close button is off
  - [x] expressions should not expand by default
  - [ ] "Not Available" shouldn't be in quotes
  - [x] re-evaluate when a frame is selected
  - [x] can't remove last expression