### PR TITLE
move the results summary into the search container

### DIFF
--- a/assets/panel/debugger.properties
+++ b/assets/panel/debugger.properties
@@ -138,7 +138,7 @@ sourceSearch.search.again.key=G
 
 # LOCALIZATION NOTE (sourceSearch.resultsSummary): Shows a summary of
 # the number of matches for autocomplete
-sourceSearch.resultsSummary=%d instances of “%S”
+sourceSearch.resultsSummary=%d results
 
 # LOCALIZATION NOTE (noMatchingStringsText): The text to display in the
 # global search results when there are no matching strings after filtering.

--- a/src/components/SourceSearch.css
+++ b/src/components/SourceSearch.css
@@ -21,8 +21,5 @@
 
 .searchinput-container {
   display: flex;
-}
-
-.searchinput-container .close-btn-big {
   border-bottom: 1px solid var(--theme-splitter-color);
 }

--- a/src/components/shared/Autocomplete.css
+++ b/src/components/shared/Autocomplete.css
@@ -8,11 +8,6 @@
   user-select: none;
 }
 
-.autocomplete .results-summary {
-  margin: 10px;
-  text-align: start;
-}
-
 .autocomplete ul {
   list-style: none;
   width: 100%;
@@ -54,15 +49,21 @@
   border: none;
   background-color: var(--theme-body-background);
   color: var(--theme-comment);
-  border-bottom: 1px solid var(--theme-splitter-color);
   outline: none;
   line-height: 30px;
   font-size: 14px;
   height: 40px;
   padding-inline-start: 30px;
+  flex: 1;
 }
 
 .autocomplete input::placeholder {
+  color: var(--theme-body-color-inactive);
+}
+
+.autocomplete .results-summary {
+  line-height: 40px;
+  padding-right: 10px;
   color: var(--theme-body-color-inactive);
 }
 

--- a/src/components/shared/Autocomplete.js
+++ b/src/components/shared/Autocomplete.js
@@ -161,11 +161,11 @@ const Autocomplete = React.createClass({
       dom.div({ className: "searchinput-container" },
       Svg("magnifying-glass"),
       this.renderInput(),
+      this.renderSummary(searchResults),
       CloseButton({
         buttonClass: "big",
         handleClick: e => this.props.close()
       })),
-      this.renderSummary(searchResults),
       this.renderResults(searchResults));
   }
 });

--- a/src/strings.json
+++ b/src/strings.json
@@ -36,7 +36,7 @@
   "sourceSearch.search": "Search Sources...",
   "sourceSearch.search.key": "F",
   "sourceSearch.search.again.key": "G",
-  "sourceSearch.resultsSummary": "%d instances of \"%S\"",
+  "sourceSearch.resultsSummary": "%d results",
   "sourceSearch.noResults": "No files matching %S found",
   "sourceFooter.debugBtnTooltip": "Prettify Source",
   "ignoreExceptions": "Ignore exceptions. Click to pause on uncaught exceptions",


### PR DESCRIPTION
Actively working on this.

Associated Issue:  #1845

### Summary of Changes

* move the summary info into the search bar container
* added keyshortcut for `Esc`
*

### Test Plan

Tell us a little a bit about how you tested your patch.

Example test plan:

- [x] Command-P opens the panel and it looks normal
- [x] cmd+shift+o opens search
- [x] cmd+shift+o, esc closes search


### Screenshots/Videos (OPTIONAL)
