### PR TITLE
Style the searchbar height so the result list doesn't go on forever

### DIFF
--- a/src/components/Editor/SearchBar.css
+++ b/src/components/Editor/SearchBar.css
@@ -1,10 +1,12 @@
 .search-bar {
   display: flex;
   flex-direction: column;
+  max-height: 50%;
 }
 
 .search-bottom-bar {
   display: flex;
+  flex-shrink: 0;
   justify-content: space-between;
   width: calc(100% - 1px);
   height: 40px;
@@ -69,6 +71,10 @@
 .search-bottom-bar .search-type-toggles .search-type-btn.active {
   color: var(--theme-selection-background);
   font-weight: bold;
+}
+
+.search-bar .result-list {
+  max-height: calc(100% - 80px);
 }
 
 .search-bar .result-list li:first-child {


### PR DESCRIPTION
Associated Issue: #2169

### Summary of Changes

* Add a max-height to the searchbar
* Disable shrinking on the bottom bar to avoid squashing by result list

### Test Plan

- [x] Open function search
- [x] Search for some functions
- [x] See that the height of the list doesn't go over ~50%

### Screenshots/Videos

![screenshot_20170226_170528](https://cloud.githubusercontent.com/assets/580982/23345117/03ee8d32-fc46-11e6-84df-9161e71c0172.png)
