### PR TITLE
Issue 1946: adding Conditional Breakpoint guillemet

### DIFF
--- a/src/components/Editor/ConditionalPanel.css
+++ b/src/components/Editor/ConditionalPanel.css
@@ -1,0 +1,30 @@
+.conditional-breakpoint-panel {
+  cursor: initial;
+  margin: 1em 0;
+  position: relative;
+  display: flex;
+  align-items: center;
+  background: var(--theme-toolbar-background);
+  border-top: 1px solid var(--theme-splitter-color);
+  border-bottom: 1px solid var(--theme-splitter-color);
+}
+
+.conditional-breakpoint-panel .prompt {
+  font-size: 1.8em;
+  color: var(--theme-highlight-blue);
+  padding-left: 3px;
+}
+
+.conditional-breakpoint-panel input {
+  margin: 5px 10px;
+  width: calc(100% - 4em);
+  border: none;
+  background: var(--theme-toolbar-background);
+  font-size: 14px;
+  color: var(--theme-comment);
+  line-height: 30px;
+}
+
+.conditional-breakpoint-panel input:focus {
+  outline-width: 0;
+}

--- a/src/components/Editor/ConditionalPanel.js
+++ b/src/components/Editor/ConditionalPanel.js
@@ -6,7 +6,6 @@ const ReactDOM = require("react-dom");
 
 require("./ConditionalPanel.css");
 
-
 function renderConditionalPanel({ condition, closePanel, setBreakpoint }:
   { condition: boolean, closePanel: Function, setBreakpoint: Function }) {
   let panel = document.createElement("div");

--- a/src/components/Editor/ConditionalPanel.js
+++ b/src/components/Editor/ConditionalPanel.js
@@ -4,6 +4,9 @@ const { DOM: dom } = React;
 
 const ReactDOM = require("react-dom");
 
+require("./ConditionalPanel.css");
+
+
 function renderConditionalPanel({ condition, closePanel, setBreakpoint }:
   { condition: boolean, closePanel: Function, setBreakpoint: Function }) {
   let panel = document.createElement("div");
@@ -22,6 +25,10 @@ function renderConditionalPanel({ condition, closePanel, setBreakpoint }:
   ReactDOM.render(
     dom.div(
       { className: "conditional-breakpoint-panel" },
+      dom.div({
+        className: "prompt",
+        dangerouslySetInnerHTML: { __html: "&raquo;" }
+      }),
       dom.input({
         defaultValue: condition,
         placeholder: L10N.getStr("editor.conditionalPanel.placeholder"),

--- a/src/components/Editor/ConditionalPanel.js
+++ b/src/components/Editor/ConditionalPanel.js
@@ -24,10 +24,7 @@ function renderConditionalPanel({ condition, closePanel, setBreakpoint }:
   ReactDOM.render(
     dom.div(
       { className: "conditional-breakpoint-panel" },
-      dom.div({
-        className: "prompt",
-        dangerouslySetInnerHTML: { __html: "&raquo;" }
-      }),
+      dom.div({ className: "prompt" }, "»"),
       dom.input({
         defaultValue: condition,
         placeholder: L10N.getStr("editor.conditionalPanel.placeholder"),

--- a/src/components/Editor/Editor.css
+++ b/src/components/Editor/Editor.css
@@ -134,28 +134,6 @@ html[dir="rtl"] .editor-mount {
   user-select: none;
 }
 
-.conditional-breakpoint-panel {
-  cursor: initial;
-  margin: 1em 0;
-  position: relative;
-  background: var(--theme-toolbar-background);
-  border-top: 1px solid var(--theme-splitter-color);
-  border-bottom: 1px solid var(--theme-splitter-color);
-}
-
-.conditional-breakpoint-panel input {
-  margin: 5px 10px;
-  width: calc(100% - 2em);
-  border: none;
-  background: var(--theme-toolbar-background);
-  font-size: 14px;
-  color: var(--theme-comment);
-  line-height: 30px;
-}
-
-.conditional-breakpoint-panel input:focus {
-  outline-width: 0;
-}
 
 .function-search .autocomplete li:first-child {
   border-top: none;


### PR DESCRIPTION
Associated Issue: #1946 

### Summary of Changes

* Moved Conditional Breakpoint Panel style from editor.css to its own file at ConditionalPanel.css
* Changed ConditionalPanel.js to include the guillemet

### Test Plan

I used the instructions on the wiki to run the source code and saw the guillemet in the correct position.

Example test plan:

- [x] Launch debugger
- [x] Navigate to desired testing page
- [x] User Control+Shift+B to add conditional breakpoint
- [x] Admire the beautiful guillemet in the panel

Here's the Debugger's Testing doc
https://docs.google.com/document/d/1oBMRxV8A2ag2t22YsQOxTdEv0mXKzIg0tggJjRkU1S0/edit#.
Feel free to improve it!

### Screenshots/Videos
![slack - firefox devtools 2017-02-22 20 37 49](https://cloud.githubusercontent.com/assets/23247/23238050/e0cd752a-f93e-11e6-86b1-25dad1e6113a.png)

