### PR TITLE
update mochitest-runner

### DIFF
--- a/bin/run-mochitests-docker
+++ b/bin/run-mochitests-docker
@@ -3,10 +3,10 @@
 node ./bin/publish-assets
 
 docker run -it \
-  -v `pwd`/assets/build/debugger.js:/firefox/devtools/client/debugger/new/bundle.js \
+  -v `pwd`/assets/build/debugger.js:/firefox/devtools/client/debugger/new/debugger.js \
   -v `pwd`/assets/build/source-map-worker.js:/firefox/devtools/client/debugger/new/source-map-worker.js \
   -v `pwd`/assets/build/pretty-print-worker.js:/firefox/devtools/client/debugger/new/pretty-print-worker.js \
-  -v `pwd`/assets/build/debugger.css:/firefox/devtools/client/debugger/new/styles.css \
+  -v `pwd`/assets/build/debugger.css:/firefox/devtools/client/debugger/new/debugger.css \
   -v `pwd`/assets/build/debugger.properties:/firefox/devtools/client/locales/en-US/debugger.properties \
   -v `pwd`/assets/build/default-prefs.js:/firefox/devtools/client/preferences/devtools.js \
   -v `pwd`/assets/build/mochitest:/firefox/devtools/client/debugger/new/test/mochitest \

--- a/src/test/mochitest/browser.ini
+++ b/src/test/mochitest/browser.ini
@@ -46,14 +46,12 @@ support-files =
 [browser_dbg-chrome-create.js]
 [browser_dbg-chrome-debugging.js]
 [browser_dbg-console.js]
-skip-if = true # Test failing with new docker image
 [browser_dbg-debugger-buttons.js]
 [browser_dbg-editor-gutter.js]
 [browser_dbg-editor-select.js]
 [browser_dbg-editor-highlight.js]
 [browser_dbg-iframes.js]
 [browser_dbg_keyboard_navigation.js]
-skip-if = true # Test failing with new docker image
 [browser_dbg_keyboard-shortcuts.js]
 [browser_dbg-pause-exceptions.js]
 [browser_dbg-navigation.js]


### PR DESCRIPTION
This updates the runner to use debugger[js|css]

hopefully the skipped tests pass:
* with navigation, i *know* it uses a fix from the new bundle so i feel good about that