### PR TITLE
Fix filename wrap in dropdown

### DIFF
--- a/src/components/shared/Dropdown.css
+++ b/src/components/shared/Dropdown.css
@@ -29,6 +29,7 @@
   overflow: hidden;
   height: 30px;
   text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .dropdown li:hover {


### PR DESCRIPTION
Associated Issue: #1941 

### Summary of Changes
Add `no-wrap` in `Dropdown.css` so that ellipsis show up in dropdown when file name is too long.

### Screenshots/Videos (OPTIONAL)
|Before|After|
|-|-|
|![before](https://cloud.githubusercontent.com/assets/1755089/22750074/7bc12030-ee55-11e6-9353-72188c4d25bc.png)|![after](https://cloud.githubusercontent.com/assets/1755089/22750078/7d7bd2c6-ee55-11e6-8839-b8d8220bf6fe.png)|