### PR TITLE
Import reps

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "dependencies": {
     "codemirror": "^5.1.0",
     "devtools-launchpad": "^0.0.21",
+    "devtools-reps": "^0.0.2",
     "documentation": "^4.0.0-beta11",
     "eslint": "^3.12.0",
     "expect.js": "^0.3.1",

--- a/src/components/Rep.js
+++ b/src/components/Rep.js
@@ -1,5 +1,5 @@
 const React = require("react");
-let { Rep, Grip } = require("devtools-modules");
+let { Rep, Grip } = require("devtools-reps");
 Rep = React.createFactory(Rep);
 
 function renderRep({ object, mode }) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -975,14 +975,14 @@ babel-register@^6.18.0:
     mkdirp "^0.5.1"
     source-map-support "^0.4.2"
 
-babel-runtime@6.11.6:
+babel-runtime@6.11.6, babel-runtime@^6.9.0:
   version "6.11.6"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.11.6.tgz#6db707fef2d49c49bfa3cb64efdb436b518b8222"
   dependencies:
     core-js "^2.4.0"
     regenerator-runtime "^0.9.5"
 
-babel-runtime@^6.0.0, babel-runtime@^6.11.6, babel-runtime@^6.18.0, babel-runtime@^6.2.0, babel-runtime@^6.20.0, babel-runtime@^6.9.0, babel-runtime@^6.9.1:
+babel-runtime@^6.0.0, babel-runtime@^6.11.6, babel-runtime@^6.18.0, babel-runtime@^6.2.0, babel-runtime@^6.20.0, babel-runtime@^6.9.1:
   version "6.20.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.20.0.tgz#87300bdcf4cd770f09bf0048c64204e17806d16f"
   dependencies:
@@ -1830,7 +1830,7 @@ devtools-config@^0.0.10:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/devtools-config/-/devtools-config-0.0.10.tgz#955a5ec1790e9e06a40009fdb1eaf5f979d168dd"
 
-devtools-launchpad@^0.0.21:
+devtools-launchpad@0.0.21, devtools-launchpad@^0.0.21:
   version "0.0.21"
   resolved "https://registry.yarnpkg.com/devtools-launchpad/-/devtools-launchpad-0.0.21.tgz#05bb5885bc12d75f32e86d5bc86a1abccab959c1"
   dependencies:
@@ -1901,6 +1901,13 @@ devtools-modules@^0.0.11:
 devtools-network-request@^0.0.9:
   version "0.0.9"
   resolved "https://registry.yarnpkg.com/devtools-network-request/-/devtools-network-request-0.0.9.tgz#cdf51f4f21d7cb8cedba5b9d89e860ba531ddeb7"
+
+devtools-reps@^0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/devtools-reps/-/devtools-reps-0.0.2.tgz#23824c5c60cafd19672109b61a71a944605b6d4b"
+  dependencies:
+    devtools-launchpad "0.0.21"
+    lodash "^4.17.2"
 
 devtools-sham-modules@^0.0.11:
   version "0.0.11"
@@ -3655,7 +3662,7 @@ lodash.words@^3.0.0:
   dependencies:
     lodash._root "^3.0.0"
 
-lodash@^4.0.0, lodash@^4.1.0, lodash@^4.11.1, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.8.0, lodash@~4.17.2:
+lodash@^4.0.0, lodash@^4.1.0, lodash@^4.11.1, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.2, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.8.0, lodash@~4.17.2:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 


### PR DESCRIPTION
Associated Issue: #1601 

This switches from using `devtools-modules/reps`  to using `devtools-reps` from Github.

This probably looks like a relatively small PR, but it is massive:

reps is updated here https://github.com/devtools-html/devtools-reps/pull/33

* there's a new publish entry point
* the bundle works in the panel as well

CC @juliandescottes, @nchevobbe, @tromey, @bgrins 