### PR TITLE
tweak editor selection highlight (#1671)

### DIFF
--- a/src/lib/codemirror-mozilla.css
+++ b/src/lib/codemirror-mozilla.css
@@ -142,6 +142,7 @@ selector in floating-scrollbar-light.css across all platforms. */
   left: 0;
   right: 0;
   content: "";
+  margin-bottom: -1px;
 }
 
 .cm-highlight-full:before {
@@ -152,12 +153,18 @@ selector in floating-scrollbar-light.css across all platforms. */
   border-left-width: 1px;
   border-left-style: solid;
   border-left-color: var(--theme-comment-alt);
+  margin: 0 0 -1px -1px;
+  border-top-left-radius: 2px;
+  border-bottom-left-radius: 2px;
 }
 
 .cm-highlight-end:before {
   border-right-width: 1px;
   border-right-style: solid;
   border-right-color: var(--theme-comment-alt);
+  margin: 0 -1px -1px 0;
+  border-top-right-radius: 2px;
+  border-bottom-right-radius: 2px;
 }
 
 /* CodeMirror dialogs styling */


### PR DESCRIPTION
Associated Issue: #1671 

### Summary of Changes

* Added rounded borders for highlight
* Added slight padding to prevent it cutting off lines.

### Test Plan

Tell us a little a bit about how you tested your patch.

Example test plan:

- [x] Open a file on the debugger
- [x] Select a token
- [x] Observe

### Screenshots/Videos (OPTIONAL)

<img width="211" alt="screen shot 2017-01-11 at 2 38 22 pm" src="https://cloud.githubusercontent.com/assets/2481105/21865429/b1289a56-d80b-11e6-9604-d03684708b64.png">

<img width="297" alt="screen shot 2017-01-11 at 2 38 41 pm" src="https://cloud.githubusercontent.com/assets/2481105/21865434/b638cd90-d80b-11e6-81d9-a9e73950bcd5.png">

