### PR TITLE
use scrollIntoView to improve result scrolling (#2106)

### DIFF
--- a/src/components/Editor/SearchBar.js
+++ b/src/components/Editor/SearchBar.js
@@ -93,7 +93,7 @@ const SearchBar = React.createClass({
       this.searchInput().focus();
     }
 
-    if (this.resultList()) {
+    if (this.refs.resultList && this.refs.resultList.refs) {
       scrollList(this, this.state.selectedResultIndex);
     }
 
@@ -193,10 +193,6 @@ const SearchBar = React.createClass({
 
   searchInput() {
     return findDOMNode(this).querySelector("input");
-  },
-
-  resultList() {
-    return findDOMNode(this).querySelector(".result-list");
   },
 
   doSearch(query: string) {
@@ -305,6 +301,10 @@ const SearchBar = React.createClass({
   },
 
   onKeyDown(e: SyntheticKeyboardEvent) {
+    if (!this.state.functionEnabled || this.props.query == "") {
+      return;
+    }
+
     const searchResults = this.getFunctionResults(),
       resultCount = searchResults.length;
 
@@ -447,6 +447,7 @@ const SearchBar = React.createClass({
       items: results,
       selected: this.state.selectedResultIndex,
       selectItem: this.selectResultItem,
+      ref: "resultList"
     });
   },
 
@@ -469,7 +470,7 @@ const SearchBar = React.createClass({
         summaryMsg: this.buildSummaryMsg(),
         onChange: this.onChange,
         onKeyUp: this.onKeyUp,
-        onKeyDown: this.state.functionSearchEnabled ? this.onKeyDown : null,
+        onKeyDown: this.onKeyDown,
         handleClose: this.closeSearch
       }),
       this.renderBottomBar(),

--- a/src/components/shared/Autocomplete.js
+++ b/src/components/shared/Autocomplete.js
@@ -39,7 +39,9 @@ const Autocomplete = React.createClass({
   },
 
   componentDidUpdate() {
-    scrollList(this, this.state.selectedIndex);
+    if (this.refs.resultList && this.refs.resultList.refs) {
+      scrollList(this.refs.resultList.refs, this.state.selectedIndex);
+    }
   },
 
   getSearchResults() {
@@ -94,6 +96,7 @@ const Autocomplete = React.createClass({
         selected: this.state.selectedIndex,
         selectItem: this.props.selectItem,
         close: this.props.close,
+        ref: "resultList"
       });
     } else if (this.state.inputValue && !results.length) {
       return dom.div({ className: "no-result-msg" },

--- a/src/components/shared/ResultList.js
+++ b/src/components/shared/ResultList.js
@@ -25,7 +25,8 @@ const ResultList = React.createClass({
     return dom.li(
       {
         onClick: () => this.props.selectItem(item),
-        key: `${item.id}${item.value}`,
+        key: `${item.id}${item.value}${index}`,
+        ref: index,
         title: item.value,
         className: classnames({
           selected: index === this.props.selected

--- a/src/utils/result-list.js
+++ b/src/utils/result-list.js
@@ -1,19 +1,6 @@
-const { findDOMNode } = require("react-dom");
-
-function scrollList(elem, index) {
-  const resultsEl = findDOMNode(elem).querySelector(".result-list");
-  if (!resultsEl || resultsEl.children.length === 0) {
-    return;
-  }
-
-  const resultsHeight = resultsEl.clientHeight;
-  const itemHeight = resultsEl.children[0].clientHeight;
-  const numVisible = resultsHeight / itemHeight;
-  const positionsToScroll = index - numVisible + 1;
-  const itemOffset = resultsHeight % itemHeight;
-  const scroll = positionsToScroll * (itemHeight + 2) + itemOffset;
-
-  resultsEl.scrollTop = Math.max(0, scroll);
+function scrollList(resultList, index) {
+  const resultEl = resultList[index];
+  resultEl.scrollIntoView({ block: "end", behavior: "smooth" });
 }
 
 function handleKeyDown(e: SyntheticKeyboardEvent) {


### PR DESCRIPTION
Associated Issue: #2106 

### Summary of Changes

* Replace scrolling function to prefer scrollIntoView method for scrolling

### Test Plan

- [x] Press CMD+P
- [x] Type a few character to start search
- [x] Navigate up and down using arrow keys
- [x] Selected result should always be in view

### Screenshots/Videos (OPTIONAL)
|Firefox|Chrome|
|-------|--------|
|![](http://g.recordit.co/EdZaIkO0yU.gif)|![](http://g.recordit.co/mqpBAUXAw3.gif)|