### PR TITLE
use CSS text-overflow: ellipsis for breakpoint snippet truncate (#1802)

### DIFF
--- a/src/components/SecondaryPanes/Breakpoints.css
+++ b/src/components/SecondaryPanes/Breakpoints.css
@@ -80,7 +80,7 @@ html .breakpoints-list .breakpoint.paused {
   overflow: hidden;
   text-overflow: ellipsis;
   padding-inline-start: 18px;
-  padding-right: 18px;
+  padding-inline-end: 18px;
 }
 
 .breakpoint .close-btn {

--- a/src/components/SecondaryPanes/Breakpoints.css
+++ b/src/components/SecondaryPanes/Breakpoints.css
@@ -77,6 +77,8 @@ html .breakpoints-list .breakpoint.paused {
 }
 
 .breakpoint-snippet {
+  overflow: hidden;
+  text-overflow: ellipsis;
   padding-inline-start: 18px;
 }
 

--- a/src/components/SecondaryPanes/Breakpoints.css
+++ b/src/components/SecondaryPanes/Breakpoints.css
@@ -80,6 +80,7 @@ html .breakpoints-list .breakpoint.paused {
   overflow: hidden;
   text-overflow: ellipsis;
   padding-inline-start: 18px;
+  padding-right: 18px;
 }
 
 .breakpoint .close-btn {

--- a/src/components/SecondaryPanes/Breakpoints.js
+++ b/src/components/SecondaryPanes/Breakpoints.js
@@ -78,7 +78,7 @@ const Breakpoints = React.createClass({
   },
 
   renderBreakpoint(breakpoint) {
-    const snippet = truncateStr(breakpoint.text || "", 30);
+    const snippet = breakpoint.text || "";
     const locationId = breakpoint.locationId;
     const line = breakpoint.location.line;
     const isCurrentlyPaused = breakpoint.isCurrentlyPaused;


### PR DESCRIPTION
Break point snippets are truncated after 30 chars #1802

<img width="1437" alt="trancate_using_css" src="https://cloud.githubusercontent.com/assets/1753718/22219667/57820174-e1b4-11e6-9a80-fca7bf293d7f.png">
