### PR TITLE
[EditorSearch] Improve searchbar and search performance on large files

### DIFF
--- a/src/utils/editor/source-search.js
+++ b/src/utils/editor/source-search.js
@@ -31,11 +31,15 @@ function SearchState() {
  */
 function getSearchState(cm: any, query, modifiers) {
   let state = cm.state.search || (cm.state.search = new SearchState());
-  let cursor = getSearchCursor(cm, query, null, modifiers);
 
-  state.results = [];
-  while (cursor.findNext()) {
-    state.results.push(cursor.pos);
+  // avoid generating a cursor and iterating over the results for an empty query
+  if (query) {
+    let cursor = getSearchCursor(cm, query, null, modifiers);
+
+    state.results = [];
+    while (cursor.findNext()) {
+      state.results.push(cursor.pos);
+    }
   }
 
   return state;


### PR DESCRIPTION
Associated Issue: #2154

### Summary of Changes

* Cache `debounce`-ed `searchResults` function
* Avoid generating a cursor and iterating over the results for an empty query

### Test Plan

#### Open/Close Panel

- [x] Open a large file
- [x] Command-F opens the search panel
- [x] Clicking “x” to close the search panel

#### Perform a search

- [x] Open a large file
- [x] Command-F opens the search panel
- [x] Enter a search query. Vary speed of input to verify debounce
