### PR TITLE
Align Text Vertically in Watch Expressions Panel Section

### DIFF
--- a/src/components/SecondaryPanes/Expressions.css
+++ b/src/components/SecondaryPanes/Expressions.css
@@ -6,7 +6,6 @@
   background-color: var(--theme-body-background);
   font-size: 12px;
   padding: 0px 20px;
-  line-height: 20px;
   color: var(--theme-highlight-blue);
 }
 
@@ -29,7 +28,7 @@
 }
 
 .expression-input-container {
-  padding: 8px 0px 0px 0px;
+  padding: 0.5em;
   display: flex;
 }
 


### PR DESCRIPTION
Associated Issue: #2123

### Summary of Changes

- Vertically align the text inside the Watch Expressions section in the panel
- Make the Watch Expressions section the same height as other sections by default

### Test Plan

- [x] It looks correct
- [x] Devtools says that the section is the correct height
- [x] Devtools shows that the text is centered

### Screenshots/Videos
![Screenshot of side panel][1]

[1]: https://cloud.githubusercontent.com/assets/7751418/23325233/e5b2f61c-fac1-11e6-9024-3d2dc2f0f98d.png