### PR TITLE
move the properties to a const outside the isDefault function

### DIFF
--- a/src/components/shared/ObjectInspector.js
+++ b/src/components/shared/ObjectInspector.js
@@ -7,6 +7,8 @@ const { MODE } = require("devtools-reps");
 
 const { DOM: dom, PropTypes } = React;
 
+const WINDOW_PROPERTIES = Object.getOwnPropertyNames(window);
+
 require("./ObjectInspector.css");
 
 // This implements a component that renders an interactive inspector
@@ -58,8 +60,7 @@ function nodeIsPrimitive(item) {
 }
 
 function isDefault(item) {
-    const properties = Object.getOwnPropertyNames(window);
-    return properties.includes(item.name);
+  return WINDOW_PROPERTIES.includes(item.name);
 }
 
 function makeNodesForProperties(objProps, parentPath) {


### PR DESCRIPTION
Gain 160ms back from expansion time.

Associated Issue: #<issue number>

### Summary of Changes

* Move the `Object.getOwnPropertyNames(window)` call outside of the function

### Test Plan

Tell us a little a bit about how you tested your patch.

Example test plan:

- [x] Check properties in the global context vs function and find they are ==

### Screenshots/Videos (OPTIONAL)

Before

![screen shot 2017-01-18 at 11 12 12 am](https://cloud.githubusercontent.com/assets/2134/22079624/6280bc60-dd71-11e6-94fe-9649cdfd976f.png)

After

![screen shot 2017-01-18 at 11 14 27 am](https://cloud.githubusercontent.com/assets/2134/22079625/6429ee2e-dd71-11e6-9bfd-f03ab0e8d0ba.png)
