### PR TITLE
Fix failing test on windows

### DIFF
--- a/src/test/node-unit-tests.js
+++ b/src/test/node-unit-tests.js
@@ -47,6 +47,8 @@ webpackConfig.resolve.alias["devtools-network-request"] =
 
 webpackConfig.node = { __dirname: false };
 
+webpackConfig.target = "node";
+
 global.Worker = require("workerjs");
 
 // disable unecessary require calls


### PR DESCRIPTION
Associated Issue: #1925 

### Summary of Changes

Previous expriment goes here https://github.com/devtools-html/devtools-core/pull/228

Let webpack `require` the correct node's `path` module in  https://github.com/devtools-html/devtools-core/blob/master/packages/devtools-network-request/stubNetworkRequest.js

### Test Plan

On Windows, run `yarn test`,  all test passed
On Ubuntu, run `yarn test`,  all test passed
