### PR TITLE
show `this` when it’s in scope

### DIFF
--- a/src/components/Editor/Preview.js
+++ b/src/components/Editor/Preview.js
@@ -101,7 +101,7 @@ class Preview extends Component {
       autoExpandDepth: 0,
       onDoubleClick: () => {},
       loadObjectProperties,
-      getActors: () => {}
+      getActors: () => ({})
     });
   }
 

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -286,10 +286,9 @@ const Editor = React.createClass({
       return;
     }
 
-    this.setState({ selectedToken: null });
-
     if (selectedToken) {
       selectedToken.classList.remove("selected-token");
+      this.setState({ selectedToken: null });
     }
 
     const variables = selectedFrame.scope.bindings.variables;

--- a/src/components/shared/ObjectInspector.js
+++ b/src/components/shared/ObjectInspector.js
@@ -102,9 +102,7 @@ const ObjectInspector = React.createClass({
       onLabelClick: () => {},
       onDoubleClick: () => {},
       autoExpandDepth: 1,
-      getActors: () => {
-        return {};
-      }
+      getActors: () => ({})
     };
   },
 
@@ -124,6 +122,7 @@ const ObjectInspector = React.createClass({
   getChildren(item: ObjectInspectorItem) {
     const { getObjectProperties } = this.props;
     const { actors } = this;
+
     return getChildren({
       getObjectProperties,
       actors,

--- a/src/components/shared/Popover.js
+++ b/src/components/shared/Popover.js
@@ -31,6 +31,7 @@ class Popover extends Component {
   render() {
     const { children, onMouseLeave } = this.props;
     const { top, left } = this.state;
+
     return dom.div(
       {
         className: "popover",


### PR DESCRIPTION
Associated Issue: #2300

### Summary of Changes

* EditorPreview now appears when `this` is selected & in scope

### Test Plan

Tell us a little a bit about how you tested your patch.

Example test plan:

- [x] Command-P opens the panel
- [x] Clicking “+” opens the panel
- [x] Clicking a source navigates to the source
- [x] Clicking "x" closes the panel

Here's the Debugger's Testing doc
https://docs.google.com/document/d/1oBMRxV8A2ag2t22YsQOxTdEv0mXKzIg0tggJjRkU1S0/edit#.
Feel free to improve it!

### Screenshots/Videos (OPTIONAL)
![editpreviewthis](https://cloud.githubusercontent.com/assets/5232812/23825812/f5d54510-065e-11e7-8986-bad6d7542707.gif)
