### PR TITLE
Tweak styles of watch expression pane

### DIFF
--- a/assets/images/refresh.svg
+++ b/assets/images/refresh.svg
@@ -1,7 +1,7 @@
 <!-- This Source Code Form is subject to the terms of the Mozilla Public
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
-<svg width="16" height="16" xmlns="http://www.w3.org/2000/svg">
+<svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
     <path d="M13.917 7C13.44 4.162 10.973 2 8 2 4.686 2 2 4.686 2 8s2.686 6 6 6c2.22 0 4.16-1.207 5.197-3H12c-.912 1.214-2.364 2-4 2-2.76 0-5-2.24-5-5s2.24-5 5-5c2.42 0 4.437 1.718 4.9 4h1.017z"/>
     <path d="M14 1L8 7h6V1zm-1 1L9 6h4V2z" fill-rule="evenodd"/>
 </svg>

--- a/src/components/SecondaryPanes/Expressions.css
+++ b/src/components/SecondaryPanes/Expressions.css
@@ -15,6 +15,13 @@
   color: var(--theme-body-color);
 }
 
+.input-expression::-moz-placeholder {
+  text-align: center;
+  font-style: italic;
+  color: var(--theme-body-color);
+  opacity: 1;
+}
+
 .input-expression:focus {
   outline-color: var(--theme-selection-background-semitransparent);
   outline-width: 2px;

--- a/src/components/SecondaryPanes/Expressions.css
+++ b/src/components/SecondaryPanes/Expressions.css
@@ -15,7 +15,7 @@
   color: var(--theme-body-color-inactive);
 }
 
-.input-expression::-moz-placeholder {
+.input-expression::placeholder {
   text-align: center;
   font-style: italic;
   color: var(--theme-body-color-inactive);

--- a/src/components/SecondaryPanes/Expressions.css
+++ b/src/components/SecondaryPanes/Expressions.css
@@ -23,7 +23,7 @@
 }
 
 .input-expression:focus {
-  outline: 2px solid var(--theme-selection-background-semitransparent);
+  outline: none;
   cursor: text;
 }
 

--- a/src/components/SecondaryPanes/Expressions.css
+++ b/src/components/SecondaryPanes/Expressions.css
@@ -28,8 +28,7 @@
 }
 
 .input-expression:focus {
-  outline-color: var(--theme-selection-background-semitransparent);
-  outline-width: 2px;
+  outline: 2px solid var(--theme-selection-background-semitransparent);
   cursor: text;
 }
 

--- a/src/components/SecondaryPanes/Expressions.css
+++ b/src/components/SecondaryPanes/Expressions.css
@@ -7,6 +7,11 @@
   color: var(--theme-body-color);
   background-color: var(--theme-body-background);
   font-size: 12px;
+  transition: all 0.5s ease;
+}
+
+.input-expression:hover {
+  background-color: var(--theme-selection-background-semitransparent);
 }
 
 .input-expression::-webkit-input-placeholder {

--- a/src/components/SecondaryPanes/Expressions.css
+++ b/src/components/SecondaryPanes/Expressions.css
@@ -12,13 +12,13 @@
 .input-expression::-webkit-input-placeholder {
   text-align: center;
   font-style: italic;
-  color: var(--theme-body-color);
+  color: var(--theme-body-color-inactive);
 }
 
 .input-expression::-moz-placeholder {
   text-align: center;
   font-style: italic;
-  color: var(--theme-body-color);
+  color: var(--theme-body-color-inactive);
   opacity: 1;
 }
 

--- a/src/components/SecondaryPanes/Expressions.css
+++ b/src/components/SecondaryPanes/Expressions.css
@@ -6,12 +6,13 @@
   cursor: pointer;
   color: var(--theme-body-color);
   background-color: var(--theme-body-background);
-  line-height: 12px;
+  font-size: 12px;
 }
 
 .input-expression::-webkit-input-placeholder {
   text-align: center;
   font-style: italic;
+  color: var(--theme-body-color);
 }
 
 .input-expression:focus {

--- a/src/components/SecondaryPanes/Expressions.css
+++ b/src/components/SecondaryPanes/Expressions.css
@@ -7,11 +7,6 @@
   color: var(--theme-body-color);
   background-color: var(--theme-body-background);
   font-size: 12px;
-  transition: all 0.5s ease;
-}
-
-.input-expression:hover {
-  background-color: var(--theme-selection-background-semitransparent);
 }
 
 .input-expression::-webkit-input-placeholder {


### PR DESCRIPTION
Styling of watch expression pane was not consistent with others in secondary pane. These are few changes to correct that.

### Summary of Changes

* Add viewbox attribute for `refresh.svg`
* Change color of placeholder for chrome and firefox
* Change font-size of `input-expression`

### Screenshots

|-|Firefox|Chrome|
|-|-|-|
|Before changes|![before-change-firefox](https://cloud.githubusercontent.com/assets/1755089/22258132/695e3408-e286-11e6-9742-11dd80e03d1b.png)|![before-change-chrome](https://cloud.githubusercontent.com/assets/1755089/22258140/74062910-e286-11e6-95fb-d95fc11f2b94.png)|
|After changes|![after-change-firefox](https://cloud.githubusercontent.com/assets/1755089/22258165/8feceef2-e286-11e6-95c5-47ee91589d42.png)|![after-change-chrome](https://cloud.githubusercontent.com/assets/1755089/22258184/9bd62dc8-e286-11e6-8438-bde0397064d3.png)|


Also when hovering over refresh button cursor is not pointer. 
I was not sure which file to edit for this change. Let me know if I missed something. 