### PR TITLE
#2310 : Trigger search when changing the type of symbol searched

### DIFF
--- a/src/components/Editor/SearchBar.js
+++ b/src/components/Editor/SearchBar.js
@@ -121,7 +121,7 @@ const SearchBar = React.createClass({
     }
   },
 
-  componentDidUpdate(prevProps: any) {
+  componentDidUpdate(prevProps: any, prevState: any) {
     const { sourceText, selectedSource, query, modifiers } = this.props;
 
     if (this.searchInput()) {
@@ -142,8 +142,12 @@ const SearchBar = React.createClass({
     const modifiersUpdated = modifiers != prevProps.modifiers;
 
     const isOpen = this.state.enabled || this.state.symbolSearchEnabled;
+    const { selectedSymbolType, symbolSearchEnabled } = this.state;
+    const changedSearchType = selectedSymbolType != prevState.selectedSymbolType
+                        || symbolSearchEnabled != prevState.symbolSearchEnabled;
 
-    if (isOpen && (doneLoading || changedFiles || modifiersUpdated)) {
+    if (isOpen &&
+      (doneLoading || changedFiles || modifiersUpdated || changedSearchType)) {
       this.doSearch(query);
     }
   },


### PR DESCRIPTION
Associated Issue: #2310 

### Summary of Changes

* Update search results when the type of symbol searched changes

### Test Plan

- [x] Open the search bar
- [x] Search for `app`
- [x] Toggle search on `functions`
- [x] Toggle search on `variables`


### Screenshots/Videos (OPTIONAL)

![debugger-search](https://cloud.githubusercontent.com/assets/4603973/23833975/966acf96-074e-11e7-8376-6124d95fffbb.gif)
