### PR TITLE
Update how Chrome Scopes are shown

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "babel-plugin-transform-es2015-modules-commonjs": "^6.22.0",
     "codemirror": "^5.1.0",
-    "devtools-launchpad": "^0.0.35",
+    "devtools-launchpad": "^0.0.36",
     "devtools-reps": "^0.0.4",
     "documentation": "^4.0.0-beta11",
     "eslint": "^3.12.0",

--- a/src/actions/pause.js
+++ b/src/actions/pause.js
@@ -7,7 +7,7 @@ const { getPause } = require("../selectors");
 const { updateFrameLocations } = require("../utils/pause");
 const { evaluateExpressions } = require("./expressions");
 
-import type { Pause, Frame, Grip } from "../types";
+import type { Pause, Frame } from "../types";
 import type { ThunkArgs } from "./types";
 
 type CommandType = { type: string };
@@ -43,7 +43,7 @@ function resumed() {
  */
 function paused(pauseInfo: Pause) {
   return async function({ dispatch, getState, client }: ThunkArgs) {
-    let { frames, why } = pauseInfo;
+    let { frames, why, loadedObjects } = pauseInfo;
     frames = await updateFrameLocations(frames);
     const frame = frames[0];
 
@@ -51,7 +51,8 @@ function paused(pauseInfo: Pause) {
       type: constants.PAUSED,
       pauseInfo: { why, frame },
       frames: frames,
-      selectedFrameId: frame.id
+      selectedFrameId: frame.id,
+      loadedObjects: loadedObjects || []
     });
 
     dispatch(evaluateExpressions(frame.id));
@@ -203,12 +204,12 @@ function selectFrame(frame: Frame) {
  * @memberof actions/pause
  * @static
  */
-function loadObjectProperties(grip: Grip) {
+function loadObjectProperties(object: any) {
   return ({ dispatch, client }: ThunkArgs) => {
     dispatch({
       type: constants.LOAD_OBJECT_PROPERTIES,
-      objectId: grip.actor,
-      [PROMISE]: client.getProperties(grip)
+      objectId: object.actor || object.objectId,
+      [PROMISE]: client.getProperties(object)
     });
   };
 }

--- a/src/actions/types.js
+++ b/src/actions/types.js
@@ -2,6 +2,7 @@
 
 import type { Source,
               Breakpoint,
+              LoadedObject,
               Location,
               SourceText,
               Frame,
@@ -117,7 +118,8 @@ type PauseAction =
                   isInterrupted?: boolean },
       frames: Frame[],
       selectedFrameId: string,
-      }
+      loadedObjects: LoadedObject[]
+    }
   | { type: "PAUSE_ON_EXCEPTIONS",
       shouldPauseOnExceptions: boolean,
       shouldIgnoreCaughtExceptions: boolean }

--- a/src/components/SecondaryPanes/ChromeScopes.js
+++ b/src/components/SecondaryPanes/ChromeScopes.js
@@ -1,59 +1,211 @@
 const React = require("react");
+
+const ImPropTypes = require("react-immutable-proptypes");
 const { bindActionCreators } = require("redux");
 const { connect } = require("react-redux");
 const actions = require("../../actions");
-const { getChromeScopes } = require("../../selectors");
+const {
+  getChromeScopes, getLoadedObjects, getPause
+} = require("../../selectors");
+const ManagedTree = React.createFactory(require("../shared/ManagedTree"));
+
 const { DOM: dom, PropTypes } = React;
 const classnames = require("classnames");
 const Svg = require("../shared/Svg");
 
 require("./Scopes.css");
 
+function info(text) {
+  return dom.div({ className: "pane-info" }, text);
+}
+
+// check to see if its an object with propertie
+function nodeHasProperties(item) {
+  return !nodeHasChildren(item)
+    && item.contents.value.type === "object";
+}
+
+function nodeIsPrimitive(item) {
+}
+
+function nodeHasChildren(item) {
+  return Array.isArray(item.contents);
+}
+
+function createNode(name, path, contents) {
+  // The path is important to uniquely identify the item in the entire
+  // tree. This helps debugging & optimizes React's rendering of large
+  // lists. The path will be separated by property name,
+  // i.e. `{ foo: { bar: { baz: 5 }}}` will have a path of `foo/bar/baz`
+  // for the inner object.
+  return { name, path, contents };
+}
+
 const Scopes = React.createClass({
   propTypes: {
-    scopes: PropTypes.array
+    scopes: PropTypes.array,
+    loadedObjects: ImPropTypes.map
   },
 
   displayName: "Scopes",
 
-  renderScopes() {
-    const { scopes } = this.props;
-
-    if (!scopes) {
-      return dom.div({ className: "pane-info" },
-        L10N.getStr("scopes.notAvailable"));
-    }
-
-    return scopes.map(scope => dom.div({},
-      this.renderItem(scope.name || scope.type)
-    ));
+  getInitialState() {
+    // Cache of dynamically built nodes. We shouldn't need to clear
+    // this out ever, since we don't ever "switch out" the object
+    // being inspected.
+    this.objectCache = {};
+    return {};
   },
 
-  renderItem(name) {
+  makeNodesForProperties(objProps, parentPath) {
+    const { ownProperties, prototype } = objProps;
+
+    const nodes = Object.keys(ownProperties).sort().filter(name => {
+      // Ignore non-concrete values like getters and setters
+      // for now by making sure we have a value.
+      return "value" in ownProperties[name];
+    }).map(name => {
+      return createNode(name, `${parentPath}/${name}`, ownProperties[name]);
+    });
+
+    // Add the prototype if it exists and is not null
+    if (prototype && prototype.type !== "null") {
+      nodes.push(createNode(
+        "__proto__",
+        `${parentPath}/__proto__`,
+        { value: prototype }
+      ));
+    }
+
+    return nodes;
+  },
+
+  renderItem(item, depth, focused, _, expanded, { setExpanded }) {
+    const notEnumberable = false;
+    const objectValue = "";
+
     return dom.div(
-      { className: classnames("node"),
-        style: { marginLeft: 15 },
+      {
+        className: classnames("node object-node",
+          {
+            focused: false,
+            "not-enumerable": notEnumberable
+          }),
+        style: { marginLeft: depth * 15 },
+        key: item.path,
+        onClick: e => {
+          e.stopPropagation();
+          setExpanded(item, !expanded);
+        }
       },
       Svg("arrow", {
         className: classnames({
-          expanded: false,
+          expanded: expanded,
+          hidden: nodeIsPrimitive(item)
         })
       }),
-      dom.span({ className: "object-label" }, name),
+      dom.span({ className: "object-label" }, item.name),
+      dom.span({ className: "object-delimiter" },
+               objectValue ? ": " : ""),
+      dom.span({ className: "object-value" }, objectValue || "")
     );
   },
 
+  getObjectProperties(item) {
+    this.props.loadedObjects.get(item.contents.value.objectId);
+  },
+
+  getChildren(item) {
+    const obj = item.contents;
+
+    // Nodes can either have children already, or be an object with
+    // properties that we need to go and fetch.
+    if (nodeHasChildren(item)) {
+      return item.contents;
+    } else if (nodeHasProperties(item)) {
+      const objectId = obj.value.objectId;
+
+      // Because we are dynamically creating the tree as the user
+      // expands it (not precalcuated tree structure), we cache child
+      // arrays. This not only helps performance, but is necessary
+      // because the expanded state depends on instances of nodes
+      // being the same across renders. If we didn't do this, each
+      // node would be a new instance every render.
+      const key = item.path;
+      if (this.objectCache[key]) {
+        return this.objectCache[key];
+      }
+
+      const loadedProps = this.getObjectProperties(item);
+      if (loadedProps) {
+        const children = this.makeNodesForProperties(loadedProps, item.path);
+        this.objectCache[actor] = children;
+        return children;
+      }
+      return [];
+    }
+    return [];
+  },
+
+  onExpand(item) {
+    const { loadObjectProperties } = this.props;
+
+    if (nodeHasProperties(item)) {
+      this.props.loadObjectProperties(item.contents.value);
+    }
+  },
+
+  getRoots() {
+    return this.props.scopes.map(scope => {
+      const name = scope.name ||
+        (scope.type == "global" ? "Window" : "");
+
+      return {
+        name: name,
+        path: name,
+        contents: { value: scope.object }
+      };
+    });
+  },
+
   render() {
+    const {
+      scopes, pauseInfo, loadObjectProperties, loadedObjects
+    } = this.props;
+
+    if (!pauseInfo) {
+      return dom.div(
+        { className: "pane scopes-list" },
+        info(L10N.getStr("scopes.notPaused"))
+      );
+    }
+
+    const roots = this.getRoots();
+
     return dom.div(
       { className: "pane scopes-list" },
-      this.renderScopes()
-    );
+      ManagedTree({
+        itemHeight: 20,
+        getParent: item => null,
+        getChildren: this.getChildren,
+        getRoots: () => roots,
+        getKey: item => item.path,
+        autoExpand: 0,
+        autoExpandDepth: 1,
+        autoExpandAll: false,
+        disabledFocus: true,
+        onExpand: this.onExpand,
+        renderItem: this.renderItem
+      })
+  );
   }
 });
 
 module.exports = connect(
   state => ({
-    scopes: getChromeScopes(state),
+    pauseInfo: getPause(state),
+    loadedObjects: getLoadedObjects(state),
+    scopes: getChromeScopes(state)
   }),
   dispatch => bindActionCreators(actions, dispatch)
 )(Scopes);

--- a/src/reducers/pause.js
+++ b/src/reducers/pause.js
@@ -39,14 +39,21 @@ const State = makeRecord(({
 function update(state = State(), action: Action): Record<PauseState> {
   switch (action.type) {
     case constants.PAUSED: {
-      const { selectedFrameId, frames, pauseInfo } = action;
+      const { selectedFrameId, frames, loadedObjects, pauseInfo } = action;
       pauseInfo.isInterrupted = pauseInfo.why.type === "interrupted";
+
+      // turn this into an object keyed by object id
+      let objectMap = {};
+      loadedObjects.forEach(obj => {
+        objectMap[obj.value.objectId] = obj;
+      });
 
       return state.merge({
         isWaitingOnBreak: false,
         pause: fromJS(pauseInfo),
         selectedFrameId,
-        frames
+        frames,
+        loadedObjects: objectMap
       });
     }
 
@@ -127,6 +134,15 @@ function getLoadedObjects(state: OuterState) {
   return state.pause.get("loadedObjects");
 }
 
+function getLoadedObject(state: OuterState, objectId: string) {
+  return getLoadedObjects(state).get(objectId);
+}
+
+function getObjectProperties(state: OuterState, parentId: string) {
+  return getLoadedObjects(state)
+    .filter(obj => obj.get("parentId") == parentId);
+}
+
 function getIsWaitingOnBreak(state: OuterState) {
   return state.pause.get("isWaitingOnBreak");
 }
@@ -161,6 +177,8 @@ module.exports = {
   getPause,
   getChromeScopes,
   getLoadedObjects,
+  getLoadedObject,
+  getObjectProperties,
   getIsWaitingOnBreak,
   getShouldPauseOnExceptions,
   getShouldIgnoreCaughtExceptions,

--- a/src/selectors.js
+++ b/src/selectors.js
@@ -32,6 +32,8 @@ module.exports = {
   getPause: pause.getPause,
   getChromeScopes: pause.getChromeScopes,
   getLoadedObjects: pause.getLoadedObjects,
+  getLoadedObject: pause.getLoadedObjects,
+  getObjectProperties: pause.getObjectProperties,
   getIsWaitingOnBreak: pause.getIsWaitingOnBreak,
   getShouldPauseOnExceptions: pause.getShouldPauseOnExceptions,
   getShouldIgnoreCaughtExceptions: pause.getShouldIgnoreCaughtExceptions,

--- a/src/types.js
+++ b/src/types.js
@@ -5,6 +5,7 @@ export type {
   Expression,
   Frame,
   Grip,
+  LoadedObject,
   Location,
   Source,
   SourceText,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1839,9 +1839,9 @@ detective@^4.0.0, detective@^4.3.1:
     acorn "^3.1.0"
     defined "^1.0.0"
 
-devtools-client-adapters@^0.0.10:
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/devtools-client-adapters/-/devtools-client-adapters-0.0.10.tgz#0d655d2f78175199d47f7e80cd42bc8ca4d73425"
+devtools-client-adapters@^0.0.11:
+  version "0.0.11"
+  resolved "https://registry.yarnpkg.com/devtools-client-adapters/-/devtools-client-adapters-0.0.11.tgz#3456e958c5a604596309196ebfa2b9add3653154"
   dependencies:
     chrome-remote-interface "0.17.0"
     devtools-config "^0.0.11"
@@ -1933,9 +1933,9 @@ devtools-launchpad@0.0.21:
     webpack-hot-middleware "^2.12.0"
     ws "^1.0.1"
 
-devtools-launchpad@^0.0.35:
-  version "0.0.35"
-  resolved "https://registry.yarnpkg.com/devtools-launchpad/-/devtools-launchpad-0.0.35.tgz#89d08e8cbd628527c576d25b1c32251fda1e77b0"
+devtools-launchpad@^0.0.36:
+  version "0.0.36"
+  resolved "https://registry.yarnpkg.com/devtools-launchpad/-/devtools-launchpad-0.0.36.tgz#38d5d7e78f1586cabf4da7c4531b6d1cea37302c"
   dependencies:
     amd-loader "0.0.5"
     babel-cli "^6.7.5"
@@ -1958,7 +1958,7 @@ devtools-launchpad@^0.0.35:
     classnames "^2.2.5"
     co "=4.6.0"
     css-loader "^0.25.0"
-    devtools-client-adapters "^0.0.10"
+    devtools-client-adapters "^0.0.11"
     devtools-config "^0.0.11"
     devtools-modules "^0.0.14"
     devtools-network-request "^0.0.9"


### PR DESCRIPTION
associated issue #1298 

This work was done in december and cleaned up during the community call. This and the client update will help us show chrome scopes along side firefox scopes.

lets wait on https://github.com/devtools-html/devtools-core/pull/131 to pull this in