### PR TITLE
Add a pretty print context menu option to the source tabs.

### DIFF
--- a/src/components/SourceTabs.js
+++ b/src/components/SourceTabs.js
@@ -67,6 +67,7 @@ const SourceTabs = React.createClass({
     closeTab: PropTypes.func.isRequired,
     closeTabs: PropTypes.func.isRequired,
     toggleFileSearch: PropTypes.func.isRequired,
+    togglePrettyPrint: PropTypes.func.isRequired,
     togglePane: PropTypes.func.isRequired,
     showSource: PropTypes.func.isRequired,
     horizontal: PropTypes.bool.isRequired,
@@ -104,7 +105,12 @@ const SourceTabs = React.createClass({
   },
 
   showContextMenu(e, tab) {
-    const { closeTab, closeTabs, sourceTabs, showSource } = this.props;
+    const {
+      closeTab,
+      closeTabs,
+      sourceTabs,
+      showSource,
+      togglePrettyPrint } = this.props;
 
     const closeTabLabel = L10N.getStr("sourceTabs.closeTab");
     const closeOtherTabsLabel = L10N.getStr("sourceTabs.closeOtherTabs");
@@ -165,6 +171,14 @@ const SourceTabs = React.createClass({
       click: () => copyToTheClipboard(sourceTab.get("url"))
     };
 
+    const prettyPrint = {
+      id: "node-menu-pretty-print",
+      label: "Pretty Print Source",
+      accesskey: "Z",
+      disabled: false,
+      click: () => togglePrettyPrint(sourceTab.get("id"))
+    };
+
     const items = [
       { item: closeTabMenuItem },
       { item: closeOtherTabsMenuItem, hidden: () => tabs.size === 1 },
@@ -181,6 +195,8 @@ const SourceTabs = React.createClass({
     if (isEnabled("showSource")) {
       items.push({ item: showSourceMenuItem });
     }
+
+    items.push({ item: prettyPrint });
 
     showMenu(e, buildMenu(items));
   },


### PR DESCRIPTION
Associated Issue: #1626 

### Summary of Changes

* add a pretty print source context menu entry to the source tabs

### Test Plan

Tell us a little a bit about how you tested your patch.

Example test plan:

- [ ] Open the debugger and select a source file that can be pretty printed
- [ ] Right click the tab in the source tabs and select the `Pretty Print Source` option
- [ ] See that the source is pretty printed

### Screenshots/Videos (OPTIONAL)
