### PR TITLE
Fix #2235 : Fix close button display for watch expression

### DIFF
--- a/src/components/SecondaryPanes/Expressions.css
+++ b/src/components/SecondaryPanes/Expressions.css
@@ -39,6 +39,7 @@
   color: var(--theme-body-color);
   background-color: var(--theme-body-background);
   display: flex;
+  position: relative;
 }
 
 .expression-container > .tree {
@@ -55,16 +56,17 @@
 }
 
 .expression-container .close-btn {
-  display: none;
-  cursor: pointer;
-  width: 20px;
-  height: 20px;
-  padding: 0 4px;
-  margin: 0;
+  position: absolute;
+  offset-inline-end: 6px;
+  top: 6px;
 }
 
-.expression-container:hover .close-btn {
-  display: flex;
+.expression-container .close {
+  display: none;
+}
+
+.expression-container:hover .close {
+  display: block;
 }
 
 .expression-input {


### PR DESCRIPTION
Associated Issue: #2235 

### Summary of Changes

* Fix the CSS related to the close button on watch expression (inspired by what is done for breakpoints)

### Test Plan

Just manual testing.

Example test plan:

- [x] Add an expression to watch
- [x] Put the cursor hover
- [x] Check that the close button appears :)

Here's the Debugger's Testing doc
https://docs.google.com/document/d/1oBMRxV8A2ag2t22YsQOxTdEv0mXKzIg0tggJjRkU1S0/edit#.
Feel free to improve it!

### Screenshots/Videos (OPTIONAL)
![debugger-demo](https://cloud.githubusercontent.com/assets/4603973/23466034/38afca9e-fe9a-11e6-826b-1edf4f437a6d.gif)
