### PR TITLE
Function Search wins

### DIFF
--- a/src/actions/sources.js
+++ b/src/actions/sources.js
@@ -13,7 +13,6 @@ const defer = require("../utils/defer");
 const { PROMISE } = require("../utils/redux/middleware/promise");
 const assert = require("../utils/assert");
 const { updateFrameLocations } = require("../utils/pause");
-const { parse } = require("../utils/parser");
 const { isEnabled } = require("devtools-config");
 
 const {
@@ -295,10 +294,6 @@ function loadSourceText(source: Source) {
           text: response.source,
           contentType: response.contentType || "text/javascript"
         };
-
-        if (isEnabled("functionSearch")) {
-          parse(sourceText);
-        }
 
         return sourceText;
         // Automatically pretty print if enabled and the test is

--- a/src/actions/sources.js
+++ b/src/actions/sources.js
@@ -13,8 +13,6 @@ const defer = require("../utils/defer");
 const { PROMISE } = require("../utils/redux/middleware/promise");
 const assert = require("../utils/assert");
 const { updateFrameLocations } = require("../utils/pause");
-const { isEnabled } = require("devtools-config");
-
 const {
   getOriginalURLs, getOriginalSourceText,
   generatedToOriginalId, isOriginalId,

--- a/src/components/Editor/SearchBar.js
+++ b/src/components/Editor/SearchBar.js
@@ -220,6 +220,30 @@ const SearchBar = React.createClass({
     return findDOMNode(this).querySelector("input");
   },
 
+  updateFunctionSearchResults(query: string) {
+    const {
+      sourceText,
+      updateSearchResults
+    } = this.props;
+
+    if (query == "" || !sourceText) {
+      return;
+    }
+
+    const functionDeclarations = getFunctionDeclarations(
+      sourceText.toJS()
+    );
+
+    const functionSearchResults = filter(
+      functionDeclarations,
+      query,
+      { key: "value" }
+    );
+
+    updateSearchResults({ count: functionSearchResults.length });
+    return this.setState({ functionSearchResults });
+  },
+
   doSearch(query: string) {
     const {
       sourceText,
@@ -235,15 +259,7 @@ const SearchBar = React.createClass({
     updateQuery(query);
 
     if (this.state.functionSearchEnabled) {
-      if (query == "") {
-        return;
-      }
-
-      const functionSearchResults = filter(
-        this.state.functionDeclarations, query, { key: "value" });
-
-      this.props.updateSearchResults({ count: functionSearchResults.length });
-      return this.setState({ functionSearchResults });
+      return this.updateFunctionSearchResults(query);
     }
 
     if (!ed) {

--- a/src/components/Editor/SearchBar.js
+++ b/src/components/Editor/SearchBar.js
@@ -14,7 +14,7 @@ const {
   countMatches,
   clearIndex
 } = require("../../utils/editor");
-const { getFunctions } = require("../../utils/parser");
+const { getFunctionDeclarations } = require("../../utils/parser");
 const { scrollList } = require("../../utils/result-list");
 const classnames = require("classnames");
 const debounce = require("lodash/debounce");
@@ -29,16 +29,6 @@ type ToggleFunctionSearchOpts = {
 }
 
 require("./SearchBar.css");
-
-function getFunctionDeclarations(selectedSource) {
-  return getFunctions(selectedSource).map(dec => ({
-    id: `${dec.name}:${dec.location.start.line}`,
-    title: dec.name,
-    subtitle: `:${dec.location.start.line}`,
-    value: dec.name,
-    location: dec.location
-  }));
-}
 
 const SearchBar = React.createClass({
 
@@ -176,13 +166,13 @@ const SearchBar = React.createClass({
 
   toggleFunctionSearch(
     e?: SyntheticKeyboardEvent, { toggle }: ToggleFunctionSearchOpts = {}) {
-    const { selectedSource } = this.props;
+    const { sourceText } = this.props;
 
     if (e) {
       e.preventDefault();
     }
 
-    if (!selectedSource) {
+    if (!sourceText) {
       return;
     }
 
@@ -199,7 +189,7 @@ const SearchBar = React.createClass({
     }
 
     const functionDeclarations = getFunctionDeclarations(
-      selectedSource.toJS()
+      sourceText.toJS()
     );
 
     if (this.props.selectedSource) {
@@ -317,7 +307,6 @@ const SearchBar = React.createClass({
   // Handlers
   selectResultItem(item: FunctionDeclaration) {
     const { selectSource, selectedSource } = this.props;
-    this.toggleFunctionSearch();
     if (selectedSource) {
       selectSource(
         selectedSource.get("id"), { line: item.location.start.line });
@@ -367,9 +356,8 @@ const SearchBar = React.createClass({
     } else if (e.key === "Enter") {
       if (searchResults.length) {
         this.selectResultItem(searchResults[this.state.selectedResultIndex]);
-      } else {
-        this.closeSearch(e);
       }
+      this.closeSearch(e);
       e.preventDefault();
     } else if (e.key === "Tab") {
       this.closeSearch(e);

--- a/src/reducers/sources.js
+++ b/src/reducers/sources.js
@@ -154,6 +154,7 @@ function _updateText(state, action : any) : Record<SourcesState> {
 
   return state.setIn(["sourcesText", source.id], I.Map({
     text: sourceText.text,
+    id: source.id,
     contentType: sourceText.contentType
   }));
 }

--- a/src/utils/tests/parser.js
+++ b/src/utils/tests/parser.js
@@ -42,27 +42,34 @@ const TodoView = Backbone.View.extend({
 });
 `);
 
+function getSourceText(name) {
+  const sources = { func, math, proto };
+  return {
+    id: name,
+    text: sources[name],
+    contentType: "text/javascript"
+  };
+}
+
 describe("parser", () => {
   describe("getFunctions", () => {
     it("finds square", () => {
-      parse({ text: func, id: "func" });
-      const fncs = getFunctions({ id: "func" });
+      const fncs = getFunctions(getSourceText("func"));
+
       const names = fncs.map(f => f.name);
 
       expect(names).to.eql(["square"]);
     });
 
     it("finds nested functions", () => {
-      parse({ text: math, id: "math" });
-      const fncs = getFunctions({ id: "math" });
+      const fncs = getFunctions(getSourceText("math"));
       const names = fncs.map(f => f.name);
 
       expect(names).to.eql(["math", "square"]);
     });
 
     it("finds object properties", () => {
-      parse({ text: proto, id: "proto" });
-      const fncs = getFunctions({ id: "proto" });
+      const fncs = getFunctions(getSourceText("proto"));
       const names = fncs.map(f => f.name);
 
       expect(names).to.eql([ "foo", "bar", "initialize", "render"]);
@@ -70,11 +77,9 @@ describe("parser", () => {
   });
 
   describe("getPathClosestToLocation", () => {
-    parse({ text: func, id: "func" });
-
     it("Can find the function declaration for square", () => {
       const closestPath = getPathClosestToLocation(
-        { id: "func" },
+        getSourceText("func"),
         {
           line: 2,
           column: 1
@@ -91,7 +96,7 @@ describe("parser", () => {
 
     it("Can find the path at the exact column", () => {
       const closestPath = getPathClosestToLocation(
-        { id: "func" },
+        getSourceText("func"),
         {
           line: 2,
           column: 10
@@ -108,7 +113,7 @@ describe("parser", () => {
     it("finds scope binding variables", () => {
       parse({ text: math, id: "math" });
       var vars = getVariablesInScope(
-        { id: "math" },
+        getSourceText("math"),
         {
           line: 2,
           column: 5


### PR DESCRIPTION
Associated Issue: #2230 #2215 #2213
### Summary of Changes

#### Search for functions in a source mapped file
* moved parsing out of loading a source file
* memoized function declarations
* made sure we closed the search bar when we selected an item
* added `id` to sourceText, which should have always had it
* solves the pretty print problem too

#### Redo search when a source is selected
* replaced  `state.functionDeclarations` with `getFunctionDeclarations`

### Screenshots/Videos (OPTIONAL)

![](http://g.recordit.co/rzGBpXxeQs.gif)