### PR TITLE
Fix watch expression tree not expanding

### DIFF
--- a/src/components/SecondaryPanes/Expressions.css
+++ b/src/components/SecondaryPanes/Expressions.css
@@ -43,8 +43,9 @@
 }
 
 .expression-container > .tree {
-  overflow: hidden;
+  overflow: auto;
   display: flex;
+  flex-direction: column;
 }
 
 :root.theme-light .expression-container:hover {

--- a/src/components/SecondaryPanes/Expressions.css
+++ b/src/components/SecondaryPanes/Expressions.css
@@ -43,7 +43,8 @@
 }
 
 .expression-container > .tree {
-  width: calc(100% - 20px);
+  width: 100%;
+  overflow: hidden;
 }
 
 :root.theme-light .expression-container:hover {

--- a/src/components/SecondaryPanes/Expressions.css
+++ b/src/components/SecondaryPanes/Expressions.css
@@ -43,9 +43,7 @@
 }
 
 .expression-container > .tree {
-  overflow: auto;
-  display: flex;
-  flex-direction: column;
+  width: calc(100% - 20px);
 }
 
 :root.theme-light .expression-container:hover {

--- a/src/components/shared/ManagedTree.css
+++ b/src/components/shared/ManagedTree.css
@@ -5,7 +5,6 @@
   -o-user-select: none;
   user-select: none;
 
-  flex: 1;
   white-space: nowrap;
   overflow: auto;
 }


### PR DESCRIPTION
I hadn't seen that @arthur801031 had claimed the issue but talked to him on Slack about opening the PR.

Associated Issue: #1970

### Summary of Changes

* remove flex box and change width to account for close button

### Test Plan

- [x] Add a watch expression and see that the tree actually expands vertically

### Screenshots/Videos

#### Before

![screenshot_20170208_225031](https://cloud.githubusercontent.com/assets/580982/22770928/031bdd54-ee51-11e6-8991-c3c9327954c2.png)

#### After

![screenshot_20170208_225014](https://cloud.githubusercontent.com/assets/580982/22770927/031bb388-ee51-11e6-939d-d2e33c1087d4.png)
