### PR TITLE
Fix border stacking for the result list in function search.

### DIFF
--- a/src/components/Editor/SearchBar.css
+++ b/src/components/Editor/SearchBar.css
@@ -102,21 +102,26 @@
 
 .search-bar .result-list {
   max-height: calc(100% - 80px);
+  border-bottom: 1px solid var(--theme-splitter-color);
+}
+
+.search-bar .result-list li {
+  border: none;
+  color: var(--theme-comment);
+  border-bottom: 1px solid var(--theme-splitter-color);
+  background-color: var(--theme-tab-toolbar-background);
+  padding: 4px 13px;
+  margin: 0;
+  display: flex;
+  justify-content: space-between;
 }
 
 .search-bar .result-list li:first-child {
   border-top: none;
 }
 
-.search-bar .result-list li {
-  border: none;
-  color: var(--theme-comment);
-  border-top: 1px solid var(--theme-splitter-color);
-  border-bottom: 1px solid var(--theme-splitter-color);
-  background-color: var(--theme-tab-toolbar-background);
-  padding: 4px;
-  margin: 0;
-  display: flex;
+.search-bar .result-list li:last-child {
+  border-bottom: none;
 }
 
 .search-bar .result-list li.selected,
@@ -127,12 +132,8 @@
 
 .search-bar .result-list li .title {
   font-weight: bold;
-  flex-grow: 2;
-  flex-basis: 95%;
 }
 
 .search-bar .result-list li .subtitle {
   font-weight: lighter;
-  flex-grow: 1;
-  flex-basis: 5%;
 }


### PR DESCRIPTION
Associated Issue: #2205 #2214 

### Summary of Changes

* Fix the borders the list and items
* Pad the items better and fix up the flex layout to avoid wrapping

### Test Plan

Example test plan:

- [x] Open debugger and function search
- [x] See the padding fixes and border stacking
- [x] See that line breaking isn't occuring anymore

### Screenshots/Videos

![screenshot_20170228_172851](https://cloud.githubusercontent.com/assets/580982/23440839/e9396f74-fddb-11e6-8bea-1bb1a4953a7e.png)

