### PR TITLE
[SourceFooter] Remove redundant css in source

### DIFF
--- a/src/components/Editor/Footer.css
+++ b/src/components/Editor/Footer.css
@@ -55,24 +55,6 @@
   width: 16px;
 }
 
-.source-footer .commands .coverage {
-  border: none;
-  outline: none;
-  background: transparent;
-  color: var(--theme-content-color3);
-  font-weight: 600;
-  padding: 1px;
-  width: 16px;
-  height: 16px;
-}
-
-.source-footer .commands .coverage:hover {
-  border: 1px solid var(--theme-body-color-inactive);
-  border-radius: 2px;
-  padding: 0px;
-  cursor: pointer;
-}
-
 .coverage-on .source-footer .commands .coverage {
   color: var(--theme-highlight-blue);
   border: 1px solid var(--theme-body-color-inactive);

--- a/src/components/Editor/Footer.css
+++ b/src/components/Editor/Footer.css
@@ -55,6 +55,10 @@
   width: 16px;
 }
 
+.source-footer .commands .coverage {
+  color: var(--theme-body-color);
+}
+
 .coverage-on .source-footer .commands .coverage {
   color: var(--theme-highlight-blue);
   border: 1px solid var(--theme-body-color-inactive);


### PR DESCRIPTION
There were some redundant styles which were causing problems with code coverage button position.

### Summary of Changes

* Remove redundant CSS

### Screenshots/Videos (OPTIONAL)
|Before|After|
|-|-|
|![footer-old](https://cloud.githubusercontent.com/assets/1755089/22984222/b00ca254-f3ca-11e6-8612-b0203472586f.png)|![footer](https://cloud.githubusercontent.com/assets/1755089/22984154/82b883fe-f3ca-11e6-9a52-7f1bfeab61a5.png)|
