### PR TITLE
Fix search selection

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "copy-assets": "node bin/copy-assets --symlink",
     "copy-assets-watch": "node bin/copy-assets --watch --symlink",
     "build-docs": "documentation build --format html --sort-order alpha --shallow  --document-exported --output docs/reference/ src/types.js src/utils/ src/reducers/ src/actions/ src/test/mochitest/head.js",
-    "flow-coverage": "flow-coverage-report --threshold 70 -i 'src/actions/*.js' -i 'src/reducers/*.js' -i 'src/utils/*.js' -t html -t text",
+    "flow-coverage": "flow-coverage-report --threshold 65 -i 'src/actions/*.js' -i 'src/reducers/*.js' -i 'src/utils/*.js' -i 'src/components/*.js' -i 'src/components/**/*.js' -t html -t text",
     "flow-utils": "flow-coverage-report -i 'src/utils/*.js' -t text",
     "flow-redux": "flow-coverage-report  -i 'src/reducers/*.js' -i 'src/actions/*.js'  -t text",
     "flow-react": "flow-coverage-report -i 'src/components/**/*.js' -t text",

--- a/src/utils/editor/index.js
+++ b/src/utils/editor/index.js
@@ -13,7 +13,8 @@ const {
   find,
   findNext,
   findPrev,
-  removeOverlay
+  removeOverlay,
+  clearIndex
 } = require("./source-search");
 
 const SourceEditor = require("./source-editor");
@@ -115,15 +116,6 @@ function traverseResults(e, ctx, query, dir, modifiers) {
   }
 }
 
-function onMouseUp(ctx, modifiers) {
-  const query = ctx.cm.getSelection();
-  if (ctx.cm.somethingSelected()) {
-    find(ctx, query, true, modifiers);
-  } else {
-    removeOverlay(ctx, query, modifiers);
-  }
-}
-
 function createEditor() {
   return new SourceEditor({
     mode: "javascript",
@@ -160,12 +152,12 @@ module.exports = {
   find,
   findNext,
   findPrev,
+  clearIndex,
   removeOverlay,
   isTextForSource,
   breakpointAtLine,
   getTextForLine,
   getCursorLine,
   resizeBreakpointGutter,
-  traverseResults,
-  onMouseUp
+  traverseResults
 };

--- a/src/utils/editor/source-search.js
+++ b/src/utils/editor/source-search.js
@@ -297,6 +297,11 @@ function findPrev(
   return doSearch(ctx, true, query, keepSelection, modifiers);
 }
 
+function clearIndex(ctx: any, query: string, modifiers: SearchModifiers) {
+  let state = getSearchState(ctx.cm, query, modifiers);
+  state.matchIndex = -1;
+}
+
 function countMatches(
   query: string, text: string, modifiers: SearchModifiers): number {
   const regexQuery = buildQuery(query, modifiers, {
@@ -308,6 +313,7 @@ function countMatches(
 
 module.exports = {
   buildQuery,
+  clearIndex,
   countMatches,
   find,
   findNext,


### PR DESCRIPTION
Associated Issue: #2065

### Summary of Changes

* I'll first land #2067 and then rebase
* I moved the search results state to the editor to simplify the state. We can further organize this later now that the state is better grouped
* the main issue was that we were not clear the search index any time the user clicked away

### Spec

#### Queries

* **typing/deleting query**
	* should search after each character, index
	* the index and count should be correct
	* the match should be  to right of the cursor

#### Iterating

* **(enter/shift enter |  cmd+g/cmd+shift+g)**
	* increments and decrements by one
	* wraps from first to last of the list and vice versa
* **moving the cursor**
	* updates the match and index to be to the right of the cursor

#### Mouse Actions

* **click on document**
	* **cmd+g** should research from that location.
	* **cmd+f** should refocus the search bar with the current query
	* **search bar** should search from the cursor location
* **select text**
	* **cmd+f** should update the query of the search bar
	* **cmd+g** should search from that location with the current query

### Screenshots/Videos (OPTIONAL)

![](http://g.recordit.co/WhDmisNaS0.gif)