### PR TITLE
addExpression expected string not object

### DIFF
--- a/src/components/Editor/EditorMenu.js
+++ b/src/components/Editor/EditorMenu.js
@@ -59,9 +59,7 @@ async function EditorMenu({
   const watchExpressionLabel = {
     accesskey: "E",
     label: L10N.getStr("expressions.placeholder"),
-    click: () => addExpression({
-      input: codeMirror.getSelection()
-    })
+    click: () => addExpression(codeMirror.getSelection())
   };
 
   const menuOptions = [];


### PR DESCRIPTION
Associated Issue: #2294

### Summary of Changes

* `addExpression` action expect `input: string` but received an object when dispatched

### Test Plan

Tell us a little a bit about how you tested your patch.

Example test plan:

- [x] Command-P opens the panel
- [x] Clicking “+” opens the panel
- [x] Clicking a source navigates to the source
- [x] Clicking "x" closes the panel

Here's the Debugger's Testing doc
https://docs.google.com/document/d/1oBMRxV8A2ag2t22YsQOxTdEv0mXKzIg0tggJjRkU1S0/edit#.
Feel free to improve it!

### Screenshots/Videos (OPTIONAL)
