### PR TITLE
Accidentally used the placeholder L10N strings in place of the button labels

### DIFF
--- a/src/components/Editor/SearchBar.js
+++ b/src/components/Editor/SearchBar.js
@@ -498,7 +498,7 @@ const SearchBar = React.createClass({
           }
           toggleSymbolSearch(e, { toggle: false, searchType });
         }
-      }, L10N.getStr(`symbolSearch.search.${searchType}Placeholder`));
+      }, searchType);
     }
 
     let classSearchBtn;


### PR DESCRIPTION
Associated Issue: N/A

### Summary of Changes

* I missed this use of L10N and had the placeholders where I didn't want them

