### PR TITLE
Collapsible End Pane in Vertical Layout

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "codemirror": "^5.1.0",
-    "devtools-launchpad": "0.0.23",
+    "devtools-launchpad": "0.0.24",
     "devtools-reps": "^0.0.2",
     "documentation": "^4.0.0-beta11",
     "eslint": "^3.12.0",

--- a/src/components/App.css
+++ b/src/components/App.css
@@ -76,20 +76,3 @@ body {
   margin-top: 25px;
   margin-right: 20px;
 }
-
-.welcomebox {
-  width: calc(100% - 1px);
-
-  /* Offsetting it by 30px for the sources-header area */
-  height: calc(100% - 30px);
-  position: absolute;
-  top: 30px;
-  left: 0;
-  padding: 50px 0;
-  text-align: center;
-  font-size: 1.25em;
-  color: var(--theme-comment-alt);
-  background-color: var(--theme-tab-toolbar-background);
-  font-weight: lighter;
-  z-index: 100;
-}

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -7,7 +7,6 @@ const { getSources, getSelectedSource, getPaneCollapse } = require("../selectors
 
 const { KeyShortcuts } = require("devtools-sham-modules");
 const shortcuts = new KeyShortcuts({ window });
-const { formatKeyShortcut } = require("../utils/text");
 const { isEnabled } = require("devtools-config");
 
 const verticalLayoutBreakpoint = window.matchMedia("(min-width: 700px)");
@@ -23,6 +22,7 @@ const SourceSearch = createFactory(require("./SourceSearch"));
 const Sources = createFactory(require("./Sources"));
 const Editor = createFactory(require("./Editor"));
 const SecondaryPanes = createFactory(require("./SecondaryPanes"));
+const WelcomeBox = createFactory(require("./WelcomeBox"));
 const SourceTabs = createFactory(require("./SourceTabs"));
 
 const App = React.createClass({
@@ -63,14 +63,6 @@ const App = React.createClass({
     });
   },
 
-  renderWelcomeBox() {
-    return dom.div(
-      { className: "welcomebox" },
-      L10N.getFormatStr("welcome.search",
-        formatKeyShortcut(`CmdOrCtrl+${L10N.getStr("sources.search.key")}`))
-    );
-  },
-
   renderEditorPane() {
     const { startPanelCollapsed, endPanelCollapsed } = this.props;
     const { horizontal } = this.state;
@@ -84,7 +76,7 @@ const App = React.createClass({
           horizontal
         }),
         Editor({ horizontal }),
-        !this.props.selectedSource ? this.renderWelcomeBox() : null,
+        !this.props.selectedSource ? WelcomeBox({ horizontal }) : null,
         SourceSearch()
       )
     );

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -83,7 +83,7 @@ const App = React.createClass({
           endPanelCollapsed,
           horizontal
         }),
-        Editor(),
+        Editor({ horizontal }),
         !this.props.selectedSource ? this.renderWelcomeBox() : null,
         SourceSearch()
       )
@@ -128,7 +128,7 @@ const App = React.createClass({
         style: { width: "100vw" },
         initialSize: "300px",
         minSize: 30,
-        maxSize: "95%",
+        maxSize: "99%",
         splitterSize: 1,
         vert: horizontal,
         startPanel: SplitBox({

--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -606,9 +606,9 @@ const Editor = React.createClass({
   },
 
   editorHeight() {
-    const { selectedSource } = this.props;
+    const { selectedSource, horizontal } = this.props;
 
-    if (!selectedSource || !shouldShowFooter(selectedSource.toJS())) {
+    if (!shouldShowFooter(selectedSource, horizontal)) {
       return "100%";
     }
 

--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -97,7 +97,8 @@ const Editor = React.createClass({
     jumpToMappedLocation: PropTypes.func,
     coverageOn: PropTypes.bool,
     selectedFrame: PropTypes.object,
-    addExpression: PropTypes.func
+    addExpression: PropTypes.func,
+    horizontal: PropTypes.bool
   },
 
   displayName: "Editor",
@@ -615,7 +616,7 @@ const Editor = React.createClass({
   },
 
   render() {
-    const { sourceText, selectedSource, coverageOn } = this.props;
+    const { sourceText, selectedSource, coverageOn, horizontal } = this.props;
 
     return (
       dom.div(
@@ -636,7 +637,7 @@ const Editor = React.createClass({
         }),
         this.renderBreakpoints(),
         this.renderHitCounts(),
-        SourceFooter({ editor: this.editor })
+        SourceFooter({ editor: this.editor, horizontal })
       )
     );
   }

--- a/src/components/SourceFooter.js
+++ b/src/components/SourceFooter.js
@@ -4,13 +4,16 @@ const { connect } = require("react-redux");
 const { bindActionCreators } = require("redux");
 const actions = require("../actions");
 const { getSelectedSource, getSourceText,
-        getPrettySource } = require("../selectors");
+        getPrettySource, getPaneCollapse } = require("../selectors");
 const Svg = require("./shared/Svg");
 const ImPropTypes = require("react-immutable-proptypes");
 const classnames = require("classnames");
 const { isEnabled } = require("devtools-config");
 const { isPretty } = require("../utils/source");
 const { shouldShowFooter, shouldShowPrettyPrint } = require("../utils/editor");
+const PaneToggleButton = React.createFactory(
+  require("./shared/Button/PaneToggle")
+);
 
 require("./SourceFooter.css");
 
@@ -31,6 +34,9 @@ const SourceFooter = React.createClass({
     selectSource: PropTypes.func,
     prettySource: ImPropTypes.map,
     editor: PropTypes.object,
+    endPanelCollapsed: PropTypes.bool,
+    togglePaneCollapse: PropTypes.func,
+    horizontal: PropTypes.bool
   },
 
   displayName: "SourceFooter",
@@ -73,6 +79,19 @@ const SourceFooter = React.createClass({
     }, "C");
   },
 
+  renderToggleButton() {
+    if (this.props.horizontal) {
+      return;
+    }
+
+    return PaneToggleButton({
+      position: "end",
+      collapsed: !this.props.endPanelCollapsed,
+      horizontal: this.props.horizontal,
+      handleClick: this.props.togglePaneCollapse
+    });
+  },
+
   render() {
     const { selectedSource } = this.props;
 
@@ -84,7 +103,8 @@ const SourceFooter = React.createClass({
       dom.div({ className: "commands" },
         this.prettyPrintButton(),
         this.coverageButton()
-      )
+      ),
+      this.renderToggleButton()
     );
   }
 });
@@ -97,6 +117,7 @@ module.exports = connect(
       selectedSource,
       sourceText: getSourceText(state, selectedId),
       prettySource: getPrettySource(state, selectedId),
+      endPanelCollapsed: getPaneCollapse(state, "end")
     };
   },
   dispatch => bindActionCreators(actions, dispatch)

--- a/src/components/SourceFooter.js
+++ b/src/components/SourceFooter.js
@@ -50,7 +50,7 @@ const SourceFooter = React.createClass({
     const sourceLoaded = selectedSource && sourceText &&
     !sourceText.get("loading");
 
-    if (!shouldShowPrettyPrint(selectedSource.toJS())) {
+    if (!shouldShowPrettyPrint(selectedSource)) {
       return;
     }
 
@@ -92,18 +92,28 @@ const SourceFooter = React.createClass({
     });
   },
 
-  render() {
+  renderCommands() {
     const { selectedSource } = this.props;
 
-    if (!selectedSource || !shouldShowFooter(selectedSource.toJS())) {
+    if (!shouldShowPrettyPrint(selectedSource)) {
+      return null;
+    }
+
+    return dom.div({ className: "commands" },
+      this.prettyPrintButton(),
+      this.coverageButton()
+    );
+  },
+
+  render() {
+    const { selectedSource, horizontal } = this.props;
+
+    if (!shouldShowFooter(selectedSource, horizontal)) {
       return null;
     }
 
     return dom.div({ className: "source-footer" },
-      dom.div({ className: "commands" },
-        this.prettyPrintButton(),
-        this.coverageButton()
-      ),
+      this.renderCommands(),
       this.renderToggleButton()
     );
   }

--- a/src/components/WelcomeBox.css
+++ b/src/components/WelcomeBox.css
@@ -1,0 +1,22 @@
+.welcomebox {
+  width: calc(100% - 1px);
+
+  /* Offsetting it by 30px for the sources-header area */
+  height: calc(100% - 30px);
+  position: absolute;
+  top: 30px;
+  left: 0;
+  padding: 50px 0 0 0;
+  text-align: center;
+  font-size: 1.25em;
+  color: var(--theme-comment-alt);
+  background-color: var(--theme-tab-toolbar-background);
+  font-weight: lighter;
+  z-index: 100;
+}
+
+.welcomebox .toggle-button-end {
+  bottom: 11px;
+  position: absolute;
+  top: auto;
+}

--- a/src/components/WelcomeBox.js
+++ b/src/components/WelcomeBox.js
@@ -1,0 +1,56 @@
+const React = require("react");
+const { DOM: dom, PropTypes, createFactory } = React;
+const { connect } = require("react-redux");
+const { bindActionCreators } = require("redux");
+const actions = require("../actions");
+
+const { getPaneCollapse } = require("../selectors");
+const { formatKeyShortcut } = require("../utils/text");
+const PaneToggleButton = createFactory(
+  require("./shared/Button/PaneToggle")
+);
+
+require("./WelcomeBox.css");
+
+const WelcomeBox = React.createClass({
+  propTypes: {
+    horizontal: PropTypes.bool,
+    togglePaneCollapse: PropTypes.func,
+    endPanelCollapsed: PropTypes.bool,
+  },
+
+  displayName: "WelcomeBox",
+
+  renderToggleButton() {
+    if (this.props.horizontal) {
+      return;
+    }
+
+    return PaneToggleButton({
+      position: "end",
+      collapsed: !this.props.endPanelCollapsed,
+      horizontal: this.props.horizontal,
+      handleClick: this.props.togglePaneCollapse
+    });
+  },
+
+  render() {
+    const searchLabel = L10N.getFormatStr("welcome.search",
+      formatKeyShortcut(
+        `CmdOrCtrl+${L10N.getStr("sources.search.key")}`
+      )
+    );
+    return dom.div(
+      { className: "welcomebox" },
+      searchLabel,
+      this.renderToggleButton()
+    );
+  }
+});
+
+module.exports = connect(
+  state => ({
+    endPanelCollapsed: getPaneCollapse(state, "end"),
+  }),
+  dispatch => bindActionCreators(actions, dispatch)
+)(WelcomeBox);

--- a/src/utils/editor.js
+++ b/src/utils/editor.js
@@ -2,6 +2,11 @@ const { isPretty, isJavaScript } = require("./source");
 const { isOriginalId } = require("../utils/source-map");
 
 function shouldShowPrettyPrint(selectedSource) {
+  if (!selectedSource) {
+    return false;
+  }
+
+  selectedSource = selectedSource.toJS();
   const _isPretty = isPretty(selectedSource);
   const _isJavaScript = isJavaScript(selectedSource.url);
   const isOriginal = isOriginalId(selectedSource.id);
@@ -14,7 +19,11 @@ function shouldShowPrettyPrint(selectedSource) {
   return true;
 }
 
-function shouldShowFooter(selectedSource) {
+function shouldShowFooter(selectedSource, horizontal) {
+  if (!horizontal) {
+    return true;
+  }
+
   return shouldShowPrettyPrint(selectedSource);
 }
 


### PR DESCRIPTION
Associated Issue: #1537 

**Requires devtools-html/devtools-core#88 to land to actually work properly.**

### Summary of Changes

* add the pane collapse button to the source footer and wire up logic to toggle end pane collapse

### Test Plan

Example test plan:

- [x] Open Debugger in vertical mode
- [x] Toggle collapse button for bottom
- [x] See the pane has collapsed/uncollapsed

### Screenshots/Videos (OPTIONAL)

![screenshot_20170114_205621](https://cloud.githubusercontent.com/assets/580982/21960130/f7abe77a-da9b-11e6-8779-297ba616af83.png)
![screenshot_20170114_205630](https://cloud.githubusercontent.com/assets/580982/21960129/f7ab81fe-da9b-11e6-85b6-9ae98399e080.png)


@jasonLaster One of the only issues I have with this approach is that the collapse button isn't visible until you open a file. I may instead render it as part of the "editorPane" in `App.js` so that it's always visible. @