### PR TITLE
[SourceTabs] Center tab close button and increase its size

### DIFF
--- a/src/components/Editor/Tabs.css
+++ b/src/components/Editor/Tabs.css
@@ -103,7 +103,6 @@
 .source-tab .close-btn .close {
   padding: 0;
   margin-top: 0;
-  line-height: 0;
-  line-height: 13px;
-  display: inline-block;
+  display: inline-flex;
+  justify-content: center;
 }

--- a/src/components/shared/Button/Close.css
+++ b/src/components/shared/Button/Close.css
@@ -14,7 +14,7 @@
 }
 
 .close-btn .close svg {
-  width: 6px;
+  width: 8px;
 }
 
 .close-btn:hover {


### PR DESCRIPTION
### Summary of Changes

* Center close tab button
* Increase size of close tab icon

### Screenshots/Videos (OPTIONAL)
| Before | After |
| --- | --- |
|![old](https://cloud.githubusercontent.com/assets/1755089/23558800/e901fd74-005a-11e7-8434-b70115600e69.png)|![new](https://cloud.githubusercontent.com/assets/1755089/23558807/ed26ce02-005a-11e7-8870-c60f375ab41e.png)|

Let me know what you think about these changes.