### PR TITLE
convert PaneToggle to a React Class

### DIFF
--- a/src/components/SourceTabs.js
+++ b/src/components/SourceTabs.js
@@ -12,7 +12,7 @@ const { isEnabled } = require("devtools-config");
 const classnames = require("classnames");
 const actions = require("../actions");
 const CloseButton = require("./shared/Button/Close");
-const PaneToggleButton = require("./shared/Button/PaneToggle");
+const PaneToggleButton = React.createFactory(require("./shared/Button/PaneToggle"));
 const Svg = require("./shared/Svg");
 const Dropdown = React.createFactory(require("./Dropdown"));
 const { showMenu, buildMenu } = require("../utils/menu");
@@ -313,9 +313,7 @@ const SourceTabs = React.createClass({
     return PaneToggleButton({
       position: "start",
       collapsed: !this.props.startPanelCollapsed,
-      handleClick: this.props.togglePaneCollapse,
-      tooltip: this.props.startPanelCollapsed ?
-        L10N.getStr("expandPanes") : L10N.getStr("collapsePanes")
+      handleClick: this.props.togglePaneCollapse
     });
   },
 
@@ -328,9 +326,7 @@ const SourceTabs = React.createClass({
       position: "end",
       collapsed: !this.props.endPanelCollapsed,
       handleClick: this.props.togglePaneCollapse,
-      horizontal: this.props.horizontal,
-      tooltip: this.props.endPanelCollapsed ?
-        L10N.getStr("expandPanes") : L10N.getStr("collapsePanes")
+      horizontal: this.props.horizontal
     });
   },
 

--- a/src/components/shared/Button/PaneToggle.js
+++ b/src/components/shared/Button/PaneToggle.js
@@ -1,18 +1,47 @@
 const React = require("react");
+const { DOM: dom, PropTypes } = React;
 const classnames = require("classnames");
 const Svg = require("../Svg");
 
 require("./PaneToggle.css");
 
-function PaneToggleButton({
-  position, collapsed, horizontal, handleClick, tooltip }) {
-  return React.DOM.div({
-    className: classnames(`toggle-button-${position}`, {
-      collapsed,
-      vertical: horizontal != null ? !horizontal : false }),
-    onClick: () => handleClick(position, collapsed),
-    title: tooltip
-  }, Svg("togglePanes"));
-}
+const PaneToggleButton = React.createClass({
+  propTypes: {
+    position: PropTypes.string.isRequired,
+    collapsed: PropTypes.bool.isRequired,
+    horizontal: PropTypes.bool,
+    handleClick: PropTypes.func.isRequired
+  },
+
+  displayName: "PaneToggleButton",
+
+  shouldComponentUpdate(nextProps, nextState) {
+    const { collapsed, horizontal } = this.props;
+
+    if (collapsed !== nextProps.collapsed) {
+      return true;
+    }
+
+    if (horizontal !== nextProps.horizontal) {
+      return true;
+    }
+
+    return false;
+  },
+
+  render() {
+    const { position, collapsed, horizontal, handleClick } = this.props;
+    const title = !collapsed ? L10N.getStr("expandPanes") : L10N.getStr("collapsePanes");
+
+    return dom.div({
+      className: classnames(`toggle-button-${position}`, {
+        collapsed,
+        vertical: horizontal != null ? !horizontal : false
+      }),
+      onClick: () => handleClick(position, collapsed),
+      title
+    }, Svg("togglePanes"));
+  }
+});
 
 module.exports = PaneToggleButton;

--- a/src/components/shared/Button/PaneToggle.js
+++ b/src/components/shared/Button/PaneToggle.js
@@ -18,15 +18,8 @@ const PaneToggleButton = React.createClass({
   shouldComponentUpdate(nextProps, nextState) {
     const { collapsed, horizontal } = this.props;
 
-    if (collapsed !== nextProps.collapsed) {
-      return true;
-    }
-
-    if (horizontal !== nextProps.horizontal) {
-      return true;
-    }
-
-    return false;
+    return horizontal !== nextProps.horizontal
+      || collapsed !== nextProps.collapsed;
   },
 
   render() {


### PR DESCRIPTION
Associated Issue: #1695

### Summary of Changes

Previously the PaneToggleButton was re-rendering every time there was a change with SourceTabs.  Now the button is a Component and keys off the `collapsed` and `horizontal` prop values coming from the SourceTabs component.

### Test Plan

- [x] Clicking left collapse button works for both open and close
- [x] Clicking right collapse button works for both open and close
- [x] Upon opening a source file the button doesn't paint
