### PR TITLE
(WIP) add editor-search tests

### DIFF
--- a/src/test/integration/runner.js
+++ b/src/test/integration/runner.js
@@ -1,26 +1,27 @@
 require("mocha/mocha");
 const expect = require("expect.js");
 
-const { prefs } = require("../../utils/prefs")
-const prettyPrint = require("./tests/pretty-print")
-const breaking = require("./tests/breaking")
-const breakpointCond = require("./tests/breakpoints-cond")
+const { prefs } = require("../../utils/prefs");
+const prettyPrint = require("./tests/pretty-print");
+const breaking = require("./tests/breaking");
+const breakpointCond = require("./tests/breakpoints-cond");
+const editorSearch = require("./tests/editor-search");
 
 window.ok = function ok(expected) {
-  expect(expected).to.be.truthy
-}
+  expect(expected).to.be.truthy;
+};
 
 window.is = function is(expected, actual) {
-  expect(expected).to.equal(actual)
-}
+  expect(expected).to.equal(actual);
+};
 
 window.info = function info(msg) {
   console.log(`info: ${msg}\n`);
-}
+};
 
 const ctx = { ok, is, info};
 
-mocha.setup({ timeout: 20000, ui: 'bdd' });
+mocha.setup({ timeout: 20000, ui: "bdd" });
 
 describe("Tests", () => {
   beforeEach(() => {
@@ -38,6 +39,10 @@ describe("Tests", () => {
 
   it("conditional breakpoints", async function() {
     await breakpointCond(ctx);
+  });
+
+  it.only("editor search", async function() {
+    await editorSearch({ ok, is });
   });
 });
 

--- a/src/test/integration/tests.js
+++ b/src/test/integration/tests.js
@@ -1,6 +1,7 @@
 const prettyPrint = require("./tests/pretty-print");
 const breakpointsCond = require("./tests/breakpoints-cond");
 const breaking = require("./tests/breaking");
+const editorSearch = require("./tests/editor-search");
 const { setupTestRunner } = require("./utils/mocha")
 const { isDevelopment } = require("devtools-config");
 
@@ -12,5 +13,6 @@ module.exports = {
   setupTestRunner,
   prettyPrint,
   breaking,
-  breakpointsCond
+  breakpointsCond,
+  editorSearch
 }

--- a/src/test/integration/tests/editor-search.js
+++ b/src/test/integration/tests/editor-search.js
@@ -1,0 +1,25 @@
+const { waitForPaused, waitForDispatch } = require("../utils/wait");
+const { findSource, findElement } = require("../utils/shared");
+
+const {
+  selectSource,
+  clickElement,
+  addBreakpoint,
+  reload,
+  stepOver,
+  invokeInTab,
+  resume,
+  stop
+} = require("../utils/commands");
+
+const { assertPausedLocation } = require("../utils/assert");
+
+const { setupTestRunner, initDebugger } = require("../utils/mocha");
+
+module.exports = async function editorSearch(ctx) {
+  const { ok, is } = ctx;
+  const dbg = await initDebugger("doc-scripts.html", "simple1");
+
+  await selectSource(dbg, "simple1");
+  await stop();
+};

--- a/src/test/integration/utils/commands.js
+++ b/src/test/integration/utils/commands.js
@@ -1,4 +1,4 @@
-const {clickEl, rightClickEl} = require("./mouse-events")
+const { clickEl, rightClickEl } = require("./mouse-events");
 
 function info(msg) {
   console.log(`info: ${msg}\n`);
@@ -25,7 +25,11 @@ const {
  * @static
  */
 async function selectSource(dbg, url, line) {
-  info("Selecting source: " + url);
+  info(`Selecting source: ${url}`);
+  if (!dbg.selectors) {
+    throw new Error("dbg is required");
+  }
+
   const source = findSource(dbg, url);
   const hasText = !!dbg.selectors.getSourceText(dbg.getState(), source.id);
   await dbg.actions.selectSource(source.id, { line });
@@ -188,8 +192,14 @@ async function clickElement(dbg, elementName, ...args) {
 async function rightClickElement(dbg, elementName, ...args) {
   const selector = getSelector(elementName, ...args);
   const el = dbg.win.document.querySelector(selector);
-  info('right click on the gutter', el)
+  info("right click on the gutter", el);
   rightClickEl(dbg.win, el);
+}
+
+async function stop() {
+  return new Promise(() => {
+
+  });
 }
 
 module.exports = {
@@ -204,10 +214,10 @@ module.exports = {
   removeBreakpoint,
   togglePauseOnExceptions,
   clickElement,
-  navigate,
   invokeInTab,
   rightClickElement,
   selectMenuItem,
   type,
-  pressKey
-}
+  pressKey,
+  stop
+};


### PR DESCRIPTION
Associated Issue: #1088 

### Summary of Changes

* sharing early here. the goal is to follow the conditional bp tests and add some tests for selecting text, and searching

1. cmd-f, opens search bar
2. type `var` should search for vars
3. type `{enter}` should iterate