### PR TITLE
Add docs on issues

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,7 @@ We respect your time and want to help you make the most of it as you learn more 
   * [Writing Code](#writing-code-computer)
     * [Your First Code Contribution](#your-first-code-contribution)
     * [Coding Standards](#coding-standards)
+    * [Issues](#issues)
     * [Pull Requests](#pull-requests)
     * [Local Development](#local-development-computer)
   * [Issues and Pull Request labels](#issues-and-pull-requests)
@@ -67,10 +68,6 @@ We have a number of tools to help you with your code contributions, the followin
 
 If you've contributed to an open source project before and would like to help this one please take a look through the `up for grabs` issues:
 
-* [up for grabs][labels-up-for-grabs] - issues should have clear requirements and a difficulty level set as a label
-
-If you find an `up for grabs` issue without a difficulty level set as a label or unclear requirements please comment in the issue so we can get that fixed.
-
 #### Your First Code Contribution
 
 If you're looking for a good issue, you can look through the `up-for-grabs` issues. These issues should be actionable and well documented.
@@ -100,15 +97,14 @@ Here are pointers to the DevTools general coding style and formatting guidelines
 
 #### Issues
 
-We use issues and milestones for planning purposes as well as tracking bugs.
-
-**Keep Issues Relevant**
-
-We try to keep the number of open issues to a minimum.  If work isn't going to be done in a timely manner we would rather close the issue than let them go stale.  Closed issues can always be reopened again when we are ready to start the work.  This process helps keep the focus of the project more understandable to others.
-
-**Intent to implement**
-
-When a person is assigned to an issue this indicates an _intent to implement_.  Please ask within the issue if you would like to work on a fix so multiple people don't create pull requests for it.
+* [Issue Titles](./docs/issuess.md#issue-titles)
+* [Issue Descriptions](./docs/issuess.md#issue-descriptions)
+* [Claiming Issues](./docs/issuess.md#claiming-issues)
+* [Labels](./docs/issuess.md#labels)
+* [Up For Grab Issues](./docs/issuess.md#up-for-grab-issues)
+* [Triaging](./docs/issuess.md#triaging)
+* [Issue Organization](./docs/issuess.md#issue-organization)
+* [Community Friendly](./docs/issuess.md#community-friendly)
 
 #### Pull Requests
 
@@ -136,39 +132,6 @@ Go to [local Development](./docs/local-development.md) to learn about:
 * [Testing](./docs/local-development.md#testing)
 * [Linting](./docs/local-development.md#linting)
 
-
-## Issues and Pull Request labels
-
-These are the [labels](https://github.com/devtools-html/debugger.html/labels) we use to help organize and communicate the state of issues and pull requests in the project.  If you find a label being used that isn't described here please file an issue to get it listed.
-
-| Label name | query:mag_right: | Description |
-| --- | --- | --- |
-| `up-for-grabs` | [search][labels-up-for-grabs] | Good for contributors to work on |
-| `difficulty:easy` | [search][labels-difficulty-easy] | Work that is small changes, updating tests, updating docs, expect very little review |
-| `difficulty:medium` | [search][labels-difficulty-medium] | Work that adapts existing code, adapts existing tests, expect quick review |
-| `difficulty:hard` | [search][labels-difficulty-hard] | Work that requires new tests, new code, and a good understanding of project; expect lots of review |
-| `docs` | [search][labels-docs] | Issues with our documentation |
-| `design` | [search][labels-design] | Issues that require design work |
-| `enhancement` | [search][labels-enhancement] | [Requests](#suggesting-enhancements-new) for features |
-| `bug` | [search][labels-bug] | [Reported Bugs](#reporting-bugs-bug) with the current code |
-| `chrome` | [search][labels-chrome] | Chrome only issues |
-| `firefox` | [search][labels-firefox] | Firefox only issues |
-| `infrastructure` | [search][labels-infrastructure] | Issues with testing / build infrastructure |
-| `not actionable` | [search][labels-not-actionable] | Issues need clearer requirements before work can be started |
-
-[labels-up-for-grabs]:https://github.com/devtools-html/debugger.html/labels/up%20for%20grabs
-[labels-first-timers-only]:https://github.com/devtools-html/debugger.html/labels/first-timers-only
-[labels-difficulty-easy]:https://github.com/devtools-html/debugger.html/labels/difficulty%3A%20easy
-[labels-difficulty-medium]:https://github.com/devtools-html/debugger.html/labels/difficulty%3A%medium
-[labels-difficulty-hard]:https://github.com/devtools-html/debugger.html/labels/difficulty%3A%hard
-[labels-docs]:https://github.com/devtools-html/debugger.html/labels/docs
-[labels-design]:https://github.com/devtools-html/debugger.html/labels/design
-[labels-enhancement]:https://github.com/devtools-html/debugger.html/labels/enhancement
-[labels-bug]:https://github.com/devtools-html/debugger.html/labels/bug
-[labels-chrome]:https://github.com/devtools-html/debugger.html/labels/chrome
-[labels-firefox]:https://github.com/devtools-html/debugger.html/labels/firefox
-[labels-infrastructure]:https://github.com/devtools-html/debugger.html/labels/infrastructure
-[labels-not-actionable]:https://github.com/devtools-html/debugger.html/labels/not%20actionable
 
 [GitHub Desktop]:https://desktop.github.com/
 

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -112,7 +112,7 @@ These are the [labels](https://github.com/devtools-html/debugger.html/labels) we
 | `chrome` | [search][labels-chrome] | Chrome only issues |
 | `firefox` | [search][labels-firefox] | Firefox only issues |
 | `infrastructure` | [search][labels-infrastructure] | Issues with testing / build infrastructure |
-| `not actionable` | [search][labels-not-actionable] | Issues need clearer requirements before work can be started |
+| `discussion` | [search][labels-discussion] | Issues need clearer requirements before work can be started |
 
 [labels-up-for-grabs]:https://github.com/devtools-html/debugger.html/labels/up%20for%20grabs
 [labels-first-timers-only]:https://github.com/devtools-html/debugger.html/labels/first-timers-only
@@ -126,7 +126,7 @@ These are the [labels](https://github.com/devtools-html/debugger.html/labels) we
 [labels-chrome]:https://github.com/devtools-html/debugger.html/labels/chrome
 [labels-firefox]:https://github.com/devtools-html/debugger.html/labels/firefox
 [labels-infrastructure]:https://github.com/devtools-html/debugger.html/labels/infrastructure
-[labels-not-actionable]:https://github.com/devtools-html/debugger.html/labels/not%20actionable
+[labels-discussion]:https://github.com/devtools-html/debugger.html/labels/discussion
 
 ### Up For Grab Issues
 

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -1,0 +1,167 @@
+## Issues
+
+* [Issue Titles](#issue-titles)
+* [Issue Descriptions](#issue-descriptions)
+* [Claiming Issues](#claiming-issues)
+* [Labels](#labels)
+* [Up For Grab Issues](#up-for-grab-issues)
+* [Triaging](#triaging)
+* [Issue Organization](#issue-organization)
+* [Community Friendly](#community-friendly)
+
+### Issue Titles
+
+**Components**
+
+Issues are organized in terms of components.
+Issue titles should include a component at the front e.g. `[Editor]`
+
+|Editor|SecondaryPanes|UI|Other|
+|----------|------|-----|----|
+|Editor|CommandBar|SourceTree|Accessibility|
+|SourceTabs|WatchExpressions|SourcesSearch|Theme|
+|SearchBar|Breakpoints|WelcomePane|Reducer|
+|SourceFooter|CallStack||Action|
+||Scopes|||RTL|
+
+**User Perspective**
+
+The best issue titles are framed in terms of the impact on the user. i.e.
+
+* [Editor] search skips odd matches
+* [WatchExpressions] can't remove an expression after it's been edited
+
+Things to try and avoid in the title
+* implementation details where possible. Refactoring is an exception where it's okay
+* vague language like e.g "debugger crashes", "can't install"
+* inflammatory language "Search is terrible". Negative language has two effects, it can make someone feel guilty for breaking something. It can guilt trip someone into feeling like they *have* to fix it now.
+
+
+### Issue Descriptions
+
+**Steps to Reproduce** *STR*
+
+Include the steps to reproduce what you found.
+
+**System Details**
+
+Often it is nice to know, which browser you were using, version of node, platform (windows, linux). You don't need to go over the top though, for instance if you're filing a UI bug then it doesn't matter which version of node you're using.
+
+**Screenshots**
+
+Include screenshots and animated GIFs in your pull request whenever possible.
+
+**Recording GIFs** There are many great tools for recording a GIF. On a mac, we recommend [recordit](http://recordit.co/), which is a free lightweight app.
+
+<details>
+<summary>
+  GIF Example
+</summary>
+
+![](http://g.recordit.co/6dE0EmM29Z.gif)
+
+```
+![](http://g.recordit.co/6dE0EmM29Z.gif)
+```
+
+</details>
+
+**Tables**: When there are multiple screenshots, such as a style change that affects different themes or rtl, it can be nice to use a table for the screenshots [docs][github-tables]
+
+<details>
+<summary>
+  Table Example
+</summary>
+
+|Firebug|Light|
+|----------|------|
+|![firebug](https://cloud.githubusercontent.com/assets/1755089/22209733/94970458-e1ad-11e6-83d4-8b082217b989.png)|![light](https://cloud.githubusercontent.com/assets/1755089/22209736/9b194f2a-e1ad-11e6-9de0-561dd529d5f0.png)|
+
+
+```
+|Firebug|Light|
+|----------|------|
+|![firebug](https://cloud.githubusercontent.com/assets/1755089/22209733/94970458-e1ad-11e6-83d4-8b082217b989.png)|![light](https://cloud.githubusercontent.com/assets/1755089/22209736/9b194f2a-e1ad-11e6-9de0-561dd529d5f0.png)|
+```
+
+</details>
+
+### Claiming Issues
+
+If you'd like to work on an issue, comment on the issue and we'll mark it `in-progress`.
+
+* We'll check up regularly to see how it's progressing and if we can help
+* Don't hesitate to ask questions on the issue or in our slack channel. Communication is the most important part. Don't worry about over communicating!
+* Don't feel bad taking yourself off the issue if you no longer have the time or interest in the issue.
+
+### Labels
+
+
+These are the [labels](https://github.com/devtools-html/debugger.html/labels) we use to help organize and communicate the state of issues and pull requests in the project.  If you find a label being used that isn't described here please file an issue to get it listed.
+
+| Label name | query:mag_right: | Description |
+| --- | --- | --- |
+| `up-for-grabs` | [search][labels-up-for-grabs] | Good for contributors to work on |
+| `difficulty:easy` | [search][labels-difficulty-easy] | Work that is small changes, updating tests, updating docs, expect very little review |
+| `difficulty:medium` | [search][labels-difficulty-medium] | Work that adapts existing code, adapts existing tests, expect quick review |
+| `difficulty:hard` | [search][labels-difficulty-hard] | Work that requires new tests, new code, and a good understanding of project; expect lots of review |
+| `docs` | [search][labels-docs] | Issues with our documentation |
+| `design` | [search][labels-design] | Issues that require design work |
+| `enhancement` | [search][labels-enhancement] | [Requests](#suggesting-enhancements-new) for features |
+| `bug` | [search][labels-bug] | [Reported Bugs](#reporting-bugs-bug) with the current code |
+| `chrome` | [search][labels-chrome] | Chrome only issues |
+| `firefox` | [search][labels-firefox] | Firefox only issues |
+| `infrastructure` | [search][labels-infrastructure] | Issues with testing / build infrastructure |
+| `not actionable` | [search][labels-not-actionable] | Issues need clearer requirements before work can be started |
+
+[labels-up-for-grabs]:https://github.com/devtools-html/debugger.html/labels/up%20for%20grabs
+[labels-first-timers-only]:https://github.com/devtools-html/debugger.html/labels/first-timers-only
+[labels-difficulty-easy]:https://github.com/devtools-html/debugger.html/labels/difficulty%3A%20easy
+[labels-difficulty-medium]:https://github.com/devtools-html/debugger.html/labels/difficulty%3A%medium
+[labels-difficulty-hard]:https://github.com/devtools-html/debugger.html/labels/difficulty%3A%hard
+[labels-docs]:https://github.com/devtools-html/debugger.html/labels/docs
+[labels-design]:https://github.com/devtools-html/debugger.html/labels/design
+[labels-enhancement]:https://github.com/devtools-html/debugger.html/labels/enhancement
+[labels-bug]:https://github.com/devtools-html/debugger.html/labels/bug
+[labels-chrome]:https://github.com/devtools-html/debugger.html/labels/chrome
+[labels-firefox]:https://github.com/devtools-html/debugger.html/labels/firefox
+[labels-infrastructure]:https://github.com/devtools-html/debugger.html/labels/infrastructure
+[labels-not-actionable]:https://github.com/devtools-html/debugger.html/labels/not%20actionable
+
+### Up For Grab Issues
+
+[up for grabs][labels-up-for-grabs] issues have clear requirements and a difficulty level.
+
+They often have a patch, which should be a good starting off point.
+Sometimes the patches are enough to fix the bug!
+
+One reason we file up for grabs issues when the solution is somewhat simple is that it's great to get a second
+set of eyes. Running the fix locally and QAing it thoroughly is a huge help. A lot of times you'll discover things that we missed.
+
+### Triaging
+
+Triaging is the act of reviewing the open issues and making sure they're up to date.
+It's one of the most helpful ways to help a project.
+
+There are a couple of ways to think about it:
+* it's great to be able to close issues that are done or stale
+* it's great to make issue descriptions as clear as possible. Our goal is for every issue to be *actionable* i.e. it's clear what needs to be done.
+* it's really helpful to double check a new bug and see if you can reproduce it.
+* it's great to ask questions that help make the issue actionable or call out vague issues.
+* it's great to sort the issues by oldest first and help make stale issues actionable.
+
+### Issue Organization
+
+In addition to labels and components, we use a couple of boards to organize our work.
+
+**Features** [features](https://github.com/devtools-html/debugger.html/projects/10) are tracked in our features board.
+
+**Bugs** [bugs](https://github.com/devtools-html/debugger.html/projects/11) are prioritized in our bugs board.
+
+### Community Friendly
+
+We focus on being community friendly for many reasons.
+
+* There's an educational value in having a large community of engineers who understand DevTools.
+* There's an incredible diversity of talent to help us with topics ranging from testing to internationalization.
+* Focusing on *contributor experience* helps us build the best development environment. For instance, if you find it's hard to describe how to make an accessibility change, maybe we should improve how we support tab navigation.

--- a/docs/pull-requests.md
+++ b/docs/pull-requests.md
@@ -71,7 +71,6 @@ We use [husky](https://github.com/typicode/husky) to check the PR before it is p
 
 Here are docs on [tests][test-docs] and [linting][linting-docs], which you can run locally.
 
-
 The integration tests will be run automatically by the CI. Our integration tests are run with [mochitest][mochitest]. The local setup process is documented [here][mochitest-docs], but the process is a bit cumbersome, so reviewers will generally help debug.
 
 #### Reviews


### PR DESCRIPTION
Docs on issues. Turned out that writing about pull requests prompted more writing on issues. 

My main goal here is that we can encourage good practices in the community and help teach. Having these points in the docs will let us point to them. It will also be a baseline we can improve over time.

CC @clarkbw, @TheLarkInn