### PR TITLE
Polish search toggle UX

### DIFF
--- a/src/components/Editor/SearchBar.css
+++ b/src/components/Editor/SearchBar.css
@@ -15,6 +15,10 @@
   padding: 0 13px;
 }
 
+.search-bottom-bar button:focus {
+  outline: none;
+}
+
 .search-bottom-bar .search-modifiers {
   display: flex;
   align-items: center;

--- a/src/components/Editor/SearchBar.js
+++ b/src/components/Editor/SearchBar.js
@@ -115,9 +115,6 @@ const SearchBar = React.createClass({
   },
 
   onEscape(e: SyntheticKeyboardEvent) {
-    if (this.state.functionSearchEnabled) {
-      this.toggleFunctionSearch(e);
-    }
     this.closeSearch(e);
   },
 
@@ -125,6 +122,7 @@ const SearchBar = React.createClass({
     const { editor: ed, query, modifiers } = this.props;
     if (ed) {
       const ctx = { ed, cm: ed.codeMirror };
+      this.props.updateQuery("");
       removeOverlay(ctx, query, modifiers);
     }
   },
@@ -133,8 +131,8 @@ const SearchBar = React.createClass({
     const { editor: ed } = this.props;
 
     if (this.state.enabled && ed) {
-      this.setState({ enabled: false });
       this.clearSearch();
+      this.setState({ enabled: false, functionSearchEnabled: false });
       e.stopPropagation();
       e.preventDefault();
     }
@@ -147,6 +145,11 @@ const SearchBar = React.createClass({
 
     if (!this.state.enabled) {
       this.setState({ enabled: true });
+    }
+
+    if (this.state.functionSearchEnabled) {
+      this.clearSearch();
+      this.setState({ functionSearchEnabled: false });
     }
 
     if (this.state.enabled && editor) {
@@ -167,7 +170,7 @@ const SearchBar = React.createClass({
     }
 
     if (this.state.functionSearchEnabled) {
-      return this.setState({ enabled: false, functionSearchEnabled: false });
+      return this.setState({ functionSearchEnabled: false });
     }
 
     if (this.props.selectedSource) {
@@ -181,9 +184,7 @@ const SearchBar = React.createClass({
         location: dec.location
       }));
 
-      this.props.updateQuery("");
       this.clearSearch();
-
       this.setState({
         functionSearchEnabled: true,
         functionDeclarations


### PR DESCRIPTION
Associated Issue: #2208 

### Summary of Changes

* <kbd>ESC</kbd> and the close button both clear and close search
* <kbd>ctrl</kbd>/<kbd>cmd</kbd>+<kbd>shift</kbd>+o always opens function search
* function search button jumps between function and code search

### Test Plan

- [x] Open debugger with document
- [x] Try <kbd>ctrl</kbd>/<kbd>cmd</kbd>+<kbd>shift</kbd>+o to see that it just toggles the function search on
- [x] <kbd>ctrl</kbd>/<kbd>cmd</kbd>+f to see that it just toggles the code search on
- [x] Click the close button and escape to see that the query is cleared
