### PR TITLE
resolved [WhyPaused] handle breakpointConditionThrown - #1611

### DIFF
--- a/assets/locales/debugger.properties
+++ b/assets/locales/debugger.properties
@@ -486,6 +486,10 @@ whyPaused.resumeLimit=Paused while stepping
 # dom event
 whyPaused.pauseOnDOMEvents=Paused on event listener
 
+# LOCALIZATION NOTE (whyPaused.breakpointConditionThrown): The text that is displayed
+# in an info block when evaluating a conditional breakpoint throws an error
+whyPaused.breakpointConditionThrown=Error with conditional breakpoint
+
 # LOCALIZATION NOTE (whyPaused.xhr): The text that is displayed
 # in a info block explaining how the debugger is currently paused on an
 # xml http request

--- a/src/components/WhyPaused.css
+++ b/src/components/WhyPaused.css
@@ -7,7 +7,6 @@
   white-space: normal;
   opacity: 0.9;
   font-size: 12px;
-  text-align: center;
   font-weight: bold;
 }
 

--- a/src/components/WhyPaused.js
+++ b/src/components/WhyPaused.js
@@ -20,11 +20,14 @@ const WhyPaused = React.createClass({
   render() {
     const { pauseInfo } = this.props;
     const reason = getPauseReason(pauseInfo);
+    const message = pauseInfo ? pauseInfo.getIn(["why"]).get("message") : null;
 
     // => here
     return reason ?
-      dom.div({ className: "pane why-paused" }, L10N.getStr(reason))
-      : null;
+      dom.div({ className: "pane why-paused" }, [
+        dom.div(null, L10N.getStr(reason)),
+        message ? dom.div(null, message) : null])
+        : null;
   }
 });
 

--- a/src/strings.json
+++ b/src/strings.json
@@ -59,6 +59,7 @@
   "whyPaused.exception": "Paused on exception",
   "whyPaused.resumeLimit": "Paused while stepping",
   "whyPaused.pauseOnDOMEvents": "Paused on event listener",
+  "whyPaused.breakpointConditionThrown": "Error with conditional breakpoint",
   "whyPaused.xhr": "Paused on XMLHttpRequest",
   "whyPaused.promiseRejection": "Paused on promise rejection",
   "whyPaused.assert": "Paused on assertion",

--- a/src/utils/pause.js
+++ b/src/utils/pause.js
@@ -29,6 +29,7 @@ const reasons = {
   "exception": "whyPaused.exception",
   "resumeLimit": "whyPaused.resumeLimit",
   "pauseOnDOMEvents": "whyPaused.pauseOnDOMEvents",
+  "breakpointConditionThrown": "whyPaused.breakpointConditionThrown",
 
   // V8
   "DOM": "whyPaused.breakpoint",


### PR DESCRIPTION
     added localisation keys for exception on conditional breakpoint
     added message error to indicate reason for breaking
     left aligned the WhyPaused message

Associated Issue: #1611 

### Summary of Changes
     added localisation keys for exception on conditional breakpoints
     added message error to indicate reason for breaking
     left aligned the WhyPaused message


### Test Plan
     followed the instructions provided by the original issue (defined a conditional breakpoint with an undefined variable)

### Screenshots
<img width="297" alt="screen shot 2017-01-17 at 20 42 00" src="https://cloud.githubusercontent.com/assets/6399886/22034606/7669c342-dcf5-11e6-934e-a2e2269107ca.png">

#GoodnessSquad
