### PR TITLE
fix console link test

### DIFF
--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -189,7 +189,8 @@ const Editor = React.createClass({
 
     if (this.props.selectedSource) {
       let sourceId = this.props.selectedSource.get("id");
-      this.editor.replaceDocument(getDocument(sourceId));
+      const doc = getDocument(sourceId) || this.editor.createDocument();
+      this.editor.replaceDocument(doc);
     } else if (this.props.sourceText) {
       this.setText(this.props.sourceText.get("text"));
     }


### PR DESCRIPTION
### Summary of Changes

Fixes two tests, which were broken by the recent vertical layout bug fix. The issue came from trying to get a source document that did not exist.

 * devtools/client/webconsole/test/browser_webconsole_bug_766001_JS_Console_in_Debugger.js  
* devtools/client/webconsole/new-console-output/test/mochitest/browser_webconsole_location_debugger_link.js