### PR TITLE
[Sources] Directories should expand/collapse on click

### DIFF
--- a/src/components/Editor/Editor.css
+++ b/src/components/Editor/Editor.css
@@ -134,7 +134,6 @@ html[dir="rtl"] .editor-mount {
   user-select: none;
 }
 
-
 .function-search .autocomplete li:first-child {
   border-top: none;
 }

--- a/src/components/SourcesTree.js
+++ b/src/components/SourcesTree.js
@@ -185,7 +185,10 @@ let SourcesTree = React.createClass({
         className: classnames("node", { focused }),
         style: { [paddingDir]: `${depth * 15}px` },
         key: item.path,
-        onClick: () => this.selectItem(item),
+        onClick: () => {
+          this.selectItem(item);
+          setExpanded(item, !expanded);
+        },
         onDoubleClick: e => setExpanded(item, !expanded),
         onContextMenu: (e) => this.onContextMenu(e, item)
       },


### PR DESCRIPTION
Associated Issue: #2085

### Summary of Changes
- Add code to allow clicking on directories' label to expand/collapse their subdirectories.

### Test Plan
- Click on a directory's label to see if it expands and click on the label again to see if it collapses.