### PR TITLE
Reconfigures Firefox to disable asm.js AOT for debuggger.

### DIFF
--- a/src/test/mochitest/browser.ini
+++ b/src/test/mochitest/browser.ini
@@ -11,6 +11,7 @@ support-files =
   examples/sourcemaps2/main.min.js
   examples/sourcemaps2/main.js
   examples/sourcemaps2/main.js.map
+  examples/doc-asm.html
   examples/doc-scripts.html
   examples/doc-script-switching.html
   examples/doc-exceptions.html
@@ -22,6 +23,7 @@ support-files =
   examples/doc-sourcemaps2.html
   examples/doc-sourcemap-bogus.html
   examples/doc-sources.html
+  examples/asm.js
   examples/bogus-map.js
   examples/entry.js
   examples/exceptions.js
@@ -37,6 +39,7 @@ support-files =
   examples/script-switching-01.js
   examples/times2.js
 
+[browser_dbg-asm.js]
 [browser_dbg-breaking.js]
 [browser_dbg-breaking-from-console.js]
 [browser_dbg-breakpoints.js]

--- a/src/test/mochitest/browser_dbg-asm.js
+++ b/src/test/mochitest/browser_dbg-asm.js
@@ -1,0 +1,33 @@
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
+
+// Tests that asm.js AOT can be disabled and debugging of the asm.js code
+// is working.
+
+add_task(function* () {
+  const dbg = yield initDebugger("doc-asm.html");
+  const { selectors: { getSelectedSource }, getState } = dbg;
+
+  yield reload(dbg);
+
+  // After reload() we are getting getSources notifiction for old sources,
+  // using the debugger statement to really stop are reloaded page.
+  yield waitForPaused(dbg);
+  yield resume(dbg);
+
+  yield waitForSources(dbg, "doc-asm.html", "asm.js");
+
+  // Expand nodes and make sure more sources appear.
+  is(findAllElements(dbg, "sourceNodes").length, 2);
+
+  clickElement(dbg, "sourceArrow", 2);
+  is(findAllElements(dbg, "sourceNodes").length, 4);
+
+  selectSource(dbg, 'asm.js');
+
+  yield addBreakpoint(dbg, "asm.js", 7);
+  invokeInTab("runAsm");
+
+  yield waitForPaused(dbg);
+  assertPausedLocation(dbg, "asm.js", 7);
+});

--- a/src/test/mochitest/examples/asm.js
+++ b/src/test/mochitest/examples/asm.js
@@ -1,0 +1,11 @@
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
+
+var asmjs = (function () {
+  "use asm";
+  function f() {
+    return 1|0;
+  }
+  return {f: f};
+})()
+

--- a/src/test/mochitest/examples/doc-asm.html
+++ b/src/test/mochitest/examples/doc-asm.html
@@ -1,0 +1,20 @@
+<!-- Any copyright is dedicated to the Public Domain.
+     http://creativecommons.org/publicdomain/zero/1.0/ -->
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8"/>
+    <title>Asm.js</title>
+    <script src="asm.js"></script>
+    <script>
+    function runAsm() {
+      console.log(asmjs.f());
+    }
+    debugger; // see browser_dbg-asm.js reload() comment
+    </script>
+  </head>
+
+  <body>
+    <button onclick="runAsm()">test</button>
+  </body>
+</html>

--- a/src/utils/client.js
+++ b/src/utils/client.js
@@ -1,7 +1,7 @@
 const { createSource, firefox } = require("devtools-client-adapters");
 const { prefs } = require("./prefs");
 
-function onFirefoxConnect(actions) {
+async function onFirefoxConnect(actions) {
   const tabTarget = firefox.getTabTarget();
   const threadClient = firefox.getThreadClient();
 
@@ -12,25 +12,26 @@ function onFirefoxConnect(actions) {
   tabTarget.on("will-navigate", actions.willNavigate);
   tabTarget.on("navigate", actions.navigated);
 
+  await threadClient.reconfigure({ observeAsmJS: true });
+
   // In Firefox, we need to initially request all of the sources. This
   // usually fires off individual `newSource` notifications as the
   // debugger finds them, but there may be existing sources already in
   // the debugger (if it's paused already, or if loading the page from
   // bfcache) so explicity fire `newSource` events for all returned
   // sources.
-  return threadClient.getSources().then(({ sources }) => {
-    actions.newSources(sources.map(createSource));
+  const { sources } = await threadClient.getSources();
+  actions.newSources(sources.map(createSource));
 
-    // If the threadClient is already paused, make sure to show a
-    // paused state.
-    const pausedPacket = threadClient.getLastPausePacket();
-    if (pausedPacket) {
-      firefox.clientEvents.paused(null, pausedPacket);
-    }
-  });
+  // If the threadClient is already paused, make sure to show a
+  // paused state.
+  const pausedPacket = threadClient.getLastPausePacket();
+  if (pausedPacket) {
+    firefox.clientEvents.paused(null, pausedPacket);
+  }
 }
 
-function onConnect(connection, actions) {
+async function onConnect(connection, actions) {
   // NOTE: the landing page does not connect to a JS process
   if (!connection) {
     return;


### PR DESCRIPTION
Associated Issue: #1767

### Summary of Changes

* onFirefoxConnect was modified to call reconfigure()
* onFirefoxConnect and onConnect are async functions

### Test Plan

A mochitest is included.

### Screenshots/Videos (OPTIONAL)
