### PR TITLE
Use proper empty message for ChromeScopes

### DIFF
--- a/src/components/ChromeScopes.js
+++ b/src/components/ChromeScopes.js
@@ -20,7 +20,8 @@ const Scopes = React.createClass({
     const { scopes } = this.props;
 
     if (!scopes) {
-      return dom.div({}, "hi");
+      return dom.div({ className: "pane-info" },
+        L10N.getStr("scopes.notAvailable"));
     }
 
     return scopes.map(scope => dom.div({},


### PR DESCRIPTION
Associated Issue: #1689 

### Summary of Changes

* Use the scopes unavailable localization string instead of outputting "hi" with empty chrome scopes

### Test Plan

Example test plan:

- [x] Enable chromeScopes
- [x] Open debugger
- [x] See that the empty message says "Scopes unavailable" instead of "hi"

### Screenshots/Videos (OPTIONAL)
