### PR TITLE
Add remark for markdown lint

### DIFF
--- a/.remarkrc
+++ b/.remarkrc
@@ -1,0 +1,7 @@
+{
+  "plugins": {
+    "validate-links": {
+      "repository": ""
+    }
+  }
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,6 @@ We respect your time and want to help you make the most of it as you learn more 
   * [Local Development](#local-development-computer)
   * [Issues](#issues)
   * [Pull Requests](#pull-requests)
-  * [Issues and Pull Request labels](#issues-and-pull-requests)
   * [Pro Tips](#pro-tips)
 * [Project Overview](#project-overview)
   * [debugger.html](#debuggerhtml)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -161,7 +161,7 @@ Go to [Pull Requests](./docs/pull-requests.md) to learn about:
 Go to [local Development](./docs/local-development.md) to learn about:
 
 * [Configs](./docs/local-development.md#configs)
-* [Hot Reloading](./docs/local-development.md#hot-reloading)
+* [Hot Reloading](./docs/local-development.md#hot-reloading-fire)
 * [Themes](./docs/local-development.md#themes)
 * [Internationalization](./docs/local-development.md#internationalization)
 * [Prefs](./docs/local-development.md#prefs)

--- a/circle.yml
+++ b/circle.yml
@@ -26,6 +26,7 @@ test:
   post:
     - yarn run lint-css
     - yarn run lint-js
+    - yarn run lint-md
     - yarn run flow
     - yarn run flow-coverage -- -t json -o $CIRCLE_TEST_REPORTS/flow-coverage
     - yarn check

--- a/configs/README.md
+++ b/configs/README.md
@@ -1,0 +1,2 @@
+## Debugger Config
+`debugger.html` can be configured with multiple options by editing/creating `configs/local.json`. A sample of config file is [here](local.sample.json).

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,4 +14,3 @@ permalink: docs/
 * [Lerna](./lerna.md)
 * [Debugging the debugger](./debugging-the-debugger.md)
 
-[Reference Documentation](./reference)

--- a/docs/client.md
+++ b/docs/client.md
@@ -1,7 +1,7 @@
 ## Debugger Architecture
 
 * [Debugger Protocol](#debugger-protocol)
-* [Client and Actors](#client-and-actors)
+* [Client and Actors](#clients-and-actors)
 
 ### Debugger Protocol
 

--- a/docs/debugger-html-react-redux-overview.md
+++ b/docs/debugger-html-react-redux-overview.md
@@ -1,7 +1,7 @@
 # Table of Contents
-1. [Architecture](#Introduction)
+1. [Architecture](#architecture)
 2. [Components](#components)
-3. [Component Data](#componentdata)
+3. [Component Data](#component-data)
 4. [Reducers](#reducers)
 5. [Actions](#actions)
 
@@ -19,7 +19,7 @@ Redux documentation can be found [here](http://redux.js.org/).
 
 As with most documentation related to code, this document may be out of date. The last edit date occurred on August 30, 2016. If you find issues in the documentation please file an issue as described in the [contributing](https://github.com/devtools-html/debugger.html/blob/master/CONTRIBUTING.md#writing-documentation-book) guide.
 
-# Architecture <a name="Introduction"></a>
+# Architecture
 
 
 Debugger.html is a React-Redux based application — the UI is constructed using React Components. the follow illustration provides a simplictic high level view:
@@ -59,7 +59,7 @@ is not modified.
 React uses a Virtual DOM; only required changes to the
 actual DOM will be rendered.
 
-# [Components](https://github.com/devtools-html/debugger.html/tree/master/src/components) <a name="components"></a>
+# Components
 
 
 debbuger.html uses React [Components](https://github.com/devtools-html/debugger.html/tree/master/src/components) to render portions of the
@@ -142,7 +142,7 @@ The farthest right section of the application is handled by many components. At 
 ![](https://docs.google.com/drawings/d/1zHogPebNmOFT9Xx6cZsaA6R6cTQLUzBXePV9sf62chA/pub?w=960&h=720)
 [Click here to Edit](https://docs.google.com/drawings/d/1zHogPebNmOFT9Xx6cZsaA6R6cTQLUzBXePV9sf62chA/edit?usp=sharing)
 
-# Component Data <a name="componentdata"></a>
+# Component Data
 
 Some components in Debugger.html are aware of the Redux store; others are
 not and are just rendering passed in properties. The Redux-aware
@@ -175,7 +175,7 @@ the Redux state. Finally, all of the actions in the actions folder are
 combined and the contained <code>actionCreators</code> in each of the files are setup
 so the actions can be called directly from the component.
 
-# [Reducers](https://github.com/devtools-html/debugger.html/tree/master/src/reducers) <a name="reducers"></a>
+# Reducers
 
 
 The [Reducers](https://github.com/devtools-html/debugger.html/tree/master/src/reducers) are all located in the src/reducers folder and are
@@ -439,7 +439,7 @@ The tabs reducer handles the following action types:
 -   <code>SELECT\_TAB</code> – This action type is triggered when a specific
     application is selected for debugging.
 
-# [Actions](https://github.com/devtools-html/debugger.html/tree/master/src/actions) <a name="actions"></a>
+# Actions
 
 The [actions](https://github.com/devtools-html/debugger.html/tree/master/src/actions) in debugger.html are all located in the
 src/actions folder; there is an action file corresponding to

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -11,14 +11,14 @@ Periodically feature flags are removed as features are either out of the experim
 
 ## Configure
 
-All feature flags are configured in the [configs directory](../configs/).  See the [config/README](../configs/README.md) for descriptions of each flag.
+All feature flags are configured in the [configs directory](../configs/).  See the [config/README][configs-readme] for descriptions of each flag.
 
 ## Development
 
 When developing features behind a feature flag there are resources within the codebase to help you.  Here are steps to follow when creating a feature flag.
 
 - Add an option to the [configs/development.json](../configs/development.json) file, default to `false` (off)
-- Create a corresponding entry in the [configs/README](../configs/README.md) that describes the flag
+- Create a corresponding entry in the [configs/README][configs-readme] that describes the flag
 - Add the code required to create the feature flag
 
 The `isEnabled` function checks the truthy value of a feature flag.  Pass in the full object name and location for the value.  Features are located within the `features` object and therefore have the name `features.X` where `X` is the name of the feature being described.
@@ -39,3 +39,5 @@ render() {
   return dom.div(null, 'pokestop!');
 }
 ```
+
+[configs-readme]: ../configs/README.md

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -107,8 +107,8 @@ These are the [labels](https://github.com/devtools-html/debugger.html/labels) we
 | `difficulty:hard` | [search][labels-difficulty-hard] | Work that requires new tests, new code, and a good understanding of project; expect lots of review |
 | `docs` | [search][labels-docs] | Issues with our documentation |
 | `design` | [search][labels-design] | Issues that require design work |
-| `enhancement` | [search][labels-enhancement] | [Requests](#suggesting-enhancements-new) for features |
-| `bug` | [search][labels-bug] | [Reported Bugs](#reporting-bugs-bug) with the current code |
+| `enhancement` | [search][labels-enhancement] | [Requests](../CONTRIBUTING.md#suggesting-enhancements-new) for features |
+| `bug` | [search][labels-bug] | [Reported Bugs](../CONTRIBUTING.md#reporting-bugs-bug) with the current code |
 | `chrome` | [search][labels-chrome] | Chrome only issues |
 | `firefox` | [search][labels-firefox] | Firefox only issues |
 | `infrastructure` | [search][labels-infrastructure] | Issues with testing / build infrastructure |

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -12,15 +12,6 @@
 * [Prefs](#prefs)
 * [SVGs](#svgs)
 * [Flow](#flow)
-  * [Adding flow to a file](#adding-flow-to-a-file)
-  * [Running flow](#running-flow)
-  * [Missing Annotation](#missing-annotation)
-  * [Where are types defined?](#where-are-types-defined?)
-  * [Checking flow coverage](#checking-flow-coverage)
-  * [Common Errors](#common-errors)
-    * [Required property](#required-property)
-    * [Missing Annotation](#missing-annotation)
-    * [Type Inconsistencies](#type-inconsistencies)
 * [Logging](#logging)
 * [Testing](#testing)
   * [Unit Tests](#unit-tests)
@@ -29,7 +20,7 @@
   * [Lint JS](#lint-js)
   * [Lint CSS](#lint-css)
 * [Colors](#colors)
-* [FAQ](#FAQ)
+* [FAQ](#faq)
 * [Getting Help](#getting-help)
 
 ### Configs
@@ -42,7 +33,7 @@ Here are the most common development configuration options:
   * `firefoxProxy` Enables logging the Firefox protocol in the terminal running `yarn start`
 * `chrome`
   * `debug` Enables listening for remotely debuggable Chrome browsers
-* `hotReloading` enables [Hot Reloading](./docs/local-development.md#hot-reloading) of CSS and React
+* `hotReloading` enables [Hot Reloading](#hot-reloading-fire) of CSS and React
 
 For a list of all the configuration options see the [packages/devtools-config/README.md][devtools-config-readme]
 
@@ -393,7 +384,7 @@ index 5996700..bb828d8 100644
 - [Adding flow to a file](./flow.md#adding-flow-to-a-file)
 - [Running flow](./flow.md#running-flow)
 - [Missing Annotation](./flow.md#missing-annotation)
-- [Where are types defined?](./flow.md#where-are-types-defined?)
+- [Where are types defined?](./flow.md#where-are-types-defined)
 - [Checking flow coverage](./flow.md#checking-flow-coverage)
 - [Common Errors](./flow.md#common-errors)
   - [Required property](./flow.md#required-property)

--- a/docs/pull-requests.md
+++ b/docs/pull-requests.md
@@ -73,13 +73,14 @@ Here are docs on [tests][test-docs] and [linting][linting-docs], which you can r
 
 The integration tests will be run automatically by the CI. Our integration tests are run with [mochitest][mochitest]. The local setup process is documented [here][mochitest-docs], but the process is a bit cumbersome, so reviewers will generally help debug.
 
-### Receiving Reviews
+### Reviews
+#### Receiving Reviews
 
 Once the tests have passed in the PR you must receive a review using the GitHub review system
 
 We have a number of contributors reviewing PRs fairly quickly, if you feel yours has been neglected please mention the team name **@devtools-html/debugger** in the PR
 
-### Reviewing a PR
+#### Reviewing a PR
 
 Giving valuable feedback is one of the best ways to contribute.
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "lint": "yarn run lint-css -s && yarn run lint-js -s",
     "lint-css": "stylelint src/components/*.css",
     "lint-js": "eslint src/**/*.js",
+    "lint-md": "remark .",
     "lint-fix": "yarn run lint-js -- --fix",
     "test": "node src/test/node-unit-tests.js",
     "test-all": "yarn run test; yarn run lint; yarn run flow",
@@ -79,5 +80,11 @@
     ]
   },
   "main": "src/main.js",
-  "author": "Jason Laster <jlaster@mozilla.com>"
+  "author": "Jason Laster <jlaster@mozilla.com>",
+  "devDependencies": {
+    "remark-cli": "^2.1.0",
+    "remark-lint": "^5.4.0",
+    "remark-preset-lint-recommended": "^1.0.0",
+    "remark-validate-links": "^5.0.0"
+  }
 }

--- a/src/test/fixtures/README.md
+++ b/src/test/fixtures/README.md
@@ -4,5 +4,5 @@
 
 + start firefox `npm run start-firefox`
 + start cypress server `npm run cypress-server`
-+ open the [fixtures.js](../integration/fixtures.js) test file and change `xdescribe` to `describe`
++ open the `fixtures.js` test file and change `xdescribe` to `describe`
 + run `cypress run`

--- a/yarn.lock
+++ b/yarn.lock
@@ -170,6 +170,12 @@ array-flatten@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-1.1.1.tgz#9a5f699051b1e7073328f2a008968b64ea2955d2"
 
+array-iterate@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/array-iterate/-/array-iterate-1.1.0.tgz#4f13148ffffa5f2756b50460e5eac8eed31a14e6"
+  dependencies:
+    has "^1.0.1"
+
 array-union@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/array-union/-/array-union-1.0.2.tgz#9a34410e4f4e3da23dea375be5be70f24778ec39"
@@ -1291,7 +1297,7 @@ check-node-version@^1.1.2:
     run-parallel "^1.1.4"
     semver "^5.0.3"
 
-chokidar@^1.0.0, chokidar@^1.0.5, chokidar@^1.2.0, chokidar@^1.6.1:
+chokidar@^1.0.0, chokidar@^1.0.5, chokidar@^1.2.0, chokidar@^1.5.1, chokidar@^1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-1.6.1.tgz#2f4447ab5e96e50fb3d789fd90d4c72e0e4c70c2"
   dependencies:
@@ -1394,7 +1400,7 @@ codemirror@^5.1.0:
   version "5.23.0"
   resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.23.0.tgz#ac9b6b2e163a79e915b44cf0f43cd115cf6982dc"
 
-collapse-white-space@^1.0.0:
+collapse-white-space@^1.0.0, collapse-white-space@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/collapse-white-space/-/collapse-white-space-1.0.2.tgz#9c463fb9c6d190d2dcae21a356a01bcae9eeef6d"
 
@@ -1500,7 +1506,7 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
 
-concat-stream@^1.0.0, concat-stream@^1.4.6, concat-stream@^1.5.0:
+concat-stream@^1.0.0, concat-stream@^1.4.6, concat-stream@^1.5.0, concat-stream@^1.5.1:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.0.tgz#0aac662fd52be78964d5532f694784e70110acf7"
   dependencies:
@@ -2377,6 +2383,10 @@ extend@^3.0.0, extend@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.0.tgz#5a474353b9f3353ddd8176dfd37b91c83a46f1d4"
 
+extend@~2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/extend/-/extend-2.0.1.tgz#1ee8010689e7395ff9448241c98652bc759a8260"
+
 extglob@^0.3.1:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/extglob/-/extglob-0.3.2.tgz#2e18ff3d2f49ab2765cec9023f011daa8d8349a1"
@@ -2537,6 +2547,10 @@ flatten@^1.0.2:
 flow-bin@^0.38.0:
   version "0.38.0"
   resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.38.0.tgz#3ae096d401c969cc8b5798253fb82381e2d0237a"
+
+fn-name@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/fn-name/-/fn-name-2.0.1.tgz#5214d7537a4d06a4a301c0cc262feb84188002e7"
 
 for-in@^0.1.5:
   version "0.1.6"
@@ -2704,6 +2718,12 @@ github-slugger@1.1.1, github-slugger@^1.0.0, github-slugger@^1.1.1:
   resolved "https://registry.yarnpkg.com/github-slugger/-/github-slugger-1.1.1.tgz#5444671f65e5a5a424cfa8ba3255cc1f7baf07ea"
   dependencies:
     emoji-regex "^6.0.0"
+
+github-url-to-object@^2.1.0:
+  version "2.2.6"
+  resolved "https://registry.yarnpkg.com/github-url-to-object/-/github-url-to-object-2.2.6.tgz#ca9250165149748eeeb30bfcc6000c6fe0d242f7"
+  dependencies:
+    is-url "^1.1.0"
 
 glob-base@^0.3.0:
   version "0.3.0"
@@ -2984,11 +3004,11 @@ husky@^0.13.1:
     is-ci "^1.0.9"
     normalize-path "^1.0.0"
 
-iconv-lite@0.4.13, iconv-lite@^0.4.5:
+iconv-lite@0.4.13:
   version "0.4.13"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.13.tgz#1f88aba4ab0b1508e8312acc39345f36e992e2f2"
 
-iconv-lite@0.4.15, iconv-lite@~0.4.13:
+iconv-lite@0.4.15, iconv-lite@^0.4.5, iconv-lite@~0.4.13:
   version "0.4.15"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.15.tgz#fe265a218ac6a57cfe854927e9d04c19825eddeb"
 
@@ -3104,6 +3124,10 @@ is-alphabetical@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-alphabetical/-/is-alphabetical-1.0.0.tgz#e2544c13058255f2144cb757066cd3342a1c8c46"
 
+is-alphanumeric@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-alphanumeric/-/is-alphanumeric-1.0.0.tgz#4a9cef71daf4c001c1d81d63d140cf53fd6889f4"
+
 is-alphanumerical@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-alphanumerical/-/is-alphanumerical-1.0.0.tgz#e06492e719c1bf15dec239e4f1af5f67b4d6e7bf"
@@ -3121,7 +3145,7 @@ is-binary-path@^1.0.0:
   dependencies:
     binary-extensions "^1.0.0"
 
-is-buffer@^1.0.2, is-buffer@~1.1.1:
+is-buffer@^1.0.2, is-buffer@^1.1.4, is-buffer@~1.1.1:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.4.tgz#cfc86ccd5dc5a52fa80489111c6920c457e2d98b"
 
@@ -3202,6 +3226,10 @@ is-glob@^3.1.0:
 is-hexadecimal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-hexadecimal/-/is-hexadecimal-1.0.0.tgz#5c459771d2af9a2e3952781fd54fcb1bcfe4113c"
+
+is-hidden@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-hidden/-/is-hidden-1.1.0.tgz#a9b04cfbc3a585c539c8c7c50a3414d91ee85119"
 
 is-my-json-valid@^2.10.0, is-my-json-valid@^2.12.4:
   version "2.15.0"
@@ -3312,6 +3340,10 @@ is-unc-path@^0.1.1:
   dependencies:
     unc-path-regex "^0.1.0"
 
+is-url@^1.1.0:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/is-url/-/is-url-1.2.2.tgz#498905a593bf47cc2d9e7f738372bbf7696c7f26"
+
 is-utf8@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
@@ -3320,9 +3352,17 @@ is-valid-glob@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/is-valid-glob/-/is-valid-glob-0.3.0.tgz#d4b55c69f51886f9b65c70d6c2622d37e29f48fe"
 
+is-whitespace-character@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-whitespace-character/-/is-whitespace-character-1.0.0.tgz#bbf4a83764ead0d451bec2a55218e91961adc275"
+
 is-windows@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-0.2.0.tgz#de1aa6d63ea29dd248737b69f1ff8b8002d2108c"
+
+is-word-character@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-word-character/-/is-word-character-1.0.0.tgz#a3a9e5ddad70c5c2ee36f4a9cfc9a53f44535247"
 
 isarray@0.0.1:
   version "0.0.1"
@@ -3367,7 +3407,7 @@ js-tokens@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.1.tgz#08e9f132484a2c45a30907e9dc4d5567b7f114d7"
 
-js-yaml@^3.3.1, js-yaml@^3.4.3, js-yaml@^3.5.1:
+js-yaml@^3.3.1, js-yaml@^3.4.3, js-yaml@^3.5.1, js-yaml@^3.6.1:
   version "3.8.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.8.1.tgz#782ba50200be7b9e5a8537001b7804db3ad02628"
   dependencies:
@@ -3513,6 +3553,10 @@ ldjson-stream@^1.2.1:
     split2 "^0.2.1"
     through2 "^0.6.1"
 
+levenshtein-edit-distance@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/levenshtein-edit-distance/-/levenshtein-edit-distance-1.0.0.tgz#895baf478cce8b5c1a0d27e45d7c1d978a661e49"
+
 levn@^0.3.0, levn@~0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/levn/-/levn-0.3.0.tgz#3b09924edf9f083c0490fdd4c0bc4421e04764ee"
@@ -3533,6 +3577,13 @@ load-json-file@^1.0.0:
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
     strip-bom "^2.0.0"
+
+load-plugin@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/load-plugin/-/load-plugin-2.1.0.tgz#5c688c560261997b47dfd0a7361faeb152acf7f5"
+  dependencies:
+    npm-prefix "^1.2.0"
+    resolve-from "^2.0.0"
 
 loader-utils@^0.2.11, loader-utils@^0.2.16, loader-utils@^0.2.3, loader-utils@^0.2.7, loader-utils@~0.2.2:
   version "0.2.16"
@@ -3692,6 +3743,10 @@ longest-streak@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/longest-streak/-/longest-streak-1.0.0.tgz#d06597c4d4c31b52ccb1f5d8f8fe7148eafd6965"
 
+longest-streak@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/longest-streak/-/longest-streak-2.0.1.tgz#42d291b5411e40365c00e63193497e2247316e35"
+
 longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
@@ -3725,9 +3780,21 @@ map-obj@^1.0.0, map-obj@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-1.0.1.tgz#d933ceb9205d82bdcf4886f6742bdc2b4dea146d"
 
+markdown-escapes@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/markdown-escapes/-/markdown-escapes-1.0.0.tgz#c8ca19f1d94d682459e0a93c86db27a7ef716b23"
+
+markdown-extensions@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/markdown-extensions/-/markdown-extensions-1.1.0.tgz#fba0f1a2ebb4f4123d25b7a93bc35792c11f504e"
+
 markdown-table@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/markdown-table/-/markdown-table-0.4.0.tgz#890c2c1b3bfe83fb00e4129b8e4cfe645270f9d1"
+
+markdown-table@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/markdown-table/-/markdown-table-1.1.0.tgz#1f5ae61659ced8808d882554c32e8b3f38dd1143"
 
 math-expression-evaluator@^1.2.14:
   version "1.2.16"
@@ -3740,6 +3807,28 @@ md5@^2.1.0, md5@^2.2.1:
     charenc "~0.0.1"
     crypt "~0.0.1"
     is-buffer "~1.1.1"
+
+mdast-comment-marker@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/mdast-comment-marker/-/mdast-comment-marker-1.0.1.tgz#f0f26c33fc5d81e41d9ec36ff4f066bb50d217fb"
+
+mdast-util-compact@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/mdast-util-compact/-/mdast-util-compact-1.0.0.tgz#4c94dedfe35932d5457f29b650b330fdc73e994a"
+  dependencies:
+    unist-util-modify-children "^1.0.0"
+    unist-util-visit "^1.1.0"
+
+mdast-util-definitions@^1.0.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/mdast-util-definitions/-/mdast-util-definitions-1.2.0.tgz#00f67b4289ed36bafc0977b558414ac0c5023b24"
+  dependencies:
+    has "^1.0.1"
+    unist-util-visit "^1.0.0"
+
+mdast-util-heading-style@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/mdast-util-heading-style/-/mdast-util-heading-style-1.0.2.tgz#14b7cf2802881d09af0cfdce42026d6bc584fff1"
 
 mdast-util-inject@^1.1.0:
   version "1.1.0"
@@ -4065,7 +4154,7 @@ normalize-url@^1.4.0:
     query-string "^4.1.0"
     sort-keys "^1.0.0"
 
-npm-prefix@^1.0.1:
+npm-prefix@^1.0.1, npm-prefix@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/npm-prefix/-/npm-prefix-1.2.0.tgz#e619455f7074ba54cc66d6d0d37dd9f1be6bcbc0"
   dependencies:
@@ -4119,7 +4208,7 @@ on-finished@~2.3.0:
   dependencies:
     ee-first "1.1.1"
 
-once@^1.3.0, once@^1.4:
+once@^1.3.0, once@^1.3.3, once@^1.4:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   dependencies:
@@ -4214,7 +4303,7 @@ parents@^1.0.0:
   dependencies:
     path-platform "~0.11.15"
 
-parse-entities@^1.0.0:
+parse-entities@^1.0.0, parse-entities@^1.0.2:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/parse-entities/-/parse-entities-1.1.0.tgz#4bc58f35fdc8e65dded35a12f2e40223ca24a3f7"
   dependencies:
@@ -4704,6 +4793,12 @@ promise@^7.0.3, promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
+propose@0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/propose/-/propose-0.0.5.tgz#48a065d9ec7d4c8667f4050b15c4a2d85dbca56b"
+  dependencies:
+    levenshtein-edit-distance "^1.0.0"
+
 protocols@^1.1.0, protocols@^1.4.0:
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/protocols/-/protocols-1.4.3.tgz#635b1c0785f0b389e8a012df1b1afffda9608b76"
@@ -5043,6 +5138,14 @@ regjsparser@^0.1.4:
   dependencies:
     jsesc "~0.5.0"
 
+remark-cli@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/remark-cli/-/remark-cli-2.1.0.tgz#d1fe363a4ebc02d7c2968135672df4ed185dc387"
+  dependencies:
+    markdown-extensions "^1.1.0"
+    remark "^6.0.0"
+    unified-args "^2.1.0"
+
 remark-html@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/remark-html/-/remark-html-3.0.0.tgz#ce2f7cb8ecebae737a91aa3e3e906e20da488d2d"
@@ -5055,7 +5158,61 @@ remark-html@3.0.0:
     trim-lines "^1.0.0"
     unist-util-visit "^1.0.0"
 
-remark-slug@^4.0.0:
+remark-lint@^5.0.0, remark-lint@^5.4.0:
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/remark-lint/-/remark-lint-5.4.0.tgz#6e7c77b90844ad1931761c62af9d65ab46e6734a"
+  dependencies:
+    decamelize "^1.0.0"
+    load-plugin "^2.0.0"
+    mdast-util-heading-style "^1.0.0"
+    mdast-util-to-string "^1.0.0"
+    plur "^2.0.0"
+    remark-message-control "^2.0.0"
+    trough "^1.0.0"
+    unist-util-generated "^1.1.0"
+    unist-util-position "^3.0.0"
+    unist-util-visit "^1.0.0"
+    vfile-location "^2.0.0"
+    vfile-sort "^2.0.0"
+    wrapped "^1.0.1"
+
+remark-message-control@^2.0.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/remark-message-control/-/remark-message-control-2.0.3.tgz#b9278fae0b118ee24679821c7c02ea9ba2a682c4"
+  dependencies:
+    mdast-comment-marker "^1.0.0"
+    trim "0.0.1"
+    unist-util-visit "^1.0.0"
+    vfile-location "^2.0.0"
+
+remark-parse@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/remark-parse/-/remark-parse-2.2.0.tgz#92a8e7750d4fbfd53cd460adad686014f2a7f43b"
+  dependencies:
+    collapse-white-space "^1.0.2"
+    has "^1.0.1"
+    is-alphabetical "^1.0.0"
+    is-decimal "^1.0.0"
+    is-whitespace-character "^1.0.0"
+    is-word-character "^1.0.0"
+    markdown-escapes "^1.0.0"
+    parse-entities "^1.0.2"
+    repeat-string "^1.5.4"
+    state-toggle "^1.0.0"
+    trim "0.0.1"
+    trim-trailing-lines "^1.0.0"
+    unherit "^1.0.4"
+    unist-util-remove-position "^1.0.0"
+    vfile-location "^2.0.0"
+    xtend "^4.0.1"
+
+remark-preset-lint-recommended@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/remark-preset-lint-recommended/-/remark-preset-lint-recommended-1.0.0.tgz#9054280d8495a79f55850d17af940c8c47f72c12"
+  dependencies:
+    remark-lint "^5.0.0"
+
+remark-slug@^4.0.0, remark-slug@^4.2.1:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/remark-slug/-/remark-slug-4.2.2.tgz#3cfaa02e2e24d98405b296072f2ebbdfad279eb6"
   dependencies:
@@ -5063,12 +5220,43 @@ remark-slug@^4.0.0:
     mdast-util-to-string "^1.0.0"
     unist-util-visit "^1.0.0"
 
+remark-stringify@^2.2.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/remark-stringify/-/remark-stringify-2.4.0.tgz#38dd286153139a082e9d9f17e2d49919792cec2f"
+  dependencies:
+    ccount "^1.0.0"
+    is-alphanumeric "^1.0.0"
+    is-decimal "^1.0.0"
+    is-whitespace-character "^1.0.0"
+    longest-streak "^2.0.1"
+    markdown-escapes "^1.0.0"
+    markdown-table "^1.1.0"
+    mdast-util-compact "^1.0.0"
+    parse-entities "^1.0.2"
+    repeat-string "^1.5.4"
+    state-toggle "^1.0.0"
+    stringify-entities "^1.0.1"
+    unherit "^1.0.4"
+    xtend "^4.0.1"
+
 remark-toc@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/remark-toc/-/remark-toc-3.1.0.tgz#fa978107005d868753001134b39690dcb2e3eb62"
   dependencies:
     mdast-util-toc "^2.0.0"
     remark-slug "^4.0.0"
+
+remark-validate-links@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/remark-validate-links/-/remark-validate-links-5.0.0.tgz#2911e1f6eec1bc56d58907f892050f2c5a1cd18f"
+  dependencies:
+    github-url-to-object "^2.1.0"
+    mdast-util-definitions "^1.0.0"
+    propose "0.0.5"
+    remark-slug "^4.2.1"
+    unist-util-visit "^1.0.0"
+    urljoin "^0.1.5"
+    xtend "^4.0.1"
 
 remark@^4.1.2:
   version "4.2.2"
@@ -5107,6 +5295,15 @@ remark@^4.1.2:
     vfile-reporter "^1.5.0"
     ware "^1.3.0"
 
+remark@^6.0.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/remark/-/remark-6.2.0.tgz#0c72614a095c7665494611f9472c32b9e032dcf9"
+  dependencies:
+    load-plugin "^2.0.0"
+    remark-parse "^2.2.0"
+    remark-stringify "^2.2.0"
+    unified "^5.0.0"
+
 remote-origin-url@0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/remote-origin-url/-/remote-origin-url-0.4.0.tgz#4d3e2902f34e2d37d1c263d87710b77eb4086a30"
@@ -5117,7 +5314,7 @@ repeat-element@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/repeat-element/-/repeat-element-1.1.2.tgz#ef089a178d1483baae4d93eb98b4f9e4e11d990a"
 
-repeat-string@^1.5.0, repeat-string@^1.5.2:
+repeat-string@^1.5.0, repeat-string@^1.5.2, repeat-string@^1.5.4:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
 
@@ -5130,6 +5327,10 @@ repeating@^2.0.0:
 replace-ext@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/replace-ext/-/replace-ext-0.0.1.tgz#29bbd92078a739f0bcce2b4ee41e837953522924"
+
+replace-ext@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/replace-ext/-/replace-ext-1.0.0.tgz#de63128373fcbf7c3ccfa4de5a480c45a67958eb"
 
 request@^2.79.0:
   version "2.79.0"
@@ -5320,6 +5521,10 @@ slice-ansi@0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-0.0.4.tgz#edbf8903f66f7ce2f8eafd6ceed65e264c831b35"
 
+sliced@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/sliced/-/sliced-1.0.1.tgz#0b3a662b5d04c3177b1926bea82b03f837a2ef41"
+
 sntp@1.x.x:
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/sntp/-/sntp-1.0.9.tgz#6541184cc90aeea6c6e7b35e2659082443c66198"
@@ -5405,6 +5610,10 @@ stack-trace@~0.0.7:
   version "0.0.9"
   resolved "https://registry.yarnpkg.com/stack-trace/-/stack-trace-0.0.9.tgz#a8f6eaeca90674c333e7c43953f275b451510695"
 
+state-toggle@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/state-toggle/-/state-toggle-1.0.0.tgz#d20f9a616bb4f0c3b98b91922d25b640aa2bc425"
+
 statuses@1, "statuses@>= 1.3.1 < 2", statuses@~1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.3.1.tgz#faf51b9eb74aaef3b3acf4ad5f61abf24cb7b93e"
@@ -5473,7 +5682,7 @@ string_decoder@^0.10.25, string_decoder@~0.10.x:
   version "0.10.31"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
 
-stringify-entities@^1.0.0:
+stringify-entities@^1.0.0, stringify-entities@^1.0.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/stringify-entities/-/stringify-entities-1.3.0.tgz#2244a516c4f1e8e01b73dad01023016776abd917"
   dependencies:
@@ -5807,6 +6016,14 @@ to-vfile@^1.0.0:
   dependencies:
     vfile "^1.0.0"
 
+to-vfile@^2.0.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/to-vfile/-/to-vfile-2.1.1.tgz#bbdaa802811af3af43b4afd4987f435f21931cc8"
+  dependencies:
+    is-buffer "^1.1.4"
+    vfile "^2.0.0"
+    x-is-string "^0.1.0"
+
 tough-cookie@~2.3.0:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.2.tgz#f081f76e4c85720e6c37a5faced737150d84072a"
@@ -5828,6 +6045,10 @@ trim-trailing-lines@^1.0.0:
 trim@0.0.1, trim@^0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/trim/-/trim-0.0.1.tgz#5858547f6b290757ee95cccc666fb50084c460dd"
+
+trough@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/trough/-/trough-1.0.0.tgz#6bdedfe7f2aa49a6f3c432257687555957f342fd"
 
 tryit@^1.0.1:
   version "1.0.3"
@@ -5898,6 +6119,39 @@ unherit@^1.0.0, unherit@^1.0.4:
     inherits "^2.0.1"
     xtend "^4.0.1"
 
+unified-args@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/unified-args/-/unified-args-2.1.0.tgz#a1223544ef88e0cedab7d717d6a7934400ded607"
+  dependencies:
+    camelcase "^3.0.0"
+    chalk "^1.1.3"
+    chokidar "^1.5.1"
+    minimist "^1.2.0"
+    text-table "^0.2.0"
+    unified-engine "^2.1.0"
+
+unified-engine@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/unified-engine/-/unified-engine-2.1.0.tgz#215ab332b32a6c2137fbca1c12c2bcbc1467d164"
+  dependencies:
+    concat-stream "^1.5.1"
+    debug "^2.2.0"
+    fn-name "^2.0.1"
+    glob "^7.0.3"
+    globby "^6.0.0"
+    is-hidden "^1.0.1"
+    js-yaml "^3.6.1"
+    load-plugin "^2.0.0"
+    minimatch "^3.0.0"
+    parse-json "^2.2.0"
+    to-vfile "^2.0.0"
+    trough "^1.0.0"
+    user-home "^2.0.0"
+    vfile-find-down "^2.0.0"
+    vfile-find-up "^2.0.0"
+    vfile-reporter "^3.0.0"
+    vfile-statistics "^1.0.0"
+
 unified@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/unified/-/unified-3.0.0.tgz#85ce4169b09ee9f084d07f4d0a1fbe3939518712"
@@ -5908,6 +6162,19 @@ unified@^3.0.0:
     unherit "^1.0.4"
     vfile "^1.0.0"
     ware "^1.3.0"
+
+unified@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/unified/-/unified-5.1.0.tgz#61268da9b91ce925be1f3d198c0278b0e9716094"
+  dependencies:
+    bail "^1.0.0"
+    extend "^3.0.0"
+    has "^1.0.1"
+    is-buffer "^1.1.4"
+    once "^1.3.3"
+    trough "^1.0.0"
+    vfile "^2.0.0"
+    x-is-string "^0.1.0"
 
 uniq@^1.0.1:
   version "1.0.1"
@@ -5936,11 +6203,31 @@ unist-builder@^1.0.0:
   dependencies:
     object-assign "^4.1.0"
 
+unist-util-generated@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/unist-util-generated/-/unist-util-generated-1.1.0.tgz#8c95657ff12b32eaffe0731fbb37da6995fae01b"
+
+unist-util-modify-children@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/unist-util-modify-children/-/unist-util-modify-children-1.1.0.tgz#559203ae85d7a76283277be1abfbaf595a177ead"
+  dependencies:
+    array-iterate "^1.0.0"
+
+unist-util-position@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/unist-util-position/-/unist-util-position-3.0.0.tgz#e6e1e03eeeb81c5e1afe553e8d4adfbd7c0d8f82"
+
 unist-util-remove-position@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/unist-util-remove-position/-/unist-util-remove-position-1.1.0.tgz#2444fedc344bc5f540dab6353e013b6d78101dc2"
   dependencies:
     unist-util-visit "^1.1.0"
+
+unist-util-stringify-position@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/unist-util-stringify-position/-/unist-util-stringify-position-1.1.0.tgz#e8ba9d6b6af891b5f8336b3a31c63a9dc85c2af0"
+  dependencies:
+    has "^1.0.1"
 
 unist-util-visit@^1.0.0, unist-util-visit@^1.0.1, unist-util-visit@^1.1.0:
   version "1.1.1"
@@ -5972,6 +6259,12 @@ url@^0.11.0:
   dependencies:
     punycode "1.3.2"
     querystring "0.2.0"
+
+urljoin@^0.1.5:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/urljoin/-/urljoin-0.1.5.tgz#b25d2c6112c55ac9d50096a49a0f1fb7f4f53921"
+  dependencies:
+    extend "~2.0.0"
 
 urllite@~0.5.0:
   version "0.5.0"
@@ -6044,11 +6337,24 @@ vfile-find-down@^1.0.0:
   dependencies:
     to-vfile "^1.0.0"
 
+vfile-find-down@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/vfile-find-down/-/vfile-find-down-2.0.1.tgz#a9fc858cb256fbbbc04f7465a5f6f2753338596e"
+  dependencies:
+    has "^1.0.1"
+    to-vfile "^2.0.0"
+
 vfile-find-up@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/vfile-find-up/-/vfile-find-up-1.0.0.tgz#5604da6fe453b34350637984eb5fe4909e280390"
   dependencies:
     to-vfile "^1.0.0"
+
+vfile-find-up@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/vfile-find-up/-/vfile-find-up-2.0.0.tgz#d32cacd13b4d327888bb47a1e827a63d68dfaad1"
+  dependencies:
+    to-vfile "^2.0.0"
 
 vfile-location@^2.0.0:
   version "2.0.1"
@@ -6079,13 +6385,44 @@ vfile-reporter@^2.0.0:
     text-table "^0.2.0"
     vfile-sort "^1.0.0"
 
+vfile-reporter@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/vfile-reporter/-/vfile-reporter-3.0.0.tgz#fe50714e373e0d2940510038a99bd609bdc8209f"
+  dependencies:
+    chalk "^1.1.0"
+    log-symbols "^1.0.2"
+    plur "^2.0.0"
+    repeat-string "^1.5.0"
+    string-width "^1.0.0"
+    strip-ansi "^3.0.1"
+    trim "0.0.1"
+    unist-util-stringify-position "^1.0.0"
+
 vfile-sort@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/vfile-sort/-/vfile-sort-1.0.0.tgz#17ee491ba43e8951bb22913fcff32a7dc4d234d4"
 
+vfile-sort@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/vfile-sort/-/vfile-sort-2.0.0.tgz#7279458d111a9ba3b18effd9f8a0169bb7c5112b"
+
+vfile-statistics@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/vfile-statistics/-/vfile-statistics-1.0.0.tgz#003d356c0f3e0233f3a2271c65e2acee5ed4d0f8"
+
 vfile@^1.0.0, vfile@^1.1.0, vfile@^1.1.2:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/vfile/-/vfile-1.4.0.tgz#c0fd6fa484f8debdb771f68c31ed75d88da97fe7"
+
+vfile@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/vfile/-/vfile-2.0.1.tgz#bd48e68e8a2322dff0d162a37f45e70d9bb30466"
+  dependencies:
+    has "^1.0.1"
+    is-buffer "^1.1.4"
+    replace-ext "1.0.0"
+    unist-util-stringify-position "^1.0.0"
+    x-is-string "^0.1.0"
 
 vinyl-fs@^2.3.1:
   version "2.4.4"
@@ -6272,6 +6609,13 @@ wrap-fn@^0.1.0:
   dependencies:
     co "3.1.0"
 
+wrapped@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/wrapped/-/wrapped-1.0.1.tgz#c783d9d807b273e9b01e851680a938c87c907242"
+  dependencies:
+    co "3.1.0"
+    sliced "^1.0.1"
+
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
@@ -6292,6 +6636,10 @@ ws@1.1.x, ws@^1.0.1:
   dependencies:
     options ">=0.0.5"
     ultron "1.0.x"
+
+x-is-string@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/x-is-string/-/x-is-string-0.1.0.tgz#474b50865af3a49a9c4657f05acd145458f77d82"
 
 xml2js@^0.4.17, xml2js@~0.4.4:
   version "0.4.17"


### PR DESCRIPTION
Associated Issue: #1944

### Summary of Changes

* Add `remark-lint`, `remark-validate-links`
* Fix links in various files
* Remove fixtures link
* Remove flow links from table of contents in `local-development.md`


I've just added `validate-links` to `.remarkrc`. We should also include `"presets": ["lint-recommended"],` in future.

Let me know if I missed something.