### PR TITLE
Fix white space queries breaking the editor

### DIFF
--- a/src/components/Editor/SearchBar.js
+++ b/src/components/Editor/SearchBar.js
@@ -152,7 +152,18 @@ const SearchBar = React.createClass({
 
     // eslint-disable-next-line react/no-did-update-set-state
     this.setState({ count, index: 0 });
-    this.search(query.trim());
+    if (!this.leadingWhiteSpaceOnly(query)) {
+      this.search(query);
+    }
+  },
+
+  leadingWhiteSpaceOnly(query: string) {
+    for (let i = 0; i < query.length; i++) {
+      if (query[i] != " ") {
+        return false;
+      }
+    }
+    return true;
   },
 
   onChange(e: any) {
@@ -178,7 +189,9 @@ const SearchBar = React.createClass({
     }
 
     const findFnc = rev ? findPrev : findNext;
-    findFnc(ctx, query.trim(), true, modifiers);
+    if (!this.leadingWhiteSpaceOnly(query)) {
+      findFnc(ctx, query, true, modifiers);
+    }
     const nextIndex = index == count - 1 ? 0 : index + 1;
     this.setState({ index: nextIndex });
   },

--- a/src/components/Editor/SearchBar.js
+++ b/src/components/Editor/SearchBar.js
@@ -152,7 +152,7 @@ const SearchBar = React.createClass({
 
     // eslint-disable-next-line react/no-did-update-set-state
     this.setState({ count, index: 0 });
-    this.search(query);
+    this.search(query.trim());
   },
 
   onChange(e: any) {
@@ -178,7 +178,7 @@ const SearchBar = React.createClass({
     }
 
     const findFnc = rev ? findPrev : findNext;
-    findFnc(ctx, query, true, modifiers);
+    findFnc(ctx, query.trim(), true, modifiers);
     const nextIndex = index == count - 1 ? 0 : index + 1;
     this.setState({ index: nextIndex });
   },

--- a/src/components/Editor/SearchBar.js
+++ b/src/components/Editor/SearchBar.js
@@ -152,18 +152,10 @@ const SearchBar = React.createClass({
 
     // eslint-disable-next-line react/no-did-update-set-state
     this.setState({ count, index: 0 });
-    if (!this.leadingWhiteSpaceOnly(query)) {
+    // Only perform a search if query contains a non-whitespace character
+    if (query.match(/\S/)) {
       this.search(query);
     }
-  },
-
-  leadingWhiteSpaceOnly(query: string) {
-    for (let i = 0; i < query.length; i++) {
-      if (query[i] != " ") {
-        return false;
-      }
-    }
-    return true;
   },
 
   onChange(e: any) {
@@ -189,7 +181,8 @@ const SearchBar = React.createClass({
     }
 
     const findFnc = rev ? findPrev : findNext;
-    if (!this.leadingWhiteSpaceOnly(query)) {
+    // Only perform a search if query contains a non-whitespace character
+    if (query.match(/\S/)) {
       findFnc(ctx, query, true, modifiers);
     }
     const nextIndex = index == count - 1 ? 0 : index + 1;

--- a/src/components/Editor/SearchBar.js
+++ b/src/components/Editor/SearchBar.js
@@ -152,10 +152,7 @@ const SearchBar = React.createClass({
 
     // eslint-disable-next-line react/no-did-update-set-state
     this.setState({ count, index: 0 });
-    // Only perform a search if query contains a non-whitespace character
-    if (query.match(/\S/)) {
-      this.search(query);
-    }
+    this.search(query);
   },
 
   onChange(e: any) {
@@ -181,10 +178,8 @@ const SearchBar = React.createClass({
     }
 
     const findFnc = rev ? findPrev : findNext;
-    // Only perform a search if query contains a non-whitespace character
-    if (query.match(/\S/)) {
-      findFnc(ctx, query, true, modifiers);
-    }
+    findFnc(ctx, query, true, modifiers);
+
     const nextIndex = index == count - 1 ? 0 : index + 1;
     this.setState({ index: nextIndex });
   },

--- a/src/utils/editor/source-search.js
+++ b/src/utils/editor/source-search.js
@@ -30,6 +30,10 @@ function getSearchCursor(cm, query: string, pos, modifiers: SearchModifiers) {
   return cm.getSearchCursor(regexQuery, pos);
 }
 
+function isWhitespace(query) {
+  return !query.match(/\S/);
+}
+
 /**
  * This returns a mode object used by CoeMirror's addOverlay function
  * to parse and style tokens in the file.
@@ -117,7 +121,7 @@ function updateCursor(cm, state, keepSelection) {
 function doSearch(ctx, rev, query, keepSelection, modifiers: SearchModifiers) {
   let { cm } = ctx;
   cm.operation(function() {
-    if (!query) {
+    if (!query || isWhitespace(query)) {
       return;
     }
 


### PR DESCRIPTION
Associated Issue: #1930

### Summary of Changes
* Add a regex to check if the query only contains whitespace. If this is true, we do not search this query. Otherwise, we perform a search.