### PR TITLE
[Sources] Make selected source highlight full width

### DIFF
--- a/src/components/shared/ManagedTree.css
+++ b/src/components/shared/ManagedTree.css
@@ -7,6 +7,7 @@
 
   white-space: nowrap;
   overflow: auto;
+  min-width: 100%;
 }
 
 .tree button {


### PR DESCRIPTION
Modify minimum width of tree to be 100% so that
the selected source highlight is full width.

Fixes #2082

### Summary of Changes

* Add `min-width` property to source tree

### Screenshots/Videos
![source](https://cloud.githubusercontent.com/assets/1755089/23364311/9b758faa-fd24-11e6-8615-ee08545170b6.gif)

