### PR TITLE
Change isDirectory logic for source-tree

### DIFF
--- a/src/utils/sources-tree.js
+++ b/src/utils/sources-tree.js
@@ -155,8 +155,8 @@ function getURL(sourceUrl: string): { path: string, group: string } {
 function isDirectory(url: Object) {
   const parts = url.path.split("/").filter(p => p !== "");
 
-  return (parts.length === 0 ||
-                 parts[parts.length - 1].indexOf(".") === -1);
+  // Assume that all urls point to files except when they end with '/'
+  return (parts.length === 0 || url.path.slice(-1) === "/");
 }
 
 /**
@@ -178,6 +178,8 @@ function addToTree(tree: any, source: TmpSource) {
   const parts = url.path.split("/").filter(p => p !== "");
   const isDir = isDirectory(url);
   parts.unshift(url.group);
+
+  //console.log(url, parts);
 
   let path = "";
   let subtree = tree;

--- a/src/utils/sources-tree.js
+++ b/src/utils/sources-tree.js
@@ -179,8 +179,6 @@ function addToTree(tree: any, source: TmpSource) {
   const isDir = isDirectory(url);
   parts.unshift(url.group);
 
-  //console.log(url, parts);
-
   let path = "";
   let subtree = tree;
 

--- a/src/utils/tests/sources-tree.js
+++ b/src/utils/tests/sources-tree.js
@@ -122,7 +122,7 @@ describe("sources-tree", () => {
 
     const [
       bFolderNode,
-      b2FolderNode,
+      b2FileNode,
       dFolderNode,
       aFileNode,
       cFileNode,
@@ -132,9 +132,7 @@ describe("sources-tree", () => {
     expect(bFolderNode.contents.length).to.be(1);
     expect(bFolderNode.contents[0].name).to.be("b_source.js");
 
-    expect(b2FolderNode.name).to.be("b2");
-    expect(b2FolderNode.contents.length).to.be(1);
-    expect(b2FolderNode.contents[0].name).to.be("(index)");
+    expect(b2FileNode.name).to.be("b2");
 
     expect(dFolderNode.name).to.be("d");
     expect(dFolderNode.contents.length).to.be(1);
@@ -145,7 +143,7 @@ describe("sources-tree", () => {
     expect(cFileNode.name).to.be("c.js");
   });
 
-  it("puts (index) at the top of the sort", () => {
+  it("puts folder at the top of the sort", () => {
     const sources = [
       Map({
         url: "http://example.com/folder/a.js",
@@ -156,10 +154,6 @@ describe("sources-tree", () => {
         actor: "actor2"
       }),
       Map({
-        url: "http://example.com/folder",
-        actor: "actor1"
-      }),
-      Map({
         url: "http://example.com/folder/c/",
         actor: "actor1"
       }),
@@ -168,13 +162,10 @@ describe("sources-tree", () => {
     const tree = createNode("root", "", []);
     sources.forEach(source => addToTree(tree, source));
     const [
-      indexNode,
       bFolderNode,
       cFolderNode,
       aFileNode,
     ] = tree.contents[0].contents[0].contents;
-
-    expect(indexNode.name).to.be("(index)");
 
     expect(bFolderNode.name).to.be("b");
     expect(bFolderNode.contents.length).to.be(1);


### PR DESCRIPTION
Associated Issue: #1352 

### Summary of changes

* Change `isDirectory` function
* Edit test

### Screenshots/Videos (OPTIONAL)
![issue](https://cloud.githubusercontent.com/assets/1755089/22620304/d196fe82-eb2e-11e6-9ccd-f2ceb67c8c24.png)

The assumption here is that all urls point to files.
I'm completely sure about changes I made here. These changes seem to resolve the issue.

Let me know what you think.