### PR TITLE
update markdown parser

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,4 @@
 theme: jekyll-theme-cayman
+markdown: kramdown
+kramdown:
+  input: GFM


### PR DESCRIPTION
This should make 

https://devtools-html.github.io/debugger.html/

consistent with

github.com/devtools-html/debugger.html