### PR TITLE
Adds a firefox prop to the firefox config

### DIFF
--- a/configs/firefox-panel.json
+++ b/configs/firefox-panel.json
@@ -3,6 +3,9 @@
   "baseWorkerURL": "resource://devtools/client/debugger/new/",
   "logging": false,
   "clientLogging": false,
+  "firefox": {
+    "mcPath": "./firefox"
+  },
   "features": {
     "watchExpressions": false,
     "chromeScopes": false,


### PR DESCRIPTION
We were running into a race condition with the development and firefox config being set. This should let the firefox config be used the entire time. 

@juliandescottes we likely want to move the `process.env.TARGET` assignment to the top of publish assets.