### PR TITLE
SourceTabs: render tabs without selected tab

### DIFF
--- a/src/components/Editor/Tabs.js
+++ b/src/components/Editor/Tabs.js
@@ -249,7 +249,7 @@ const SourceTabs = React.createClass({
   renderTab(source) {
     const { selectedSource, selectSource, closeTab } = this.props;
     const filename = getFilename(source.toJS());
-    const active = source.get("id") == selectedSource.get("id");
+    const active = selectedSource && source.get("id") == selectedSource.get("id");
     const isPrettyCode = isPretty({ url: source.get("url") });
 
     function onClickClose(ev) {

--- a/src/reducers/sources.js
+++ b/src/reducers/sources.js
@@ -279,11 +279,6 @@ function getSourceText(state: OuterState, id: string) {
 }
 
 function getSourceTabs(state: OuterState) {
-  const selectedLocation = getSelectedLocation(state);
-  if (!selectedLocation) {
-    return new I.List([]);
-  }
-
   return state.sources.tabs
     .filter(tab => getSourceByURL(state, tab));
 }


### PR DESCRIPTION
Associated Issue: #1705 
### Summary of Changes

* Return list of source tabs even when no tab is selected
* If no tab is selected, select the first tab.

Question: Should we persist the selected tab for the user so that the application brings the user back to the same tab? @jasonLaster @clarkbw 

### Test Plan

Tell us a little a bit about how you tested your patch.

### Screenshots/Videos (OPTIONAL)
![](http://g.recordit.co/jVQy8X9NKe.gif)