### PR TITLE
Convert to es6 modules

### DIFF
--- a/src/actions/breakpoints.js
+++ b/src/actions/breakpoints.js
@@ -8,10 +8,11 @@
  * @module actions/breakpoints
  */
 
-const constants = require("../constants");
-const { PROMISE } = require("../utils/redux/middleware/promise");
-const { getBreakpoint, getBreakpoints, getSource } = require("../selectors");
+import constants from "../constants";
+import { PROMISE } from "../utils/redux/middleware/promise";
+import selectors from "../selectors";
 
+const { getBreakpoint, getBreakpoints, getSource } = selectors;
 const {
   getOriginalLocation, getGeneratedLocation, isOriginalId
 } = require("../utils/source-map");

--- a/src/actions/expressions.js
+++ b/src/actions/expressions.js
@@ -3,7 +3,8 @@
 const constants = require("../constants");
 const { PROMISE } = require("../utils/redux/middleware/promise");
 
-const { getExpressions, getSelectedFrame } = require("../selectors");
+import selectors from "../selectors"
+const { getExpressions, getSelectedFrame } = selectors;
 
 import type { Expression } from "../types";
 import type { ThunkArgs } from "./types";

--- a/src/actions/expressions.js
+++ b/src/actions/expressions.js
@@ -3,7 +3,7 @@
 const constants = require("../constants");
 const { PROMISE } = require("../utils/redux/middleware/promise");
 
-import selectors from "../selectors"
+import selectors from "../selectors";
 const { getExpressions, getSelectedFrame } = selectors;
 
 import type { Expression } from "../types";

--- a/src/actions/pause.js
+++ b/src/actions/pause.js
@@ -3,7 +3,8 @@ const constants = require("../constants");
 const { selectSource } = require("./sources");
 const { PROMISE } = require("../utils/redux/middleware/promise");
 
-const { getPause, getLoadedObject } = require("../selectors");
+import selectors from "../selectors";
+const { getPause, getLoadedObject } = selectors;
 const { updateFrameLocations } = require("../utils/pause");
 const { evaluateExpressions } = require("./expressions");
 

--- a/src/actions/sources.js
+++ b/src/actions/sources.js
@@ -29,10 +29,11 @@ const { getPrettySourceURL } = require("../utils/source");
 const constants = require("../constants");
 const { removeDocument } = require("../utils/editor");
 
+import selectors from "../selectors";
 const {
   getSource, getSourceByURL, getSourceText,
   getPendingSelectedLocation, getFrames
-} = require("../selectors");
+} = selectors;
 
 import type { Source, SourceText } from "../types";
 import type { ThunkArgs } from "./types";
@@ -227,7 +228,7 @@ function togglePrettyPrint(sourceId: string) {
     }
 
     assert(isGeneratedId(sourceId),
-           "Pretty-printing only allowed on generated sources");
+      "Pretty-printing only allowed on generated sources");
 
     const url = getPrettySourceURL(source.url);
     const id = generatedToOriginalId(source.id, url);

--- a/src/actions/ui.js
+++ b/src/actions/ui.js
@@ -1,6 +1,8 @@
 // @flow
 const constants = require("../constants");
-const { getSource, getFileSearchState } = require("../selectors");
+import selectors from "../selectors";
+
+const { getSource, getFileSearchState } = selectors;
 import type { ThunkArgs } from "./types";
 
 function toggleFileSearch() {

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -4,7 +4,8 @@ const { DOM: dom, PropTypes, createFactory } = React;
 const { connect } = require("react-redux");
 const { bindActionCreators } = require("redux");
 const actions = require("../actions");
-const { getSources, getSelectedSource, getPaneCollapse } = require("../selectors");
+import selectors from "../selectors";
+const { getSources, getSelectedSource, getPaneCollapse } = selectors;
 
 const { KeyShortcuts } = require("devtools-sham-modules");
 const shortcuts = new KeyShortcuts({ window });

--- a/src/components/Editor/Tabs.js
+++ b/src/components/Editor/Tabs.js
@@ -4,10 +4,11 @@ const { DOM: dom, PropTypes } = React;
 const ImPropTypes = require("react-immutable-proptypes");
 const { connect } = require("react-redux");
 const { bindActionCreators } = require("redux");
+import selectors from "../../selectors";
 const {
   getSelectedSource, getSourceTabs,
   getFileSearchState, getSourceByURL
-} = require("../../selectors");
+} = selectors;
 const { getFilename, isPretty } = require("../../utils/source");
 const classnames = require("classnames");
 const actions = require("../../actions");

--- a/src/components/SecondaryPanes/Frames.js
+++ b/src/components/SecondaryPanes/Frames.js
@@ -8,8 +8,9 @@ import { connect } from "react-redux";
 import actions from "../../actions";
 import { endTruncateStr } from "../../utils/utils";
 import { getFilename } from "../../utils/source";
+import selectors from "../../selectors";
 
-const { getFrames, getSelectedFrame, getSource } = require("../../selectors");
+const { getFrames, getSelectedFrame, getSource } = selectors;
 
 import { showMenu } from "../shared/menu";
 import { copyToTheClipboard } from "../../utils/clipboard";

--- a/src/components/SourceSearch.js
+++ b/src/components/SourceSearch.js
@@ -4,11 +4,12 @@ const { DOM: dom, PropTypes, createFactory } = React;
 const { connect } = require("react-redux");
 const { bindActionCreators } = require("redux");
 const actions = require("../actions");
+import selectors from "../selectors";
 const {
   getSources,
   getSelectedSource,
   getFileSearchState
-} = require("../selectors");
+} = selectors;
 const { endTruncateStr } = require("../utils/utils");
 const { parse: parseURL } = require("url");
 const { isPretty } = require("../utils/source");

--- a/src/components/Sources.js
+++ b/src/components/Sources.js
@@ -7,7 +7,8 @@ const { connect } = require("react-redux");
 const { formatKeyShortcut } = require("../utils/text");
 const SourcesTree = React.createFactory(require("./SourcesTree"));
 const actions = require("../actions");
-const { getSelectedSource, getSources } = require("../selectors");
+import selectors from "../selectors";
+const { getSelectedSource, getSources } = selectors;
 
 require("./Sources.css");
 

--- a/src/reducers/async-requests.js
+++ b/src/reducers/async-requests.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const constants = require("../constants");
+import constants from "../constants";
 const initialState = [];
 
 function update(state = initialState, action) {
@@ -24,4 +24,4 @@ function update(state = initialState, action) {
   return state;
 }
 
-module.exports = update;
+export default update;

--- a/src/reducers/breakpoints.js
+++ b/src/reducers/breakpoints.js
@@ -10,19 +10,19 @@
 
 import fromJS from "../utils/fromJS";
 import { updateObj } from "../utils/utils";
-import I from "immutable";
+import { Map } from "immutable";
 import makeRecord from "../utils/makeRecord";
 import type { Breakpoint, Location } from "../types";
 import type { Action } from "../actions/types";
 import type { Record } from "../utils/makeRecord";
 
 export type BreakpointsState = {
-    breakpoints: I.Map<string, Breakpoint>,
+    breakpoints: Map<string, Breakpoint>,
   breakpointsDisabled: false
 }
 
 const State = makeRecord(({
-  breakpoints: I.Map(),
+  breakpoints: Map(),
   breakpointsDisabled: false
 } : BreakpointsState));
 
@@ -51,7 +51,7 @@ function allBreakpointsDisabled(state) {
   return state.breakpoints.every(x => x.disabled);
 }
 
-function update(state = State(), action: Action) {
+function update(state: any = State(), action: Action) {
   switch (action.type) {
     case "ADD_BREAKPOINT": {
       const id = makeLocationId(action.breakpoint.location);

--- a/src/reducers/breakpoints.js
+++ b/src/reducers/breakpoints.js
@@ -8,17 +8,16 @@
  * @module reducers/breakpoints
  */
 
-const fromJS = require("../utils/fromJS");
-const { updateObj } = require("../utils/utils");
-const I = require("immutable");
-const makeRecord = require("../utils/makeRecord");
-
+import fromJS from "../utils/fromJS";
+import { updateObj } from "../utils/utils";
+import I from "immutable";
+import makeRecord from "../utils/makeRecord";
 import type { Breakpoint, Location } from "../types";
 import type { Action } from "../actions/types";
 import type { Record } from "../utils/makeRecord";
 
 export type BreakpointsState = {
-  breakpoints: I.Map<string, Breakpoint>,
+    breakpoints: I.Map<string, Breakpoint>,
   breakpointsDisabled: false
 }
 
@@ -41,7 +40,7 @@ function firstString(...args) {
 function locationMoved(location, newLocation) {
   return location.line !== newLocation.line ||
     (location.column != null &&
-     location.column !== newLocation.column);
+    location.column !== newLocation.column);
 }
 
 function makeLocationId(location: Location) {
@@ -68,7 +67,7 @@ function update(state = State(), action: Action) {
           // condition.
           condition: firstString(action.condition, bp.condition)
         }))
-        .set("breakpointsDisabled", false);
+          .set("breakpointsDisabled", false);
       } else if (action.status === "done") {
         const { id: breakpointId, text } = action.value;
         let location = action.breakpoint.location;
@@ -80,7 +79,7 @@ function update(state = State(), action: Action) {
 
           const movedId = makeLocationId(actualLocation);
           const currentBp = (state.breakpoints.get(movedId) ||
-                             fromJS(action.breakpoint));
+          fromJS(action.breakpoint));
           const newBp = updateObj(currentBp, { location: actualLocation });
           state = state.setIn(["breakpoints", movedId], newBp);
           location = actualLocation;
@@ -184,13 +183,13 @@ function getBreakpointsDisabled(state: OuterState): boolean {
 function getBreakpointsLoading(state: OuterState) {
   const breakpoints = getBreakpoints(state);
   const isLoading = !!breakpoints.valueSeq()
-                    .filter(bp => bp.loading)
-                    .first();
+    .filter(bp => bp.loading)
+    .first();
 
   return breakpoints.size > 0 && isLoading;
 }
 
-module.exports = {
+export default {
   State,
   update,
   makeLocationId,

--- a/src/reducers/coverage.js
+++ b/src/reducers/coverage.js
@@ -7,7 +7,7 @@
 
 import constants from "../constants";
 import makeRecord from "../utils/makeRecord";
-import I from "immutable";
+import { Map } from "immutable";
 import fromJS from "../utils/fromJS";
 
 import type { Action } from "../actions/types";
@@ -20,10 +20,10 @@ export type CoverageState = {
 
 const State = makeRecord(({
   coverageOn: false,
-  hitCount: I.Map()
+  hitCount: Map()
 } : CoverageState));
 
-function update(state = State(), action: Action): Record<CoverageState> {
+function update(state: any = State(), action: Action): Record<CoverageState> {
   switch (action.type) {
     case constants.RECORD_COVERAGE:
       return state

--- a/src/reducers/coverage.js
+++ b/src/reducers/coverage.js
@@ -5,10 +5,10 @@
  * @module reducers/coverage
  */
 
-const constants = require("../constants");
-const makeRecord = require("../utils/makeRecord");
-const I = require("immutable");
-const fromJS = require("../utils/fromJS");
+import constants from "../constants";
+import makeRecord from "../utils/makeRecord";
+import I from "immutable";
+import fromJS from "../utils/fromJS";
 
 import type { Action } from "../actions/types";
 import type { Record } from "../utils/makeRecord";
@@ -49,7 +49,7 @@ function getCoverageEnabled(state: OuterState) {
   return state.coverage.get("coverageOn");
 }
 
-module.exports = {
+export default {
   State,
   update,
   getHitCountForSource,

--- a/src/reducers/event-listeners.js
+++ b/src/reducers/event-listeners.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const constants = require("../constants");
+import constants from "../constants";
 
 const initialState = {
   activeEventNames: [],
@@ -35,7 +35,7 @@ function getEventListeners(state) {
   return state.eventListeners.listeners;
 }
 
-module.exports = {
+export default {
   update,
   getEventListeners
 };

--- a/src/reducers/expressions.js
+++ b/src/reducers/expressions.js
@@ -1,8 +1,8 @@
 // @flow
 
-const constants = require("../constants");
-const makeRecord = require("../utils/makeRecord");
-const I = require("immutable");
+import constants from "../constants";
+import makeRecord from "../utils/makeRecord";
+import I from "immutable";
 
 import type { Expression } from "../types";
 import type { Action } from "../actions/types";
@@ -75,7 +75,7 @@ function getExpressions(state: OuterState) {
   return state.expressions.get("expressions");
 }
 
-module.exports = {
+export default {
   State,
   update,
   getExpressions

--- a/src/reducers/expressions.js
+++ b/src/reducers/expressions.js
@@ -2,21 +2,21 @@
 
 import constants from "../constants";
 import makeRecord from "../utils/makeRecord";
-import I from "immutable";
+import { List } from "immutable";
 
 import type { Expression } from "../types";
 import type { Action } from "../actions/types";
 import type { Record } from "../utils/makeRecord";
 
 type ExpressionState = {
-  expressions: I.List<Expression>
+  expressions: List<Expression>
 }
 
 const State = makeRecord(({
-  expressions: I.List()
+  expressions: List()
 } : ExpressionState));
 
-function update(state = State(), action: Action): Record<ExpressionState> {
+function update(state: any = State(), action: Action): Record<ExpressionState> {
   switch (action.type) {
 
     case constants.ADD_EXPRESSION:

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -2,16 +2,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const expressions = require("./expressions");
-const eventListeners = require("./event-listeners");
-const sources = require("./sources");
-const breakpoints = require("./breakpoints");
-const asyncRequests = require("./async-requests");
-const pause = require("./pause");
-const ui = require("./ui");
-const coverage = require("./coverage");
+import expressions from "./expressions";
+import eventListeners from "./event-listeners";
+import sources from "./sources";
+import breakpoints from "./breakpoints";
+import asyncRequests from "./async-requests";
+import pause from "./pause";
+import ui from "./ui";
+import coverage from "./coverage";
 
-module.exports = {
+export default {
   expressions: expressions.update,
   eventListeners: eventListeners.update,
   sources: sources.update,

--- a/src/reducers/pause.js
+++ b/src/reducers/pause.js
@@ -7,7 +7,7 @@ import constants from "../constants";
 import fromJS from "../utils/fromJS";
 import makeRecord from "../utils/makeRecord";
 import { prefs } from "../utils/prefs";
-import {Map, List} from "immutable";
+import { Map, List } from "immutable";
 
 import type { Frame, Pause,
   Expression } from "../types";

--- a/src/reducers/pause.js
+++ b/src/reducers/pause.js
@@ -7,7 +7,7 @@ import constants from "../constants";
 import fromJS from "../utils/fromJS";
 import makeRecord from "../utils/makeRecord";
 import { prefs } from "../utils/prefs";
-import I from "immutable";
+import {Map, List} from "immutable";
 
 import type { Frame, Pause,
   Expression } from "../types";
@@ -22,7 +22,7 @@ type PauseState = {
   loadedObjects: Object,
   shouldPauseOnExceptions: boolean,
   shouldIgnoreCaughtExceptions: boolean,
-  expressions: I.List<Expression>
+  expressions: List<Expression>
 }
 
 const State = makeRecord(({
@@ -30,13 +30,13 @@ const State = makeRecord(({
   isWaitingOnBreak: false,
   frames: undefined,
   selectedFrameId: undefined,
-  loadedObjects: I.Map(),
+  loadedObjects: Map(),
   shouldPauseOnExceptions: prefs.pauseOnExceptions,
   shouldIgnoreCaughtExceptions: prefs.ignoreCaughtExceptions,
-  expressions: I.List()
+  expressions: List()
 } : PauseState));
 
-function update(state = State(), action: Action): Record<PauseState> {
+function update(state: any = State(), action: Action): Record<PauseState> {
   switch (action.type) {
     case constants.PAUSED: {
       const { selectedFrameId, frames, loadedObjects, pauseInfo } = action;

--- a/src/reducers/pause.js
+++ b/src/reducers/pause.js
@@ -3,11 +3,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const constants = require("../constants");
-const fromJS = require("../utils/fromJS");
-const makeRecord = require("../utils/makeRecord");
-const { prefs } = require("../utils/prefs");
-const I = require("immutable");
+import constants from "../constants";
+import fromJS from "../utils/fromJS";
+import makeRecord from "../utils/makeRecord";
+import { prefs } from "../utils/prefs";
+import I from "immutable";
 
 import type { Frame, Pause,
   Expression } from "../types";
@@ -100,8 +100,10 @@ function update(state = State(), action: Action): Record<PauseState> {
         const ownSymbols = action.value.ownSymbols || [];
         const prototype = action.value.prototype;
 
-        return state.setIn(["loadedObjects", action.objectId],
-                           { ownProperties, prototype, ownSymbols });
+        return state.setIn(
+           ["loadedObjects", action.objectId],
+           { ownProperties, prototype, ownSymbols }
+        );
       }
       break;
 
@@ -185,7 +187,7 @@ function getChromeScopes(state: OuterState) {
   return frame ? frame.scopeChain : undefined;
 }
 
-module.exports = {
+export default {
   State,
   update,
   getPause,

--- a/src/reducers/sources.js
+++ b/src/reducers/sources.js
@@ -8,7 +8,7 @@
  * @module reducers/sources
  */
 
-import { Map, List} from "immutable";
+import { Map, List } from "immutable";
 import makeRecord from "../utils/makeRecord";
 import { getPrettySourceURL } from "../utils/source";
 import { prefs } from "../utils/prefs";

--- a/src/reducers/sources.js
+++ b/src/reducers/sources.js
@@ -8,17 +8,17 @@
  * @module reducers/sources
  */
 
-const I = require("immutable");
-const makeRecord = require("../utils/makeRecord");
-const { getPrettySourceURL } = require("../utils/source");
-const { prefs } = require("../utils/prefs");
+import I from "immutable";
+import makeRecord from "../utils/makeRecord";
+import { getPrettySourceURL } from "../utils/source";
+import { prefs } from "../utils/prefs";
 
 import type { Source, Location } from "../types";
 import type { Action } from "../actions/types";
 import type { Record } from "../utils/makeRecord";
 
 export type SourcesState = {
-  sources: I.Map<string, any>,
+    sources: I.Map<string, any>,
   selectedLocation?: {
     sourceId: string,
     line?: number,
@@ -238,7 +238,7 @@ function getNewSelectedSourceId(state: SourcesState, availableTabs) : string {
   const lastAvailbleTabIndex = availableTabs.size - 1;
   const newSelectedTabIndex = Math.min(leftNeighborIndex, lastAvailbleTabIndex);
   let tabSource = state.sources.find(source =>
-    source.get("url") === availableTabs.toJS()[newSelectedTabIndex]);
+  source.get("url") === availableTabs.toJS()[newSelectedTabIndex]);
 
   if (tabSource) {
     return tabSource.get("id");
@@ -311,7 +311,7 @@ function getPrettySource(state: OuterState, id: string) {
   return getSourceByURL(state, getPrettySourceURL(source.get("url")));
 }
 
-module.exports = {
+export default {
   State,
   update,
   getSource,

--- a/src/reducers/sources.js
+++ b/src/reducers/sources.js
@@ -5,7 +5,7 @@
 
 /**
  * Sources reducer
- * @module reducers/sources
+ * @module reducers/sources //
  */
 
 import { Map, List } from "immutable";

--- a/src/reducers/sources.js
+++ b/src/reducers/sources.js
@@ -5,7 +5,7 @@
 
 /**
  * Sources reducer
- * @module reducers/sources //
+ * @module reducers/sources
  */
 
 import { Map, List } from "immutable";

--- a/src/reducers/sources.js
+++ b/src/reducers/sources.js
@@ -8,7 +8,7 @@
  * @module reducers/sources
  */
 
-import I from "immutable";
+import { Map, List} from "immutable";
 import makeRecord from "../utils/makeRecord";
 import { getPrettySourceURL } from "../utils/source";
 import { prefs } from "../utils/prefs";
@@ -18,7 +18,7 @@ import type { Action } from "../actions/types";
 import type { Record } from "../utils/makeRecord";
 
 export type SourcesState = {
-    sources: I.Map<string, any>,
+    sources: Map<string, any>,
   selectedLocation?: {
     sourceId: string,
     line?: number,
@@ -30,19 +30,19 @@ export type SourcesState = {
     column?: number
   },
   selectedLocation?: Location,
-  sourcesText: I.Map<string, any>,
-  tabs: I.List<any>
+  sourcesText: Map<string, any>,
+  tabs: List<any>
 };
 
 const State = makeRecord(({
-  sources: I.Map(),
+  sources: Map(),
   selectedLocation: undefined,
   pendingSelectedLocation: prefs.pendingSelectedLocation,
-  sourcesText: I.Map(),
-  tabs: I.List(restoreTabs())
+  sourcesText: Map(),
+  tabs: List(restoreTabs())
 } : SourcesState));
 
-function update(state = State(), action: Action) : Record<SourcesState> {
+function update(state: any = State(), action: Action) : Record<SourcesState> {
   let availableTabs = null;
   let location = null;
 
@@ -139,12 +139,12 @@ function _updateText(state, action : any) : Record<SourcesState> {
   }
 
   if (action.status === "error") {
-    return state.setIn(["sourcesText", source.id], I.Map({
+    return state.setIn(["sourcesText", source.id], Map({
       error: action.error
     }));
   }
 
-  return state.setIn(["sourcesText", source.id], I.Map({
+  return state.setIn(["sourcesText", source.id], Map({
     text: sourceText.text,
     contentType: sourceText.contentType
   }));

--- a/src/reducers/tests/sources.js
+++ b/src/reducers/tests/sources.js
@@ -2,7 +2,8 @@
 declare var describe: (name: string, func: () => void) => void;
 declare var it: (desc: string, func: () => void) => void;
 
-const { State, update } = require("../sources");
+import sources from "../sources";
+const { State, update } = sources;
 const { foobar } = require("../../test/fixtures");
 const fakeSources = foobar.sources.sources;
 const expect = require("expect.js");

--- a/src/selectors.js
+++ b/src/selectors.js
@@ -1,17 +1,17 @@
 // @flow
-const expressions = require("./reducers/expressions");
-const sources = require("./reducers/sources");
-const pause = require("./reducers/pause");
-const breakpoints = require("./reducers/breakpoints");
-const eventListeners = require("./reducers/event-listeners");
-const ui = require("./reducers/ui");
-const coverage = require("./reducers/coverage");
+import expressions from "./reducers/expressions";
+import sources from "./reducers/sources";
+import pause from "./reducers/pause";
+import breakpoints from "./reducers/breakpoints";
+import eventListeners from "./reducers/event-listeners";
+import ui from "./reducers/ui";
+import coverage from "./reducers/coverage";
 
 /**
  * @param object - location
  */
 
-module.exports = {
+export default {
   getSource: sources.getSource,
   getSourceByURL: sources.getSourceByURL,
   getSourceById: sources.getSourceById,

--- a/src/utils/test-head.js
+++ b/src/utils/test-head.js
@@ -5,11 +5,11 @@
  * @module utils/test-head
  */
 
-const { combineReducers } = require("redux");
-const reducers = require("../reducers");
-const actions = require("../actions");
-const selectors = require("../selectors");
-const constants = require("../constants");
+import { combineReducers } from "redux";
+import reducers from "../reducers";
+import selectors from "../selectors";
+import actions from "../actions";
+import constants from "../constants";
 
 const configureStore = require("../utils/create-store");
 


### PR DESCRIPTION
Associated Issue: https://github.com/devtools-html/debugger.html/issues/1884

### Summary of Changes

* refactor `actions` to es6 modules: `breakpoints.js`, `sources.js` - partially
* refactor `reducers` to es6 modules
* refactor `utils` `test-head.js` to es6 modules
* refactor `selectors.js`


