### PR TITLE
Fix pause on exceptions button

### DIFF
--- a/src/components/CommandBar.css
+++ b/src/components/CommandBar.css
@@ -42,13 +42,13 @@
 }
 
 .command-bar .toggleBreakpoints.breakpoints-disabled path {
-  stroke: var(--theme-highlight-blue);
+  fill: var(--theme-highlight-blue);
 }
 
 .command-bar span.pause-exceptions.uncaught {
-  stroke: var(--theme-highlight-purple);
+  fill: var(--theme-highlight-purple);
 }
 
 .command-bar span.pause-exceptions.all {
-  stroke: var(--theme-highlight-blue);
+  fill: var(--theme-highlight-blue);
 }


### PR DESCRIPTION
Fixes #1086

### Summary of Changes

Replaces `stroke` with `fill`

Thanks @nt1m for pointing this out

### Screenshots/Videos (OPTIONAL)

#### New
![](http://g.recordit.co/mw4bOfYNDs.gif)

#### Old

![](http://g.recordit.co/tcdSV3qnoe.gif)