### PR TITLE
Support Cmd+O to open search.

### DIFF
--- a/assets/locales/debugger.properties
+++ b/assets/locales/debugger.properties
@@ -116,6 +116,10 @@ blackBoxCheckboxTooltip=Toggle black boxing
 # searching all the source files the debugger has seen.
 sources.search.key=P
 
+# LOCALIZATION NOTE (sources.search.key2): Alternative key shortcut to open the
+# search for searching all the source files the debugger has seen.
+sources.search.key2=O
+
 # LOCALIZATION NOTE (sourceSearch.search.key): Key shortcut to open the search
 # for searching within a the currently opened files in the editor
 sourceSearch.search.key=F

--- a/src/components/SourceSearch.js
+++ b/src/components/SourceSearch.js
@@ -59,12 +59,17 @@ const Search = React.createClass({
     const shortcuts = this.context.shortcuts;
     shortcuts.off(`CmdOrCtrl+${L10N.getStr("sources.search.key")}`,
       this.toggle);
+    shortcuts.off(`CmdOrCtrl+${L10N.getStr("sources.search.key2")}`,
+      this.toggle);
     shortcuts.off("Escape", this.onEscape);
   },
 
   componentDidMount() {
     const shortcuts = this.context.shortcuts;
-    shortcuts.on(`CmdOrCtrl+${L10N.getStr("sources.search.key")}`, this.toggle);
+    shortcuts.on(`CmdOrCtrl+${L10N.getStr("sources.search.key")}`,
+      this.toggle);
+    shortcuts.on(`CmdOrCtrl+${L10N.getStr("sources.search.key2")}`,
+      this.toggle);
     shortcuts.on("Escape", this.onEscape);
   },
 

--- a/src/strings.json
+++ b/src/strings.json
@@ -29,6 +29,7 @@
   "sources.header": "Sources",
   "sources.search": "%S to search",
   "sources.search.key": "P",
+  "sources.search.key2": "O",
   "watchExpressions.header": "Watch Expressions",
   "watchExpressions.refreshButton": "Refresh",
   "welcome.search1": "%S to search for sources",


### PR DESCRIPTION
Implements #1756, so that Cmd+O can be used in the same way as Cmd+P.