### PR TITLE
Stick the commandbar to the top of the seconday panel.

### DIFF
--- a/src/components/SecondaryPanes/CommandBar.css
+++ b/src/components/SecondaryPanes/CommandBar.css
@@ -4,6 +4,10 @@
   display: flex;
   height: 30px;
   overflow: hidden;
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  background-color: var(--theme-body-background);
 }
 
 .command-bar > button {


### PR DESCRIPTION
Associated Issue: #1918 

### Summary of Changes

* Sticky `.command-bar` to the top using `position: sticky`.
* z-index so the static elements don't go on top of it.
* Background-color to prevent the command bar from showing the scrolled elements underneath it.

### Test Plan

Start up debugger, set a breakpoint, open the `window` scope variables. Scroll some.
