### PR TITLE
Expand source directories on click

### DIFF
--- a/src/components/SourcesTree.js
+++ b/src/components/SourcesTree.js
@@ -25,7 +25,7 @@ type CreateTree = {
   uncollapsedTree: any,
   listItems?: any,
   highlightItems?: any
-}
+};
 
 let SourcesTree = React.createClass({
   propTypes: {
@@ -185,8 +185,10 @@ let SourcesTree = React.createClass({
         className: classnames("node", { focused }),
         style: { [paddingDir]: `${depth * 15}px` },
         key: item.path,
-        onClick: () => this.selectItem(item),
-        onDoubleClick: e => setExpanded(item, !expanded),
+        onClick: () => {
+          this.selectItem(item);
+          setExpanded(item, !expanded);
+        },
         onContextMenu: (e) => this.onContextMenu(e, item)
       },
       dom.div(null, arrow, icon, item.name)


### PR DESCRIPTION
Associated Issue: #2085 

### Summary of Changes

* to match expected UX from editors like Atom/Sublime I've modified the source tree to expand directories on click. Since this change was made the double click behavior seemed redundant and was removed.

### Test Plan

- [x] Open debugger and click on a source directory to toggle its open state
- [x] Click it again to toggle it closed
- [x] Click a file to ensure that files still open as they did before.
