### PR TITLE
Fix the nom command to remove yarn.lock file

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "flow-react": "flow-coverage-report -i 'src/components/**/*.js' -t text",
     "prepush": "yarn run lint && yarn run test -- --dots && yarn run flow",
     "postmerge": "node bin/post-merge.js",
-    "nom": "rm -rf node_modules yarn.log; yarn install"
+    "nom": "rm -rf node_modules yarn.lock; yarn install"
   },
   "dependencies": {
     "babel-plugin-transform-es2015-modules-commonjs": "^6.22.0",


### PR DESCRIPTION
Fixed a typo in the package.json file (`yarn.log` => `yarn.lock`)
