### PR TITLE
Disable the search modifiers when function search is enabled.

### DIFF
--- a/src/components/Editor/SearchBar.css
+++ b/src/components/Editor/SearchBar.css
@@ -50,6 +50,10 @@
   fill: white;
 }
 
+.search-bottom-bar .search-modifiers button.disabled svg {
+  fill: var(--theme-comment-alt);
+}
+
 .search-bottom-bar .search-type-toggles {
   display: flex;
   align-items: center;

--- a/src/components/Editor/SearchBar.js
+++ b/src/components/Editor/SearchBar.js
@@ -394,37 +394,28 @@ const SearchBar = React.createClass({
     const {
       modifiers: { caseSensitive, wholeWord, regexMatch },
       toggleModifier } = this.props;
+    const { functionSearchEnabled } = this.state;
+
+    function searchModBtn(modVal, className, svgName) {
+      const defaultMods = { caseSensitive, wholeWord, regexMatch };
+      return dom.button({
+        className: classnames(className, {
+          active: !functionSearchEnabled && !Object.values(modVal)[0],
+          disabled: functionSearchEnabled
+        }),
+        onClick: () => !functionSearchEnabled ?
+        toggleModifier(Object.assign(defaultMods, modVal)) : null
+      }, Svg(svgName));
+    }
 
     return dom.div(
       { className: "search-modifiers" },
-      // render buttons. On clicks toggle search modifiers.
-      dom.button({
-        className: classnames("regex-match-btn",
-          { active: regexMatch }),
-        onClick: () => {
-          toggleModifier(
-            { caseSensitive, wholeWord, regexMatch: !regexMatch });
-          this.doSearch(this.props.query);
-        }
-      }, Svg("regex-match")),
-      dom.button({
-        className: classnames("case-sensitive-btn",
-          { active: caseSensitive }),
-        onClick: () => {
-          toggleModifier(
-            { caseSensitive: !caseSensitive, wholeWord, regexMatch });
-          this.doSearch(this.props.query);
-        }
-      }, Svg("case-match")),
-      dom.button({
-        className: classnames("whole-word-btn",
-          { active: wholeWord }),
-        onClick: () => {
-          toggleModifier(
-            { caseSensitive, wholeWord: !wholeWord, regexMatch });
-          this.doSearch(this.props.query);
-        }
-      }, Svg("whole-word-match")),
+      searchModBtn({
+        regexMatch: !regexMatch }, "regex-match-btn", "regex-match"),
+      searchModBtn({
+        caseSensitive: !caseSensitive }, "case-sensitive-btn", "case-match"),
+      searchModBtn({
+        wholeWord: !wholeWord }, "whole-word-btn", "whole-word-match")
     );
   },
 


### PR DESCRIPTION
Associated Issue: #2195 

### Summary of Changes

* disable the search modifiers when function search is enabled

### Test Plan

- [x] open debugger with a document
- [x] open file search <kbd>ctrl</kbd>/<kbd>cmd</kbd>+F and toggle function search
- [x] see that the search modifiers get greyed out and do nothing when clicked
- [x] toggle function search off again and see that they are enabled  again.


### Screenshots/Videos

![screenshot_20170228_001616](https://cloud.githubusercontent.com/assets/580982/23395307/240db4a2-fd4b-11e6-81e1-6cc580d3381b.png)

