### PR TITLE
Load examples page on launching chrome

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "test": "node src/test/node-unit-tests.js",
     "test-all": "yarn run test; yarn run lint; yarn run flow",
     "firefox": "./node_modules/.bin/start-firefox --start --location https://devtools-html.github.io/debugger-examples/",
-    "chrome": "./node_modules/.bin/start-chrome",
+    "chrome": "./node_modules/.bin/start-chrome --location https://devtools-html.github.io/debugger-examples/",
     "copy-assets": "node bin/copy-assets",
     "copy-assets-watch": "node bin/copy-assets --watch",
     "build-docs": "documentation build --format html --sort-order alpha --shallow  --document-exported --output docs/reference/ src/types.js src/utils/ src/reducers/ src/actions/ src/test/mochitest/head.js",


### PR DESCRIPTION
Associated Issue: #1709

### Summary of Changes

* Open debugger examples on launching chrome

### Test Plan

Tell us a little a bit about how you tested your patch.

Example test plan:

- [x] do `yarn run chrome`
- [x] It should open the debugger examples page
