### PR TITLE
fixed pane toggle button direction

### DIFF
--- a/src/components/shared/Button/PaneToggle.css
+++ b/src/components/shared/Button/PaneToggle.css
@@ -18,8 +18,8 @@ html[dir="rtl"] .toggle-button-start svg {
   transform: rotate(180deg);
 }
 
-.toggle-button-end.vertical svg {
-  transform: rotate(-90deg) !important;
+html .toggle-button-end.vertical svg {
+  transform: rotate(-90deg);
 }
 
 .toggle-button-start {

--- a/src/components/shared/Button/PaneToggle.css
+++ b/src/components/shared/Button/PaneToggle.css
@@ -19,7 +19,7 @@ html[dir="rtl"] .toggle-button-start svg {
 }
 
 .toggle-button-end.vertical svg {
-  transform: rotate(-90deg);
+  transform: rotate(-90deg) !important;
 }
 
 .toggle-button-start {


### PR DESCRIPTION
Associated Issue: #1834

added !important to explicitly state that the rule should be applied in vertical mode.