### PR TITLE
Add a width/height to the search modfier svgs to fix a chrome render issue

### DIFF
--- a/src/components/Editor/SearchBar.css
+++ b/src/components/Editor/SearchBar.css
@@ -40,6 +40,8 @@
 
 .search-bottom-bar .search-modifiers button svg {
   fill: var(--theme-comment);
+  height: 16px;
+  width: 16px;
 }
 
 .search-bottom-bar .search-modifiers button.active {


### PR DESCRIPTION
Associated Issue: #2196 

### Summary of Changes

* Adding width/height to fix chrome rendering issue with the buttons

### Test Plan

- [x] Open debugger and document
- [x] Open editor search <kbd>ctrl</kbd>/<kbd>cmd</kbd>+F and see that the buttons render properly


### Screenshots/Videos

#### Before
![screenshot_20170227_230344](https://cloud.githubusercontent.com/assets/580982/23393836/cb53cf52-fd42-11e6-8552-59c765a7993e.png)

#### After
![screenshot_20170227_231705](https://cloud.githubusercontent.com/assets/580982/23393852/dec14baa-fd42-11e6-8601-68deaec16785.png)
