### PR TITLE
Add buckets for objects and keys

### DIFF
--- a/docs/integration-tests.md
+++ b/docs/integration-tests.md
@@ -14,6 +14,8 @@ The integration tests are async functions that drive the debugger in two context
 
 ### Running Tests
 
+* Launch firefox
+* Make sure the other debugger windows are closed
 * Running: `localhost:8000/integration`
 * Selecting a test: Go to `runner.js` and add `it.only` to select which tests to run
 * Skipping a test: Go to `runner.js` and replace `it` with `xit` to skip a test

--- a/src/utils/object-inspector.js
+++ b/src/utils/object-inspector.js
@@ -5,8 +5,12 @@ if (typeof window == "object") {
   WINDOW_PROPERTIES = Object.getOwnPropertyNames(window);
 }
 
+function isBucket(item) {
+  return item.path.match(/bucket(\d+)$/);
+}
+
 function nodeHasChildren(item) {
-  return Array.isArray(item.contents);
+  return Array.isArray(item.contents) || isBucket(item);
 }
 
 function nodeIsOptimizedOut(item) {
@@ -44,17 +48,52 @@ function sortProperties(properties) {
   });
 }
 
-function makeNodesForProperties(objProps, parentPath) {
+/*
+
+ * Ignore non-concrete values like getters and setters
+ * for now by making sure we have a value.
+*/
+function makeNodesForProperties(objProps, parentPath, {
+  bucketSize = 100
+} = {}) {
   const { ownProperties, prototype, ownSymbols } = objProps;
 
-  const nodes = sortProperties(Object.keys(ownProperties))
-    .filter(name => {
-    // Ignore non-concrete values like getters and setters
-    // for now by making sure we have a value.
-      return "value" in ownProperties[name];
-    }).map(name => {
-      return createNode(name, `${parentPath}/${name}`, ownProperties[name]);
-    });
+  const properties = sortProperties(Object.keys(ownProperties))
+    .filter(name => ownProperties[name].hasOwnProperty("value"));
+
+  let nodes;
+  const numProperties = properties.length;
+
+  if (numProperties > bucketSize) {
+    const numBuckets = Math.ceil(numProperties / bucketSize);
+    let buckets = [];
+    for (let i = 1; i <= numBuckets; i++) {
+      const bucketKey = `bucket${i}`;
+      const minKey = (i - 1) * bucketSize;
+      const maxKey = Math.min(i * bucketSize - 1, numProperties);
+      const bucketName = `[${minKey}..${maxKey}]`;
+      const bucketProperties = properties.slice(minKey, maxKey);
+
+      const bucketNodes = bucketProperties.map(name => createNode(
+        name,
+        `${parentPath}/${bucketKey}/${name}`,
+        ownProperties[name]
+      ));
+
+      buckets.push(createNode(
+        bucketName,
+        `${parentPath}/${bucketKey}`,
+        bucketNodes
+      ));
+    }
+    nodes = buckets;
+  } else {
+    nodes = properties.map(name => createNode(
+      name,
+      `${parentPath}/${name}`,
+      ownProperties[name]
+    ));
+  }
 
   for (let index in ownSymbols) {
     nodes.push(createNode(ownSymbols[index].name,
@@ -83,6 +122,52 @@ function createNode(name, path, contents) {
   return { name, path, contents };
 }
 
+function getChildren({
+  getObjectProperties,
+  actors,
+  item
+}) {
+  const obj = item.contents;
+
+  // Nodes can either have children already, or be an object with
+  // properties that we need to go and fetch.
+  if (nodeHasChildren(item)) {
+    return item.contents;
+  }
+
+  if (nodeHasProperties(item)) {
+    const actor = obj.value.actor;
+
+    // Because we are dynamically creating the tree as the user
+    // expands it (not precalcuated tree structure), we cache child
+    // arrays. This not only helps performance, but is necessary
+    // because the expanded state depends on instances of nodes
+    // being the same across renders. If we didn't do this, each
+    // node would be a new instance every render.
+    const key = item.path;
+    if (actors[key]) {
+      return actors[key];
+    }
+
+    if (isBucket(item)) {
+      return item.contents.children;
+    }
+
+    const loadedProps = getObjectProperties(actor);
+    const { ownProperties, prototype } = loadedProps || {};
+
+    if (!ownProperties && !prototype) {
+      return [];
+    }
+
+    const children = makeNodesForProperties(loadedProps, item.path);
+    actors[actor] = children;
+    return children;
+  }
+
+  return [];
+}
+
 module.exports = {
   nodeHasChildren,
   nodeIsOptimizedOut,
@@ -92,5 +177,6 @@ module.exports = {
   isDefault,
   sortProperties,
   makeNodesForProperties,
+  getChildren,
   createNode
 };

--- a/src/utils/object-inspector.js
+++ b/src/utils/object-inspector.js
@@ -6,7 +6,7 @@ if (typeof window == "object") {
 }
 
 function isBucket(item) {
-  return item.path.match(/bucket(\d+)$/);
+  return item.path && item.path.match(/bucket(\d+)$/);
 }
 
 function nodeHasChildren(item) {

--- a/src/utils/object-inspector.js
+++ b/src/utils/object-inspector.js
@@ -135,37 +135,37 @@ function getChildren({
     return item.contents;
   }
 
-  if (nodeHasProperties(item)) {
-    const actor = obj.value.actor;
-
-    // Because we are dynamically creating the tree as the user
-    // expands it (not precalcuated tree structure), we cache child
-    // arrays. This not only helps performance, but is necessary
-    // because the expanded state depends on instances of nodes
-    // being the same across renders. If we didn't do this, each
-    // node would be a new instance every render.
-    const key = item.path;
-    if (actors[key]) {
-      return actors[key];
-    }
-
-    if (isBucket(item)) {
-      return item.contents.children;
-    }
-
-    const loadedProps = getObjectProperties(actor);
-    const { ownProperties, prototype } = loadedProps || {};
-
-    if (!ownProperties && !prototype) {
-      return [];
-    }
-
-    const children = makeNodesForProperties(loadedProps, item.path);
-    actors[actor] = children;
-    return children;
+  if (!nodeHasProperties(item)) {
+    return [];
   }
 
-  return [];
+  const actor = obj.value.actor;
+
+  // Because we are dynamically creating the tree as the user
+  // expands it (not precalcuated tree structure), we cache child
+  // arrays. This not only helps performance, but is necessary
+  // because the expanded state depends on instances of nodes
+  // being the same across renders. If we didn't do this, each
+  // node would be a new instance every render.
+  const key = item.path;
+  if (actors[key]) {
+    return actors[key];
+  }
+
+  if (isBucket(item)) {
+    return item.contents.children;
+  }
+
+  const loadedProps = getObjectProperties(actor);
+  const { ownProperties, prototype } = loadedProps || {};
+
+  if (!ownProperties && !prototype) {
+    return [];
+  }
+
+  const children = makeNodesForProperties(loadedProps, item.path);
+  actors[key] = children;
+  return children;
 }
 
 module.exports = {

--- a/src/utils/tests/object-inspector.js
+++ b/src/utils/tests/object-inspector.js
@@ -83,5 +83,24 @@ describe("object-inspector", () => {
         "root/bar", "root/__proto__"
       ]);
     });
+
+    it("bucketing", () => {
+      let objProps = { ownProperties: {}};
+      for (let i = 0; i < 331; i++) {
+        objProps.ownProperties[i] = { value: {}};
+      }
+      const nodes = makeNodesForProperties(objProps, "root");
+
+      const names = nodes.map(n => n.name);
+      const paths = nodes.map(n => n.path);
+
+      expect(names).to.eql([
+        "[0..99]", "[100..199]", "[200..299]", "[300..331]"
+      ]);
+
+      expect(paths).to.eql([
+        "root/bucket1", "root/bucket2", "root/bucket3", "root/bucket4"
+      ]);
+    });
   });
 });


### PR DESCRIPTION
Associated Issue: #2025

### Summary of Changes

This adds the logic for bucketing objects and arrays with lots of keys. It's still pretty rough, so it would be great to get some thoughts on how to clean it up.

### Test Plan

- [ ] add some unit tests
- [ ] add an integration test

### Screenshots/Videos (OPTIONAL)

![object keys](https://cloud.githubusercontent.com/assets/254562/22956141/31ab9316-f2ee-11e6-8c1b-96358110a440.gif)
