### PR TITLE
Persist scopes

### DIFF
--- a/src/components/Editor/Breakpoint.js
+++ b/src/components/Editor/Breakpoint.js
@@ -22,7 +22,7 @@ function makeMarker(isDisabled: boolean) {
 const Breakpoint = React.createClass({
   propTypes: {
     breakpoint: PropTypes.object.isRequired,
-    editor: PropTypes.object
+    editor: PropTypes.object.isRequired
   },
 
   displayName: "Breakpoint",

--- a/src/components/Editor/Breakpoint.js
+++ b/src/components/Editor/Breakpoint.js
@@ -22,7 +22,7 @@ function makeMarker(isDisabled: boolean) {
 const Breakpoint = React.createClass({
   propTypes: {
     breakpoint: PropTypes.object.isRequired,
-    editor: PropTypes.object.isRequired
+    editor: PropTypes.object
   },
 
   displayName: "Breakpoint",

--- a/src/components/SecondaryPanes/Scopes.js
+++ b/src/components/SecondaryPanes/Scopes.js
@@ -136,6 +136,9 @@ function getScopes(pauseInfo, selectedFrame) {
   return scopes;
 }
 
+let expandedCache = new Set();
+let actorsCache = [];
+
 const Scopes = createClass({
   propTypes: {
     pauseInfo: ImPropTypes.map,
@@ -180,6 +183,14 @@ const Scopes = createClass({
         roots: scopes,
         getObjectProperties: id => loadedObjects.get(id),
         loadObjectProperties: loadObjectProperties,
+        getExpanded: expanded => {
+          expandedCache = expanded;
+        },
+        setExpanded: () => expandedCache,
+        getActors: actors => {
+          actorsCache = actors;
+        },
+        setActors: () => actorsCache,
         onLabelClick: (item, { expanded, setExpanded }) => {
           setExpanded(item, !expanded);
         }

--- a/src/components/SecondaryPanes/Scopes.js
+++ b/src/components/SecondaryPanes/Scopes.js
@@ -183,14 +183,14 @@ const Scopes = createClass({
         roots: scopes,
         getObjectProperties: id => loadedObjects.get(id),
         loadObjectProperties: loadObjectProperties,
-        getExpanded: expanded => {
+        setExpanded: expanded => {
           expandedCache = expanded;
         },
-        setExpanded: () => expandedCache,
-        getActors: actors => {
+        getExpanded: () => expandedCache,
+        setActors: actors => {
           actorsCache = actors;
         },
-        setActors: () => actorsCache,
+        getActors: () => actorsCache,
         onLabelClick: (item, { expanded, setExpanded }) => {
           setExpanded(item, !expanded);
         }

--- a/src/components/shared/ManagedTree.js
+++ b/src/components/shared/ManagedTree.js
@@ -1,6 +1,6 @@
 // @flow
-const React = require("react");
-const Tree = React.createFactory(require("devtools-sham-modules").Tree);
+import { createClass, PropTypes, createFactory } from "react";
+const Tree = createFactory(require("devtools-sham-modules").Tree);
 require("./ManagedTree.css");
 
 type ManagedTreeItem = {
@@ -13,8 +13,8 @@ type NextProps = {
   autoExpandAll: boolean,
   autoExpandDepth: number,
   getChildren: () => any,
-  getKey: (ManagedTreeItem, number) => string,
-  getParent: (ManagedTreeItem) => any,
+  getKey: () => string,
+  getParent: () => any,
   getRoots: () => any,
   highlightItems: Array<ManagedTreeItem>,
   itemHeight: number,
@@ -28,14 +28,21 @@ type InitialState = {
   focusedItem: ?ManagedTreeItem
 };
 
-let ManagedTree = React.createClass({
-  propTypes: Tree.propTypes,
+let ManagedTree = createClass({
+  propTypes: Object.assign({},
+    Tree.propTypes,
+    {
+      getExpanded: PropTypes.func,
+      setExpanded: PropTypes.func
+    }
+  ),
 
   displayName: "ManagedTree",
 
   getInitialState(): InitialState {
+    const { setExpanded } = this.props;
     return {
-      expanded: new Set(),
+      expanded: setExpanded ? setExpanded() : new Set(),
       focusedItem: null
     };
   },
@@ -50,6 +57,12 @@ let ManagedTree = React.createClass({
     if (highlightItems && highlightItems != this.props.highlightItems &&
        highlightItems.length) {
       this.highlightItem(highlightItems);
+    }
+  },
+
+  componentWillUnmount() {
+    if (this.props.getExpanded) {
+      this.props.getExpanded(this.state.expanded);
     }
   },
 

--- a/src/components/shared/ManagedTree.js
+++ b/src/components/shared/ManagedTree.js
@@ -40,9 +40,8 @@ let ManagedTree = createClass({
   displayName: "ManagedTree",
 
   getInitialState(): InitialState {
-    const { setExpanded } = this.props;
     return {
-      expanded: setExpanded ? setExpanded() : new Set(),
+      expanded: new Set(),
       focusedItem: null
     };
   },
@@ -60,9 +59,16 @@ let ManagedTree = createClass({
     }
   },
 
-  componentWillUnmount() {
+  componentWillMount() {
     if (this.props.getExpanded) {
-      this.props.getExpanded(this.state.expanded);
+      const expanded = this.props.getExpanded();
+      this.setState({ expanded });
+    }
+  },
+
+  componentWillUnmount() {
+    if (this.props.setExpanded) {
+      this.props.setExpanded(this.state.expanded);
     }
   },
 

--- a/src/components/shared/ObjectInspector.js
+++ b/src/components/shared/ObjectInspector.js
@@ -54,7 +54,11 @@ const ObjectInspector = React.createClass({
     getObjectProperties: PropTypes.func.isRequired,
     loadObjectProperties: PropTypes.func.isRequired,
     onLabelClick: PropTypes.func,
-    onDoubleClick: PropTypes.func
+    onDoubleClick: PropTypes.func,
+    getExpanded: PropTypes.func,
+    setExpanded: PropTypes.func,
+    getActors: PropTypes.func,
+    setActors: PropTypes.func
   },
 
   displayName: "ObjectInspector",
@@ -63,7 +67,8 @@ const ObjectInspector = React.createClass({
     // Cache of dynamically built nodes. We shouldn't need to clear
     // this out ever, since we don't ever "switch out" the object
     // being inspected.
-    this.actorCache = {};
+    const { setActors } = this.props;
+    this.actors = setActors ? setActors() : {};
     return {};
   },
 
@@ -73,6 +78,12 @@ const ObjectInspector = React.createClass({
       onDoubleClick: () => {},
       autoExpandDepth: 1
     };
+  },
+
+  componentWillUnmount() {
+    if (this.props.getActors) {
+      this.props.getActors(this.actors);
+    }
   },
 
   getChildren(item) {
@@ -95,8 +106,8 @@ const ObjectInspector = React.createClass({
       // being the same across renders. If we didn't do this, each
       // node would be a new instance every render.
       const key = item.path;
-      if (this.actorCache[key]) {
-        return this.actorCache[key];
+      if (this.actors[key]) {
+        return this.actors[key];
       }
 
       const loadedProps = getObjectProperties(actor);
@@ -106,7 +117,7 @@ const ObjectInspector = React.createClass({
       }
 
       const children = makeNodesForProperties(loadedProps, item.path);
-      this.actorCache[actor] = children;
+      this.actors[key] = children;
       return children;
     }
 
@@ -168,7 +179,7 @@ const ObjectInspector = React.createClass({
 
   render() {
     const { name, desc, loadObjectProperties,
-            autoExpandDepth } = this.props;
+            autoExpandDepth, getExpanded, setExpanded } = this.props;
 
     let roots = this.props.roots;
     if (!roots) {
@@ -190,7 +201,8 @@ const ObjectInspector = React.createClass({
           loadObjectProperties(item.contents.value);
         }
       },
-
+      getExpanded,
+      setExpanded,
       renderItem: this.renderItem
     });
   }

--- a/src/components/shared/ObjectInspector.js
+++ b/src/components/shared/ObjectInspector.js
@@ -67,8 +67,6 @@ const ObjectInspector = React.createClass({
     // Cache of dynamically built nodes. We shouldn't need to clear
     // this out ever, since we don't ever "switch out" the object
     // being inspected.
-    const { setActors } = this.props;
-    this.actors = setActors ? setActors() : {};
     return {};
   },
 
@@ -80,9 +78,15 @@ const ObjectInspector = React.createClass({
     };
   },
 
-  componentWillUnmount() {
+  componentWillMount() {
     if (this.props.getActors) {
-      this.props.getActors(this.actors);
+      this.actors = this.props.getActors();
+    }
+  },
+
+  componentWillUnmount() {
+    if (this.props.setActors) {
+      this.props.setActors(this.actors);
     }
   },
 
@@ -178,8 +182,10 @@ const ObjectInspector = React.createClass({
   },
 
   render() {
-    const { name, desc, loadObjectProperties,
-            autoExpandDepth, getExpanded, setExpanded } = this.props;
+    const {
+      name, desc, loadObjectProperties,
+      autoExpandDepth, getExpanded, setExpanded
+    } = this.props;
 
     let roots = this.props.roots;
     if (!roots) {


### PR DESCRIPTION
Associated Issue: #1617

### Summary of Changes

* Added get and set functions which enable us cache the `actors` and `expanded` states across `ObjectInspector` component mounts.
* Fixed a key bug in the `getChildren` function. The loaded children were cached against the `actor` rather than the `key`. ( Finding this was the nightmare)  :)

### Test Plan

- [x] Set a breakpoint
- [x] Once the breakpoint is hit
- [x] Open up the scopes
- [x] Hit the step over button
- [x] The state should be preserved in the scopes pane


### Screenshots/Videos (OPTIONAL)
![persist-scopes](https://cloud.githubusercontent.com/assets/792924/23188424/948ff100-f886-11e6-9420-bab20d56d289.gif)

