### PR TITLE
add clojure syntax mode for editor (#2307)

### DIFF
--- a/src/utils/editor/source-editor.js
+++ b/src/utils/editor/source-editor.js
@@ -13,6 +13,7 @@ require("codemirror/mode/htmlmixed/htmlmixed");
 require("codemirror/mode/coffeescript/coffeescript");
 require("codemirror/mode/jsx/jsx");
 require("codemirror/mode/elm/elm");
+require("codemirror/mode/clojure/clojure");
 require("../../components/Editor/codemirror-mozilla.css");
 require("codemirror/addon/search/searchcursor");
 

--- a/src/utils/source.js
+++ b/src/utils/source.js
@@ -100,6 +100,7 @@ const contentTypeModeMap = {
   },
   "text/jsx": "jsx",
   "text/x-elm": "elm",
+  "text/x-clojure": "clojure",
   "text/wasm": { name: "text" },
   "html": { name: "htmlmixed" }
 };
@@ -121,7 +122,7 @@ function getMode(sourceText: SourceText) {
     return contentTypeModeMap["text/typescript"];
   }
 
-  if (/script|elm|jsx|wasm/.test(contentType)) {
+  if (/script|elm|jsx|clojure|wasm/.test(contentType)) {
     if (contentType in contentTypeModeMap) {
       return contentTypeModeMap[contentType];
     }
@@ -161,6 +162,10 @@ function getContentType(url: string) {
 
   if (url.match(/elm$/)) {
     return "text/elm";
+  }
+
+  if (url.match(/cljs$/)) {
+    return "text/x-clojure";
   }
 
   return "text/plain";

--- a/src/utils/tests/source.js
+++ b/src/utils/tests/source.js
@@ -69,5 +69,21 @@ describe("sources", () => {
       };
       expect(getMode(sourceText).base.typescript).to.be(true);
     });
+
+    it("clojure", () => {
+      const sourceText = {
+        contentType: "text/x-clojure",
+        text: ""
+      };
+      expect(getMode(sourceText)).to.be("clojure");
+    });
+
+    it("coffeescript", () => {
+      const sourceText = {
+        contentType: "text/coffeescript",
+        text: ""
+      };
+      expect(getMode(sourceText)).to.be("coffeescript");
+    });
   });
 });


### PR DESCRIPTION
Associated Issue: #2307

### Summary of Changes

* Add support for clojure syntax

I looked quite a lot to find a closure sample I could run locally, or even add to debugger-examples. But I'll come back it it.

### Test Plan

### Screenshots/Videos (OPTIONAL)
**Old**
<img width="563" alt="screen shot 2017-03-10 at 9 06 46 pm" src="https://cloud.githubusercontent.com/assets/2481105/23819572/0d5333a2-05d6-11e7-8ba9-0ba5cdb89a3e.png">

**New**
<img width="538" alt="screen shot 2017-03-10 at 7 48 32 pm" src="https://cloud.githubusercontent.com/assets/2481105/23818604/b623f2ca-05ca-11e7-8d99-12ad2f15a020.png">
