### PR TITLE
Fix whole word search modifier clearing search and count showing as NaN

### DIFF
--- a/src/utils/editor/build-query.js
+++ b/src/utils/editor/build-query.js
@@ -15,7 +15,7 @@ type QueryOptions = {
  * @static
  */
 function ignoreWhiteSpace(str: string): string {
-  return /^\s{0,2}$/.test(str) ? "(?!\s*.*)" : str;
+  return /^\s{0,2}$/.test(str) ? "(?!\\s*.*)" : str;
 }
 
 function wholeMatch(query: string, wholeWord: boolean): string {

--- a/src/utils/editor/source-search.js
+++ b/src/utils/editor/source-search.js
@@ -94,7 +94,7 @@ function searchOverlay(query, modifiers) {
         matchLength = len;
         return "highlight highlight-start";
       }
-      while (!stream.match(query, false) && stream.peek()) {
+      while (!stream.match(regexQuery, false) && stream.peek()) {
         stream.next();
       }
     }
@@ -147,7 +147,7 @@ function getMatchIndex(count: number, currentIndex: number, rev: boolean) {
  */
 function doSearch(ctx, rev, query, keepSelection, modifiers: SearchModifiers) {
   let { cm } = ctx;
-  let matchIndex;
+  let matchIndex = 0;
   cm.operation(function() {
     if (!query || isWhitespace(query)) {
       return;

--- a/src/utils/tests/build-query.js
+++ b/src/utils/tests/build-query.js
@@ -173,7 +173,7 @@ describe("build-query", () => {
       regexMatch: false
     }, { ignoreSpaces: true });
 
-    expect(query.source).to.be(escapeRegExp("(?!\s*.*)"));
+    expect(query.source).to.be(escapeRegExp("(?!\\s*.*)"));
     expect(query.flags).to.be("");
     expect(query.global).to.be(false);
     expect(query.ignoreCase).to.be(false);
@@ -186,7 +186,7 @@ describe("build-query", () => {
       regexMatch: false
     }, { isGlobal: true, ignoreSpaces: true });
 
-    expect(query.source).to.be(escapeRegExp("(?!\s*.*)"));
+    expect(query.source).to.be(escapeRegExp("(?!\\s*.*)"));
     expect(query.flags).to.be("g");
     expect(query.global).to.be(true);
     expect(query.ignoreCase).to.be(false);


### PR DESCRIPTION
Associated Issue: #2105 #2199 

### Summary of Changes

* Match against the built query in `searchOverlay` rather than the raw query
* Initialize our matchIndex as zero rather than null

### Test Plan

- [x] Open debugger and document
- [x] Run a code search with whole word modifier enabled
- [x] See that the search runs and doesn't clear document
- [x] See that `NaN` isn't flashed in the `n of m results` message
