### PR TITLE
RTL friendly styles for breakpoints component

### DIFF
--- a/src/components/Breakpoints.css
+++ b/src/components/Breakpoints.css
@@ -9,19 +9,30 @@
   padding: 0.5em 1px;
   line-height: 1em;
   position: relative;
-  border-left: 4px solid transparent;
   transition: all 0.25s ease;
+}
+
+html[dir="rtl"] .breakpoints-list .breakpoint {
+  border-right: 4px solid transparent;
+}
+
+html:not([dir="rtl"]) .breakpoints-list .breakpoint {
+  border-left: 4px solid transparent;
 }
 
 .breakpoints-list .breakpoint:last-of-type {
   padding-bottom: 0.45em;
 }
 
-.breakpoints-list .breakpoint.is-conditional {
+html:not([dir="rtl"]) .breakpoints-list .breakpoint.is-conditional {
   border-left-color: var(--theme-graphs-yellow);
 }
 
-.breakpoints-list .breakpoint.paused {
+html[dir="rtl"] .breakpoints-list .breakpoint.is-conditional {
+  border-right-color: var(--theme-graphs-yellow);
+}
+
+html .breakpoints-list .breakpoint.paused {
   background-color: var(--theme-toolbar-background-alt);
   border-color: var(--breakpoint-active-color);
 }
@@ -41,12 +52,12 @@
 }
 
 .breakpoints-list .breakpoint-checkbox {
-  margin-left: 0;
+  margin-inline-start: 0;
 }
 
 .breakpoints-list .breakpoint-label {
   display: inline-block;
-  padding-left: 2px;
+  padding-inline-start: 2px;
   padding-bottom: 4px;
 }
 
@@ -57,12 +68,12 @@
 
 .breakpoint-snippet {
   color: var(--theme-comment);
-  padding-left: 18px;
+  padding-inline-start: 18px;
 }
 
 .breakpoint .close-btn {
   position: absolute;
-  right: 6px;
+  offset-inline-end: 6px;
   top: 12px;
 }
 


### PR DESCRIPTION
Associated Issue: #1506 

### Summary of Changes
Changed some styles in `Editor/Breakpoints.css` to make it more RTL friendly

* [X] the green border should be on the right
* [X] the left padding should be on the right so that items line up well
* [X] breakpoint close button should be on left side

### Screenshots
#### Before
![screenshot from 2017-01-13 00-12-38](https://cloud.githubusercontent.com/assets/1755089/21903868/7246feb4-d927-11e6-85c3-43fef288c4df.png)

#### After
![screenshot from 2017-01-13 00-12-03](https://cloud.githubusercontent.com/assets/1755089/21903886/7f33c65c-d927-11e6-9a19-a00c237bbfee.png)


