### PR TITLE
clean up testing docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ We respect your time and want to help you make the most of it as you learn more 
 * [Getting Started](#getting-started-runner)
   * [Your First Code Contribution](#your-first-code-contribution)
   * [Coding Standards](#coding-standards)
-  * [Local Development](#local-development-computer)
+  * [Development Guide](#development-guide-computer)
   * [Issues](#issues)
   * [Pull Requests](#pull-requests)
   * [Debugging Tips](#debugging-tips)
@@ -133,7 +133,7 @@ Here are pointers to the DevTools general coding style and formatting guidelines
 * [JS Coding Style](https://wiki.mozilla.org/DevTools/CodingStandards#Code_style)
 * [Formatting Comments](https://wiki.mozilla.org/DevTools/CodingStandards#Comments)
 
-### Local Development :computer:
+### Development Guide :computer:
 
 Go to [local Development](./docs/local-development.md) to learn about:
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# debugger.html 
+# debugger.html
 
 [![slack-badge]][slack] ![][ci-status] [![npm-version]][npm-package] [![PRs Welcome]][make-a-pull-request]
 
@@ -40,6 +40,20 @@ If this is your [first PR][make-a-pull-request] or you're not sure where to get 
 say hi in [slack] and a team member would be happy to mentor you.
 
 We strive for collaboration with [mutual respect for each other][contributing]. Mozilla also has a set of [participation guidelines] which goes into greater detail specific to Mozilla employees and contributors.
+
+### Development Guide
+
+We strive to make the Debugger as development friendly as possible. If you have a question that's not answered in the guide, ask us in [slack]. We also :heart: documentation PRs!
+
+* [Configs](./docs/local-development.md#configs)
+* [Hot Reloading](./docs/local-development.md#hot-reloading-fire)
+* [Themes](./docs/local-development.md#themes)
+* [Internationalization](./docs/local-development.md#internationalization)
+* [Prefs](./docs/local-development.md#prefs)
+* [Flow](./docs/local-development.md#flow)
+* [Logging](./docs/local-development.md#logging)
+* [Testing](./docs/local-development.md#testing)
+* [Linting](./docs/local-development.md#linting)
 
 ### Discussion
 

--- a/README.md
+++ b/README.md
@@ -45,15 +45,17 @@ We strive for collaboration with [mutual respect for each other][contributing]. 
 
 We strive to make the Debugger as development friendly as possible. If you have a question that's not answered in the guide, ask us in [slack]. We also :heart: documentation PRs!
 
-* [Configs](./docs/local-development.md#configs)
-* [Hot Reloading](./docs/local-development.md#hot-reloading-fire)
-* [Themes](./docs/local-development.md#themes)
-* [Internationalization](./docs/local-development.md#internationalization)
-* [Prefs](./docs/local-development.md#prefs)
-* [Flow](./docs/local-development.md#flow)
-* [Logging](./docs/local-development.md#logging)
-* [Testing](./docs/local-development.md#testing)
-* [Linting](./docs/local-development.md#linting)
+| Topics | Overview |
+|--|--|
+| [Themes] | theming changes for light, dark, firebug |
+| [Internationalization] | using or adding localized text (l10n) |
+| [Prefs] | using or adding a preferences |
+| [Flow] | flow best practices and common gotchas |
+| [Logging] | tips for logging redux and client |
+| [Testing] | unit and integration test tips |
+| [Linting] | css, js, markdown linting |
+| [Configs] | overview of debugger settings |
+| [Hot Reloading] | steps for enabling hot reloading |
 
 ### Discussion
 
@@ -98,3 +100,13 @@ Say hello in [slack] or in the [#devtools-html][irc-devtools-html] channel on ir
 [irc-devtools-html]: irc://irc.mozilla.org/devtools-html
 [community-call]: https://hangouts.google.com/hangouts/_/calendar/amFzb24ubGFzdGVyLjExQGdtYWlsLmNvbQ.30mdpa6ncqn8uttvmrj9b9d3jc
 [devtools-call]: https://wiki.mozilla.org/DevTools
+
+[Configs]: ./docs/local-development.md#configs
+[Hot Reloading]: ./docs/local-development.md#hot-reloading-fire
+[Themes]: ./docs/local-development.md#themes
+[Internationalization]: ./docs/local-development.md#internationalization
+[Prefs]: ./docs/local-development.md#prefs
+[Flow]: ./docs/local-development.md#flow
+[Logging]: ./docs/local-development.md#logging
+[Testing]: ./docs/local-development.md#testing
+[Linting]: ./docs/local-development.md#linting

--- a/README.md
+++ b/README.md
@@ -48,6 +48,14 @@ We strive to make the Debugger as development friendly as possible. If you have 
 |||
 |------|-----|
 |[Themes]|theming changes for light, dark, firebug|
+|[Internationalization]|using or adding a localized string *(l10n)*|
+|[Prefs]|using or adding a preferences|
+|[Flow]|flow best practices and common gotchas|
+|[Logging]|tips for logging redux and client|
+|[Testing]|unit and integration test tips|
+|[Linting]|css, js, markdown linting|
+|[Configs]|how to use debugger settings locally|
+|[Hot Reloading]|steps for enabling hot reloading|
 
 ### Discussion
 

--- a/README.md
+++ b/README.md
@@ -45,17 +45,9 @@ We strive for collaboration with [mutual respect for each other][contributing]. 
 
 We strive to make the Debugger as development friendly as possible. If you have a question that's not answered in the guide, ask us in [slack]. We also :heart: documentation PRs!
 
-| Topics | Overview |
-|--|--|
-| [Themes] | theming changes for light, dark, firebug |
-| [Internationalization] | using or adding localized text (l10n) |
-| [Prefs] | using or adding a preferences |
-| [Flow] | flow best practices and common gotchas |
-| [Logging] | tips for logging redux and client |
-| [Testing] | unit and integration test tips |
-| [Linting] | css, js, markdown linting |
-| [Configs] | overview of debugger settings |
-| [Hot Reloading] | steps for enabling hot reloading |
+|||
+|------|-----|
+|[Themes]|theming changes for light, dark, firebug|
 
 ### Discussion
 

--- a/docs/integration-tests.md
+++ b/docs/integration-tests.md
@@ -1,7 +1,8 @@
 ## Integration Tests
 
 + [Overview](#overview)
-+ [Running Tests](#running-tests)
++ [Running the Tests](#running-the-tests)
++ [Gotchas](#gotchas)
 + [Writing Tests](#writing-tests)
 + [Adding a New Test](#adding-a-new-test)
 
@@ -12,13 +13,26 @@ The integration tests are async functions that drive the debugger in two context
 **Firefox** the tests are run in the panel with [mochitest].
 **Web** the tests are run in an iframe with [mocha].
 
-### Running Tests
+### Running the Tests
 
-* Launch firefox
-* Make sure the other debugger windows are closed
-* Running: `localhost:8000/integration`
-* Selecting a test: Go to `runner.js` and add `it.only` to select which tests to run
-* Skipping a test: Go to `runner.js` and replace `it` with `xit` to skip a test
+Open `localhost:8000/integration`
+
+Tips:
+
+* You can select tests to run or skip in the `runner.js` by replacing `it` with `it.only` and `xit`.
+
+### Gotchas
+
+#### Make sure firefox is running
+
+The tests communicate with firefox over a websocket like the launchpad, so it's important firefox is running.
+
+One easy thing to do to start firefox, is click the "launch Firefox" button in the launchpad app.
+
+#### Make sure the other debugger windows are closed
+
+Because the tests communicate over the same websocket connection as the launchpad, it's important that the other debugger windows are closed. Keeping them open means that some of the messages could be dropped!
+
 
 ### Writing Tests
 
@@ -27,7 +41,6 @@ The integration tests are async functions that drive the debugger in two context
 * Environment specific utilities [mocha.js] [mochitest.js]
 * Assertions: `ok`, `is`
 * HTML Examples are [here][examples-dir]
-
 
 **Example:**
 

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -1,4 +1,4 @@
-## Local Development
+## Development Guide
 
 * [Configs](#configs)
   * [Enabling a Feature Flag](#enabling-a-feature-flag)
@@ -435,12 +435,16 @@ yarn run test-all
 * [http://localhost:8000/mocha](http://localhost:8000/mocha) - Run tests in the browser when you have `yarn start` running [gif](http://g.recordit.co/Go1GOu1Pli.gif))
 
 
-#### Integration tests
+#### Integration Tests
 
-We use [mochitests](https://developer.mozilla.org/en-US/docs/Mozilla/Projects/Mochitest) to do integration testing.  Running these integration tests locally requires some finesse and so as a contributor we only ask that you run the unit tests.   The mochitests will be run by the automated testing which runs once you've made a pull request and the maintainers are happy to help you through any issues which arise from that.
+The Debugger integration tests are run in two contexts: [firefox][mochitest] and the [web][mocha].
+We recommend running the tests in the browser as it's an easier development environment.
 
-Learn more about mochitests in our [mochitests docs](./mochitests.md).
-
++ [Overview](./integration-tests.md#overview)
++ [Running the Tests](./integration-tests.md#running-the-tests)
++ [Gotchas](./integration-tests.md#gotchas)
++ [Writing Tests](./integration-tests.md#writing-tests)
++ [Adding a New Test](./integration-tests.md#adding-a-new-test)
 
 ### Linting
 
@@ -564,3 +568,6 @@ your questions on [slack][slack].
 [firebug-ui-screen]: https://cloud.githubusercontent.com/assets/1755089/22209733/94970458-e1ad-11e6-83d4-8b082217b989.png
 [light-ui-screen]: https://cloud.githubusercontent.com/assets/1755089/22209736/9b194f2a-e1ad-11e6-9de0-561dd529d5f0.png
 [pr-table]: ./pull-requests.md#screenshots
+
+[mochitest]: ./mochitests.md
+[mocha]: ./integration-tests.md

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -1,9 +1,6 @@
 ## Development Guide
 
 * [Configs](#configs)
-  * [Enabling a Feature Flag](#enabling-a-feature-flag)
-  * [Updating the config locally](#updating-the-config-locally)
-  * [Creating a new Feature Flag](#creating-a-new-feature-flag)
 * [Hot Reloading](#hot-reloading-fire)
 * [Themes](#themes)
 * [Internationalization](#internationalization)
@@ -25,74 +22,9 @@
 
 ### Configs
 
-All default config values are in [`development.json`][development-json], to override these values you need to [create a local config file][create-local-config].
+The Debugger uses configs for settings like `theme`, `hotReloading`, and feature flags.
 
-Here are the most common development configuration options:
-
-* `logging`
-  * `firefoxProxy` Enables logging the Firefox protocol in the terminal running `yarn start`
-* `chrome`
-  * `debug` Enables listening for remotely debuggable Chrome browsers
-* `hotReloading` enables [Hot Reloading](#hot-reloading-fire) of CSS and React
-
-For a list of all the configuration options see the [packages/devtools-config/README.md][devtools-config-readme]
-
-#### Updating the config locally
-
-You can create a `configs/local.json` file to override development configs. This is great for enabling features locally or changing the theme.
-
-* Copy the `local.sample.json` to get started.
-
-```bash
-cp configs/local.sample.json configs/local.json
-```
-
-* Restart your development server by typing <kbd>ctrl</kbd>+<kbd>c</kbd> in the Terminal and run `yarn start` again
-
-You can quickly change your local config `configs/local.json`.
-
-* edit the `configs/local.json`
-
-```diff
-diff --git a/configs/local.json b/configs/local.json
-index fdbdb4e..4759c14 100644
---- a/configs/local.json
-+++ b/configs/local.json
-@@ -1,6 +1,6 @@
- {
-   "theme": "light",
--  "hotReloading": false,
-+  "hotReloading": true,
-   "logging": {
-     "actions": false
-   },
-```
-
-* Restart your development server by typing <kbd>ctrl</kbd>+<kbd>c</kbd> in the Terminal and run `yarn start` again
-
-#### Enabling a Feature Flag
-
-Feature flags help us work on features darkly. We've used them to work on source tabs, watch expressions, and many other features.
-
-The features are listed in the configs [development.json](../configs/development.json), [firefox-panel.json](../configs/firefox-panel.json). You can turn a feature on, by adding it to your local config.
-
-
-```diff
-diff --git a/configs/local.json b/configs/local.json
-index fdbdb4e..4759c14 100644
---- a/configs/local.json
-+++ b/configs/local.json
-@@ -1,6 +1,6 @@
- {
-   "theme": "light",
-   "features": {
-     "watchExpressions": {
-       "label": "Watch Expressions",
--      "enabled": false
-+      "enabled": true
-     }
-   },
-```
+The default development configs are in [development-json]. It's easy to change a setting in the Launchpad's settings tab or by updating your `configs/local.json` file.
 
 #### Creating a new Feature Flag
 
@@ -170,6 +102,8 @@ index 038fd01..ea7a545 100644
 * Restart your development server by typing <kbd>ctrl</kbd>+<kbd>c</kbd> in the Terminal and run `yarn start` again
 
 ### Hot Reloading :fire:
+
+:construction: Hot Reloading is currently broken as we need to upgrade `react-hot-reloader` 3.0 [issue](https://github.com/devtools-html/devtools-core/issues/195)
 
 Hot Reloading watches for changes in the React Components JS and CSS and propagates those changes up to the application without changing the state of the application.  You want this turned on.
 
@@ -448,11 +382,12 @@ We recommend running the tests in the browser as it's an easier development envi
 
 ### Linting
 
-Run all of lint checks (JS + CSS) run the following command:
-
-```bash
-yarn run lint
-```
+| | |
+|--|--|
+| all | `yarn run lint` |
+| css | `yarn run lint-css` |
+| js | `yarn run lint-js` |
+| markdown | `yarn run lint-md` |
 
 #### Lint CSS
 
@@ -468,17 +403,15 @@ yarn run lint-css
 
 We use [eslint](http://eslint.org/) to maintain our JavaScript styles.  The [.eslintrc](../.eslintrc) file contains our style definitions, please adhere to those styles when making changes.
 
-To test your JS changes run the command:
-
-```bash
-yarn run lint-js
-```
-
 To automatically fix many errors run the command:
 
 ```bash
 yarn run lint-fix
 ```
+
+#### Lint Markdown
+
+We use [remark](https://github.com/wooorm/remark-lint) to help lint our markdown. It checks for broken images, links, and a set of style rules.
 
 ### Colors
 

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -1,7 +1,5 @@
 ## Development Guide
 
-* [Configs](#configs)
-* [Hot Reloading](#hot-reloading-fire)
 * [Themes](#themes)
 * [Internationalization](#internationalization)
   * [L10N](#l10n)
@@ -17,117 +15,10 @@
   * [Lint JS](#lint-js)
   * [Lint CSS](#lint-css)
 * [Colors](#colors)
+* [Configs](#configs)
+* [Hot Reloading](#hot-reloading-fire)
 * [FAQ](#faq)
 * [Getting Help](#getting-help)
-
-### Configs
-
-The Debugger uses configs for settings like `theme`, `hotReloading`, and feature flags.
-
-The default development configs are in [development-json]. It's easy to change a setting in the Launchpad's settings tab or by updating your `configs/local.json` file.
-
-#### Creating a new Feature Flag
-
-When you're starting a new feature, it's always good to ask yourself if the feature should be added behind a feature flag.
-
-* does this feature need testing or introduce risk?
-* will this feature be built over several PRs?
-* is it possible we'll want to turn it off quickly?
-
-It's easy to add a new feature flag to the project.
-
-1. add the flag to `development.json` and `firefox-panel.json`
-2. add `isEnabled` calls in the code
-
-Here's an example of adding a new feature "awesome sauce" to the Debugger:
-
-```diff
-diff --git a/configs/development.json b/configs/development.json
-index c82b299..d9de5f3 100755
---- a/configs/development.json
-+++ b/configs/development.json
-@@ -14,7 +14,8 @@
-     "eventListeners": {
-       "label": "Event Listeners",
-       "enabled": false
-     },
-     "codeCoverage": {
-       "label": "Code Coverage",
-       "enabled": false
--    }
-+    },
-+    "awesomeSauce": {
-+      "label": "Awesome Sauce",
-+      "enabled": false
-+    }
-   },
-   "chrome": {
-     "debug": true,
-diff --git a/configs/firefox-panel.json b/configs/firefox-panel.json
-index c91b562..bf485bb 100644
---- a/configs/firefox-panel.json
-+++ b/configs/firefox-panel.json
-@@ -10,6 +10,7 @@
-     "eventListeners": {
-       "label": "Event Listeners",
-       "enabled": false
-     },
-     "codeCoverage": {
-       "label": "Code Coverage",
-       "enabled": false
--    }
-+    },
-+    "awesomeSauce": {
-+      "label": "Awesome Sauce",
-+      "enabled": false
-+    }
-   }
- }
-
-diff --git a/src/components/Editor/index.js b/src/components/Editor/index.js
-index 038fd01..ea7a545 100644
---- a/src/components/Editor/index.js
-+++ b/src/components/Editor/index.js
-@@ -114,6 +114,10 @@ const Editor = React.createClass({
-       return;
-     }
-
-+    if (isEnabled("awesomeSauce")) {
-+      // sauce goops out of the breakpoint...
-+    }
-+
-```
-
-
-* Restart your development server by typing <kbd>ctrl</kbd>+<kbd>c</kbd> in the Terminal and run `yarn start` again
-
-### Hot Reloading :fire:
-
-:construction: Hot Reloading is currently broken as we need to upgrade `react-hot-reloader` 3.0 [issue](https://github.com/devtools-html/devtools-core/issues/195)
-
-Hot Reloading watches for changes in the React Components JS and CSS and propagates those changes up to the application without changing the state of the application.  You want this turned on.
-
-To enabled Hot Reloading:
-
-* [Create a local config file][create-local-config] if you don't already have one
-* edit `hotReloading`
-
-```diff
-diff --git a/configs/local.json b/configs/local.json
-index fdbdb4e..4759c14 100644
---- a/configs/local.json
-+++ b/configs/local.json
-@@ -1,6 +1,6 @@
- {
-   "theme": "light",
--  "hotReloading": false,
-+  "hotReloading": true,
-   "logging": {
-     "actions": false
-   },
-```
-
-* Restart your development server by typing <kbd>ctrl</kbd>+<kbd>c</kbd> in the Terminal and run `yarn start` again
 
 ### Themes
 
@@ -429,6 +320,115 @@ When you need to update a variable, you should check to make sure it looks good 
 Often, it is more practicle to create a new variable.
 
 It's helpful to share the changes as a themes [table][pr-table] when you're done.
+
+### Configs
+
+The Debugger uses configs for settings like `theme`, `hotReloading`, and feature flags.
+
+The default development configs are in [development-json]. It's easy to change a setting in the Launchpad's settings tab or by updating your `configs/local.json` file.
+
+#### Creating a new Feature Flag
+
+When you're starting a new feature, it's always good to ask yourself if the feature should be added behind a feature flag.
+
+* does this feature need testing or introduce risk?
+* will this feature be built over several PRs?
+* is it possible we'll want to turn it off quickly?
+
+It's easy to add a new feature flag to the project.
+
+1. add the flag to `development.json` and `firefox-panel.json`
+2. add `isEnabled` calls in the code
+
+Here's an example of adding a new feature "awesome sauce" to the Debugger:
+
+```diff
+diff --git a/configs/development.json b/configs/development.json
+index c82b299..d9de5f3 100755
+--- a/configs/development.json
++++ b/configs/development.json
+@@ -14,7 +14,8 @@
+     "eventListeners": {
+       "label": "Event Listeners",
+       "enabled": false
+     },
+     "codeCoverage": {
+       "label": "Code Coverage",
+       "enabled": false
+-    }
++    },
++    "awesomeSauce": {
++      "label": "Awesome Sauce",
++      "enabled": false
++    }
+   },
+   "chrome": {
+     "debug": true,
+diff --git a/configs/firefox-panel.json b/configs/firefox-panel.json
+index c91b562..bf485bb 100644
+--- a/configs/firefox-panel.json
++++ b/configs/firefox-panel.json
+@@ -10,6 +10,7 @@
+     "eventListeners": {
+       "label": "Event Listeners",
+       "enabled": false
+     },
+     "codeCoverage": {
+       "label": "Code Coverage",
+       "enabled": false
+-    }
++    },
++    "awesomeSauce": {
++      "label": "Awesome Sauce",
++      "enabled": false
++    }
+   }
+ }
+
+diff --git a/src/components/Editor/index.js b/src/components/Editor/index.js
+index 038fd01..ea7a545 100644
+--- a/src/components/Editor/index.js
++++ b/src/components/Editor/index.js
+@@ -114,6 +114,10 @@ const Editor = React.createClass({
+       return;
+     }
+
++    if (isEnabled("awesomeSauce")) {
++      // sauce goops out of the breakpoint...
++    }
++
+```
+
+
+* Restart your development server by typing <kbd>ctrl</kbd>+<kbd>c</kbd> in the Terminal and run `yarn start` again
+
+### Hot Reloading :fire:
+
+:construction: Hot Reloading is currently broken as we need to upgrade `react-hot-reloader` 3.0 [issue](https://github.com/devtools-html/devtools-core/issues/195)
+
+Hot Reloading watches for changes in the React Components JS and CSS and propagates those changes up to the application without changing the state of the application.  You want this turned on.
+
+To enabled Hot Reloading:
+
+* [Create a local config file][create-local-config] if you don't already have one
+* edit `hotReloading`
+
+```diff
+diff --git a/configs/local.json b/configs/local.json
+index fdbdb4e..4759c14 100644
+--- a/configs/local.json
++++ b/configs/local.json
+@@ -1,6 +1,6 @@
+ {
+   "theme": "light",
+-  "hotReloading": false,
++  "hotReloading": true,
+   "logging": {
+     "actions": false
+   },
+```
+
+* Restart your development server by typing <kbd>ctrl</kbd>+<kbd>c</kbd> in the Terminal and run `yarn start` again
 
 ### FAQ
 


### PR DESCRIPTION
### Summary of Changes

* makes the integration tests linkable
* updates integration test overview
* adds a more prominent section in the readme for dev information as people lose in the contributing guide
* changes "local development" to "development guide",


![screen shot 2017-02-24 at 1 50 30 pm](https://cloud.githubusercontent.com/assets/254562/23316403/3e4ea67e-fa98-11e6-8e9a-ae1816845329.png)

