### PR TITLE
Update panel

### DIFF
--- a/assets/locales/debugger.properties
+++ b/assets/locales/debugger.properties
@@ -124,6 +124,14 @@ sourceSearch.search.key=F
 # the search for re-searching the same search triggered from a sourceSearch
 sourceSearch.search.next.key=G
 
+# LOCALIZATION NOTE (sourceSearch.search.again.key): Key shortcut to re-open
+# the search for re-searching the same search triggered from a sourceSearch
+sourceSearch.search.again.key=G
+
+# LOCALIZATION NOTE (sourceSearch.search.resultsSummary): Shows a summary of
+# the number of matches for autocomplete
+sourceSearch.resultsSummary=%d instances of \"%S\"
+
 # LOCALIZATION NOTE (noMatchingStringsText): The text to display in the
 # global search results when there are no matching strings after filtering.
 noMatchingStringsText=No matches found

--- a/bin/run-mochitests-docker
+++ b/bin/run-mochitests-docker
@@ -3,10 +3,10 @@
 node ./bin/publish-assets
 
 docker run -it \
-  -v `pwd`/assets/build/bundle.js:/firefox/devtools/client/debugger/new/bundle.js \
+  -v `pwd`/assets/build/debugger.js:/firefox/devtools/client/debugger/new/bundle.js \
   -v `pwd`/assets/build/source-map-worker.js:/firefox/devtools/client/debugger/new/source-map-worker.js \
   -v `pwd`/assets/build/pretty-print-worker.js:/firefox/devtools/client/debugger/new/pretty-print-worker.js \
-  -v `pwd`/assets/build/bundle.css:/firefox/devtools/client/debugger/new/styles.css \
+  -v `pwd`/assets/build/debugger.css:/firefox/devtools/client/debugger/new/styles.css \
   -v `pwd`/assets/build/debugger.properties:/firefox/devtools/client/locales/en-US/debugger.properties \
   -v `pwd`/assets/build/default-prefs.js:/firefox/devtools/client/preferences/devtools.js \
   -v `pwd`/assets/build/mochitest:/firefox/devtools/client/debugger/new/test/mochitest \

--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -490,7 +490,7 @@ const Editor = React.createClass({
     this.editor.destroy();
     this.editor = null;
 
-    const searchAgainKey = L10N.getStr("sourceSearch.search.again.key");
+    const searchAgainKey = L10N.getStr("sourceSearch.search.next.key");
     const shortcuts = this.context.shortcuts;
     shortcuts.off("CmdOrCtrl+B");
     shortcuts.off("CmdOrCtrl+Shift+B");

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -17,7 +17,8 @@ function buildConfig(envConfig) {
     output: {
       path: path.join(__dirname, "assets/build"),
       filename: "[name].js",
-      publicPath: "/assets/build"
+      publicPath: "/assets/build",
+      library: "Debugger"
     },
 
     resolve: {


### PR DESCRIPTION
When we upgraded the launchpad we started exporting bundles with the bundle name `debugger.js` which were not being tested. Therefore, we allowed some regressions. This PR fixes that and there will be another bugzilla patch for using debugger.js.
