### PR TITLE
Fix SecondaryPanes contents to flex properly.

### DIFF
--- a/src/components/SecondaryPanes/CommandBar.css
+++ b/src/components/SecondaryPanes/CommandBar.css
@@ -1,5 +1,5 @@
 .command-bar {
-  height: 30px;
+  flex: 0 0 30px;
   border-bottom: 1px solid var(--theme-splitter-color);
   display: flex;
 }

--- a/src/components/SecondaryPanes/SecondaryPanes.css
+++ b/src/components/SecondaryPanes/SecondaryPanes.css
@@ -13,6 +13,7 @@
 .secondary-panes .accordion {
   overflow-y: auto;
   overflow-x: hidden;
+  flex: 1 0 auto;
 }
 
 .pane {

--- a/src/components/SecondaryPanes/WhyPaused.css
+++ b/src/components/SecondaryPanes/WhyPaused.css
@@ -8,6 +8,7 @@
   opacity: 0.9;
   font-size: 12px;
   font-weight: bold;
+  flex: 0 1 auto;
 }
 
 .theme-dark .secondary-panes .why-paused {


### PR DESCRIPTION
Associated Issue: #1882 

### Summary of Changes

* Set proper flex values to SecondaryPane's contents.

### Test Plan

Open up the debugger in Chrome and FF, get it paused where it will show a reason why. Then make the *height* of the viewport smaller. Before this caused the height of the Commandbar to shrink, now it stays at 30px with no overflow.

### Screenshots/Videos

![no-overlap](https://cloud.githubusercontent.com/assets/868301/22467432/a65831f4-e792-11e6-8f0d-b185ce1994c6.png)
