### PR TITLE
Increase pane toggle button size and margin

### DIFF
--- a/src/components/Editor/Tabs.css
+++ b/src/components/Editor/Tabs.css
@@ -41,7 +41,7 @@
   min-width: 40px;
   overflow: hidden;
   padding: 6px;
-  margin-inline-start: 8px;
+  margin-inline-start: 3px;
   margin-top: 2px;
 }
 

--- a/src/components/shared/Button/PaneToggle.css
+++ b/src/components/shared/Button/PaneToggle.css
@@ -8,7 +8,7 @@
 
 .toggle-button-start svg,
 .toggle-button-end svg {
-  width: 14px;
+  width: 16px;
   fill: var(--theme-comment);
 }
 
@@ -19,6 +19,11 @@
 
 .toggle-button-end {
   margin-left: auto;
+  margin-right: 5px;
+}
+
+.toggle-button-start {
+  margin-left: 5px;
 }
 
 html:not([dir="rtl"]) .toggle-button-end svg,
@@ -28,6 +33,10 @@ html[dir="rtl"] .toggle-button-start svg {
 
 html .toggle-button-end.vertical svg {
   transform: rotate(-90deg);
+}
+
+.toggle-button-end.vertical {
+  margin-bottom: 2px;
 }
 
 .toggle-button-start.collapsed,


### PR DESCRIPTION
Associated Issue: #2141

### Summary of Changes

* Increased size of pane toggle buttons
* Reduced starting tab margin size to account for toggle button moving further right
* Added left and right margin increase to toggle buttons on horizontal, and bottom margin in vertical for bottom toggle

Debugger's Testing doc
https://docs.google.com/document/d/1oBMRxV8A2ag2t22YsQOxTdEv0mXKzIg0tggJjRkU1S0/edit#.


### Screenshots/Videos (OPTIONAL)

<img width="1110" alt="screen shot 2017-03-07 at 6 17 56 pm" src="https://cloud.githubusercontent.com/assets/12941622/23682569/7b67ff4c-0362-11e7-838c-f4a8c934be58.png">

<img width="710" alt="screen shot 2017-03-07 at 6 18 13 pm" src="https://cloud.githubusercontent.com/assets/12941622/23682577/843318e6-0362-11e7-8256-6855701efa44.png">
