### PR TITLE
Add `flex-shrink: 0` to the search input so it doesn't shrink on chrome.

### DIFF
--- a/src/components/shared/SearchInput.css
+++ b/src/components/shared/SearchInput.css
@@ -4,6 +4,7 @@
   background-color: var(--theme-body-background);
   border-bottom: 1px solid var(--theme-splitter-color);
   display: flex;
+  flex-shrink: 0;
 }
 
 .search-field i {


### PR DESCRIPTION
Associated Issue: #2204 

### Summary of Changes

* `SearchInput` needed `flex-shrink: 0` to not collapse

