### PR TITLE
Fix Tab Dropdown in RTL Mode

### DIFF
--- a/src/components/shared/Dropdown.css
+++ b/src/components/shared/Dropdown.css
@@ -1,13 +1,18 @@
 .dropdown {
+  --width: 150px;
   background: var(--theme-body-background);
   border: 1px solid var(--theme-splitter-color);
   box-shadow: 0 4px 4px 0 var(--theme-search-overlays-semitransparent);
   max-height: 300px;
   position: absolute;
-  offset-inline-end: 8px;
+  right: 8px;
   top: 35px;
-  width: 150px;
+  width: var(--width);
   z-index: 1000;
+}
+
+html[dir="rtl"] .dropdown {
+  right: calc((var(--width) - 11px) * (-1));
 }
 
 .dropdown-block {


### PR DESCRIPTION
Associated Issue: #2075 

### Summary of Changes

- Make the tab-overflow dropdown visible in RTL mode. 

### Test Plan

- [x] Looks right
- [x] Is the same position as original code gave before being passed through postcss-bidirection

### Screenshots/Videos

| LTR | RTL | 
|---|---|
| ![screenshot from 2017-02-28 16-24-55](https://cloud.githubusercontent.com/assets/7751418/23440462/0cf365ec-fdea-11e6-92fc-4aff40f5bb50.png) | ![screenshot from 2017-02-28 16-20-23](https://cloud.githubusercontent.com/assets/7751418/23440461/0cef36b6-fdea-11e6-9c68-9619bd5a77e9.png) |