### PR TITLE
Fix tab close button positioning

### DIFF
--- a/src/components/Editor/Tabs.css
+++ b/src/components/Editor/Tabs.css
@@ -35,15 +35,14 @@
   border: 1px solid transparent;
   border-top-left-radius: 2px;
   border-top-right-radius: 2px;
-  height: 26px;
+  height: 30px;
   display: inline-flex;
+  align-items: center;
   position: relative;
   transition: all 0.25s ease;
   min-width: 40px;
   overflow: hidden;
-  padding-top: 4px;
-  padding-inline-start: 12px;
-  padding-inline-end: 20px;
+  padding: 6px;
   margin-inline-start: 8px;
   margin-top: 6px;
 }
@@ -72,15 +71,12 @@ html[dir="rtl"] .source-tab.active {
 }
 
 .source-tab .prettyPrint {
-  display: block;
-  position: absolute;
-  top: 3px;
-  left: 6px;
+  line-height: 0;
 }
 
 .source-tab .prettyPrint svg {
-  height: 1em;
-  width: 1em;
+  height: 12px;
+  width: 12px;
 }
 
 .source-tab .prettyPrint path {
@@ -94,13 +90,20 @@ html[dir="rtl"] .source-tab.active {
 }
 
 .source-tab.pretty .filename {
-  padding-left: 12px;
+  padding-left: 8px;
 }
 
 .source-tab .close-btn {
-  top: 3px;
-  offset-inline-end: 4px;
   visibility: hidden;
+  line-height: 0;
+}
+
+html[dir="ltr"] .source-tab .close-btn {
+  margin-left: 6px;
+}
+
+html[dir="rtl"] .source-tab .close-btn {
+  margin-right: 6px;
 }
 
 html[dir="ltr"] .source-tab:hover .close-btn,

--- a/src/components/Editor/Tabs.css
+++ b/src/components/Editor/Tabs.css
@@ -44,18 +44,16 @@
   overflow: hidden;
   padding: 6px;
   margin-inline-start: 8px;
-  margin-top: 6px;
+  margin-top: 2px;
 }
 
-html[dir="ltr"] .source-tab:hover,
-html[dir="rtl"] .source-tab:hover {
+.source-tab:hover {
   background-color: var(--theme-toolbar-background-alt);
   border-color: var(--theme-splitter-color);
   cursor: pointer;
 }
 
-html[dir="ltr"] .source-tab.active,
-html[dir="rtl"] .source-tab.active {
+.source-tab.active {
   color: var(--theme-body-color);
   background-color: var(--theme-body-background);
   border-color: var(--theme-splitter-color);
@@ -90,24 +88,20 @@ html[dir="rtl"] .source-tab.active {
 }
 
 .source-tab.pretty .filename {
-  padding-left: 8px;
+  padding-inline-start: 8px;
 }
 
 .source-tab .close-btn {
   visibility: hidden;
   line-height: 0;
+  margin-inline-start: 6px;
 }
 
-html[dir="ltr"] .source-tab .close-btn {
-  margin-left: 6px;
+.source-tab.active .close-btn {
+  visibility: visible;
 }
 
-html[dir="rtl"] .source-tab .close-btn {
-  margin-right: 6px;
-}
-
-html[dir="ltr"] .source-tab:hover .close-btn,
-html[dir="rtl"] .source-tab:hover .close-btn {
+.source-tab:hover .close-btn {
   visibility: visible;
 }
 

--- a/src/components/Editor/Tabs.css
+++ b/src/components/Editor/Tabs.css
@@ -36,7 +36,7 @@
   border-top-left-radius: 2px;
   border-top-right-radius: 2px;
   height: 26px;
-  display: inline-block;
+  display: inline-flex;
   position: relative;
   transition: all 0.25s ease;
   min-width: 40px;
@@ -98,7 +98,6 @@ html[dir="rtl"] .source-tab.active {
 }
 
 .source-tab .close-btn {
-  position: absolute;
   top: 3px;
   offset-inline-end: 4px;
   visibility: hidden;


### PR DESCRIPTION
Associated Issue: #2041 

### Summary of Changes

* make the tabs into inline flexboxes and remove absolute positioning from the close button.

### Test Plan

Tell us a little a bit about how you tested your patch.

Example test plan:

- [x] open debugger
- [x] open some tabs
- [x] see tab close button is in proper position for `ltr` mode (rtl will be in separate PR as there is more broken there.)

### Screenshots/Videos

#### Before
![screenshot_20170216_232152](https://cloud.githubusercontent.com/assets/580982/23060568/7fcc0f34-f4bb-11e6-9e78-82ca30cd7389.png)

#### After
![screenshot_20170217_030222](https://cloud.githubusercontent.com/assets/580982/23061047/85590c2a-f4bd-11e6-9375-b0c618b4257a.png)

Seems like the close button is a little too close to the tab title. 🤔 
