### PR TITLE
Highlight line longer after jumping to file from Console

### DIFF
--- a/src/components/Editor/Editor.css
+++ b/src/components/Editor/Editor.css
@@ -98,7 +98,7 @@ html[dir="rtl"] .editor-mount {
 }
 
 .highlight-line .CodeMirror-line {
-  animation: fade-highlight-out 4s normal forwards;
+  animation: fade-highlight-out 3s normal forwards;
 }
 
 @keyframes fade-highlight-out {

--- a/src/components/Editor/Editor.css
+++ b/src/components/Editor/Editor.css
@@ -98,7 +98,7 @@ html[dir="rtl"] .editor-mount {
 }
 
 .highlight-line .CodeMirror-line {
-  animation: fade-highlight-out 1.5s normal forwards;
+  animation: fade-highlight-out 4s normal forwards;
 }
 
 @keyframes fade-highlight-out {


### PR DESCRIPTION
Associated Issue: #1663 

### Summary of Changes

* Change the animation time from 1.5s to 4s.

### Screenshots/Videos
### 4s Animation (animation-timing-function: normal):
![rs4oktdqbx](https://cloud.githubusercontent.com/assets/4562118/22540349/a7ad6672-e95a-11e6-91a1-150d2f7ea3f7.gif)


### 1.5s Animation:
![ff580476-d74a-11e6-880a-1181a022fcab](https://cloud.githubusercontent.com/assets/4562118/22540428/00ba118e-e95b-11e6-8fa2-b58fceb1e791.gif)
(GIF by @jnachtigall )

