### PR TITLE
fix frame location color change on hover

### DIFF
--- a/src/components/SecondaryPanes/Frames.css
+++ b/src/components/SecondaryPanes/Frames.css
@@ -58,11 +58,8 @@
   color: white;
 }
 
-:root.theme-light .frames ul li:hover .location,
 :root.theme-light .frames ul li.selected .location,
 :root.theme-firebug .frames ul li.selected .location,
-:root.theme-firebug .frames ul li:hover .location,
-:root.theme-dark .frames ul li:hover .location,
 :root.theme-dark .frames ul li.selected .location {
   color: white;
 }


### PR DESCRIPTION
Associated Issue: #2083

### Summary of Changes

* Removed CSS that changes the frame location's color on hover
* Removed it for all themes (let me know if you'd like to put it back for the dark theme)

### Test Plan

Tell us a little a bit about how you tested your patch.

Example test plan:

- [x] Command-P opens the panel
- [x] Clicking “+” opens the panel
- [x] Clicking a source navigates to the source
- [x] Clicking "x" closes the panel

Here's the Debugger's Testing doc
https://docs.google.com/document/d/1oBMRxV8A2ag2t22YsQOxTdEv0mXKzIg0tggJjRkU1S0/edit#.
Feel free to improve it!

### Screenshots/Videos (OPTIONAL)
![light_theme](https://cloud.githubusercontent.com/assets/5232812/23343482/3aa10302-fc3a-11e6-9d7d-ce5a0b3c1501.gif)
