### PR TITLE
unlink codemirror doc on component unmount

### DIFF
--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -195,7 +195,10 @@ const Editor = React.createClass({
     resizeBreakpointGutter(this.editor.codeMirror);
     debugGlobal("cm", this.editor.codeMirror);
 
-    if (this.props.sourceText) {
+    if (this.props.selectedSource) {
+      let sourceId = this.props.selectedSource.get("id");
+      this.editor.replaceDocument(getDocument(sourceId));
+    } else if (this.props.sourceText) {
       this.setText(this.props.sourceText.get("text"));
     }
   },

--- a/src/utils/editor/source-editor.js
+++ b/src/utils/editor/source-editor.js
@@ -49,7 +49,10 @@ class SourceEditor {
   }
 
   destroy() {
-    // No need to do anything.
+    // Unlink the current document.
+    if (this.editor.doc) {
+      this.editor.doc.cm = null;
+    }
   }
 
   get codeMirror(): any {


### PR DESCRIPTION
Associated Issue: #2127

### Summary of Changes

* unlink codemirror document on editor destroy
* try to set codemirror document from existing source documents rather than plain text when possible

### Test Plan

- [x] open a source in the debugger
- [x] resize the window to switch between vertical/horizontal layouts
- [x] close the source tab
- [x] reopen the same source

(or see gif in #2127 )
