### PR TITLE
add shouldComponentUpdate to default accordions

### DIFF
--- a/src/components/Breakpoints.js
+++ b/src/components/Breakpoints.js
@@ -49,6 +49,11 @@ const Breakpoints = React.createClass({
 
   displayName: "Breakpoints",
 
+  shouldComponentUpdate(nextProps, nextState) {
+    const { breakpoints } = this.props;
+    return breakpoints !== nextProps.breakpoints;
+  },
+
   handleCheckbox(breakpoint) {
     if (breakpoint.loading) {
       return;

--- a/src/components/Expressions.js
+++ b/src/components/Expressions.js
@@ -51,6 +51,12 @@ const Expressions = React.createClass({
 
   displayName: "Expressions",
 
+  shouldComponentUpdate(nextProps, nextState) {
+    const { expressions, loadedObjects } = this.props;
+    return expressions !== nextProps.expressions
+      || loadedObjects !== nextProps.loadedObjects;
+  },
+
   inputKeyPress(e, { id }) {
     if (e.key !== "Enter") {
       return;

--- a/src/components/Frames.js
+++ b/src/components/Frames.js
@@ -41,6 +41,14 @@ const Frames = React.createClass({
 
   displayName: "Frames",
 
+  shouldComponentUpdate(nextProps, nextState) {
+    const { frames, selectedFrame } = this.props;
+    const { showAllFrames } = this.state;
+    return frames !== nextProps.frames
+      || selectedFrame !== nextProps.selectedFrame
+      || showAllFrames !== nextState.showAllFrames;
+  },
+
   getInitialState() {
     return { showAllFrames: false };
   },

--- a/src/components/Scopes.js
+++ b/src/components/Scopes.js
@@ -145,6 +145,13 @@ const Scopes = React.createClass({
 
   displayName: "Scopes",
 
+  shouldComponentUpdate(nextProps, nextState) {
+    const { pauseInfo, selectedFrame, loadedObjects } = this.props;
+    return pauseInfo !== nextProps.pauseInfo
+      || selectedFrame !== nextProps.selectedFrame
+      || loadedObjects !== nextProps.loadedObjects;
+  },
+
   getInitialState() {
     const { pauseInfo, selectedFrame } = this.props;
     return { scopes: getScopes(pauseInfo, selectedFrame) };


### PR DESCRIPTION
Breakpoints, Expressions, Frames, and Scopes were all re-rendering based on changes unrelated to their responsibilities.

### Summary of Changes

You can reproduce this easily right now.  Set a breakpoint on the render method for any of the Accordions in the secondary pane.  Then expand or collapse any of the other accordions and you'll hit that breakpoint.

* Added `shouldComponentUpdate` to each component so it only renders as needed per component

### Test Plan

Tell us a little a bit about how you tested your patch.

Example test plan:

- [x] Added and removed breakpoints
- [x] Paused the debugger to check that accordions worked correctly
- [x] Navigated frames when paused
