### PR TITLE
Restore tooltips for debug buttons

### DIFF
--- a/src/components/SecondaryPanes/CommandBar.js
+++ b/src/components/SecondaryPanes/CommandBar.js
@@ -89,6 +89,7 @@ function debugBtn(onClick, type, className, tooltip, disabled = false) {
       className,
       key: type,
       "aria-label": tooltip,
+      title: tooltip,
       disabled
     },
     Svg(type)


### PR DESCRIPTION
Associated Issue: #2097

### Summary of Changes

* Restore tooltips

### Screenshots/Videos (OPTIONAL)
![tooltip](https://cloud.githubusercontent.com/assets/1755089/23266040/9b45dbd6-fa0c-11e6-8c37-0b41d5a749ca.gif)
