### PR TITLE
Render the source search at the "top-level" in vertical mode.

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -72,7 +72,7 @@ const App = React.createClass({
         }),
         Editor({ horizontal }),
         !this.props.selectedSource ? WelcomeBox({ horizontal }) : null,
-        SourceSearch()
+        horizontal ? SourceSearch() : null
       )
     );
   },
@@ -114,6 +114,7 @@ const App = React.createClass({
 
     return dom.div(
       { className: "debugger" },
+      SourceSearch(),
       SplitBox({
         style: { width: "100vw" },
         initialSize: "300px",


### PR DESCRIPTION
Associated Issue: #2076 

### Summary of Changes

* when in vertical mode render the project/source search at the "top-level"

### Test Plan

- [x] Open debugger
- [x] Resize debugger to vertical layout (sub 700px)
- [x] Open project search <kbd>ctrl</kbd>/<kbd>cmd</kbd> + <kbd>P</kbd> and see it renders to take up the full view under the tab bar.


### Screenshots/Videos

#### Before

![screenshot_20170222_131843](https://cloud.githubusercontent.com/assets/580982/23233679/d93ee186-f90c-11e6-92ca-0a89d41ebc6d.png)

#### After

![screenshot_20170222_143327](https://cloud.githubusercontent.com/assets/580982/23233657/c702e04e-f90c-11e6-9ef6-bae75db9bf96.png)
