### PR TITLE
Add search modifiers to utils

### DIFF
--- a/src/components/Editor/SearchBar.js
+++ b/src/components/Editor/SearchBar.js
@@ -13,6 +13,12 @@ const ImPropTypes = require("react-immutable-proptypes");
 
 require("./SearchBar.css");
 
+const defaultModifiers = {
+  caseSensitive: true,
+  wholeWord: false,
+  regexMatch: false
+};
+
 function countMatches(query, text) {
   const re = new RegExp(escapeRegExp(query), "g");
   const match = text.match(re);
@@ -166,7 +172,7 @@ const SearchBar = React.createClass({
       this.setState({ enabled: true });
     }
 
-    findPrev(ctx, query);
+    findPrev(ctx, query, false, defaultModifiers);
     const nextIndex = index == 0 ? count - 1 : index - 1;
     this.setState({ index: nextIndex });
   },
@@ -188,7 +194,7 @@ const SearchBar = React.createClass({
       this.setState({ enabled: true });
     }
 
-    findNext(ctx, query);
+    findNext(ctx, query, false, defaultModifiers);
     const nextIndex = index == count - 1 ? 0 : index + 1;
     this.setState({ index: nextIndex });
   },
@@ -215,7 +221,7 @@ const SearchBar = React.createClass({
     const ed = this.props.editor;
     const ctx = { ed, cm: ed.codeMirror };
 
-    find(ctx, query);
+    find(ctx, query, false, defaultModifiers);
   }, 100),
 
   renderSummary() {

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -8,7 +8,9 @@ const { connect } = require("react-redux");
 const classnames = require("classnames");
 
 const SourceEditor = require("../../utils/source-editor");
-const { find, findNext, findPrev, removeOverlay } = require("../../utils/source-search");
+const {
+  find, findNext, findPrev, removeOverlay
+} = require("../../utils/source-search");
 const { getMode } = require("../../utils/source");
 const Footer = createFactory(require("./Footer"));
 const SearchBar = createFactory(require("./SearchBar"));
@@ -34,6 +36,12 @@ const { isOriginalId, hasMappedSource } = require("../../utils/source-map");
 const { copyToTheClipboard } = require("../../utils/clipboard");
 
 require("./Editor.css");
+
+const defaultModifiers = {
+  caseSensitive: true,
+  wholeWord: false,
+  regexMatch: false
+};
 
 function isTextForSource(sourceText) {
   return !sourceText.get("loading") && !sourceText.get("error");
@@ -69,16 +77,16 @@ function traverseResults(e, ctx, dir) {
   e.stopPropagation() || e.preventDefault();
   const query = ctx.cm.getSelection();
   if (dir == "prev") {
-    findPrev(ctx, query);
+    findPrev(ctx, query, true, defaultModifiers);
   } else if (dir == "next") {
-    findNext(ctx, query);
+    findNext(ctx, query, true, defaultModifiers);
   }
 }
 
 function onCursorActivity(ctx) {
   if (ctx.cm.somethingSelected()) {
     const query = ctx.cm.getSelection();
-    find(ctx, query, true);
+    find(ctx, query, true, defaultModifiers);
   } else {
     removeOverlay(ctx);
   }
@@ -183,7 +191,7 @@ const Editor = React.createClass({
       menuOptions.push(jumpLabel);
     }
 
-    var textSelected = this.editor.codeMirror.somethingSelected()
+    const textSelected = this.editor.codeMirror.somethingSelected();
     if (isEnabled("watchExpressions") && textSelected) {
       menuOptions.push(watchExpressionLabel);
     }

--- a/src/test/node-unit-tests.js
+++ b/src/test/node-unit-tests.js
@@ -72,15 +72,22 @@ if (isCI) {
 
 testFiles.forEach(file => mocha.addFile(file));
 
-webpack(webpackConfig).run(function(_, stats) {
-  if (stats.compilation.errors.length) {
-    stats.compilation.errors.forEach(err => {
-      console.log(err.message);
-    });
-    return;
-  }
+// flip this if you want (dangerous), but faster runs
+if (true) {
+  webpack(webpackConfig).run(function(_, stats) {
+    if (stats.compilation.errors.length) {
+      stats.compilation.errors.forEach(err => {
+        console.log(err.message);
+      });
+      return;
+    }
 
+    mocha.run(function(failures) {
+      process.exit(failures);
+    });
+  });
+} else {
   mocha.run(function(failures) {
     process.exit(failures);
   });
-});
+}

--- a/src/types.js
+++ b/src/types.js
@@ -1,5 +1,11 @@
 // @flow
 
+export type SearchModifiers = {
+  caseSensitive: boolean,
+  wholeWord: boolean,
+  regexMatch: boolean
+};
+
 export type {
   Breakpoint,
   Expression,

--- a/src/utils/build-query.js
+++ b/src/utils/build-query.js
@@ -1,0 +1,73 @@
+// @flow
+const escapeRegExp = require("lodash/escapeRegExp");
+
+import type { SearchModifiers } from "../types";
+
+type QueryOptions = {
+  isGlobal: boolean,
+  ignoreSpaces?: boolean
+}
+
+/**
+ * Ignore doing outline matches for less than 3 whitespaces
+ *
+ * @memberof utils/source-search
+ * @static
+ */
+function ignoreWhiteSpace(str: string): string {
+  return /^\s{0,2}$/.test(str) ? "(?!\s*.*)" : str;
+}
+
+function wholeMatch(query: string, wholeWord: boolean): string {
+  if (query == "" || !wholeWord) {
+    return query;
+  }
+
+  return `\\b${query}\\b`;
+}
+
+function buildFlags(modifiers, isGlobal) {
+  const { caseSensitive } = modifiers;
+
+  if (caseSensitive && !isGlobal) {
+    return undefined;
+  }
+
+  if (isGlobal && caseSensitive) {
+    return "g";
+  }
+
+  if (isGlobal && !caseSensitive) {
+    return "gi";
+  }
+
+  return "i";
+}
+
+function buildQuery(
+  originalQuery: string, modifiers: SearchModifiers, {
+    isGlobal = false,
+    ignoreSpaces = false
+  }: QueryOptions): RegExp {
+  const { regexMatch, wholeWord } = modifiers;
+
+  if (originalQuery == "") {
+    return new RegExp(originalQuery);
+  }
+
+  let query = originalQuery;
+  if (ignoreSpaces) {
+    query = ignoreWhiteSpace(query);
+  }
+
+  if (!regexMatch) {
+    query = escapeRegExp(query);
+  }
+
+  query = wholeMatch(query, wholeWord);
+  const flags = buildFlags(modifiers, isGlobal);
+
+  return new RegExp(query, flags);
+}
+
+module.exports = buildQuery;

--- a/src/utils/source-search.js
+++ b/src/utils/source-search.js
@@ -26,10 +26,8 @@ function getSearchState(cm: any) {
  * @static
  */
 function getSearchCursor(cm, query: string, pos, modifiers: SearchModifiers) {
-  const { caseSensitive } = modifiers;
-
-  const regexQuery = buildQuery(query, modifiers, { isGlobal: false });
-  return cm.getSearchCursor(regexQuery, pos, !caseSensitive);
+  const regexQuery = buildQuery(query, modifiers, { isGlobal: true });
+  return cm.getSearchCursor(regexQuery, pos);
 }
 
 /**
@@ -47,11 +45,7 @@ function getSearchCursor(cm, query: string, pos, modifiers: SearchModifiers) {
  * @static
  */
 function searchOverlay(query, modifiers) {
-  const regexQuery = buildQuery(query, modifiers, {
-    isGlobal: false,
-    ignoreSpaces: true
-  });
-
+  const regexQuery = buildQuery(query, modifiers, { ignoreSpaces: true });
   let matchLength = null;
   return {
     token: function(stream) {
@@ -231,8 +225,10 @@ function findPrev(
 }
 
 function countMatches(
-  query: string, text: string, modifiers: SearchModifiers) {
-  const regexQuery = buildQuery(query, modifiers, { isGlobal: true });
+  query: string, text: string, modifiers: SearchModifiers): number {
+  const regexQuery = buildQuery(query, modifiers, {
+    isGlobal: true
+  });
   const match = text.match(regexQuery);
   return match ? match.length : 0;
 }

--- a/src/utils/tests/build-query.js
+++ b/src/utils/tests/build-query.js
@@ -16,6 +16,18 @@ describe("build-query", () => {
     expect(query.ignoreCase).to.be(false);
   });
 
+  it("case-sensitive, whole-word, regex search, global", () => {
+    const query = buildQuery("hi.*", {
+      caseSensitive: true,
+      wholeWord: true,
+      regexMatch: true
+    }, { isGlobal: true });
+
+    expect(query.source).to.be("\\bhi.*\\b");
+    expect(query.flags).to.be("g");
+    expect(query.ignoreCase).to.be(false);
+  });
+
   it("case-insensitive, non-whole, string search", () => {
     const query = buildQuery("hi", {
       caseSensitive: false,
@@ -25,6 +37,18 @@ describe("build-query", () => {
 
     expect(query.source).to.be("hi");
     expect(query.flags).to.be("i");
+    expect(query.ignoreCase).to.be(true);
+  });
+
+  it("case-insensitive, non-whole, string search, global", () => {
+    const query = buildQuery("hi", {
+      caseSensitive: false,
+      wholeWord: false,
+      regexMatch: false
+    }, { isGlobal: true });
+
+    expect(query.source).to.be("hi");
+    expect(query.flags).to.be("gi");
     expect(query.ignoreCase).to.be(true);
   });
 
@@ -48,6 +72,7 @@ describe("build-query", () => {
     }, {});
 
     expect(query.source).to.be("\\bhi\\b");
+    expect(query.flags).to.be("i");
     expect(query.ignoreCase).to.be(true);
   });
 
@@ -60,6 +85,7 @@ describe("build-query", () => {
 
     expect(query.source).to.be("hi.*");
     expect(query.flags).to.be("i");
+    expect(query.global).to.be(false);
     expect(query.ignoreCase).to.be(true);
   });
 
@@ -71,6 +97,21 @@ describe("build-query", () => {
     }, {});
 
     expect(query.source).to.be("\\bhi\\b");
+    expect(query.flags).to.be("");
+    expect(query.global).to.be(false);
+    expect(query.ignoreCase).to.be(false);
+  });
+
+  it("string search with wholeWord and case sensitivity, global", () => {
+    const query = buildQuery("hi", {
+      caseSensitive: true,
+      wholeWord: true,
+      regexMatch: false
+    }, { isGlobal: true });
+
+    expect(query.source).to.be("\\bhi\\b");
+    expect(query.flags).to.be("g");
+    expect(query.global).to.be(true);
     expect(query.ignoreCase).to.be(false);
   });
 
@@ -82,21 +123,22 @@ describe("build-query", () => {
     }, {});
 
     expect(query.source).to.be("\\bhi\\.\\*\\b");
+    expect(query.flags).to.be("");
+    expect(query.global).to.be(false);
     expect(query.ignoreCase).to.be(false);
   });
 
-  it("global search", () => {
-    const query = buildQuery("hi", {
+  it("string search with regex chars escaped, global", () => {
+    const query = buildQuery("hi.*", {
       caseSensitive: true,
-      wholeWord: false,
+      wholeWord: true,
       regexMatch: false
-    }, {
-      isGlobal: true
-    });
+    }, { isGlobal: true });
 
-    expect(query.source).to.be("hi");
-    expect(query.ignoreCase).to.be(false);
+    expect(query.source).to.be("\\bhi\\.\\*\\b");
+    expect(query.flags).to.be("g");
     expect(query.global).to.be(true);
+    expect(query.ignoreCase).to.be(false);
   });
 
   it("ignore spaces w/o spaces", () => {
@@ -104,13 +146,25 @@ describe("build-query", () => {
       caseSensitive: true,
       wholeWord: false,
       regexMatch: false
-    }, {
-      ignoreSpaces: true
-    });
+    }, { ignoreSpaces: true });
 
     expect(query.source).to.be("hi");
-    expect(query.ignoreCase).to.be(false);
+    expect(query.flags).to.be("");
     expect(query.global).to.be(false);
+    expect(query.ignoreCase).to.be(false);
+  });
+
+  it("ignore spaces w/o spaces, global", () => {
+    const query = buildQuery("hi", {
+      caseSensitive: true,
+      wholeWord: false,
+      regexMatch: false
+    }, { isGlobal: true, ignoreSpaces: true });
+
+    expect(query.source).to.be("hi");
+    expect(query.flags).to.be("g");
+    expect(query.global).to.be(true);
+    expect(query.ignoreCase).to.be(false);
   });
 
   it("ignore spaces w/ spaces", () => {
@@ -118,28 +172,24 @@ describe("build-query", () => {
       caseSensitive: true,
       wholeWord: false,
       regexMatch: false
-    }, {
-      ignoreSpaces: true
-    });
+    }, { ignoreSpaces: true });
 
     expect(query.source).to.be(escapeRegExp("(?!\s*.*)"));
-    expect(query.ignoreCase).to.be(false);
+    expect(query.flags).to.be("");
     expect(query.global).to.be(false);
+    expect(query.ignoreCase).to.be(false);
   });
 
-  it("global, case-insensitive search", () => {
-    const query = buildQuery("hi.*", {
-      caseSensitive: false,
+  it("ignore spaces w/ spaces, global", () => {
+    const query = buildQuery("  ", {
+      caseSensitive: true,
       wholeWord: false,
-      regexMatch: true
-    }, {
-      isGlobal: true
-    });
+      regexMatch: false
+    }, { isGlobal: true, ignoreSpaces: true });
 
-    console.log(query.source, query.ignoreCase, query.global, query.flags);
-    expect(query.source).to.be("hi.*");
-    expect(query.ignoreCase).to.be(true);
+    expect(query.source).to.be(escapeRegExp("(?!\s*.*)"));
+    expect(query.flags).to.be("g");
     expect(query.global).to.be(true);
-    expect(query.flags).to.be("gi");
+    expect(query.ignoreCase).to.be(false);
   });
 });

--- a/src/utils/tests/build-query.js
+++ b/src/utils/tests/build-query.js
@@ -1,0 +1,145 @@
+const expect = require("expect.js");
+const escapeRegExp = require("lodash/escapeRegExp");
+
+const buildQuery = require("../build-query");
+
+describe("build-query", () => {
+  it("case-sensitive, whole-word, regex search", () => {
+    const query = buildQuery("hi.*", {
+      caseSensitive: true,
+      wholeWord: true,
+      regexMatch: true
+    }, {});
+
+    expect(query.source).to.be("\\bhi.*\\b");
+    expect(query.flags).to.be("");
+    expect(query.ignoreCase).to.be(false);
+  });
+
+  it("case-insensitive, non-whole, string search", () => {
+    const query = buildQuery("hi", {
+      caseSensitive: false,
+      wholeWord: false,
+      regexMatch: false
+    }, {});
+
+    expect(query.source).to.be("hi");
+    expect(query.flags).to.be("i");
+    expect(query.ignoreCase).to.be(true);
+  });
+
+  it("case-sensitive string search", () => {
+    const query = buildQuery("hi", {
+      caseSensitive: true,
+      wholeWord: false,
+      regexMatch: false
+    }, {});
+
+    expect(query.source).to.be("hi");
+    expect(query.flags).to.be("");
+    expect(query.ignoreCase).to.be(false);
+  });
+
+  it("string search with wholeWord", () => {
+    const query = buildQuery("hi", {
+      caseSensitive: false,
+      wholeWord: true,
+      regexMatch: false
+    }, {});
+
+    expect(query.source).to.be("\\bhi\\b");
+    expect(query.ignoreCase).to.be(true);
+  });
+
+  it("case-insensitive, regex search", () => {
+    const query = buildQuery("hi.*", {
+      caseSensitive: false,
+      wholeWord: false,
+      regexMatch: true
+    }, {});
+
+    expect(query.source).to.be("hi.*");
+    expect(query.flags).to.be("i");
+    expect(query.ignoreCase).to.be(true);
+  });
+
+  it("string search with wholeWord and case sensitivity", () => {
+    const query = buildQuery("hi", {
+      caseSensitive: true,
+      wholeWord: true,
+      regexMatch: false
+    }, {});
+
+    expect(query.source).to.be("\\bhi\\b");
+    expect(query.ignoreCase).to.be(false);
+  });
+
+  it("string search with regex chars escaped", () => {
+    const query = buildQuery("hi.*", {
+      caseSensitive: true,
+      wholeWord: true,
+      regexMatch: false
+    }, {});
+
+    expect(query.source).to.be("\\bhi\\.\\*\\b");
+    expect(query.ignoreCase).to.be(false);
+  });
+
+  it("global search", () => {
+    const query = buildQuery("hi", {
+      caseSensitive: true,
+      wholeWord: false,
+      regexMatch: false
+    }, {
+      isGlobal: true
+    });
+
+    expect(query.source).to.be("hi");
+    expect(query.ignoreCase).to.be(false);
+    expect(query.global).to.be(true);
+  });
+
+  it("ignore spaces w/o spaces", () => {
+    const query = buildQuery("hi", {
+      caseSensitive: true,
+      wholeWord: false,
+      regexMatch: false
+    }, {
+      ignoreSpaces: true
+    });
+
+    expect(query.source).to.be("hi");
+    expect(query.ignoreCase).to.be(false);
+    expect(query.global).to.be(false);
+  });
+
+  it("ignore spaces w/ spaces", () => {
+    const query = buildQuery("  ", {
+      caseSensitive: true,
+      wholeWord: false,
+      regexMatch: false
+    }, {
+      ignoreSpaces: true
+    });
+
+    expect(query.source).to.be(escapeRegExp("(?!\s*.*)"));
+    expect(query.ignoreCase).to.be(false);
+    expect(query.global).to.be(false);
+  });
+
+  it("global, case-insensitive search", () => {
+    const query = buildQuery("hi.*", {
+      caseSensitive: false,
+      wholeWord: false,
+      regexMatch: true
+    }, {
+      isGlobal: true
+    });
+
+    console.log(query.source, query.ignoreCase, query.global, query.flags);
+    expect(query.source).to.be("hi.*");
+    expect(query.ignoreCase).to.be(true);
+    expect(query.global).to.be(true);
+    expect(query.flags).to.be("gi");
+  });
+});

--- a/src/utils/tests/source-search.js
+++ b/src/utils/tests/source-search.js
@@ -1,0 +1,49 @@
+const expect = require("expect.js");
+
+const { countMatches } = require("../source-search");
+
+describe("source-search", () => {
+  it("counts basic string match", () => {
+    const text = "the test string with test in it multiple times test.";
+    const query = "test";
+    const count = countMatches(query, text, {
+      caseSensitive: true,
+      wholeWord: false,
+      regexMatch: false
+    });
+    expect(count).to.be(3);
+  });
+
+  it("counts basic string match case-sensitive", () => {
+    const text = "the Test string with test in it multiple times test.";
+    const query = "Test";
+    const count = countMatches(query, text, {
+      caseSensitive: true,
+      wholeWord: false,
+      regexMatch: false
+    });
+    expect(count).to.be(1);
+  });
+
+  it("counts whole word string match", () => {
+    const text = "the test string with test in it multiple times whoatestthe.";
+    const query = "test";
+    const count = countMatches(query, text, {
+      caseSensitive: true,
+      wholeWord: true,
+      regexMatch: false
+    });
+    expect(count).to.be(2);
+  });
+
+  it("counts regex match", () => {
+    const text = "the test string with test in it multiple times whoatestthe.";
+    const query = "(\\w+)\\s+(\\w+)";
+    const count = countMatches(query, text, {
+      caseSensitive: true,
+      wholeWord: false,
+      regexMatch: true
+    });
+    expect(count).to.be(5);
+  });
+});


### PR DESCRIPTION
Associated Issue: #1637 

### Summary of Changes

This PR extracts the source-search utils from #1644 and adds some unit tests around `buildQuery`

### Test Plan

- [ ] test searching
- [ ] test selecting text
- [ ] test iterating with cmd+g
