### PR TITLE
Rework function parser helpers into symbol parser helpers that parse functions, variables, and classes

### DIFF
--- a/src/components/Editor/SearchBar.js
+++ b/src/components/Editor/SearchBar.js
@@ -14,7 +14,7 @@ const {
   countMatches,
   clearIndex
 } = require("../../utils/editor");
-const { getFunctionDeclarations } = require("../../utils/parser");
+const { getSymbolDeclarations } = require("../../utils/parser");
 const { scrollList } = require("../../utils/result-list");
 const classnames = require("classnames");
 const debounce = require("lodash/debounce");
@@ -22,7 +22,7 @@ const SearchInput = createFactory(require("../shared/SearchInput"));
 const ResultList = createFactory(require("../shared/ResultList"));
 const ImPropTypes = require("react-immutable-proptypes");
 
-import type { SymbolDeclaration } from "../../utils/parser";
+import type { FormattedSymbolDeclaration } from "../../utils/parser";
 
 type ToggleFunctionSearchOpts = {
   toggle: boolean
@@ -223,9 +223,9 @@ const SearchBar = React.createClass({
       return;
     }
 
-    const functionDeclarations = getFunctionDeclarations(
+    const functionDeclarations = getSymbolDeclarations(
       sourceText.toJS()
-    );
+    ).functions;
 
     const functionSearchResults = filter(
       functionDeclarations,
@@ -314,7 +314,7 @@ const SearchBar = React.createClass({
   },
 
   // Handlers
-  selectResultItem(item: SymbolDeclaration) {
+  selectResultItem(item: FormattedSymbolDeclaration) {
     const { selectSource, selectedSource } = this.props;
     if (selectedSource) {
       selectSource(
@@ -322,7 +322,7 @@ const SearchBar = React.createClass({
     }
   },
 
-  onSelectResultItem(item: SymbolDeclaration) {
+  onSelectResultItem(item: FormattedSymbolDeclaration) {
     const { selectSource, selectedSource } = this.props;
     if (selectedSource) {
       selectSource(

--- a/src/components/Editor/SearchBar.js
+++ b/src/components/Editor/SearchBar.js
@@ -14,7 +14,7 @@ const {
   countMatches,
   clearIndex
 } = require("../../utils/editor");
-const { getSymbolDeclarations } = require("../../utils/parser");
+const { getSymbols } = require("../../utils/parser");
 const { scrollList } = require("../../utils/result-list");
 const classnames = require("classnames");
 const debounce = require("lodash/debounce");
@@ -223,9 +223,7 @@ const SearchBar = React.createClass({
       return;
     }
 
-    const functionDeclarations = getSymbolDeclarations(
-      sourceText.toJS()
-    ).functions;
+    const functionDeclarations = getSymbols(sourceText.toJS()).functions;
 
     const functionSearchResults = filter(
       functionDeclarations,

--- a/src/utils/parser.js
+++ b/src/utils/parser.js
@@ -111,6 +111,13 @@ function getFunctions(source: SourceText): Array<SymbolDeclaration> {
 }
 
 function getVariableNames(path) {
+  if (t.isObjectProperty(path) && !isFunction(path.node.value)) {
+    return [{
+      name: path.node.key.name,
+      location: path.node.loc
+    }];
+  }
+
   if (!path.node.declarations) {
     return path.node.params
     .map(dec => ({
@@ -118,6 +125,7 @@ function getVariableNames(path) {
       location: dec.loc
     }));
   }
+
   return path.node.declarations
     .map(dec => ({
       name: dec.id.name,
@@ -127,7 +135,8 @@ function getVariableNames(path) {
 
 function isVariable(path) {
   return t.isVariableDeclaration(path) ||
-    (isFunction(path) && path.node.params.length);
+    (isFunction(path) && path.node.params.length) ||
+    (t.isObjectProperty(path) && !isFunction(path.node.value));
 }
 
 function getVariables(source: SourceText): Array<SymbolDeclaration> {

--- a/src/utils/parser.js
+++ b/src/utils/parser.js
@@ -111,11 +111,23 @@ function getFunctions(source: SourceText): Array<SymbolDeclaration> {
 }
 
 function getVariableNames(path) {
+  if (!path.node.declarations) {
+    return path.node.params
+    .map(dec => ({
+      name: dec.name,
+      location: dec.loc
+    }));
+  }
   return path.node.declarations
     .map(dec => ({
       name: dec.id.name,
       location: dec.loc
     }));
+}
+
+function isVariable(path) {
+  return t.isVariableDeclaration(path) ||
+    (isFunction(path) && path.node.params.length);
 }
 
 function getVariables(source: SourceText): Array<SymbolDeclaration> {
@@ -125,7 +137,7 @@ function getVariables(source: SourceText): Array<SymbolDeclaration> {
 
   traverse(ast, {
     enter(path) {
-      if (t.isVariableDeclaration(path)) {
+      if (isVariable(path)) {
         variables.push(...getVariableNames(path));
       }
     }

--- a/src/utils/parser.js
+++ b/src/utils/parser.js
@@ -110,6 +110,30 @@ function getFunctions(source: SourceText): Array<SymbolDeclaration> {
   return functions;
 }
 
+function getVariableNames(path) {
+  return path.node.declarations
+    .map(dec => ({
+      name: dec.id.name,
+      location: dec.loc
+    }));
+}
+
+function getVariables(source: SourceText): Array<SymbolDeclaration> {
+  const ast = getAst(source);
+
+  const variables = [];
+
+  traverse(ast, {
+    enter(path) {
+      if (t.isVariableDeclaration(path)) {
+        variables.push(...getVariableNames(path));
+      }
+    }
+  });
+
+  return variables;
+}
+
 function getFunctionDeclarations(sourceText: SourceText) {
   if (functionDeclarations.has(sourceText.id)) {
     return functionDeclarations.get(sourceText.id);
@@ -169,6 +193,7 @@ function getVariablesInScope(source: SourceText, location: Location) {
 module.exports = {
   parse,
   getFunctions,
+  getVariables,
   getFunctionDeclarations,
   getPathClosestToLocation,
   getVariablesInScope

--- a/src/utils/parser.js
+++ b/src/utils/parser.js
@@ -28,6 +28,7 @@ export type SymbolDeclaration = {
 export type SymbolDeclarations = {
   functions: Array<SymbolDeclaration>,
   variables: Array<SymbolDeclaration>,
+  classes: Array<SymbolDeclaration>,
 };
 
 const ASTs = new Map();
@@ -127,11 +128,7 @@ function isVariable(path) {
 
 function getSymbols(source: SourceText): SymbolDeclarations {
   const ast = getAst(source);
-
-  const symbols = {
-    functions: [],
-    variables: []
-  };
+  const symbols = { functions: [], variables: [], classes: [] };
 
   traverse(ast, {
     enter(path) {
@@ -142,6 +139,13 @@ function getSymbols(source: SourceText): SymbolDeclarations {
       if (isFunction(path)) {
         symbols.functions.push({
           name: getFunctionName(path),
+          location: path.node.loc
+        });
+      }
+
+      if (t.isClassDeclaration(path)) {
+        symbols.classes.push({
+          name: path.node.id.name,
           location: path.node.loc
         });
       }

--- a/src/utils/tests/parser.js
+++ b/src/utils/tests/parser.js
@@ -107,28 +107,28 @@ describe("parser", () => {
     it("finds square", () => {
       const fncs = getSymbols(getSourceText("func")).functions;
 
-      const names = fncs.map(f => f.name);
+      const names = fncs.map(f => f.value);
 
       expect(names).to.eql(["square"]);
     });
 
     it("finds nested functions", () => {
       const fncs = getSymbols(getSourceText("math")).functions;
-      const names = fncs.map(f => f.name);
+      const names = fncs.map(f => f.value);
 
       expect(names).to.eql(["math", "square"]);
     });
 
     it("finds object properties", () => {
       const fncs = getSymbols(getSourceText("proto")).functions;
-      const names = fncs.map(f => f.name);
+      const names = fncs.map(f => f.value);
 
       expect(names).to.eql([ "foo", "bar", "initialize", "doThing", "render"]);
     });
 
     it("finds class methods", () => {
       const fncs = getSymbols(getSourceText("classTest")).functions;
-      const names = fncs.map(f => f.name);
+      const names = fncs.map(f => f.value);
       expect(names).to.eql([ "constructor", "bar"]);
     });
   });
@@ -136,15 +136,15 @@ describe("parser", () => {
   describe("getSymbols -> variables", () => {
     it("finds var, let, const", () => {
       const vars = getSymbols(getSourceText("varTest")).variables;
-      const names = vars.map(v => v.name);
+      const names = vars.map(v => v.value);
       expect(names).to.eql(["foo", "bar", "baz", "a", "b"]);
     });
 
     it("finds arguments, properties", () => {
       const protoVars = getSymbols(getSourceText("proto")).variables;
       const classVars = getSymbols(getSourceText("classTest")).variables;
-      const protoNames = protoVars.map(v => v.name);
-      const classNames = classVars.map(v => v.name);
+      const protoNames = protoVars.map(v => v.value);
+      const classNames = classVars.map(v => v.value);
       expect(protoNames).to.eql(["foo", "bar", "TodoView", "tagName", "b"]);
       expect(classNames).to.eql(["a"]);
     });
@@ -153,7 +153,7 @@ describe("parser", () => {
   describe("getSymbols -> classes", () => {
     it("finds class declarations", () => {
       const classClasses = getSymbols(getSourceText("classTest")).classes;
-      const classNames = classClasses.map(c => c.name);
+      const classNames = classClasses.map(c => c.value);
       expect(classNames).to.eql(["Test", "Test2"]);
     });
   });
@@ -161,7 +161,7 @@ describe("parser", () => {
   describe("getSymbols -> All together", () => {
     it("finds function, variable and class declarations", () => {
       const allSymbols = getSymbols(getSourceText("allSymbols"));
-      expect(allSymbols.functions.map(f => f.name)).to.eql([
+      expect(allSymbols.functions.map(f => f.value)).to.eql([
         "incrementCounter",
         "sum",
         "doThing",
@@ -169,7 +169,7 @@ describe("parser", () => {
         "constructor",
         "beAwesome"
       ]);
-      expect(allSymbols.variables.map(v => v.name)).to.eql([
+      expect(allSymbols.variables.map(v => v.value)).to.eql([
         "TIME",
         "count",
         "counter",
@@ -180,7 +180,7 @@ describe("parser", () => {
         "foo",
         "person"
       ]);
-      expect(allSymbols.classes.map(c => c.name)).to.eql(["Ultra"]);
+      expect(allSymbols.classes.map(c => c.value)).to.eql(["Ultra"]);
     });
   });
 

--- a/src/utils/tests/parser.js
+++ b/src/utils/tests/parser.js
@@ -2,6 +2,7 @@ const expect = require("expect.js");
 const {
   parse,
   getFunctions,
+  getVariables,
   getVariablesInScope,
   getPathClosestToLocation
 } = require("../parser");
@@ -57,8 +58,15 @@ const classTest = formatCode(`
   }
 `);
 
+const varTest = formatCode(`
+  var foo = 1;
+  let bar = 2;
+  const baz = 3;
+  const a = 4, b = 5;
+`);
+
 function getSourceText(name) {
-  const sources = { func, math, proto, classTest };
+  const sources = { func, math, proto, classTest, varTest };
   return {
     id: name,
     text: sources[name],
@@ -94,6 +102,14 @@ describe("parser", () => {
       const fncs = getFunctions(getSourceText("classTest"));
       const names = fncs.map(f => f.name);
       expect(names).to.eql([ "constructor", "bar"]);
+    });
+  });
+
+  describe("getVariables", () => {
+    it("finds var, let, const", () => {
+      const vars = getVariables(getSourceText("varTest"));
+      const names = vars.map(v => v.name);
+      expect(names).to.eql(["foo", "bar", "baz", "a", "b"]);
     });
   });
 

--- a/src/utils/tests/parser.js
+++ b/src/utils/tests/parser.js
@@ -114,7 +114,7 @@ describe("parser", () => {
       const classVars = getVariables(getSourceText("classTest"));
       const protoNames = protoVars.map(v => v.name);
       const classNames = classVars.map(v => v.name);
-      expect(protoNames).to.eql(["foo", "bar", "TodoView", "b"]);
+      expect(protoNames).to.eql(["foo", "bar", "TodoView", "tagName", "b"]);
       expect(classNames).to.eql(["a"]);
     });
   });

--- a/src/utils/tests/parser.js
+++ b/src/utils/tests/parser.js
@@ -1,8 +1,7 @@
 const expect = require("expect.js");
 const {
   parse,
-  getFunctions,
-  getVariables,
+  getSymbols,
   getVariablesInScope,
   getPathClosestToLocation
 } = require("../parser");
@@ -72,9 +71,9 @@ function getSourceText(name) {
 }
 
 describe("parser", () => {
-  describe("getFunctions", () => {
+  describe("getSymbols -> functions", () => {
     it("finds square", () => {
-      const fncs = getFunctions(getSourceText("func"));
+      const fncs = getSymbols(getSourceText("func")).functions;
 
       const names = fncs.map(f => f.name);
 
@@ -82,36 +81,36 @@ describe("parser", () => {
     });
 
     it("finds nested functions", () => {
-      const fncs = getFunctions(getSourceText("math"));
+      const fncs = getSymbols(getSourceText("math")).functions;
       const names = fncs.map(f => f.name);
 
       expect(names).to.eql(["math", "square"]);
     });
 
     it("finds object properties", () => {
-      const fncs = getFunctions(getSourceText("proto"));
+      const fncs = getSymbols(getSourceText("proto")).functions;
       const names = fncs.map(f => f.name);
 
       expect(names).to.eql([ "foo", "bar", "initialize", "doThing", "render"]);
     });
 
     it("finds class methods", () => {
-      const fncs = getFunctions(getSourceText("classTest"));
+      const fncs = getSymbols(getSourceText("classTest")).functions;
       const names = fncs.map(f => f.name);
       expect(names).to.eql([ "constructor", "bar"]);
     });
   });
 
-  describe("getVariables", () => {
+  describe("getSymbols -> variables", () => {
     it("finds var, let, const", () => {
-      const vars = getVariables(getSourceText("varTest"));
+      const vars = getSymbols(getSourceText("varTest")).variables;
       const names = vars.map(v => v.name);
       expect(names).to.eql(["foo", "bar", "baz", "a", "b"]);
     });
 
     it("finds arguments, properties", () => {
-      const protoVars = getVariables(getSourceText("proto"));
-      const classVars = getVariables(getSourceText("classTest"));
+      const protoVars = getSymbols(getSourceText("proto")).variables;
+      const classVars = getSymbols(getSourceText("classTest")).variables;
       const protoNames = protoVars.map(v => v.name);
       const classNames = classVars.map(v => v.name);
       expect(protoNames).to.eql(["foo", "bar", "TodoView", "tagName", "b"]);

--- a/src/utils/tests/parser.js
+++ b/src/utils/tests/parser.js
@@ -52,7 +52,9 @@ const SOURCES = {
       bar(a) {
         console.log("bar", a);
       }
-    }
+    };
+
+    class Test2 {}
   `),
   varTest: formatCode(`
     var foo = 1;
@@ -60,6 +62,36 @@ const SOURCES = {
     const baz = 3;
     const a = 4, b = 5;
   `),
+  allSymbols: formatCode(`
+    const TIME = 60;
+    let count = 0;
+
+    function incrementCounter(counter) {
+      return counter++;
+    }
+
+    const sum = (a, b) => a + b;
+
+    const Obj = {
+      foo: 1,
+      doThing() {
+        console.log('hey');
+      },
+      doOtherThing: function() {
+        return 42;
+      }
+    };
+
+    class Ultra {
+      constructor() {
+        this.awesome = true;
+      }
+
+      beAwesome(person) {
+        console.log(person + " is Awesome!");
+      }
+    };
+  `)
 };
 
 function getSourceText(name) {
@@ -115,6 +147,40 @@ describe("parser", () => {
       const classNames = classVars.map(v => v.name);
       expect(protoNames).to.eql(["foo", "bar", "TodoView", "tagName", "b"]);
       expect(classNames).to.eql(["a"]);
+    });
+  });
+
+  describe("getSymbols -> classes", () => {
+    it("finds class declarations", () => {
+      const classClasses = getSymbols(getSourceText("classTest")).classes;
+      const classNames = classClasses.map(c => c.name);
+      expect(classNames).to.eql(["Test", "Test2"]);
+    });
+  });
+
+  describe("getSymbols -> All together", () => {
+    it("finds function, variable and class declarations", () => {
+      const allSymbols = getSymbols(getSourceText("allSymbols"));
+      expect(allSymbols.functions.map(f => f.name)).to.eql([
+        "incrementCounter",
+        "sum",
+        "doThing",
+        "doOtherThing",
+        "constructor",
+        "beAwesome"
+      ]);
+      expect(allSymbols.variables.map(v => v.name)).to.eql([
+        "TIME",
+        "count",
+        "counter",
+        "sum",
+        "a",
+        "b",
+        "Obj",
+        "foo",
+        "person"
+      ]);
+      expect(allSymbols.classes.map(c => c.name)).to.eql(["Ultra"]);
     });
   });
 


### PR DESCRIPTION
Associated Issue: #2249 

### Summary of Changes

* Rework `getFunctions` into `getSymbols` function that traverses an AST and extracts variable, function and class declaration names and locations

### Test Plan

- [x] Run the unit tests and see that they're passing
- [x] Test that function search is still working as expected