### PR TITLE
disable all new debugger tests on debug platforms

### DIFF
--- a/src/test/mochitest/browser.ini
+++ b/src/test/mochitest/browser.ini
@@ -1,7 +1,7 @@
 [DEFAULT]
 tags = devtools
 subsuite = devtools
-skip-if = (os == 'linux' && debug && bits == 32)
+skip-if = debug # Disabled on debug platforms while tests are not run in debug on Github.
 support-files =
   head.js
   !/devtools/client/commandline/test/helpers.js


### PR DESCRIPTION
Let's skip all new debugger tests on debug platforms until they run regularly during development.
Otherwise this makes the release process too random.