### PR TITLE
Removed fill for .close-btn-bigpath to make close button less dark.

### DIFF
--- a/src/components/shared/Button/Close.css
+++ b/src/components/shared/Button/Close.css
@@ -33,7 +33,6 @@
 }
 
 .close-btn-big path {
-  fill: var(--theme-body-color);
 }
 
 .close-btn-big .close {


### PR DESCRIPTION
Associated Issue: #1807

### Summary of Changes

*Removed fill for '.close-btn-big path' making the icon less darker.

### Test Plan

Inspected button using dev tools - modified the fill color of '.close-btn-big' and found that the fill was not required in order to match the other icons.

Example test plan:

- [x] Command-Shift I to open dev tools
- [x] Used inspector and picked the X
- [x] Changed fill color in this element for .close-btn-big
- [x] In order to match other icons color, fill was removed
![screen shot 2017-01-23 at 8 26 47 pm](https://cloud.githubusercontent.com/assets/11824162/22234106/5075eada-e1aa-11e6-8d6a-6e0c0ae9e3ed.png)


Here's the Debugger's Testing doc
https://docs.google.com/document/d/1oBMRxV8A2ag2t22YsQOxTdEv0mXKzIg0tggJjRkU1S0/edit#.
Feel free to improve it!

### Screenshots/Videos (OPTIONAL)
![screen shot 2017-01-23 at 8 26 47 pm](https://cloud.githubusercontent.com/assets/11824162/22234117/5ca16528-e1aa-11e6-91c6-d12073656d9b.png)


