### PR TITLE
Conditionally hide watch expressions label

### DIFF
--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -156,7 +156,6 @@ const Editor = React.createClass({
 
     const watchExpressionLabel = {
       accesskey: "E",
-      disabled: !this.editor.codeMirror.somethingSelected(),
       label: L10N.getStr("expressions.placeholder"),
       click: () => this.props.addExpression({
         input: this.editor.codeMirror.getSelection()
@@ -169,7 +168,8 @@ const Editor = React.createClass({
       menuOptions.push(jumpLabel);
     }
 
-    if (isEnabled("watchExpressions")) {
+    var textSelected = this.editor.codeMirror.somethingSelected()
+    if (isEnabled("watchExpressions") && textSelected) {
       menuOptions.push(watchExpressionLabel);
     }
 

--- a/src/components/shared/menu.js
+++ b/src/components/shared/menu.js
@@ -60,6 +60,10 @@ function onShown(menu, popup) {
 }
 
 function showMenu(e, items) {
+  if (items.length === 0) {
+    return;
+  }
+
   const menu = new Menu();
   items.forEach(item => menu.append(new MenuItem(item)));
 
@@ -68,7 +72,7 @@ function showMenu(e, items) {
   }
 
   menu.on("open", (_, popup) => onShown(menu, popup));
-  return menu.popup(e.clientX, e.clientY, { doc: document });
+  menu.popup(e.clientX, e.clientY, { doc: document });
 }
 
 function buildMenu(items) {


### PR DESCRIPTION
Fix issue #1789:

- Hide Watch Expressions menu item if no text is selected
- Don't show empty context menus

I removed the `return` statement from `return menu.popup`, as it suggests the `popup` function returns a meaningful value, when in fact it just returns `undefined`.