### PR TITLE
Make close button appear correctly upon opening the conditional panel

### DIFF
--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -370,7 +370,8 @@ const Editor = React.createClass({
     });
 
     this.cbPanel = this.editor.codeMirror.addLineWidget(line, panel, {
-      coverGutter: true
+      coverGutter: true,
+      noHScroll: true
     });
     this.cbPanel.node.querySelector("input").focus();
   },

--- a/src/components/shared/Button/Close.css
+++ b/src/components/shared/Button/Close.css
@@ -32,6 +32,7 @@
 
 .close-btn-big {
   padding: 11px;
+  margin-right: 7px;
   width: 27px;
   height: 40px;
 }


### PR DESCRIPTION
Associated Issue: #2287 

This is a partial fix making the close button appear correctly upon opening of the conditional panel. It is still possible to cover the button by dragging the right panel over it, however.  This does not always happen, but I was able to reproduce it.

When it becomes possible to catch drag events this issue should be revisited.  

I also added a bit of space between the button and the right panel. 

### Test

* Open source code with very long lines (ie. jQuery) in the debugger and press 
  CTRL-SHIFT-b to open the conditional panel.  The close button should be visible 
  in the conditional panel to the right of the editor.