### PR TITLE
[EditorSearch] cmd+f without a selection should refocus the search bar

### DIFF
--- a/src/components/Editor/SearchBar.js
+++ b/src/components/Editor/SearchBar.js
@@ -156,7 +156,6 @@ const SearchBar = React.createClass({
     const { editor: ed, query, modifiers } = this.props;
     if (ed) {
       const ctx = { ed, cm: ed.codeMirror };
-      this.props.updateQuery("");
       removeOverlay(ctx, query, modifiers);
     }
   },
@@ -194,7 +193,9 @@ const SearchBar = React.createClass({
     if (this.state.enabled && editor) {
       const selection = editor.codeMirror.getSelection();
       this.setSearchValue(selection);
-      this.doSearch(selection);
+      if (selection !== "") {
+        this.doSearch(selection);
+      }
       this.selectSearchInput();
     }
   },

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -310,10 +310,9 @@ const Editor = React.createClass({
   },
 
   updateQuery(query) {
-    if (this.state.query == "" && query == "") {
+    if (this.state.query == query) {
       return;
     }
-
     this.setState({ query });
   },
 


### PR DESCRIPTION
This is not pretty, but an ok solution.. I think, please review

The logic is a bit too spread out and I function deliberately ignored function search.

Luckily there is a refactor planned I understood from jlast

Associated Issue: #2103 

### Summary of Changes

* Make sure that last search is in the search bar even if it becomes unmarked in
  the editor.

* Selection in the editor becomes the search.  Not 100% sure this is the right approach.

### Test Plan

Simple
- [x] Open the debug editor on some source code containing the string "fun"
- [x] Press CTRL-f to open the search bar and type 3 letters: "fun"
- [x] Press escape and CTRL-f again: the search bar contains "fun"

Again
- [x] Delete last search, press ESC, CTRL-f to search for "fun" again
- [x] Press escape to close the search bar and click on the code, the highlighting of the search term disappears.
- [x] CTRL-f to search again.  The search bar contains "fun".

Typing
- [x] Edit text in the search bar and press ESC, CTRL-f again and the text is still there

Selection
- [x] CTRL-f to open the search bar, search for "fun", then select some text in the editor
- [x] Press escape to close search bar, CTRL-f and the text in the search bar is now the previously selected text.

### Screenshots/Videos (OPTIONAL)
