### PR TITLE
Use native buttons for CommandBar

### DIFF
--- a/src/components/SecondaryPanes/CommandBar.css
+++ b/src/components/SecondaryPanes/CommandBar.css
@@ -1,51 +1,60 @@
 .command-bar {
   height: 30px;
-  padding: 8px 5px;
   border-bottom: 1px solid var(--theme-splitter-color);
+  display: flex;
 }
 
-.command-bar > span {
+.command-bar > button {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background: transparent;
+  border: none;
   cursor: pointer;
-  width: 16px;
-  height: 17px;
   display: inline-block;
   text-align: center;
   transition: all 0.25s ease;
+  padding: 8px 5px;
+  position: relative;
+  fill: currentColor;
 }
 
-:root.theme-dark .command-bar > span {
-  fill: var(--theme-body-color);
+:root.theme-dark .command-bar > button {
+  color: var(--theme-body-color);
 }
 
-:root.theme-dark .command-bar > span:hover {
-  fill: var(--theme-selection-color);
-}
-
-.command-bar > span {
+.command-bar > button {
   margin-inline-end: 0.7em;
 }
 
-.command-bar > span.disabled {
+html .command-bar > button:disabled {
   opacity: 0.3;
   cursor: default;
 }
 
-.command-bar .stepOut {
-  margin-inline-end: 2em;
+.command-bar > button > i {
+  height: 100%;
+  width: 100%;
+  display: block;
+}
+
+.command-bar > button > i > svg {
+  width: 16px;
+  height: 16px;
+}
+
+.command-bar button.pause-exceptions {
+  margin-inline-start: .5em;
 }
 
 .command-bar .subSettings {
   float: right;
 }
 
-.command-bar .toggleBreakpoints.breakpoints-disabled path {
-  fill: var(--theme-highlight-blue);
+.command-bar button.pause-exceptions.uncaught {
+  color: var(--theme-highlight-purple);
 }
 
-.command-bar span.pause-exceptions.uncaught {
-  fill: var(--theme-highlight-purple);
-}
-
-.command-bar span.pause-exceptions.all {
-  fill: var(--theme-highlight-blue);
+.command-bar button.pause-exceptions.all {
+  color: var(--theme-highlight-blue);
 }

--- a/src/components/SecondaryPanes/CommandBar.js
+++ b/src/components/SecondaryPanes/CommandBar.js
@@ -76,15 +76,18 @@ function handlePressAnimation(button) {
   }, 200);
 }
 
-function debugBtn(onClick, type, className, tooltip) {
+
+function debugBtn(onClick, type, className, tooltip, disabled = false) {
   className = `${type} ${className}`;
-  return dom.span(
+  return dom.button(
     {
       onClick,
       className,
-      key: type
+      key: type,
+      "aria-label": tooltip,
+      disabled
     },
-    Svg(type, { title: tooltip })
+    Svg(type)
   );
 }
 
@@ -146,25 +149,31 @@ const CommandBar = React.createClass({
   },
 
   renderStepButtons() {
-    const className = this.props.pause ? "active" : "disabled";
+    const isPaused = this.props.pause;
+    const className = isPaused ? "active" : "disabled";
+    const isDisabled = !this.props.pause;
+
     return [
       debugBtn(
         this.props.stepOver,
         "stepOver",
         className,
-        L10N.getFormatStr("stepOverTooltip1", formatKey("stepOver"))
+        L10N.getFormatStr("stepOverTooltip1", formatKey("stepOver")),
+        isDisabled
       ),
       debugBtn(
         this.props.stepIn,
         "stepIn",
         className,
-        L10N.getFormatStr("stepInTooltip1", formatKey("stepIn"))
+        L10N.getFormatStr("stepInTooltip1", formatKey("stepIn")),
+        isDisabled
       ),
       debugBtn(
         this.props.stepOut,
         "stepOut",
         className,
-        L10N.getFormatStr("stepOutTooltip1", formatKey("stepOut"))
+        L10N.getFormatStr("stepOutTooltip1", formatKey("stepOut")),
+        isDisabled
       )
     ];
   },
@@ -186,7 +195,8 @@ const CommandBar = React.createClass({
         null,
         "pause",
         "disabled",
-        L10N.getStr("pausePendingButtonTooltip")
+        L10N.getStr("pausePendingButtonTooltip"),
+        true
       );
     }
 


### PR DESCRIPTION
Associated Issue: #1773 

### Summary of Changes

* `debugBtn` returns a button element and takes a `disabled` parameter
*  styling updated to handle buttons instead of spans for CommandBar items.
* Also addressed minor styling error with generated markup using the `pointer` cursor for disabled items.

### Test Plan

Load up the debugger and verify the CommandBar still looks the way it should. Upon clicking in the right area to make sure it is first in line for tab order, press tab to see the "Pause on next execution" and then Exception buttons highlight.

### Screenshots/Videos

![commandbar](https://cloud.githubusercontent.com/assets/868301/22215268/b4482d44-e168-11e6-91af-d0b673cfbb85.png)

