### PR TITLE
Disable menu items with disabled property

### DIFF
--- a/src/components/menu.css
+++ b/src/components/menu.css
@@ -17,6 +17,8 @@ menuitem {
   line-height: 20px;
   font-weight: 500;
   font-size: 13px;
+  -moz-user-select: none;
+  user-select: none;
 }
 
 menuitem:hover {
@@ -31,6 +33,7 @@ menuitem[disabled=true] {
 
 menuitem[disabled=true]:hover {
   background-color: transparent;
+  cursor: default;
 }
 
 menuseparator {

--- a/src/components/menu.css
+++ b/src/components/menu.css
@@ -25,6 +25,14 @@ menuitem:hover {
   cursor: pointer;
 }
 
+menuitem[disabled=true] {
+  color: #cccccc;
+}
+
+menuitem[disabled=true]:hover {
+  background-color: transparent;
+}
+
 menuseparator {
   border-bottom: 1px solid #cacdd3;
   width: 100%;

--- a/src/utils/menu.js
+++ b/src/utils/menu.js
@@ -50,14 +50,12 @@ function onShown(menu, popup) {
   popup.childNodes.forEach((menuitem, index) => {
     const item = menu.items[index];
 
-    if (item.disabled) {
-      return;
+    if (!item.disabled) {
+      menuitem.onclick = () => {
+        item.click();
+        popup.hidePopup();
+      };
     }
-
-    menuitem.onclick = () => {
-      item.click();
-      popup.hidePopup();
-    };
   });
 }
 

--- a/src/utils/menu.js
+++ b/src/utils/menu.js
@@ -49,6 +49,11 @@ if (!isFirefoxPanel()) {
 function onShown(menu, popup) {
   popup.childNodes.forEach((menuitem, index) => {
     const item = menu.items[index];
+
+    if (item.disabled) {
+      return;
+    }
+
     menuitem.onclick = () => {
       item.click();
       popup.hidePopup();


### PR DESCRIPTION
Associated Issue: #1607 

### Summary of Changes

* Prevent the onclick handler from being registered if the item is disabled.
* Adds styling for the disabled state.

### Test Plan

Am not that familiar with the project so didn't know a better way, I just hardcoded a line to disable the first menu item, here's a patch:

```diff
diff --git a/src/utils/menu.js b/src/utils/menu.js
index 0c3b85a..375a57e 100644
--- a/src/utils/menu.js
+++ b/src/utils/menu.js
@@ -63,6 +63,7 @@ function onShown(menu, popup) {
 
 function showMenu(e, items) {
   const menu = new Menu();
+  items[0].disabled = true;
   items.forEach(item => menu.append(new MenuItem(item)));
 
   if (isFirefoxPanel()) {
```
Then:

1. Open any source file
2. Right click on some code
3. Notice that the first item in the context menu is disabled, clicking it does nothing.

### Screenshots/Videos

![debugger-context-menu-item](https://cloud.githubusercontent.com/assets/3685626/21641666/341ac4b2-d275-11e6-83c1-802d2c3fea22.gif)

Hope that's what you're looking for 🙂  Let me know if any changes required. Thanks!