### PR TITLE
Fix #1510. [Editor] Multiple Highlight Lines

### DIFF
--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -25,7 +25,7 @@ const Breakpoint = React.createFactory(require("./Editor/Breakpoint"));
 const HitMarker = React.createFactory(require("./Editor/HitMarker"));
 
 const { getDocument, setDocument } = require("../utils/source-documents");
-const { shouldShowFooter } = require("../utils/editor");
+const { shouldShowFooter, clearLineClass } = require("../utils/editor");
 const { isFirefox } = require("devtools-config");
 const { showMenu } = require("../utils/menu");
 const { isEnabled } = require("devtools-config");
@@ -278,23 +278,19 @@ const Editor = React.createClass({
     }
   },
 
+  // If the location has changed and a specific line is requested,
+  // move to that line and flash it.
   highlightLine() {
     if (!this.pendingJumpLine) {
       return;
     }
-
-    // If the location has changed and a specific line is requested,
-    // move to that line and flash it.
-    const codeMirror = this.editor.codeMirror;
 
     // Make sure to clean up after ourselves. Not only does this
     // cancel any existing animation, but it avoids it from
     // happening ever again (in case CodeMirror re-applies the
     // class, etc).
     if (this.lastJumpLine) {
-      Array(codeMirror.lineCount()).fill().forEach((v, i) => {
-        codeMirror.removeLineClass(i, "line", "highlight-line");
-      });
+      clearLineClass(this.editor.codeMirror, "highlight-line");
     }
 
     const line = this.pendingJumpLine;

--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -292,9 +292,9 @@ const Editor = React.createClass({
     // happening ever again (in case CodeMirror re-applies the
     // class, etc).
     if (this.lastJumpLine) {
-      codeMirror.removeLineClass(
-        this.lastJumpLine - 1, "line", "highlight-line"
-      );
+      Array(codeMirror.lineCount()).fill().forEach((v, i) => {
+        codeMirror.removeLineClass(i, "line", "highlight-line");
+      });
     }
 
     const line = this.pendingJumpLine;

--- a/src/utils/editor.js
+++ b/src/utils/editor.js
@@ -18,7 +18,22 @@ function shouldShowFooter(selectedSource) {
   return shouldShowPrettyPrint(selectedSource);
 }
 
+function forEachLine(codeMirror, iter) {
+  codeMirror.doc.iter(0, codeMirror.lineCount(), iter);
+}
+
+function removeLineClass(codeMirror, line, className) {
+  codeMirror.removeLineClass(line, "line", className);
+}
+
+function clearLineClass(codeMirror, className) {
+  forEachLine(codeMirror, line => {
+    removeLineClass(codeMirror, line, className);
+  });
+}
+
 module.exports = {
   shouldShowPrettyPrint,
-  shouldShowFooter
+  shouldShowFooter,
+  clearLineClass,
 };


### PR DESCRIPTION
Associated Issue: #1510 

We would need to keep lastJumpLine for every tab separately (not just one globally) - so the easiest thing to do to fix this is to go through all bp lines instead.