### PR TITLE
function search updates

### DIFF
--- a/assets/panel/debugger.properties
+++ b/assets/panel/debugger.properties
@@ -136,9 +136,9 @@ sourceSearch.search.key=F
 # the search for re-searching the same search triggered from a sourceSearch
 sourceSearch.search.again.key=G
 
-# LOCALIZATION NOTE (sourceSearch.resultsSummary): Shows a summary of
+# LOCALIZATION NOTE (sourceSearch.resultsSummary1): Shows a summary of
 # the number of matches for autocomplete
-sourceSearch.resultsSummary=%d results
+sourceSearch.resultsSummary1=%d results
 
 # LOCALIZATION NOTE (noMatchingStringsText): The text to display in the
 # global search results when there are no matching strings after filtering.

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -171,6 +171,9 @@ const Editor = React.createClass({
       if (cm.listSelections().length > 1) {
         cm.execCommand("singleSelection");
         e.preventDefault();
+      } else if (this.state.functionSearchEnabled) {
+        e.preventDefault();
+        this.toggleFunctionSearch(e);
       }
     });
 

--- a/src/components/shared/Autocomplete.js
+++ b/src/components/shared/Autocomplete.js
@@ -142,7 +142,7 @@ const Autocomplete = React.createClass({
     let resultCountSummary = "";
     if (this.state.inputValue) {
       resultCountSummary = L10N.getFormatStr(
-        "sourceSearch.resultsSummary",
+        "sourceSearch.resultsSummary1",
         searchResults.length,
         this.state.inputValue);
     }

--- a/src/strings.json
+++ b/src/strings.json
@@ -36,7 +36,7 @@
   "sourceSearch.search": "Search Sources...",
   "sourceSearch.search.key": "F",
   "sourceSearch.search.again.key": "G",
-  "sourceSearch.resultsSummary": "%d results",
+  "sourceSearch.resultsSummary1": "%d results",
   "sourceSearch.noResults": "No files matching %S found",
   "sourceFooter.debugBtnTooltip": "Prettify Source",
   "ignoreExceptions": "Ignore exceptions. Click to pause on uncaught exceptions",


### PR DESCRIPTION
Followup to PR: #2037
Associated Issue:  #1845

### Summary of Changes

* actually adds the `Esc` key
* bumps the l10n key to `sourceSearch.resultsSummary1`

### Test Plan

Tell us a little a bit about how you tested your patch.

Example test plan:

- [x] cmd+shift+o, esc closes the panel
