### PR TITLE
Rename "Show source" to "Reveal in Tree"

### DIFF
--- a/src/components/SourceTabs.js
+++ b/src/components/SourceTabs.js
@@ -159,7 +159,7 @@ const SourceTabs = React.createClass({
 
     const showSourceMenuItem = {
       id: "node-menu-show-source",
-      label: "Show source",
+      label: "Reveal in Tree",
       accesskey: "s",
       disabled: false,
       click: () => showSource(tab)


### PR DESCRIPTION
Associated Issue: #1494 

### Summary of Changes

Renamed the context menu item in source tab from "Show source" to "Reveal in Tree"

### Screenshots
![recored-2017-01-10_004503-opt](https://cloud.githubusercontent.com/assets/1755089/21779599/61bb5b5e-d6ce-11e6-99b9-89dfede63d59.gif)
