### PR TITLE
#1085 fixed dark theme secondary color

### DIFF
--- a/src/components/Breakpoints.css
+++ b/src/components/Breakpoints.css
@@ -66,8 +66,17 @@ html .breakpoints-list .breakpoint.paused {
   order: 3;
 }
 
-.breakpoint-snippet {
+:root.theme-light .breakpoint-snippet,
+:root.theme-firebug .breakpoint-snippet {
   color: var(--theme-comment);
+}
+
+:root.theme-dark .breakpoint-snippet {
+  color: var(--theme-body-color);
+  opacity: 0.6;
+}
+
+.breakpoint-snippet {
   padding-inline-start: 18px;
 }
 

--- a/src/components/Frames.css
+++ b/src/components/Frames.css
@@ -28,8 +28,17 @@
 }
 
 .frames .location {
-  color: var(--theme-comment);
   font-weight: lighter;
+}
+
+:root.theme-light .frames .location,
+:root.theme-firebug .frames .location {
+  color: var(--theme-comment);
+}
+
+:root.theme-dark .frames .location {
+  color: var(--theme-body-color);
+  opacity: 0.6;
 }
 
 .frames .title {


### PR DESCRIPTION
Associated Issue: #1085

### Summary of Changes

* Made dark theme secondary text look more alive in the dark theme

### Test Plan

Tell us a little a bit about how you tested your patch.

Example test plan:

- [x] Opened todo app and put some breakpoint in app.js. Verified the dark theme so it does not have the grey color in the call stack (frames) and in the breakpoints area. 
- [x] Checked light theme is unchanged
- [x] Checked firebug theme is unchanged
- [x] Checked all of the above in Chrommium

### Screenshots/Videos (OPTIONAL)
Before
![before](https://cloud.githubusercontent.com/assets/922368/21997397/fddb7958-dc26-11e6-977c-c4f38edbea06.png)
After (made it use the [theme-highlight-bluegrey](https://github.com/devtools-html/debugger.html/search?utf8=%E2%9C%93&q=bluegrey&type=Code) color)
![after-theme-highlight-bluegrey](https://cloud.githubusercontent.com/assets/922368/21997396/fdd9105a-dc26-11e6-8da5-9478b234b300.png)
Firebug - unchanged
![firebug](https://cloud.githubusercontent.com/assets/922368/21997395/fdd8393c-dc26-11e6-96e3-40ffcc311b90.png)
Light theme - unchanged
![light](https://cloud.githubusercontent.com/assets/922368/21997398/fddc8442-dc26-11e6-834e-5f7f9caf2c65.png)
