### PR TITLE
Clenaup flow references

### DIFF
--- a/src/actions/breakpoints.js
+++ b/src/actions/breakpoints.js
@@ -17,7 +17,7 @@ const {
 } = require("../utils/source-map");
 
 import type { ThunkArgs } from "./types";
-import type { Location } from "devtools-client-adapters/src/types";
+import type { Location } from "../types";
 
 type addBreakpointOptions = {
   condition: string,

--- a/src/actions/expressions.js
+++ b/src/actions/expressions.js
@@ -5,7 +5,7 @@ const { PROMISE } = require("../utils/redux/middleware/promise");
 
 const { getExpressions, getSelectedFrame } = require("../selectors");
 
-import type { Expression } from "devtools-client-adapters/src/types";
+import type { Expression } from "../types";
 import type { ThunkArgs } from "./types";
 
 type frameIdType = string | null;

--- a/src/actions/pause.js
+++ b/src/actions/pause.js
@@ -7,7 +7,7 @@ const { getPause } = require("../selectors");
 const { updateFrameLocations } = require("../utils/pause");
 const { evaluateExpressions } = require("./expressions");
 
-import type { Pause, Frame, Grip } from "devtools-client-adapters/src/types";
+import type { Pause, Frame, Grip } from "../types";
 import type { ThunkArgs } from "./types";
 
 type CommandType = { type: string };

--- a/src/actions/sources.js
+++ b/src/actions/sources.js
@@ -31,7 +31,7 @@ const {
   getPendingSelectedLocation, getFrames
 } = require("../selectors");
 
-import type { Source } from "devtools-client-adapters/src/types";
+import type { Source } from "../types";
 import type { ThunkArgs } from "./types";
 
 /**

--- a/src/actions/types.js
+++ b/src/actions/types.js
@@ -5,7 +5,7 @@ import type { Source,
               Location,
               SourceText,
               Frame,
-              Why } from "devtools-client-adapters/src/types";
+              Why } from "../types";
 
 /**
  * Flow types

--- a/src/components/SecondaryPanes/Frames.js
+++ b/src/components/SecondaryPanes/Frames.js
@@ -12,7 +12,7 @@ const { getFrames, getSelectedFrame, getSource } = require("../../selectors");
 const classNames = require("classnames");
 
 import type { List } from "immutable";
-import type { Frame, Source } from "devtools-client-adapters/src/types";
+import type { Frame, Source } from "../../types";
 
 if (typeof window == "object") {
   require("./Frames.css");

--- a/src/reducers/breakpoints.js
+++ b/src/reducers/breakpoints.js
@@ -13,7 +13,7 @@ const { updateObj } = require("../utils/utils");
 const I = require("immutable");
 const makeRecord = require("../utils/makeRecord");
 
-import type { Breakpoint, Location } from "devtools-client-adapters/src/types";
+import type { Breakpoint, Location } from "../types";
 import type { Action } from "../actions/types";
 import type { Record } from "../utils/makeRecord";
 

--- a/src/reducers/expressions.js
+++ b/src/reducers/expressions.js
@@ -2,7 +2,7 @@ const constants = require("../constants");
 const makeRecord = require("../utils/makeRecord");
 const I = require("immutable");
 
-import type { Expression } from "devtools-client-adapters/src/types";
+import type { Expression } from "../types";
 import type { Action } from "../actions/types";
 import type { Record } from "../utils/makeRecord";
 

--- a/src/reducers/pause.js
+++ b/src/reducers/pause.js
@@ -10,7 +10,7 @@ const { prefs } = require("../utils/prefs");
 const I = require("immutable");
 
 import type { Frame, Pause,
-  Expression } from "devtools-client-adapters/src/types";
+  Expression } from "../types";
 import type { Action } from "../actions/types";
 import type { Record } from "../utils/makeRecord";
 

--- a/src/reducers/sources.js
+++ b/src/reducers/sources.js
@@ -13,7 +13,7 @@ const makeRecord = require("../utils/makeRecord");
 const { getPrettySourceURL } = require("../utils/source");
 const { prefs } = require("../utils/prefs");
 
-import type { Source, Location } from "devtools-client-adapters/src/types";
+import type { Source, Location } from "../types";
 import type { Action } from "../actions/types";
 import type { Record } from "../utils/makeRecord";
 

--- a/src/types.js
+++ b/src/types.js
@@ -1,0 +1,13 @@
+// @flow
+
+export type {
+  Breakpoint,
+  Expression,
+  Frame,
+  Grip,
+  Location,
+  Source,
+  SourceText,
+  Pause,
+  Why
+} from "devtools-client-adapters/src/types";

--- a/src/utils/pause.js
+++ b/src/utils/pause.js
@@ -3,7 +3,7 @@ const { Frame } = require("../tcomb-types");
 const { getOriginalLocation } = require("./source-map");
 
 import type { Pause,
-  Frame as FrameType } from "devtools-client-adapters/src/types";
+  Frame as FrameType } from "../types";
 
 function updateFrameLocations(frames: FrameType[]): Promise<FrameType[]> {
   if (!frames) {

--- a/src/utils/source-map-worker.js
+++ b/src/utils/source-map-worker.js
@@ -18,7 +18,7 @@ const {
   isOriginalId
 } = require("./source-map-util");
 
-import type { Location, Source } from "devtools-client-adapters/src/types";
+import type { Location, Source } from "../types";
 type Message = {
   data: {
     id: string,

--- a/src/utils/source.js
+++ b/src/utils/source.js
@@ -8,7 +8,7 @@
 const { endTruncateStr } = require("./utils");
 const { basename } = require("../utils/path");
 
-import type { Source, SourceText } from "devtools-client-adapters/src/types";
+import type { Source, SourceText } from "../types";
 
 /**
  * Trims the query part or reference identifier of a url string, if necessary.


### PR DESCRIPTION
#979 

This helps clean up our flow type references so that you don't need to know about devtools-client-adapters. Lots of things can be exported from `types.js`

CC @arthur801031, @clarkbw 