### PR TITLE
Polish dark theme ui

### DIFF
--- a/src/components/Editor/Editor.css
+++ b/src/components/Editor/Editor.css
@@ -96,6 +96,10 @@ html[dir="rtl"] .editor-mount {
   line-height: 14px;
 }
 
+.theme-dark .editor-wrapper .CodeMirror-line .cm-comment {
+  color: var(--theme-content-color3);
+}
+
 .debug-line .CodeMirror-line {
   background-color: var(--breakpoint-active-color) !important;
 }

--- a/src/components/Editor/Preview.css
+++ b/src/components/Editor/Preview.css
@@ -1,5 +1,5 @@
 .preview {
-  background: white;
+  background: var(--theme-body-background);
   min-width: 200px;
   min-height: 80px;
   border: 1px solid #cccccc;
@@ -51,4 +51,12 @@
 
 .function-signature .comma {
   color: var(--object-colosr);
+}
+
+.theme-dark .preview {
+  border-color: var(--theme-body-color);
+}
+
+.theme-dark .preview .arrow svg {
+  fill: var(--theme-comment);;
 }

--- a/src/components/Editor/Preview.css
+++ b/src/components/Editor/Preview.css
@@ -2,7 +2,7 @@
   background: var(--theme-body-background);
   min-width: 200px;
   min-height: 80px;
-  border: 1px solid #cccccc;
+  border: 1px solid var(--theme-comment);
   padding: 10px;
   height: auto;
   min-height: inherit;
@@ -50,7 +50,7 @@
 }
 
 .function-signature .comma {
-  color: var(--object-colosr);
+  color: var(--object-color);
 }
 
 .theme-dark .preview {
@@ -58,5 +58,5 @@
 }
 
 .theme-dark .preview .arrow svg {
-  fill: var(--theme-comment);;
+  fill: var(--theme-comment);
 }

--- a/src/components/SecondaryPanes/CommandBar.css
+++ b/src/components/SecondaryPanes/CommandBar.css
@@ -7,7 +7,10 @@
   position: sticky;
   top: 0;
   z-index: 1;
-  background-color: var(--theme-body-background);
+}
+
+.theme-dark .command-bar {
+  background-color: var(--theme-tab-toolbar-background);
 }
 
 .command-bar > button {

--- a/src/components/SourceSearch.css
+++ b/src/components/SourceSearch.css
@@ -19,3 +19,7 @@
   display: flex;
   border-bottom: 1px solid var(--theme-splitter-color);
 }
+
+.theme-dark .result-list li .subtitle {
+  color: var(--theme-comment-alt);
+}

--- a/src/components/Sources.css
+++ b/src/components/Sources.css
@@ -24,6 +24,10 @@
   justify-content: flex-end;
 }
 
+.theme-dark .sources-header {
+  background-color: var(--theme-tab-toolbar-background);
+}
+
 .sources-header {
   padding-inline-start: 10px;
 }

--- a/src/components/shared/Button/PaneToggle.css
+++ b/src/components/shared/Button/PaneToggle.css
@@ -12,6 +12,11 @@
   fill: var(--theme-comment);
 }
 
+.theme-dark .toggle-button-start svg,
+.theme-dark .toggle-button-end svg {
+  fill: var(--theme-comment-alt);
+}
+
 .toggle-button-end {
   margin-left: auto;
 }


### PR DESCRIPTION
Associated Issue: #2178

### Summary of Changes

* Sidebar pane headers are the same dark grey as tabs
* Toggle buttons are grey
* Changed colors for comments & subtitle text under search results from grey to blue
* Dark theme for Editor Preview
* I could reproduce the source search jumping the other night but after the most recent rebase, I can't reproduce it. 

### Test Plan

Tell us a little a bit about how you tested your patch.

Example test plan:

- [x] Command-P opens the panel
- [x] Clicking “+” opens the panel
- [x] Clicking a source navigates to the source
- [x] Clicking "x" closes the panel

Here's the Debugger's Testing doc
https://docs.google.com/document/d/1oBMRxV8A2ag2t22YsQOxTdEv0mXKzIg0tggJjRkU1S0/edit#.
Feel free to improve it!

### Screenshots/Videos (OPTIONAL)
<img width="850" alt="screen shot 2017-02-28 at 10 49 13 pm" src="https://cloud.githubusercontent.com/assets/5232812/23445256/3266940c-fe08-11e6-8b55-e2cf293838f7.png">

<img width="1277" alt="screen shot 2017-02-28 at 10 42 04 pm" src="https://cloud.githubusercontent.com/assets/5232812/23445268/411987b6-fe08-11e6-8ac6-023fa88995df.png">

<img width="445" alt="screen shot 2017-02-28 at 10 44 18 pm" src="https://cloud.githubusercontent.com/assets/5232812/23445290/5e6314ae-fe08-11e6-8a21-e6875881ecc4.png">
