### PR TITLE
Fix icons dark theme

### DIFF
--- a/src/components/Editor/Tabs.css
+++ b/src/components/Editor/Tabs.css
@@ -64,7 +64,8 @@
   fill: var(--theme-faded-tab-color);
 }
 
-.source-tab.active path {
+.source-tab.active path,
+.source-tab:hover path {
   fill: var(--theme-body-color);
 }
 

--- a/src/components/SecondaryPanes/SecondaryPanes.css
+++ b/src/components/SecondaryPanes/SecondaryPanes.css
@@ -28,6 +28,6 @@
   user-select: none;
 }
 
-:root.theme-dark .secondary-panes .accordion .arrow svg {
+.theme-dark .secondary-panes .accordion .arrow svg {
   fill: var(--theme-comment);
 }

--- a/src/components/SecondaryPanes/SecondaryPanes.css
+++ b/src/components/SecondaryPanes/SecondaryPanes.css
@@ -27,3 +27,7 @@
   -moz-user-select: none;
   user-select: none;
 }
+
+:root.theme-dark .secondary-panes .accordion .arrow svg {
+  fill: var(--theme-comment);
+}

--- a/src/components/Sources.css
+++ b/src/components/Sources.css
@@ -43,6 +43,6 @@
   overflow: hidden;
 }
 
-:root.theme-dark .sources-list .tree .node:not(.focused) svg {
+.theme-dark .sources-list .tree .node:not(.focused) svg {
   fill: var(--theme-comment);
 }

--- a/src/components/Sources.css
+++ b/src/components/Sources.css
@@ -42,3 +42,7 @@
   display: flex;
   overflow: hidden;
 }
+
+:root.theme-dark .sources-list .tree .node:not(.focused) svg {
+  fill: var(--theme-comment);
+}


### PR DESCRIPTION
Associated Issue: #2163

### Summary of Changes

* Changed close icons in Tabs to be more visible
* Changed arrow icons in Sources & Secondary Panes to be more visible

### Test Plan

Tell us a little a bit about how you tested your patch.

Example test plan:
- [x] Command-P opens the panel
- [x] Clicking “+” opens the panel
- [x] Clicking a source navigates to the source
- [x] Clicking "x" closes the panel

Here's the Debugger's Testing doc
https://docs.google.com/document/d/1oBMRxV8A2ag2t22YsQOxTdEv0mXKzIg0tggJjRkU1S0/edit#.
Feel free to improve it!

### Screenshots/Videos (OPTIONAL)
<img width="171" alt="screen shot 2017-02-26 at 10 21 38 pm" src="https://cloud.githubusercontent.com/assets/5232812/23347714/28b45ba2-fc72-11e6-8c35-31280f2d2591.png">
<img width="558" alt="screen shot 2017-02-26 at 10 21 10 pm" src="https://cloud.githubusercontent.com/assets/5232812/23347720/2d8cecb6-fc72-11e6-96a8-319e6bfad62c.png">
<img width="299" alt="screen shot 2017-02-26 at 10 20 51 pm" src="https://cloud.githubusercontent.com/assets/5232812/23347728/3baa176a-fc72-11e6-965b-ece1f44473db.png">
