### PR TITLE
[Docs] Remove README front matter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
----
-title: debugger.html
-permalink: /
----
-# debugger.html &middot; [![slack-badge]][slack] ![][ci-status] [![npm-version]][npm-package] [![PRs Welcome]][make-a-pull-request]
+# debugger.html 
+
+[![slack-badge]][slack] ![][ci-status] [![npm-version]][npm-package] [![PRs Welcome]][make-a-pull-request]
 
 debugger.html is a hackable debugger for modern times, built from the ground up using [React] and [Redux].  It is designed to be approachable, yet powerful.  And it is engineered to be predictable, understandable, and testable.
 


### PR DESCRIPTION
Associated Issue: #2024 

### Summary of Changes

* Remove front matter from `README.md`
* Move badges below title

Current version
* Github: [https://github.com/devtools-html/debugger.html/blob/361b79b1c5206a8d5bf5cd97b064f943b60d66ac/README.md](https://github.com/devtools-html/debugger.html/blob/361b79b1c5206a8d5bf5cd97b064f943b60d66ac/README.md)
* Github pages: [https://irfanhudda.github.io/debugger.html/](https://irfanhudda.github.io/debugger.html/)
