### PR TITLE
Fix positioning of toggle pane button in RTL

### DIFF
--- a/src/components/Editor/Tabs.css
+++ b/src/components/Editor/Tabs.css
@@ -118,38 +118,3 @@
 .source-tab:hover .close {
   display: block;
 }
-
-.toggle-button-start,
-.toggle-button-end {
-  position: absolute;
-  width: 16px;
-  height: 16px;
-  margin: 0 4px;
-  cursor: pointer;
-}
-
-.toggle-button-start svg,
-.toggle-button-end svg {
-  fill: var(--theme-comment);
-}
-
-html:not([dir="rtl"]) .toggle-button-end svg,
-html[dir="rtl"] .toggle-button-start svg {
-  transform: rotate(180deg);
-}
-
-.toggle-button-start {
-  top: 8px;
-  offset-inline-start: 0;
-}
-
-.toggle-button-end {
-  top: 8px;
-  offset-inline-end: 0;
-}
-
-.toggle-button-start.collapsed,
-.toggle-button-end.collapsed {
-  transform: rotate(180deg);
-  flex: 1;
-}

--- a/src/components/Editor/Tabs.css
+++ b/src/components/Editor/Tabs.css
@@ -24,7 +24,7 @@
   height: 14px;
   display: inline-block;
   position: relative;
-  top: 5px;
+  top: 4px;
   margin: 4px;
   margin-inline-start: 8px;
   line-height: 0;

--- a/src/components/Editor/Tabs.css
+++ b/src/components/Editor/Tabs.css
@@ -24,7 +24,7 @@
   height: 14px;
   display: inline-block;
   position: relative;
-  top: 4px;
+  top: 5px;
   margin: 4px;
   margin-inline-start: 8px;
   line-height: 0;

--- a/src/components/Editor/Tabs.css
+++ b/src/components/Editor/Tabs.css
@@ -133,18 +133,19 @@
   fill: var(--theme-comment);
 }
 
-.toggle-button-end svg {
+html:not([dir="rtl"]) .toggle-button-end svg,
+html[dir="rtl"] .toggle-button-start svg {
   transform: rotate(180deg);
 }
 
 .toggle-button-start {
   top: 8px;
-  left: 0;
+  offset-inline-start: 0;
 }
 
 .toggle-button-end {
   top: 8px;
-  right: 0;
+  offset-inline-end: 0;
 }
 
 .toggle-button-start.collapsed,

--- a/src/components/shared/Button/PaneToggle.css
+++ b/src/components/shared/Button/PaneToggle.css
@@ -12,7 +12,8 @@
   fill: var(--theme-comment);
 }
 
-.toggle-button-end svg {
+html:not([dir="rtl"]) .toggle-button-end svg,
+html[dir="rtl"] .toggle-button-start svg {
   transform: rotate(180deg);
 }
 
@@ -26,12 +27,12 @@
 
 .toggle-button-start {
   top: 7px;
-  left: 0;
+  offset-inline-start: 0;
 }
 
 .toggle-button-end {
   top: 7px;
-  right: 0;
+  offset-inline-end: 0;
 }
 
 .toggle-button-start.collapsed,

--- a/src/components/shared/Button/PaneToggle.css
+++ b/src/components/shared/Button/PaneToggle.css
@@ -18,8 +18,7 @@ html[dir="rtl"] .toggle-button-start svg {
   transform: rotate(180deg);
 }
 
-html:not([dir="rtl"]) .toggle-button-end.vertical svg,
-html[dir="rtl"] .toggle-button-end.vertical svg {
+html .toggle-button-end.vertical svg {
   transform: rotate(-90deg);
 }
 

--- a/src/components/shared/Button/PaneToggle.css
+++ b/src/components/shared/Button/PaneToggle.css
@@ -5,6 +5,7 @@
   height: 16px;
   transition: transform 0.25s ease-in-out;
   margin: 0 4px;
+  cursor: pointer;
 }
 
 .toggle-button-start svg,

--- a/src/components/shared/Button/PaneToggle.css
+++ b/src/components/shared/Button/PaneToggle.css
@@ -23,12 +23,12 @@ html .toggle-button-end.vertical svg {
 }
 
 .toggle-button-start {
-  top: 7px;
+  top: 8px;
   offset-inline-start: 0;
 }
 
 .toggle-button-end {
-  top: 7px;
+  top: 8px;
   offset-inline-end: 0;
 }
 

--- a/src/components/shared/Button/PaneToggle.css
+++ b/src/components/shared/Button/PaneToggle.css
@@ -18,7 +18,7 @@ html[dir="rtl"] .toggle-button-start svg {
   transform: rotate(180deg);
 }
 
-html .toggle-button-end.vertical svg {
+.toggle-button-end.vertical svg {
   transform: rotate(-90deg);
 }
 

--- a/src/components/shared/Button/PaneToggle.css
+++ b/src/components/shared/Button/PaneToggle.css
@@ -23,12 +23,12 @@ html[dir="rtl"] .toggle-button-start svg {
 }
 
 .toggle-button-start {
-  top: 8px;
+  top: 7px;
   offset-inline-start: 0;
 }
 
 .toggle-button-end {
-  top: 8px;
+  top: 7px;
   offset-inline-end: 0;
 }
 

--- a/src/components/shared/Button/PaneToggle.css
+++ b/src/components/shared/Button/PaneToggle.css
@@ -18,12 +18,9 @@ html[dir="rtl"] .toggle-button-start svg {
   transform: rotate(180deg);
 }
 
-.toggle-button-start.vertical svg {
+html:not([dir="rtl"]) .toggle-button-end.vertical svg,
+html[dir="rtl"] .toggle-button-end.vertical svg {
   transform: rotate(-90deg);
-}
-
-.toggle-button-end.vertical svg {
-  transform: rotate(90deg);
 }
 
 .toggle-button-start {

--- a/src/components/shared/Dropdown.css
+++ b/src/components/shared/Dropdown.css
@@ -13,12 +13,13 @@
 .dropdown-button {
   position: absolute;
   offset-inline-end: 18px;
-  top: 1px;
+  top: 4px;
   font-size: 18px;
   color: var(--theme-comment);
   cursor: pointer;
   background: none;
   border: none;
+  padding: 0 5px;
 }
 
 .dropdown li {

--- a/src/components/shared/Dropdown.css
+++ b/src/components/shared/Dropdown.css
@@ -13,9 +13,9 @@
 .dropdown-button {
   position: absolute;
   offset-inline-end: 18px;
-  top: 4px;
+  top: 1px;
   font-size: 18px;
-  color: var(--theme-body-color);
+  color: var(--theme-comment);
   cursor: pointer;
   background: none;
   border: none;

--- a/src/components/shared/Dropdown.css
+++ b/src/components/shared/Dropdown.css
@@ -20,6 +20,7 @@
   background: none;
   border: none;
   padding: 0 5px;
+  font-weight: 100;
 }
 
 .dropdown li {

--- a/src/components/shared/Dropdown.css
+++ b/src/components/shared/Dropdown.css
@@ -4,7 +4,7 @@
   box-shadow: 0 4px 4px 0 var(--theme-search-overlays-semitransparent);
   max-height: 300px;
   position: absolute;
-  right: 8px;
+  offset-inline-end: 8px;
   top: 35px;
   width: 150px;
   z-index: 1000;
@@ -12,7 +12,7 @@
 
 .dropdown-button {
   position: absolute;
-  right: 18px;
+  offset-inline-end: 18px;
   top: 4px;
   font-size: 18px;
   color: var(--theme-body-color);


### PR DESCRIPTION
Toggle pane buttons were switched in RTL layout. This cause following issue
![recored-2017-01-14_233515-opt](https://cloud.githubusercontent.com/assets/1755089/22075827/8e696202-ddd3-11e6-8b10-951ca280c07b.gif)

There is also some duplication of styles for toggle pane button in [components/SourceTabs.css#L122](https://github.com/devtools-html/debugger.html/blob/master/src/components/SourceTabs.css#L122) and [components/shared/Button/PaneToggle.css](https://github.com/devtools-html/debugger.html/blob/master/src/components/shared/Button/PaneToggle.css). I wasn't sure which styles should be removed so I modified both for now. 

Let me know which styles should be removed so I can update this pull request


### Summary of Changes

* Update position of toggle pane button for RTL layout
* Update rotation of toggle pane button

### Screenshots/Videos (OPTIONAL)
![recored-2017-01-18_230002-opt](https://cloud.githubusercontent.com/assets/1755089/22076041/70a21a2e-ddd4-11e6-8b0a-94ebd06adbe8.gif)
