### PR TITLE
Show source tab for paused evals

### DIFF
--- a/src/components/SourceTabs.js
+++ b/src/components/SourceTabs.js
@@ -8,7 +8,7 @@ const {
   getSourceTabs,
   getFileSearchState
 } = require("../selectors");
-const { getFilename, getRawSourceURL, isPretty } = require("../utils/source");
+const { getFilename, isPretty } = require("../utils/source");
 const { isEnabled } = require("devtools-config");
 const classnames = require("classnames");
 const actions = require("../actions");
@@ -18,7 +18,6 @@ const Svg = require("./shared/Svg");
 const Dropdown = React.createFactory(require("./Dropdown"));
 const { showMenu, buildMenu } = require("../utils/menu");
 const { debounce } = require("lodash");
-const { getURL } = require("../utils/sources-tree.js");
 const { formatKeyShortcut } = require("../utils/text");
 require("./SourceTabs.css");
 require("./Dropdown.css");
@@ -255,7 +254,7 @@ const SourceTabs = React.createClass({
 
   renderTab(source) {
     const { selectedSource, selectSource, closeTab } = this.props;
-    const filename = getRawSourceURL(getURL(source.get("url")).filename);
+    const filename = getFilename(source.toJS());
     const active = source.get("id") == selectedSource.get("id");
     const isPrettyCode = isPretty({ url: source.get("url") });
 
@@ -273,7 +272,7 @@ const SourceTabs = React.createClass({
         key: source.get("id"),
         onClick: () => selectSource(source.get("id")),
         onContextMenu: (e) => this.onTabContextMenu(e, source.get("id")),
-        title: getRawSourceURL(source.get("url"))
+        title: getFilename(source.toJS())
       },
       isPrettyCode ? Svg("prettyPrint") : null,
       dom.div({ className: "filename" }, filename),

--- a/src/utils/source.js
+++ b/src/utils/source.js
@@ -75,13 +75,14 @@ function getRawSourceURL(url: string): string {
  * @static
  */
 function getFilename(source: Source) {
-  const { url, id } = source;
+  let { url, id } = source;
   if (!url) {
     const sourceId = id.split("/")[1];
     return `SOURCE${sourceId}`;
   }
 
-  const name = basename(source.url || "") || "(index)";
+  url = getRawSourceURL(url || "");
+  const name = basename(url) || "(index)";
   return endTruncateStr(name, 50);
 }
 


### PR DESCRIPTION
I found while updating the bundle that we were not showing source tabs for eval'd sources that paused.

This fixes that by re-using some of the existing logic:

@clarkbw, @darkwing 