### PR TITLE
Bug 1331375 - Can't navigate out of debugger content window using key…

### DIFF
--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -26,7 +26,7 @@ const Breakpoint = React.createFactory(require("./Editor/Breakpoint"));
 const HitMarker = React.createFactory(require("./Editor/HitMarker"));
 
 const { getDocument, setDocument } = require("../utils/source-documents");
-const { shouldShowFooter, clearLineClass } = require("../utils/editor");
+const { shouldShowFooter, clearLineClass, onKeyDown } = require("../utils/editor");
 const { isFirefox } = require("devtools-config");
 const { showMenu } = require("../utils/menu");
 const { isEnabled } = require("devtools-config");
@@ -416,6 +416,11 @@ const Editor = React.createClass({
     );
 
     this.editor.codeMirror.on("gutterClick", this.onGutterClick);
+
+    // Set code editor wrapper to be focusable
+    this.editor.codeMirror.getWrapperElement().tabIndex = 0;
+    this.editor.codeMirror.getWrapperElement()
+      .addEventListener("keydown", e => onKeyDown(this.editor.codeMirror, e));
 
     const ctx = { ed: this.editor, cm: this.editor.codeMirror };
     ctx.cm.on("cursorActivity", cm => onCursorActivity(ctx));

--- a/src/test/mochitest/browser.ini
+++ b/src/test/mochitest/browser.ini
@@ -51,6 +51,7 @@ support-files =
 [browser_dbg-editor-select.js]
 [browser_dbg-editor-highlight.js]
 [browser_dbg-iframes.js]
+[browser_dbg_keyboard_navigation.js]
 [browser_dbg_keyboard-shortcuts.js]
 [browser_dbg-pause-exceptions.js]
 [browser_dbg-navigation.js]

--- a/src/test/mochitest/browser_dbg-console.js
+++ b/src/test/mochitest/browser_dbg-console.js
@@ -37,6 +37,9 @@ add_task(function* () {
 
   // close the console
   clickElement(dbg, "codeMirror");
+  // First time to focus out of text area
+  pressKey(dbg, "Escape");
+  // Second time to hide console
   pressKey(dbg, "Escape");
   ok(!dbg.toolbox.splitConsole, "Split console is hidden.");
 });

--- a/src/test/mochitest/browser_dbg_keyboard_navigation.js
+++ b/src/test/mochitest/browser_dbg_keyboard_navigation.js
@@ -1,0 +1,29 @@
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
+
+// Tests that keyboard navigation into and out of debugger code editor
+
+add_task(function* () {
+  const dbg = yield initDebugger("doc-scripts.html");
+  let doc = dbg.win.document;
+
+  yield selectSource(dbg, "simple2");
+
+  yield waitForElement(dbg, ".CodeMirror");
+  findElementWithSelector(dbg, ".CodeMirror").focus();
+
+  // Enter code editor
+  pressKey(dbg, "Enter");
+  is(findElementWithSelector(dbg, "textarea"), doc.activeElement,
+    "Editor is enabled");
+
+  // Exit code editor and focus on container
+  pressKey(dbg, "Escape");
+  is(findElementWithSelector(dbg, ".CodeMirror"), doc.activeElement,
+    "Focused on container");
+
+  // Enter code editor
+  pressKey(dbg, "Tab");
+  is(findElementWithSelector(dbg, "textarea"), doc.activeElement,
+    "Editor is enabled");
+});

--- a/src/test/mochitest/head.js
+++ b/src/test/mochitest/head.js
@@ -539,6 +539,7 @@ const keyMappings = {
   "Enter": { code: "VK_RETURN" },
   "Up": { code: "VK_UP" },
   "Down": { code: "VK_DOWN" },
+  "Tab": { code: "VK_TAB" },
   "Escape": { code: "VK_ESCAPE" },
   pauseKey: { code: "VK_F8" },
   resumeKey: { code: "VK_F8" },

--- a/src/utils/editor.js
+++ b/src/utils/editor.js
@@ -19,6 +19,22 @@ function shouldShowPrettyPrint(selectedSource) {
   return true;
 }
 
+function onKeyDown(codeMirror, e) {
+  let { key, target } = e;
+  let codeWrapper = codeMirror.getWrapperElement();
+  let textArea = codeWrapper.querySelector("textArea");
+
+  if (key === "Escape" && target == textArea) {
+    e.stopPropagation();
+    e.preventDefault();
+    codeWrapper.focus();
+  } else if (key === "Enter" && target == codeWrapper) {
+    e.preventDefault();
+    // Focus into editor's text area
+    textArea.focus();
+  }
+}
+
 function shouldShowFooter(selectedSource, horizontal) {
   if (!horizontal) {
     return true;
@@ -45,4 +61,5 @@ module.exports = {
   shouldShowPrettyPrint,
   shouldShowFooter,
   clearLineClass,
+  onKeyDown
 };


### PR DESCRIPTION
…board. r?yzen, jlast

Associated Issue: https://bugzilla.mozilla.org/show_bug.cgi?id=1331375

### Summary of Changes

Added a keydown listener to handle entering and exiting code wrapper, (onkeydown in Editor.js)

### Test Plan

Tested manually and wrote a unit test.

Test plan:
- Tab to code editor wrapper
- Enter focuses into editor input
- Escape exits input and places focus back on code editor wrapper
