### PR TITLE
convert WhyPaused to use es6 class

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,6 @@
 {
   "plugins": [
+    "transform-es2015-modules-commonjs",
     "transform-es2015-block-scoping",
     "transform-es2015-destructuring",
     "transform-es2015-parameters",

--- a/package.json
+++ b/package.json
@@ -76,5 +76,8 @@
     ]
   },
   "main": "src/main.js",
-  "author": "Jason Laster <jlaster@mozilla.com>"
+  "author": "Jason Laster <jlaster@mozilla.com>",
+  "devDependencies": {
+    "babel-plugin-transform-es2015-modules-commonjs": "^6.22.0"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "postmerge": "bin/post-merge"
   },
   "dependencies": {
+    "babel-plugin-transform-es2015-modules-commonjs": "^6.22.0",
     "codemirror": "^5.1.0",
     "devtools-launchpad": "^0.0.32",
     "devtools-reps": "^0.0.4",
@@ -76,8 +77,5 @@
     ]
   },
   "main": "src/main.js",
-  "author": "Jason Laster <jlaster@mozilla.com>",
-  "devDependencies": {
-    "babel-plugin-transform-es2015-modules-commonjs": "^6.22.0"
-  }
+  "author": "Jason Laster <jlaster@mozilla.com>"
 }

--- a/src/components/SecondaryPanes/WhyPaused.js
+++ b/src/components/SecondaryPanes/WhyPaused.js
@@ -1,21 +1,15 @@
-const React = require("react");
-const { bindActionCreators } = require("redux");
-const { connect } = require("react-redux");
-const ImPropTypes = require("react-immutable-proptypes");
-const actions = require("../../actions");
-const { getPause } = require("../../selectors");
-const { DOM: dom } = React;
+import { DOM as dom, Component } from "react";
+import { bindActionCreators } from "redux";
+import { connect } from "react-redux";
+import ImPropTypes from "react-immutable-proptypes";
+import actions from "../../actions";
+import { getPause } from "../../selectors";
 
-const { getPauseReason } = require("../../utils/pause");
+import { getPauseReason } from "../../utils/pause";
 
-require("./WhyPaused.css");
+import "./WhyPaused.css";
 
-const WhyPaused = React.createClass({
-  propTypes: {
-    pauseInfo: ImPropTypes.map
-  },
-
-  displayName: "WhyPaused",
+class WhyPaused extends Component {
 
   render() {
     const { pauseInfo } = this.props;
@@ -29,9 +23,15 @@ const WhyPaused = React.createClass({
         message ? dom.div(null, message) : null])
         : null;
   }
-});
+}
 
-module.exports = connect(
+WhyPaused.displayName = "WhyPaused";
+
+WhyPaused.propTypes = {
+  pauseInfo: ImPropTypes.map
+};
+
+export default connect(
   state => ({
     pauseInfo: getPause(state)
   }),

--- a/src/components/SecondaryPanes/index.js
+++ b/src/components/SecondaryPanes/index.js
@@ -12,7 +12,7 @@ const { getPause, getBreakpoints,
 const { prefs } = require("../../utils/prefs");
 
 const actions = require("../../actions");
-const WhyPaused = React.createFactory(require("./WhyPaused"));
+const WhyPaused = React.createFactory(require("./WhyPaused").default);
 const Breakpoints = React.createFactory(require("./Breakpoints"));
 const Expressions = React.createFactory(require("./Expressions"));
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -308,6 +308,14 @@ babel-code-frame@^6.11.0, babel-code-frame@^6.16.0, babel-code-frame@^6.20.0:
     esutils "^2.0.2"
     js-tokens "^2.0.0"
 
+babel-code-frame@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.22.0.tgz#027620bee567a88c32561574e7fd0801d33118e4"
+  dependencies:
+    chalk "^1.1.0"
+    esutils "^2.0.2"
+    js-tokens "^3.0.0"
+
 babel-core@^6.0.14, babel-core@^6.17.0, babel-core@^6.18.0, babel-core@^6.5.2:
   version "6.21.0"
   resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-6.21.0.tgz#75525480c21c803f826ef3867d22c19f080a3724"
@@ -489,6 +497,12 @@ babel-loader@^6.2.4:
     loader-utils "^0.2.11"
     mkdirp "^0.5.1"
     object-assign "^4.0.1"
+
+babel-messages@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.yarnpkg.com/babel-messages/-/babel-messages-6.22.0.tgz#36066a214f1217e4ed4164867669ecb39e3ea575"
+  dependencies:
+    babel-runtime "^6.22.0"
 
 babel-messages@^6.8.0:
   version "6.8.0"
@@ -719,6 +733,15 @@ babel-plugin-transform-es2015-modules-commonjs@^6.18.0:
     babel-template "^6.16.0"
     babel-types "^6.18.0"
 
+babel-plugin-transform-es2015-modules-commonjs@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.22.0.tgz#6ca04e22b8e214fb50169730657e7a07dc941145"
+  dependencies:
+    babel-plugin-transform-strict-mode "^6.22.0"
+    babel-runtime "^6.22.0"
+    babel-template "^6.22.0"
+    babel-types "^6.22.0"
+
 babel-plugin-transform-es2015-modules-systemjs@^6.18.0:
   version "6.19.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.19.0.tgz#50438136eba74527efa00a5b0fefaf1dc4071da6"
@@ -877,6 +900,13 @@ babel-plugin-transform-strict-mode@^6.18.0:
     babel-runtime "^6.0.0"
     babel-types "^6.18.0"
 
+babel-plugin-transform-strict-mode@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.22.0.tgz#e008df01340fdc87e959da65991b7e05970c8c7c"
+  dependencies:
+    babel-runtime "^6.22.0"
+    babel-types "^6.22.0"
+
 babel-plugin-webpack-alias@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/babel-plugin-webpack-alias/-/babel-plugin-webpack-alias-2.1.2.tgz#05a1ba23c28595660fb6ea5736424fc596b4a247"
@@ -982,16 +1012,23 @@ babel-register@^6.18.0:
     mkdirp "^0.5.1"
     source-map-support "^0.4.2"
 
-babel-runtime@6.11.6:
+babel-runtime@6.11.6, babel-runtime@^6.9.0:
   version "6.11.6"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.11.6.tgz#6db707fef2d49c49bfa3cb64efdb436b518b8222"
   dependencies:
     core-js "^2.4.0"
     regenerator-runtime "^0.9.5"
 
-babel-runtime@^6.0.0, babel-runtime@^6.11.6, babel-runtime@^6.18.0, babel-runtime@^6.2.0, babel-runtime@^6.20.0, babel-runtime@^6.9.0, babel-runtime@^6.9.1:
+babel-runtime@^6.0.0, babel-runtime@^6.11.6, babel-runtime@^6.18.0, babel-runtime@^6.2.0, babel-runtime@^6.20.0, babel-runtime@^6.9.1:
   version "6.20.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.20.0.tgz#87300bdcf4cd770f09bf0048c64204e17806d16f"
+  dependencies:
+    core-js "^2.4.0"
+    regenerator-runtime "^0.10.0"
+
+babel-runtime@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.22.0.tgz#1cf8b4ac67c77a4ddb0db2ae1f74de52ac4ca611"
   dependencies:
     core-js "^2.4.0"
     regenerator-runtime "^0.10.0"
@@ -1003,6 +1040,16 @@ babel-template@^6.14.0, babel-template@^6.15.0, babel-template@^6.16.0, babel-te
     babel-runtime "^6.9.0"
     babel-traverse "^6.16.0"
     babel-types "^6.16.0"
+    babylon "^6.11.0"
+    lodash "^4.2.0"
+
+babel-template@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.22.0.tgz#403d110905a4626b317a2a1fcb8f3b73204b2edb"
+  dependencies:
+    babel-runtime "^6.22.0"
+    babel-traverse "^6.22.0"
+    babel-types "^6.22.0"
     babylon "^6.11.0"
     lodash "^4.2.0"
 
@@ -1020,11 +1067,34 @@ babel-traverse@^6.15.0, babel-traverse@^6.16.0, babel-traverse@^6.18.0, babel-tr
     invariant "^2.2.0"
     lodash "^4.2.0"
 
+babel-traverse@^6.22.0:
+  version "6.22.1"
+  resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.22.1.tgz#3b95cd6b7427d6f1f757704908f2fc9748a5f59f"
+  dependencies:
+    babel-code-frame "^6.22.0"
+    babel-messages "^6.22.0"
+    babel-runtime "^6.22.0"
+    babel-types "^6.22.0"
+    babylon "^6.15.0"
+    debug "^2.2.0"
+    globals "^9.0.0"
+    invariant "^2.2.0"
+    lodash "^4.2.0"
+
 babel-types@^6.13.0, babel-types@^6.14.0, babel-types@^6.15.0, babel-types@^6.16.0, babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.20.0, babel-types@^6.21.0, babel-types@^6.7.2, babel-types@^6.8.0, babel-types@^6.9.0:
   version "6.21.0"
   resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.21.0.tgz#314b92168891ef6d3806b7f7a917fdf87c11a4b2"
   dependencies:
     babel-runtime "^6.20.0"
+    esutils "^2.0.2"
+    lodash "^4.2.0"
+    to-fast-properties "^1.0.1"
+
+babel-types@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.22.0.tgz#2a447e8d0ea25d2512409e4175479fd78cc8b1db"
+  dependencies:
+    babel-runtime "^6.22.0"
     esutils "^2.0.2"
     lodash "^4.2.0"
     to-fast-properties "^1.0.1"
@@ -1039,6 +1109,10 @@ babelify@^7.2.0:
 babylon@^6.11.0, babylon@^6.13.0, babylon@^6.5.2:
   version "6.14.1"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.14.1.tgz#956275fab72753ad9b3435d7afe58f8bf0a29815"
+
+babylon@^6.15.0:
+  version "6.15.0"
+  resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.15.0.tgz#ba65cfa1a80e1759b0e89fb562e27dccae70348e"
 
 bail@^1.0.0:
   version "1.0.1"
@@ -3471,6 +3545,10 @@ js-base64@^2.1.9:
 js-tokens@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-2.0.0.tgz#79903f5563ee778cc1162e6dcf1a0027c97f9cb5"
+
+js-tokens@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.0.tgz#a2f2a969caae142fb3cd56228358c89366957bd1"
 
 js-yaml@^3.3.1, js-yaml@^3.4.3, js-yaml@^3.5.1:
   version "3.7.0"


### PR DESCRIPTION
### Summary of Changes

* Minimally converted the `WhyPaused` component to use es6 classes 
* Tried to use `PureComponent` but it doesn't seem to be defined in `react` where it should.  Needs more investigation.

If we want to really clean up the syntax to make things cleaner and more readable I think we might need to go even further down this rabbit hole which includes JSX #1747 (which would remove the need for the `createFactory` calls).

Our webpack config continues to confound me so I don't think I've done that correctly but it didn't like me using `export` so I needed a new transform plugin.  I gave up trying to do anymore as I think the presets would handle most of this.  I need a 12 week intensive course with Julian and Jason on webpack sorcery to make any more progress here.

This does show that its possible to slowly convert components over.  With a tracking issue for all components you could have each one move over to this fairly quickly.

### Test Plan

- [x] Paused on breakpoints to check that component renders correctly
- [x] Checked console for errors
