### PR TITLE
Add variables.css to debugger.html and remove references to undefined css var

### DIFF
--- a/src/components/App.css
+++ b/src/components/App.css
@@ -29,7 +29,7 @@
   height: 100%;
   display: flex;
   z-index: 200;
-  background-color: var(--theme-search-overlays-semitransparent);
+  background-color: var(--search-overlays-semitransparent);
 }
 
 .search-container .close-button {

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -11,6 +11,7 @@ const shortcuts = new KeyShortcuts({ window });
 
 const verticalLayoutBreakpoint = window.matchMedia("(min-width: 700px)");
 
+require("./variables.css");
 require("./App.css");
 require("./shared/menu.css");
 require("./shared/SplitBox.css");

--- a/src/components/Editor/Tabs.css
+++ b/src/components/Editor/Tabs.css
@@ -30,7 +30,6 @@
 }
 
 .source-tab {
-  color: var(--theme-faded-tab-color);
   border: 1px solid transparent;
   border-top-left-radius: 2px;
   border-top-right-radius: 2px;
@@ -57,10 +56,6 @@
   background-color: var(--theme-body-background);
   border-color: var(--theme-splitter-color);
   border-bottom-color: transparent;
-}
-
-.source-tab path {
-  fill: var(--theme-faded-tab-color);
 }
 
 .source-tab.active path,

--- a/src/components/SecondaryPanes/Breakpoints.css
+++ b/src/components/SecondaryPanes/Breakpoints.css
@@ -44,7 +44,7 @@ html .breakpoints-list .breakpoint.paused {
 
 .breakpoints-list .breakpoint:hover {
   cursor: pointer;
-  background-color: var(--theme-search-overlays-semitransparent);
+  background-color: var(--search-overlays-semitransparent);
 }
 
 .breakpoints-list .breakpoint.paused:hover {

--- a/src/components/SecondaryPanes/Expressions.css
+++ b/src/components/SecondaryPanes/Expressions.css
@@ -52,7 +52,7 @@
 }
 
 :root.theme-dark .expression-container:hover {
-  background-color: var(--theme-search-overlays-semitransparent);
+  background-color: var(--search-overlays-semitransparent);
 }
 
 .expression-container .close-btn {

--- a/src/components/SecondaryPanes/Frames.css
+++ b/src/components/SecondaryPanes/Frames.css
@@ -78,5 +78,5 @@
 }
 
 .show-more:hover {
-  background-color: var(--theme-search-overlays-semitransparent);
+  background-color: var(--search-overlays-semitransparent);
 }

--- a/src/components/shared/Accordion.css
+++ b/src/components/shared/Accordion.css
@@ -24,7 +24,7 @@
 }
 
 .accordion ._header:hover {
-  background-color: var(--theme-search-overlays-semitransparent);
+  background-color: var(--search-overlays-semitransparent);
 }
 
 .accordion ._header button svg,

--- a/src/components/shared/Dropdown.css
+++ b/src/components/shared/Dropdown.css
@@ -2,7 +2,7 @@
   --width: 150px;
   background: var(--theme-body-background);
   border: 1px solid var(--theme-splitter-color);
-  box-shadow: 0 4px 4px 0 var(--theme-search-overlays-semitransparent);
+  box-shadow: 0 4px 4px 0 var(--search-overlays-semitransparent);
   max-height: 300px;
   position: absolute;
   right: 8px;
@@ -42,7 +42,7 @@ html[dir="rtl"] .dropdown {
 }
 
 .dropdown li:hover {
-  background-color: var(--theme-search-overlays-semitransparent);
+  background-color: var(--search-overlays-semitransparent);
   cursor: pointer;
 }
 

--- a/src/components/variables.css
+++ b/src/components/variables.css
@@ -1,0 +1,9 @@
+:root.theme-light,
+:root .theme-light {
+  --search-overlays-semitransparent: rgba(221, 225, 228, 0.66);
+}
+
+:root.theme-dark,
+:root .theme-dark {
+  --search-overlays-semitransparent: rgba(42, 46, 56, 0.66);
+}


### PR DESCRIPTION
Associated Issue: #2232 

### Summary of Changes

* replace --theme-search-overlays-semitransparent by --search-overlays-semitransparent
* create new file variables.css required by App.js
* add definitions for --search-overlays-semitransparent in variables.css
* remove rules using --theme-faded-tab-color which was not defined and therefore not evaluated

### Test Plan

Started the debugger and checked I didn't see visual regressions.
