### PR TITLE
Fix readme title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+---
+title: debugger.html
+permalink: /
+---
 # debugger.html &middot; [![slack-badge]][slack] ![][ci-status] [![npm-version]][npm-package] [![PRs Welcome]][make-a-pull-request]
 
 debugger.html is a hackable debugger for modern times, built from the ground up using [React] and [Redux].  It is designed to be approachable, yet powerful.  And it is engineered to be predictable, understandable, and testable.


### PR DESCRIPTION
Title of [https://devtools-html.github.io/debugger.html/](https://devtools-html.github.io/debugger.html/) is `<title>debugger.html · [![slack-badge]][slack] ![][ci-status] [![npm-version]][npm-package] [![PRs Welcome]][make-a-pull-request]</title>`

![title](https://cloud.githubusercontent.com/assets/1755089/22652629/2ee4f984-ecad-11e6-9898-e2932f1be777.png)


### Summary of Changes

* Explicitly declare title for `README.md`

Live version is [https://irfanhudda.github.io/debugger.html/](https://irfanhudda.github.io/debugger.html/)

Also this will change how `README.md` is displayed in github [https://github.com/irfanhudda/debugger.html/blob/gh-pages/README.md](https://github.com/irfanhudda/debugger.html/blob/gh-pages/README.md)