### PR TITLE
Stop selecting sources with no url

### DIFF
--- a/src/reducers/sources.js
+++ b/src/reducers/sources.js
@@ -238,7 +238,7 @@ function getNewSelectedSourceId(state: SourcesState, availableTabs) : string {
   const lastAvailbleTabIndex = availableTabs.size - 1;
   const newSelectedTabIndex = Math.min(leftNeighborIndex, lastAvailbleTabIndex);
   let tabSource = state.sources.find(source =>
-    source.get("url") == availableTabs.toJS()[newSelectedTabIndex]);
+    source.get("url") === availableTabs.toJS()[newSelectedTabIndex]);
 
   if (tabSource) {
     return tabSource.get("id");


### PR DESCRIPTION
### Summary of Changes

At some point we stopped showing the welcome box when you would close all of the sources.

This fixes that by not selecting sources with empty URLs.

### Test Plan

* TODO: add an integration test

### Screenshot

<img width="755" alt="screen shot 2017-02-13 at 3 15 05 pm" src="https://cloud.githubusercontent.com/assets/254562/22901342/4f75d2ac-f1ff-11e6-89cf-67cee520f259.png">
