### PR TITLE
When function search is enabled don't run the code search.

### DIFF
--- a/src/components/Editor/SearchBar.js
+++ b/src/components/Editor/SearchBar.js
@@ -118,13 +118,20 @@ const SearchBar = React.createClass({
     this.closeSearch(e);
   },
 
-  closeSearch(e: SyntheticEvent) {
+  clearSearch() {
     const { editor: ed, query, modifiers } = this.props;
+    if (ed) {
+      const ctx = { ed, cm: ed.codeMirror };
+      removeOverlay(ctx, query, modifiers);
+    }
+  },
+
+  closeSearch(e: SyntheticEvent) {
+    const { editor: ed } = this.props;
 
     if (this.state.enabled && ed) {
       this.setState({ enabled: false });
-      const ctx = { ed, cm: ed.codeMirror };
-      removeOverlay(ctx, query, modifiers);
+      this.clearSearch();
       e.stopPropagation();
       e.preventDefault();
     }
@@ -171,6 +178,8 @@ const SearchBar = React.createClass({
         location: dec.location
       }));
 
+      this.clearSearch();
+
       this.setState({
         functionSearchEnabled: true,
         functionDeclarations
@@ -210,6 +219,10 @@ const SearchBar = React.createClass({
     }
 
     updateQuery(query);
+
+    if (this.state.functionSearchEnabled) {
+      return;
+    }
 
     if (!ed) {
       return;


### PR DESCRIPTION
Associated Issue: #2171 

### Summary of Changes

* Only run the function search when it's enabled rather than both it and code search

### Test Plan

- [x] Open debugger and a document
- [x] Open searchbar and enable function search
- [x] See that searching for functions only does that search type and not code search
