### PR TITLE
Document Firefox WebSocket workflow

### DIFF
--- a/.remarkrc
+++ b/.remarkrc
@@ -2,7 +2,9 @@
   "presets": ["lint-recommended"],
   "plugins": {
     "lint": {
+      "list-item-bullet-indent": false,
       "list-item-indent": false,
+      "ordered-list-marker-style": false,
       "no-unused-definitions": false,
       "no-shortcut-reference-link": false,
       "no-shortcut-reference-image": false

--- a/configs/application.json
+++ b/configs/application.json
@@ -39,7 +39,7 @@
   "firefox": {
     "webSocketConnection": false,
     "proxyHost": "localhost:9000",
-    "websocketHost": "localhost:6080"
+    "webSocketHost": "localhost:6080"
   },
   "development": {
     "serverPort": 8000,

--- a/configs/development.json
+++ b/configs/development.json
@@ -49,7 +49,7 @@
   "firefox": {
     "webSocketConnection": false,
     "proxyHost": "localhost:9000",
-    "websocketHost": "localhost:6080",
+    "webSocketHost": "localhost:6080",
     "mcPath": "./firefox"
   },
   "development": {

--- a/docs/getting-setup.md
+++ b/docs/getting-setup.md
@@ -70,7 +70,8 @@ yarn start
 
 ### Starting Firefox
 
-If you're looking for an alternative to `yarn run firefox`, you have two options: cli, gcli.
+If you're looking for an alternative to `yarn run firefox`, you have several
+alternatives.
 
 #### Firefox CLI
 
@@ -101,6 +102,29 @@ Close firefox and re-open it with the `firefox-bin` command.
 
 NOTE: This assumes that you've already set the other preferences in
 `about:config`.
+
+#### Firefox using WebSocket transport
+
+The default, traditional way to connect to Firefox uses a custom TCP protocol.
+However, Firefox also now supports connecting via WebSockets as well.  To use
+this mode:
+
+1. Create a `configs/local.json` file in your `debugger.html` clone with:
+```
+{
+  "firefox": {
+    "webSocketConnection": true,
+    "webSocketHost": "localhost:6080"
+  }
+}
+```
+2. Enable WebSocket mode when opening the server socket
+  * With the Firefox CLI approach, add the `ws:` prefix to the port:
+  ```bash
+  /Applications/Firefox.app/Contents/MacOS/firefox-bin --start-debugger-server ws:6080 -P development
+  ```
+  * With the GCLI approach, enter `listen 6080 websocket`
+
 
 ### Starting Chrome
 

--- a/docs/getting-setup.md
+++ b/docs/getting-setup.md
@@ -72,16 +72,16 @@ yarn start
 
 If you're looking for an alternative to `yarn run firefox`, you have two options: cli, gcli.
 
-**Firefox CLI**
+#### Firefox CLI
 
-1. Run `firefox-bin` from the command line
+##### 1. Run `firefox-bin` from the command line
 ```bash
 /Applications/Firefox.app/Contents/MacOS/firefox-bin --start-debugger-server 6080 -P development
 ```
 
 You'll be shown a prompt to create a new "development" profile. The development profile is where your remote development user settings will be kept. *It's a good thing :)*
 
-1. Go to `about:config` and set these configs
+##### 2. Go to `about:config` and set these preferences
 
 Navigate to `about:config` and accept any warning message. Then search for the following preferences and double click them to toggle their values to the following. [example](http://g.recordit.co/3VsHIooZ9q.gif)
 
@@ -89,17 +89,18 @@ Navigate to `about:config` and accept any warning message. Then search for the f
 * `devtools.chrome.enabled` to `true`
 * `devtools.debugger.prompt-connection` to `false`
 
-1. Restart Firefox
+##### 3. Restart Firefox
 
 Close firefox and re-open it with the `firefox-bin` command.
 
-**Firefox GCLI**
+#### Firefox GCLI
 
-* Open Firefox
-* *<kbd>shift</kbd>+<kbd>F2</kbd>* Open GCLI
-* Type `listen 6080` into the GCLI
+1. Open Firefox
+2. Press <kbd>shift</kbd>+<kbd>F2</kbd> to open GCLI
+3. Type `listen 6080` into GCLI
 
-NOTE: this assumes that you've set the other appropriate `about:configs`
+NOTE: This assumes that you've already set the other preferences in
+`about:config`.
 
 ### Starting Chrome
 


### PR DESCRIPTION
### Summary of Changes

* Fix typo in the config key `webSocketHost`
* Improve styling of Firefox getting started docs
* Add new docs about the WebSocket workflow

### Details

This should make it easier for people to choose the WebSocket transport with Firefox if they'd like to.