### PR TITLE
[Editor] Add close button to conditional breakpoint panel

### DIFF
--- a/assets/panel/debugger.properties
+++ b/assets/panel/debugger.properties
@@ -265,7 +265,7 @@ editor.conditionalPanel.placeholder=This breakpoint will pause when the expressi
 
 # LOCALIZATION NOTE (editor.conditionalPanel.placeholder): Tooltip text for
 # close button inside ConditionalPanel component
-editor.conditionalPanel.close=Save breakpoint and close
+editor.conditionalPanel.close=Cancel edit breakpoint and close
 
 # LOCALIZATION NOTE (editor.jumpToMappedLocation1): Context menu item
 # for navigating to a source mapped location

--- a/assets/panel/debugger.properties
+++ b/assets/panel/debugger.properties
@@ -263,6 +263,10 @@ editor.addConditionalBreakpoint=Add Conditional Breakpoint
 # input element inside ConditionalPanel component
 editor.conditionalPanel.placeholder=This breakpoint will pause when the expression is true
 
+# LOCALIZATION NOTE (editor.conditionalPanel.placeholder): Tooltip text for
+# close button inside ConditionalPanel component
+editor.conditionalPanel.close=Save breakpoint and close
+
 # LOCALIZATION NOTE (editor.jumpToMappedLocation1): Context menu item
 # for navigating to a source mapped location
 editor.jumpToMappedLocation1=Jump to %S location

--- a/src/components/Editor/Breakpoint.js
+++ b/src/components/Editor/Breakpoint.js
@@ -39,6 +39,8 @@ const Breakpoint = React.createClass({
     this.props.editor.addLineClass(line, "line", "new-breakpoint");
     if (bp.condition) {
       this.props.editor.addLineClass(line, "line", "has-condition");
+    } else {
+      this.props.editor.removeLineClass(line, "line", "has-condition");
     }
   },
 

--- a/src/components/Editor/ConditionalPanel.js
+++ b/src/components/Editor/ConditionalPanel.js
@@ -3,6 +3,7 @@ const React = require("react");
 const { DOM: dom } = React;
 
 const ReactDOM = require("react-dom");
+const CloseButton = require("../shared/Button/Close");
 
 require("./ConditionalPanel.css");
 
@@ -29,6 +30,10 @@ function renderConditionalPanel({ condition, closePanel, setBreakpoint }:
         defaultValue: condition,
         placeholder: L10N.getStr("editor.conditionalPanel.placeholder"),
         onKeyPress: onKey
+      }),
+      CloseButton({
+        handleClick: closePanel,
+        buttonClass: "big"
       })
     ),
     panel

--- a/src/components/Editor/ConditionalPanel.js
+++ b/src/components/Editor/ConditionalPanel.js
@@ -43,7 +43,7 @@ function renderConditionalPanel({ condition, closePanel, setBreakpoint }:
         ref: setInput
       }),
       CloseButton({
-        handleClick: saveAndClose,
+        handleClick: closePanel,
         buttonClass: "big",
         tooltip: L10N.getStr("editor.conditionalPanel.close")
       })

--- a/src/components/Editor/ConditionalPanel.js
+++ b/src/components/Editor/ConditionalPanel.js
@@ -10,14 +10,24 @@ require("./ConditionalPanel.css");
 function renderConditionalPanel({ condition, closePanel, setBreakpoint }:
   { condition: boolean, closePanel: Function, setBreakpoint: Function }) {
   let panel = document.createElement("div");
+  let input = null;
 
-  function onKey(e: SyntheticKeyboardEvent) {
-    if (e.key != "Enter") {
-      return;
+  function setInput(node) {
+    input = node;
+  }
+
+  function saveAndClose() {
+    if (input) {
+      setBreakpoint(input.value);
     }
 
-    if (e.target && e.target.value) {
-      setBreakpoint(e.target.value);
+    closePanel();
+  }
+
+  function onKey(e: SyntheticKeyboardEvent) {
+    if (e.key === "Enter") {
+      saveAndClose();
+    } else if (e.key === "Escape") {
       closePanel();
     }
   }
@@ -29,10 +39,11 @@ function renderConditionalPanel({ condition, closePanel, setBreakpoint }:
       dom.input({
         defaultValue: condition,
         placeholder: L10N.getStr("editor.conditionalPanel.placeholder"),
-        onKeyPress: onKey
+        onKeyDown: onKey,
+        ref: setInput
       }),
       CloseButton({
-        handleClick: closePanel,
+        handleClick: saveAndClose,
         buttonClass: "big"
       })
     ),

--- a/src/components/Editor/ConditionalPanel.js
+++ b/src/components/Editor/ConditionalPanel.js
@@ -44,7 +44,8 @@ function renderConditionalPanel({ condition, closePanel, setBreakpoint }:
       }),
       CloseButton({
         handleClick: saveAndClose,
-        buttonClass: "big"
+        buttonClass: "big",
+        tooltip: L10N.getStr("editor.conditionalPanel.close")
       })
     ),
     panel

--- a/src/strings.json
+++ b/src/strings.json
@@ -17,6 +17,7 @@
   "editor.editBreakpoint": "Edit Breakpoint",
   "editor.addConditionalBreakpoint": "Add Conditional Breakpoint",
   "editor.conditionalPanel.placeholder": "This breakpoint will pause when the expression is true",
+  "editor.conditionalPanel.close": "Save breakpoint and close",
   "editor.jumpToMappedLocation": "Jump to %S location",
   "generated": "generated",
   "original": "original",

--- a/src/strings.json
+++ b/src/strings.json
@@ -17,7 +17,7 @@
   "editor.editBreakpoint": "Edit Breakpoint",
   "editor.addConditionalBreakpoint": "Add Conditional Breakpoint",
   "editor.conditionalPanel.placeholder": "This breakpoint will pause when the expression is true",
-  "editor.conditionalPanel.close": "Save breakpoint and close",
+  "editor.conditionalPanel.close": "Cancel edit breakpoint and close",
   "editor.jumpToMappedLocation": "Jump to %S location",
   "generated": "generated",
   "original": "original",


### PR DESCRIPTION
Associated Issue: #1945

### Summary of Changes

* Using the 'x' saves and closes the panel
* Pressing "Escape" closes without saving
* Pressing "Enter" always saves. If there is no content, it converts to a "regular" breakpoint

### Test Plan

#### Save on Close Button

- [x] Open a source file
- [x] Right click gutter to "Add conditional breakpoint"
- [x] Enter a breakpoint (e.g. `console.log('test')`)
- [x] Clicking "x" closes the panel
- [x] Right click breakpoint to "Edit breakpoint"
- [x] Conditional breakpoint panel should contain specified condition

#### Save on Enter

- [x] Open a source file
- [x] Right click gutter to "Add conditional breakpoint"
- [x] Enter a breakpoint (e.g. `console.log('test')`)
- [x] Press <Enter> key
- [x] Right click breakpoint to "Edit breakpoint"
- [x] Conditional breakpoint panel should contain specified condition

#### Cancel add on Escape

- [x] Open a source file
- [x] Right click gutter to "Add conditional breakpoint"
- [x] Enter a breakpoint (e.g. `console.log('test')`)
- [x] Press <Escape> key
- [x] No breakpoint should be created

#### Cancel edit on Escape

- [x] Open a source file
- [x] Right click gutter to "Add conditional breakpoint"
- [x] Enter a breakpoint (e.g. `console.log('test')`)
- [x] Press <Enter> key or click close button
- [x] Right click breakpoint to "Edit breakpoint"
- [x] Edit breakpoint (e.g. `console.log('updated')`)
- [x] Press <Escape> key
- [x] Right click breakpoint to "Edit breakpoint"
- [x] Breakpoint should contain original condition

#### Convert to normal breakpoint

- [x] Open a source file
- [x] Right click gutter to "Add conditional breakpoint"
- [x] Enter a breakpoint (e.g. `console.log('test')`)
- [x] Press <Enter> key or click close button
- [x] Right click breakpoint to "Edit breakpoint"
- [x] Remove condition
- [x] Press <Enter> key or click close button
- [x] Breakpoint should render as normal breakpoint

### Screenshots/Videos

![closebutton](https://cloud.githubusercontent.com/assets/788456/23366753/82979638-fccd-11e6-991d-fa0d612f1014.gif)