### PR TITLE
Adds missing dbg parameter in reload()

### DIFF
--- a/src/test/mochitest/head.js
+++ b/src/test/mochitest/head.js
@@ -439,7 +439,7 @@ function resume(dbg) {
  * @static
  */
 function reload(dbg, ...sources) {
-  return dbg.client.reload().then(() => waitForSources(...sources));
+  return dbg.client.reload().then(() => waitForSources(dbg, ...sources));
 }
 
 /**


### PR DESCRIPTION
Associated Issue: n/a

### Summary of Changes

* adds dbg for waitForSources call

### Test Plan

In most of the cases we call reload() without second argument, so this was not exposed earlier. browser_dbg-navigation.js test did not regress for me locally.

### Screenshots/Videos (OPTIONAL)
