### PR TITLE
[Tabs] Tweak tab button position in vertical layout

### DIFF
--- a/src/components/Editor/Tabs.css
+++ b/src/components/Editor/Tabs.css
@@ -3,7 +3,6 @@
   width: 100%;
   height: 30px;
   display: flex;
-  justify-content: space-between;
   align-items: flex-end;
 }
 


### PR DESCRIPTION
Tweak new tab button position and tab position in vertical layout.

Fixes #2080

### Summary of Changes

* Remove redundant CSS attribute to fix vertical mode tab position

### Screenshots/Videos (OPTIONAL)

| | |
|-|-|
|![vert-none](https://cloud.githubusercontent.com/assets/1755089/23465847/7e3cdcd0-febf-11e6-80ce-4e78385e459e.png)|![vert-single](https://cloud.githubusercontent.com/assets/1755089/23465854/7ffd2d2c-febf-11e6-90b1-538816563640.png)|

