### PR TITLE
Add flow to source-documents.js and source-editor.js

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -10,3 +10,5 @@
 [libs]
 ./src/global-types.js
 
+[options]
+unsafe.enable_getters_and_setters=true

--- a/src/types.js
+++ b/src/types.js
@@ -11,6 +11,17 @@ export type Expression = {
    input: string
  };
 
+ export type Mode = String | {
+   name: string,
+   typescript?: boolean,
+   base?: {
+     name: string,
+     typescript: boolean
+   }
+ }
+
+export type AlignOpts = "top" | "center" | "bottom";
+
 export type {
   Breakpoint,
   Frame,

--- a/src/utils/editor/source-documents.js
+++ b/src/utils/editor/source-documents.js
@@ -1,14 +1,16 @@
+// @flow
+
 let sourceDocs = {};
 
-function getDocument(key) {
+function getDocument(key: string) {
   return sourceDocs[key];
 }
 
-function setDocument(key, doc) {
+function setDocument(key: string, doc: any) {
   sourceDocs[key] = doc;
 }
 
-function removeDocument(key) {
+function removeDocument(key: string) {
   delete sourceDocs[key];
 }
 

--- a/src/utils/editor/source-editor.js
+++ b/src/utils/editor/source-editor.js
@@ -16,6 +16,8 @@ require("codemirror/mode/elm/elm");
 require("../../components/Editor/codemirror-mozilla.css");
 require("codemirror/addon/search/searchcursor");
 
+import type { Mode, AlignOpts } from "../../types";
+
 // Maximum allowed margin (in number of lines) from top or bottom of the editor
 // while shifting to a line which was initially out of view.
 const MAX_VERTICAL_OFFSET = 3;
@@ -62,7 +64,7 @@ class SourceEditor {
     return this.editor.getValue();
   }
 
-  setMode(value: Object) {
+  setMode(value: Mode) {
     this.editor.setOption("mode", value);
   }
 
@@ -89,7 +91,7 @@ class SourceEditor {
    * bottom.
    * @memberof utils/source-editor
    */
-  alignLine(line: number, align: string = "top") {
+  alignLine(line: number, align: AlignOpts = "top") {
     let cm = this.editor;
     let from = cm.lineAtHeight(0, "page");
     let to = cm.lineAtHeight(cm.getWrapperElement().clientHeight, "page");

--- a/src/utils/editor/source-editor.js
+++ b/src/utils/editor/source-editor.js
@@ -1,3 +1,5 @@
+// @flow
+
 /**
  * CodeMirror source editor utils
  * @module utils/source-editor
@@ -18,12 +20,29 @@ require("codemirror/addon/search/searchcursor");
 // while shifting to a line which was initially out of view.
 const MAX_VERTICAL_OFFSET = 3;
 
+type SourceEditorOpts = {
+  enableCodeFolding: boolean,
+  extraKeys: Object,
+  gutters: string[],
+  lineNumbers: boolean,
+  lineWrapping: boolean,
+  matchBrackets: boolean,
+  mode: string,
+  readOnly: boolean,
+  showAnnotationRuler: boolean,
+  theme: string,
+  value: string,
+};
+
 class SourceEditor {
-  constructor(opts) {
+  opts: SourceEditorOpts;
+  editor: any;
+
+  constructor(opts: SourceEditorOpts) {
     this.opts = opts;
   }
 
-  appendToLocalElement(node) {
+  appendToLocalElement(node: any) {
     this.editor = CodeMirror(node, this.opts);
   }
 
@@ -31,11 +50,11 @@ class SourceEditor {
     // No need to do anything.
   }
 
-  get codeMirror() {
+  get codeMirror(): any {
     return this.editor;
   }
 
-  setText(str) {
+  setText(str: string) {
     this.editor.setValue(str);
   }
 
@@ -43,7 +62,7 @@ class SourceEditor {
     return this.editor.getValue();
   }
 
-  setMode(value) {
+  setMode(value: Object) {
     this.editor.setOption("mode", value);
   }
 
@@ -51,7 +70,7 @@ class SourceEditor {
    * Replaces the current document with a new source document
    * @memberof utils/source-editor
    */
-  replaceDocument(doc) {
+  replaceDocument(doc: any) {
     this.editor.swapDoc(doc);
   }
 
@@ -70,7 +89,7 @@ class SourceEditor {
    * bottom.
    * @memberof utils/source-editor
    */
-  alignLine(line, align = "top") {
+  alignLine(line: number, align: string = "top") {
     let cm = this.editor;
     let from = cm.lineAtHeight(0, "page");
     let to = cm.lineAtHeight(cm.getWrapperElement().clientHeight, "page");
@@ -102,7 +121,7 @@ class SourceEditor {
    * Scrolls the view such that the given line number is the first visible line.
    * @memberof utils/source-editor
    */
-  setFirstVisibleLine(line) {
+  setFirstVisibleLine(line: number) {
     let { top } = this.editor.charCoords({ line: line, ch: 0 }, "local");
     this.editor.scrollTo(0, top);
   }


### PR DESCRIPTION
Associated Issue: #1785

### Summary of Changes

* Add flow to source-documents.js and source-editor.js

### Test Plan
- Passed 
`yarn run flow`
`npm run lint-css -s; npm run lint-js -s`
`node src/test/node-unit-tests.js --dots`