### PR TITLE
Conditionally show jump to original location option (#1749)

### DIFF
--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -121,13 +121,17 @@ const Editor = React.createClass({
     this.toggleBreakpoint(line);
   },
 
-  onContextMenu(cm, event) {
+  async onContextMenu(cm, event) {
     if (event.target.classList.contains("CodeMirror-linenumber")) {
       return this.onGutterContextMenu(event);
     }
 
+    const { selectedLocation } = this.props;
+
     event.stopPropagation();
     event.preventDefault();
+
+    const isMapped = await hasMappedSource(selectedLocation);
 
     const { line, ch } = this.editor.codeMirror.coordsChar({
       left: event.clientX,
@@ -161,7 +165,7 @@ const Editor = React.createClass({
 
     const menuOptions = [];
 
-    if (this.state.hasMappedSource) {
+    if (isMapped) {
       menuOptions.push(jumpLabel);
     }
 
@@ -504,12 +508,6 @@ const Editor = React.createClass({
 
     this.setDebugLine(nextProps.selectedFrame, selectedLocation);
     resizeBreakpointGutter(this.editor.codeMirror);
-
-    if (selectedLocation) {
-      selectedLocation.line = selectedLocation.line || 1;
-      hasMappedSource(selectedLocation)
-        .then(value => this.setState({ hasMappedSource: value }));
-    }
   },
 
   showMessage(msg) {
@@ -609,12 +607,6 @@ const Editor = React.createClass({
     }
 
     return "";
-  },
-
-  getInitialState() {
-    return {
-      hasMappedSource: false
-    };
   },
 
   render() {

--- a/src/utils/source-map.js
+++ b/src/utils/source-map.js
@@ -36,14 +36,13 @@ function shouldSourceMap(): boolean {
   return prefs.clientSourceMapsEnabled;
 }
 
-function hasMappedSource(location: Location): Promise<boolean> {
+async function hasMappedSource(location: Location): Promise<boolean> {
   if (isOriginalId(location.sourceId)) {
-    return Promise.resolve(true);
+    return true;
   }
-  return new Promise(resolve => {
-    getOriginalLocation(location)
-      .then(loc => resolve(loc.sourceId !== location.sourceId));
-  });
+
+  const loc = await getOriginalLocation(location);
+  return loc.sourceId !== location.sourceId;
 }
 
 const getOriginalURLs = workerTask(sourceMapWorker, "getOriginalURLs");

--- a/src/utils/source-map.js
+++ b/src/utils/source-map.js
@@ -10,6 +10,8 @@ const {
 } = require("./source-map-util");
 const { prefs } = require("./prefs");
 
+import type { Location } from "../types";
+
 let sourceMapWorker;
 function restartWorker() {
   if (sourceMapWorker) {
@@ -34,6 +36,16 @@ function shouldSourceMap(): boolean {
   return prefs.clientSourceMapsEnabled;
 }
 
+function hasMappedSource(location: Location): Promise<boolean> {
+  if (isOriginalId(location.sourceId)) {
+    return Promise.resolve(true);
+  }
+  return new Promise(resolve => {
+    getOriginalLocation(location)
+      .then(loc => resolve(loc.sourceId !== location.sourceId));
+  });
+}
+
 const getOriginalURLs = workerTask(sourceMapWorker, "getOriginalURLs");
 const getGeneratedLocation = workerTask(sourceMapWorker,
                                         "getGeneratedLocation");
@@ -49,6 +61,7 @@ module.exports = {
   generatedToOriginalId,
   isGeneratedId,
   isOriginalId,
+  hasMappedSource,
   getOriginalURLs,
   getGeneratedLocation,
   getOriginalLocation,


### PR DESCRIPTION
Associated Issue: #1749

### Summary of Changes

* Add a handler to show jump to original location only if the source has an original source.

### Test Plan

Visual testing

Example test plan:

- [x] Right click in Editor on a source mapped source.
- [x] Should give option for "Jump to Original Source".
- [x] Right click in Editor on a source mapped original source.
- [x] Should give option for "Jump to Generated Source".
- [x] Right click in Editor on a non source mapped source.
- [x] There should not be an option for "Jump to Original Source".

### Screenshots/Videos (OPTIONAL)
#### When it shouldn't appear
<img width="499" alt="screen shot 2017-01-19 at 9 11 02 pm" src="https://cloud.githubusercontent.com/assets/2481105/22135536/f3a20a30-de8b-11e6-82cd-f2bcea96bc4c.png">

#### When it should appear
<img width="499" alt="screen shot 2017-01-19 at 9 11 30 pm" src="https://cloud.githubusercontent.com/assets/2481105/22135539/f7f99efe-de8b-11e6-962a-3d5c3ccc3b89.png">

<img width="498" alt="screen shot 2017-01-19 at 9 11 43 pm" src="https://cloud.githubusercontent.com/assets/2481105/22135541/fb61ccb0-de8b-11e6-9b1b-5d843ebcda55.png">
