### PR TITLE
Polish overlay clearing

### DIFF
--- a/src/utils/editor/source-search.js
+++ b/src/utils/editor/source-search.js
@@ -242,6 +242,8 @@ function searchNext(ctx, rev, query, newQuery, modifiers) {
 function removeOverlay(ctx: any, query: string, modifiers: SearchModifiers) {
   let state = getSearchState(ctx.cm, query, modifiers);
   ctx.cm.removeOverlay(state.overlay);
+  ctx.cm.doc.setSelection(
+    { line: 0, ch: 0 }, { line: 0, ch: 0 }, { scroll: false });
 }
 
 /**

--- a/src/utils/editor/source-search.js
+++ b/src/utils/editor/source-search.js
@@ -242,8 +242,8 @@ function searchNext(ctx, rev, query, newQuery, modifiers) {
 function removeOverlay(ctx: any, query: string, modifiers: SearchModifiers) {
   let state = getSearchState(ctx.cm, query, modifiers);
   ctx.cm.removeOverlay(state.overlay);
-  ctx.cm.doc.setSelection(
-    { line: 0, ch: 0 }, { line: 0, ch: 0 }, { scroll: false });
+  const { line, ch } = ctx.cm.getCursor();
+  ctx.cm.doc.setSelection({ line, ch }, { line, ch }, { scroll: false });
 }
 
 /**


### PR DESCRIPTION
Associated Issue: #2228 

### Summary of Changes

* when we remove overlay reset our selection to the beginning of the document (essentially clearing it)

### Test Plan

- [x] Open a document
- [x] Do a code search
- [x] Close the search and see that the highlights are cleared
