### PR TITLE
Fix #1948 - Use orangish color to note paused breakpoint

### DIFF
--- a/src/components/Editor/codemirror-mozilla.css
+++ b/src/components/Editor/codemirror-mozilla.css
@@ -5,16 +5,14 @@
 :root {
   /* --breakpoint-background: url("chrome://devtools/skin/images/breakpoint.svg#light"); */
   /* --breakpoint-hover-background: url("chrome://devtools/skin/images/breakpoint.svg#light-hover"); */
-  --breakpoint-active-color: rgba(44,187,15,.2);
-  --breakpoint-active-color-hover: rgba(44,187,15,.5);
+  --breakpoint-active-color: rgba(239,192,82,.6);
+  --breakpoint-active-color-hover: rgba(239,192,82,.8);
   /* --breakpoint-conditional-background: url("chrome://devtools/skin/images/breakpoint.svg#light-conditional"); */
 }
 
 .theme-dark:root {
   /* --breakpoint-background: url("chrome://devtools/skin/images/breakpoint.svg#dark"); */
   /* --breakpoint-hover-background: url("chrome://devtools/skin/images/breakpoint.svg#dark-hover"); */
-  --breakpoint-active-color: rgba(0,255,175,.4);
-  --breakpoint-active-color-hover: rgba(0,255,175,.7);
   /* --breakpoint-conditional-background: url("chrome://devtools/skin/images/breakpoint.svg#dark-conditional"); */
 }
 
@@ -74,10 +72,6 @@
 
 .conditional .CodeMirror-linenumber:before {
   background-image: var(--breakpoint-conditional-background) !important;
-}
-
-.debug-line .CodeMirror-linenumber {
-  background-color: var(--breakpoint-active-color);
 }
 
 .theme-dark .debug-line .CodeMirror-linenumber {

--- a/src/components/SecondaryPanes/WhyPaused.css
+++ b/src/components/SecondaryPanes/WhyPaused.css
@@ -10,7 +10,3 @@
   font-weight: bold;
   flex: 0 1 auto;
 }
-
-.theme-dark .secondary-panes .why-paused {
-  color: white;
-}


### PR DESCRIPTION
This is based on `--theme-graphs-yellow`, lightened to match the debugger's color palette.  I also wanted a color that would look decent in both themes.

<img width="1289" alt="lighter" src="https://cloud.githubusercontent.com/assets/46655/22714042/6bc4103a-ed50-11e6-8f39-2fe066027b14.png">

I'm happy to make any updates, let me know your thoughts.