### PR TITLE
Create onClick handler to show file search ui

### DIFF
--- a/src/components/Sources.css
+++ b/src/components/Sources.css
@@ -35,6 +35,7 @@
   white-space: nowrap;
   padding-inline-end: 10px;
   float: end;
+  cursor: pointer;
 }
 
 .sources-list {

--- a/src/components/Sources.js
+++ b/src/components/Sources.js
@@ -14,14 +14,19 @@ const Sources = React.createClass({
   propTypes: {
     sources: ImPropTypes.map.isRequired,
     selectSource: PropTypes.func.isRequired,
-    horizontal: PropTypes.bool.isRequired
+    horizontal: PropTypes.bool.isRequired,
+    toggleFileSearch: PropTypes.func
   },
 
   displayName: "Sources",
 
   renderShortcut() {
     if (this.props.horizontal) {
-      return dom.span({ className: "sources-header-info" },
+      return dom.span(
+        {
+          className: "sources-header-info",
+          onClick: () => this.props.toggleFileSearch(true)
+        },
         L10N.getFormatStr("sources.search",
           formatKeyShortcut(`CmdOrCtrl+${L10N.getStr("sources.search.key")}`))
       );


### PR DESCRIPTION
Associated Issue: #1621 

### Summary of Changes

* Added on click handler for "Cmd+P to search" search label

### Test Plan

Tell us a little a bit about how you tested your patch.

Example test plan:

- [x] Command-P opens the panel
- [x] Clicking “+” opens the panel
- [x] Clicking a source navigates to the source
- [x] Clicking "x" closes the panel

