### PR TITLE
Fixed max-height in Result List

### DIFF
--- a/src/components/Editor/SearchBar.css
+++ b/src/components/Editor/SearchBar.css
@@ -108,7 +108,7 @@
 }
 
 .search-bar .result-list {
-  max-height: calc(100% - 80px);
+  max-height: 230px;
   border-bottom: 1px solid var(--theme-splitter-color);
   background-color: var(--theme-body-background);
 }


### PR DESCRIPTION
Associated Issue: #2240 
### Summary of Changes

* Changed the max height of the result list to fit about 7 items.
* Considering the box model of each item, its height comes to be 33px. With that in mind, 230px should be enough to limit the visualization to about 7 items. 

### Test Plan

- [x] Navigate to some large file. In this case I opened jQuery
- [x] Ctrl+F to open the find dialog
- [x] Choose **function** from **Search for:**
- [x] Enter some filter, as **h**
- [x] It should be displayed no more than 7 items in the result list