### PR TITLE
Do not render breakpoint toggle if none exist.

### DIFF
--- a/src/components/SecondaryPanes.js
+++ b/src/components/SecondaryPanes.js
@@ -59,7 +59,11 @@ const SecondaryPanes = React.createClass({
     const isIndeterminate = !breakpointsDisabled &&
       breakpoints.some(x => x.disabled);
 
-    return breakpoints.size > 0 ? dom.input({
+    if (breakpoints.size == 0) {
+      return null;
+    }
+
+    return dom.input({
       type: "checkbox",
       "aria-label": breakpointsDisabled ? L10N.getStr("breakpoints.enable") :
         L10N.getStr("breakpoints.disable"),
@@ -74,7 +78,7 @@ const SecondaryPanes = React.createClass({
       },
       title: breakpointsDisabled ? L10N.getStr("breakpoints.enable") :
         L10N.getStr("breakpoints.disable")
-    }) : null;
+    });
   },
 
   watchExpressionHeaderButtons() {

--- a/src/components/SecondaryPanes.js
+++ b/src/components/SecondaryPanes.js
@@ -56,17 +56,17 @@ const SecondaryPanes = React.createClass({
     const { toggleAllBreakpoints, breakpoints,
             breakpointsDisabled, breakpointsLoading } = this.props;
     const boxClassName = "breakpoints-toggle";
-
-    const breakpointsExist = breakpoints.size > 0;
     const isIndeterminate = !breakpointsDisabled &&
       breakpoints.some(x => x.disabled);
 
-    return dom.input({
+    return breakpoints.size > 0 ? dom.input({
       type: "checkbox",
+      "aria-label": breakpointsDisabled ? L10N.getStr("breakpoints.enable") :
+        L10N.getStr("breakpoints.disable"),
       className: boxClassName,
-      disabled: !breakpointsExist || breakpointsLoading,
+      disabled: breakpointsLoading,
       onClick: () => toggleAllBreakpoints(!breakpointsDisabled),
-      checked: !breakpointsDisabled && !isIndeterminate && breakpointsExist,
+      checked: !breakpointsDisabled && !isIndeterminate,
       ref: (input) => {
         if (input) {
           input.indeterminate = isIndeterminate;
@@ -74,7 +74,7 @@ const SecondaryPanes = React.createClass({
       },
       title: breakpointsDisabled ? L10N.getStr("breakpoints.enable") :
         L10N.getStr("breakpoints.disable")
-    });
+    }) : null;
   },
 
   watchExpressionHeaderButtons() {


### PR DESCRIPTION
Associated Issue: #1648

### Summary of Changes

* Check for breakpoint(s) existence before rendering the toggle button.

### Test Plan

Open up clean debugger profile. See by default there is no breakpoint toggle checkbox. Set a breakpoint somewhere and verify the checkbox then renders.

### Screenshots

No Breakpoints:

![no-points](https://cloud.githubusercontent.com/assets/868301/21785923/8d9e6976-d68f-11e6-81f5-a853a3df2b7d.png)

Breakpoints:

![breakpoints](https://cloud.githubusercontent.com/assets/868301/21785932/98671fd8-d68f-11e6-8d8d-5c1502623365.png)
