### PR TITLE
utils/defer is not covered by flow

### DIFF
--- a/src/utils/defer.js
+++ b/src/utils/defer.js
@@ -20,8 +20,8 @@ function defer(): Defer {
     reject = innerReject;
   });
   return {
-    resolve: Resolve,
-    reject: Reject,
+    resolve,
+    reject,
     promise
   };
 }

--- a/src/utils/defer.js
+++ b/src/utils/defer.js
@@ -10,8 +10,8 @@ export type Defer = {
 };
 
 function defer(): Defer {
-  let resolve: Resolve;
-  let reject: Reject;
+  let resolve: Resolve; // eslint-disable-line no-unused-vars
+  let reject: Reject;   // eslint-disable-line no-unused-vars
   const promise: Promise<any> = new Promise(function(
     innerResolve: Resolve,
     innerReject: Reject

--- a/src/utils/defer.js
+++ b/src/utils/defer.js
@@ -1,25 +1,28 @@
-/* flow */
+/* @flow */
 
-export type deferred = {
-  resolve: (result: any) => void,
-  reject: (result: any) => void,
-  promise: Promise
+declare var Resolve: (result: any) => void;
+declare var Reject: (result: any) => void;
+
+export type Defer = {
+  resolve: Resolve,
+  reject: Reject,
+  promise: Promise<any>
 };
 
-function defer(): deferred {
-  let resolve: (result: any) => void;
-  let reject: (result: any) => void;
-  let promise = new Promise(function(
-    innerResolve: (result: any) => void,
-    innerReject: (result: any) => void
+function defer(): Defer {
+  let resolve: Resolve;
+  let reject: Reject;
+  const promise: Promise<any> = new Promise(function(
+    innerResolve: Resolve,
+    innerReject: Reject
   ) {
     resolve = innerResolve;
     reject = innerReject;
   });
   return {
-    resolve: resolve,
-    reject: reject,
-    promise: promise
+    resolve: Resolve,
+    reject: Reject,
+    promise
   };
 }
 


### PR DESCRIPTION
Associated Issue: #1758

### Summary of Changes

* Fix utils/defer is not covered by flow

### Test Plan
- [x] Passed `yarn run flow`
- [x] Passed `npm run lint-css -s; npm run lint-js -s`
- [x] Passed `node src/test/node-unit-tests.js --dots`