### PR TITLE
Cleaned up pretty print button and other footer actions

### DIFF
--- a/src/components/Editor/Footer.css
+++ b/src/components/Editor/Footer.css
@@ -50,8 +50,8 @@
 }
 
 .source-footer > .commands > .action svg {
-  height: 1em;
-  width: 1em;
+  height: 16px;
+  width: 16px;
 }
 
 .source-footer .commands .coverage {

--- a/src/components/Editor/Footer.css
+++ b/src/components/Editor/Footer.css
@@ -10,11 +10,12 @@
   z-index: 100;
   -moz-user-select: none;
   user-select: none;
+  height: 30px;
+  box-sizing: border-box;
 }
 
 .source-footer .commands {
   display: flex;
-  padding: 8px 0.7em;
 }
 
 .source-footer .commands * {
@@ -30,6 +31,14 @@
   transition: opacity 200ms;
   border: none;
   background: transparent;
+  padding: 8px 0.7em;
+}
+
+.source-footer > .commands > .action i {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
 }
 
 :root.theme-dark .source-footer > .commands > .action {

--- a/src/components/Editor/Footer.js
+++ b/src/components/Editor/Footer.js
@@ -17,14 +17,6 @@ const PaneToggleButton = React.createFactory(
 
 require("./Footer.css");
 
-function debugBtn(onClick, type, className = "active", tooltip) {
-  className = `${type} ${className} action`;
-  return dom.button(
-    { onClick, className, key: type },
-    Svg(type, { title: tooltip, "aria-label": tooltip })
-  );
-}
-
 const SourceFooter = React.createClass({
   propTypes: {
     selectedSource: ImPropTypes.map,
@@ -54,14 +46,20 @@ const SourceFooter = React.createClass({
       return;
     }
 
-    return debugBtn(
-      this.onClickPrettyPrint,
-      "prettyPrint",
-      classnames({
-        active: sourceLoaded,
-        pretty: isPretty(selectedSource.toJS())
-      }),
-      L10N.getStr("sourceFooter.debugBtnTooltip")
+    const tooltip = L10N.getStr("sourceFooter.debugBtnTooltip");
+    const type = "prettyPrint";
+
+    return dom.button({
+        onClick: this.onClickPrettyPrint,
+        className: classnames('action', type, {
+            active: sourceLoaded,
+            pretty: isPretty(selectedSource.toJS())
+        }),
+        key: type,
+        title: tooltip,
+        "aria-label": tooltip
+    },
+      Svg(type)
     );
   },
 
@@ -72,11 +70,18 @@ const SourceFooter = React.createClass({
       return;
     }
 
+    const type = "coverage";
+    const className = classnames({
+      action: true,
+      type,
+    });
+
     return dom.button({
-      className: "coverage",
+      className,
       title: "Code Coverage",
-      onClick: () => recordCoverage()
-    }, "C");
+      onClick: () => recordCoverage(),
+      "aria-label": "Code Coverage"
+  }, "C");
   },
 
   renderToggleButton() {

--- a/src/components/Editor/Footer.js
+++ b/src/components/Editor/Footer.js
@@ -50,14 +50,14 @@ const SourceFooter = React.createClass({
     const type = "prettyPrint";
 
     return dom.button({
-        onClick: this.onClickPrettyPrint,
-        className: classnames('action', type, {
-            active: sourceLoaded,
-            pretty: isPretty(selectedSource.toJS())
-        }),
-        key: type,
-        title: tooltip,
-        "aria-label": tooltip
+      onClick: this.onClickPrettyPrint,
+      className: classnames("action", type, {
+        active: sourceLoaded,
+        pretty: isPretty(selectedSource.toJS())
+      }),
+      key: type,
+      title: tooltip,
+      "aria-label": tooltip
     },
       Svg(type)
     );
@@ -70,18 +70,12 @@ const SourceFooter = React.createClass({
       return;
     }
 
-    const type = "coverage";
-    const className = classnames({
-      action: true,
-      type,
-    });
-
     return dom.button({
-      className,
+      className: "coverage action",
       title: "Code Coverage",
       onClick: () => recordCoverage(),
       "aria-label": "Code Coverage"
-  }, "C");
+    }, "C");
   },
 
   renderToggleButton() {


### PR DESCRIPTION
Associated Issue: #1837

### Summary of Changes

* Fixed commands height for footer.
* Center aligned the inlined svg contents
* Moved padding into actions from the command bar itself on the bottom to give more touch area
* Moved a11y attributes onto parent button from the SVG for more surface area to trigger.
* Added aria-label while I was here for the code coverage button
* Removed `debugbtn` method used only once for the footer.

### Test Plan

Boot up debugger and check out the pretty print button. Functions the same as the CommandBar does now.

Example test plan:

- Hover pretty print button area to see the title shows for the full surface area instead of just over the icon.
- See icon is centered and not oddly placed higher than the center of the line.

### Screenshots/Videos

![selection_027](https://cloud.githubusercontent.com/assets/868301/22302409/b6471246-e2fc-11e6-855f-dedd615fb66c.png)

