### PR TITLE
Fix postmerge script

### DIFF
--- a/bin/post-merge.js
+++ b/bin/post-merge.js
@@ -3,8 +3,8 @@
 
 const execFile = require("child_process").execFile;
 
-execFile("git diff-tree",
-  ["-r", "--name-only", "--no-commit-id", "ORIG_HEAD", "HEAD"],
+execFile("git",
+  ["diff-tree", "-r", "--name-only", "--no-commit-id", "ORIG_HEAD", "HEAD"],
   (error, stdout, stderr) => {
   if (error) {
     console.error("stderr", stderr);


### PR DESCRIPTION
`execFIle` needs the pure executable binary as the first param. Every option/argument in the array following. This moves `diff-tree` into the arguments.

To test, you can setup a branch and reset it back a ways so you have a `yarn.lock` mismatch. Then, have another branch fully updated and apply this patch. Then run `git merge {latest-branch-with-patch}` while in the reset branch and it will complete fine and tell you to run `yarn install` as expected.