### PR TITLE
Force LTR for search hint

### DIFF
--- a/src/components/Sources.js
+++ b/src/components/Sources.js
@@ -25,6 +25,7 @@ const Sources = React.createClass({
       return dom.span(
         {
           className: "sources-header-info",
+          dir: "ltr",
           onClick: () => this.props.toggleFileSearch(true)
         },
         L10N.getFormatStr("sources.search",


### PR DESCRIPTION
Associated Issue: #1798 

### Summary of Changes

* Force RTL mode on the search hint

### Test Plan

If I understand correctly this patch needs to be verified by someone who's language is RTL as the issue occurs due to the way non-English RTL works.

Example test plan:

- Open panel with native RTL language and verify the search hint displays without `P` at the start of the string.

### Screenshots/Videos

N/A - English user so my RTL mode doesn't trigger the problem as described.