### PR TITLE
fixed the close button alignment with the open tabs by changing flexb…

### DIFF
--- a/src/components/Editor/Tabs.css
+++ b/src/components/Editor/Tabs.css
@@ -5,7 +5,7 @@
   flex: 1;
   flex-flow: row wrap;
   -webkit-align-items: stretch;
-  align-items: stretch;
+  align-items: center;
 }
 
 .source-header * {


### PR DESCRIPTION
…ox property of the parent container

Associated Issue: #<issue number>

### Summary of Changes

* Adjusted tab alignments by changing flexbox property of their parent container

### Test Plan

Look at the style, it's centered.