### PR TITLE
Fix call to `scrollList` to pass the right ref.

### DIFF
--- a/src/components/Editor/SearchBar.js
+++ b/src/components/Editor/SearchBar.js
@@ -94,7 +94,7 @@ const SearchBar = React.createClass({
     }
 
     if (this.refs.resultList && this.refs.resultList.refs) {
-      scrollList(this, this.state.selectedResultIndex);
+      scrollList(this.refs.resultList.refs, this.state.selectedResultIndex);
     }
 
     const hasLoaded = sourceText && !sourceText.get("loading");
@@ -301,7 +301,7 @@ const SearchBar = React.createClass({
   },
 
   onKeyDown(e: SyntheticKeyboardEvent) {
-    if (!this.state.functionEnabled || this.props.query == "") {
+    if (!this.state.functionSearchEnabled || this.props.query == "") {
       return;
     }
 


### PR DESCRIPTION
Associated Issue: N/A

### Summary of Changes

* Missed this reference to the right refs, fixed the call

### Test Plan

- [ ] Run function search and try scrolling up/down the list.
