### PR TITLE
Add parsing support for ES6 object method shorthand and class methods.

### DIFF
--- a/src/components/Editor/SearchBar.js
+++ b/src/components/Editor/SearchBar.js
@@ -22,7 +22,7 @@ const SearchInput = createFactory(require("../shared/SearchInput"));
 const ResultList = createFactory(require("../shared/ResultList"));
 const ImPropTypes = require("react-immutable-proptypes");
 
-import type { FunctionDeclaration } from "../../utils/parser";
+import type { SymbolDeclaration } from "../../utils/parser";
 
 type ToggleFunctionSearchOpts = {
   toggle: boolean
@@ -188,16 +188,9 @@ const SearchBar = React.createClass({
       return;
     }
 
-    const functionDeclarations = getFunctionDeclarations(
-      sourceText.toJS()
-    );
-
     if (this.props.selectedSource) {
       this.clearSearch();
-      this.setState({
-        functionSearchEnabled: true,
-        functionDeclarations
-      });
+      this.setState({ functionSearchEnabled: true });
     }
   },
 
@@ -321,7 +314,7 @@ const SearchBar = React.createClass({
   },
 
   // Handlers
-  selectResultItem(item: FunctionDeclaration) {
+  selectResultItem(item: SymbolDeclaration) {
     const { selectSource, selectedSource } = this.props;
     if (selectedSource) {
       selectSource(
@@ -329,7 +322,7 @@ const SearchBar = React.createClass({
     }
   },
 
-  onSelectResultItem(item: FunctionDeclaration) {
+  onSelectResultItem(item: SymbolDeclaration) {
     const { selectSource, selectedSource } = this.props;
     if (selectedSource) {
       selectSource(

--- a/src/utils/parser.js
+++ b/src/utils/parser.js
@@ -20,7 +20,7 @@ type ASTLocation = {
   }
 };
 
-export type FunctionDeclaration = {
+export type SymbolDeclaration = {
   name: string,
   location: ASTLocation
 };
@@ -91,7 +91,7 @@ function isFunction(path) {
     t.isObjectMethod(path) || t.isClassMethod(path);
 }
 
-function getFunctions(source: SourceText): Array<FunctionDeclaration> {
+function getFunctions(source: SourceText): Array<SymbolDeclaration> {
   const ast = getAst(source);
 
   const functions = [];

--- a/src/utils/parser.js
+++ b/src/utils/parser.js
@@ -75,11 +75,20 @@ function getFunctionName(path) {
     return parent.key.name;
   }
 
+  if (parent.type == "ObjectExpression" || path.node.type == "ClassMethod") {
+    return path.node.key.name;
+  }
+
   if (parent.type == "VariableDeclarator") {
     return parent.id.name;
   }
 
   return "anonymous";
+}
+
+function isFunction(path) {
+  return t.isFunction(path) || t.isArrowFunctionExpression(path) ||
+    t.isObjectMethod(path) || t.isClassMethod(path);
 }
 
 function getFunctions(source: SourceText): Array<FunctionDeclaration> {
@@ -89,7 +98,7 @@ function getFunctions(source: SourceText): Array<FunctionDeclaration> {
 
   traverse(ast, {
     enter(path) {
-      if (t.isFunction(path)) {
+      if (isFunction(path)) {
         functions.push({
           name: getFunctionName(path),
           location: path.node.loc

--- a/src/utils/tests/parser.js
+++ b/src/utils/tests/parser.js
@@ -36,14 +36,29 @@ const bar = () => {}
 const TodoView = Backbone.View.extend({
   tagName:  'li',
   initialize: function () {},
+  doThing() {
+    console.log('hi');
+  },
   render: function () {
     return this;
   },
 });
 `);
 
+const classTest = formatCode(`
+  class Test {
+    constructor() {
+      this.foo = "foo"
+    }
+
+    bar() {
+      console.log("bar");
+    }
+  }
+`);
+
 function getSourceText(name) {
-  const sources = { func, math, proto };
+  const sources = { func, math, proto, classTest };
   return {
     id: name,
     text: sources[name],
@@ -72,7 +87,13 @@ describe("parser", () => {
       const fncs = getFunctions(getSourceText("proto"));
       const names = fncs.map(f => f.name);
 
-      expect(names).to.eql([ "foo", "bar", "initialize", "render"]);
+      expect(names).to.eql([ "foo", "bar", "initialize", "doThing", "render"]);
+    });
+
+    it("finds class methods", () => {
+      const fncs = getFunctions(getSourceText("classTest"));
+      const names = fncs.map(f => f.name);
+      expect(names).to.eql([ "constructor", "bar"]);
     });
   });
 


### PR DESCRIPTION
Associated Issue: #2221 

### Summary of Changes

* more intelligently detect if we're dealing with a function and extract the names for ES6 shorthand and ES6 class methods

### Test Plan

- [x] Open debugger against a source with ES6 shorthand code or class code (The create react app example is cool for class code.)
- [x] Open the function search
- [x] Search for functions and see that the methods populate in search
