### PR TITLE
Quote property names when required

### DIFF
--- a/src/utils/object-inspector.js
+++ b/src/utils/object-inspector.js
@@ -1,4 +1,5 @@
 const get = require("lodash/get");
+const { maybeEscapePropertyName } = require("devtools-reps");
 
 let WINDOW_PROPERTIES = {};
 
@@ -111,7 +112,7 @@ function makeNodesForProperties(objProps, parentPath, {
     nodes = buckets;
   } else {
     nodes = properties.map(name => createNode(
-      name,
+      maybeEscapePropertyName(name),
       `${parentPath}/${name}`,
       ownProperties[name]
     ));

--- a/src/utils/tests/object-inspector.js
+++ b/src/utils/tests/object-inspector.js
@@ -102,6 +102,26 @@ describe("object-inspector", () => {
         "root/bucket1", "root/bucket2", "root/bucket3", "root/bucket4"
       ]);
     });
+
+    it("quotes property names", () => {
+      const nodes = makeNodesForProperties({
+        ownProperties: {
+          // Numbers are ok.
+          332217: { value: {}},
+          "needs-quotes": { value: {}},
+          unquoted: { value: {}},
+          "": { value: {}},
+        }
+      }, "root");
+
+      const names = nodes.map(n => n.name);
+      const paths = nodes.map(n => n.path);
+
+      expect(names).to.eql(["\"\"", "332217", "\"needs-quotes\"", "unquoted"]);
+      expect(paths).to.eql([
+        "root/", "root/332217", "root/needs-quotes", "root/unquoted"
+      ]);
+    });
   });
 });
 


### PR DESCRIPTION
This changes the object inspector to quote property names when quotes
would be required by JS object literal syntax.

This is https://bugzilla.mozilla.org/show_bug.cgi?id=1137281.
