### PR TITLE
Persist expressions

### DIFF
--- a/src/components/SecondaryPanes/Expressions.js
+++ b/src/components/SecondaryPanes/Expressions.js
@@ -59,7 +59,10 @@ class Expressions extends React.Component {
   }
 
   componentDidMount() {
-    this.props.evaluateExpressions();
+    const { expressions, evaluateExpressions } = this.props;
+    if (expressions.size > 0) {
+      evaluateExpressions();
+    }
   }
 
   shouldComponentUpdate(nextProps, nextState) {

--- a/src/components/SecondaryPanes/Expressions.js
+++ b/src/components/SecondaryPanes/Expressions.js
@@ -43,16 +43,8 @@ function getValue(expression) {
   };
 }
 
-const Expressions = React.createClass({
-  propTypes: {
-    expressions: ImPropTypes.list.isRequired,
-    addExpression: PropTypes.func.isRequired,
-    updateExpression: PropTypes.func.isRequired,
-    deleteExpression: PropTypes.func.isRequired,
-    evaluateExpressions: PropTypes.func.isRequired,
-    loadObjectProperties: PropTypes.func,
-    loadedObjects: ImPropTypes.map.isRequired
-  },
+class Expressions extends React.Component {
+  _input: null | any;
 
   state: {
     editing: null | Node,
@@ -76,13 +68,6 @@ const Expressions = React.createClass({
       evaluateExpressions();
     }
   }
-
-  componentDidMount() {
-    const { expressions, evaluateExpressions } = this.props;
-    if (expressions.size > 0) {
-      evaluateExpressions();
-    }
-  },
 
   shouldComponentUpdate(nextProps, nextState) {
     const { editing } = this.state;
@@ -239,7 +224,7 @@ export default connect(
   state => ({
     pauseInfo: getPause(state),
     expressions: getExpressions(state),
-    loadedObjects: getLoadedObjects(state)
+    loadedObjects: getLoadedObjects(state),
   }),
   dispatch => bindActionCreators(actions, dispatch),
 )(Expressions);

--- a/src/components/SecondaryPanes/Expressions.js
+++ b/src/components/SecondaryPanes/Expressions.js
@@ -78,7 +78,10 @@ const Expressions = React.createClass({
   }
 
   componentDidMount() {
-    this.props.evaluateExpressions();
+    const { expressions, evaluateExpressions } = this.props;
+    if (expressions.size > 0) {
+      evaluateExpressions();
+    }
   },
 
   shouldComponentUpdate(nextProps, nextState) {

--- a/src/components/SecondaryPanes/Expressions.js
+++ b/src/components/SecondaryPanes/Expressions.js
@@ -4,6 +4,7 @@ import { connect } from "react-redux";
 import { bindActionCreators } from "redux";
 import ImPropTypes from "react-immutable-proptypes";
 import actions from "../../actions";
+import { prefs } from "../../utils/prefs";
 import { getExpressions, getLoadedObjects, getPause } from "../../selectors";
 const CloseButton = React.createFactory(
   require("../shared/Button/Close").default,
@@ -68,6 +69,15 @@ class Expressions extends React.Component {
       evaluateExpressions();
     }
   }
+
+  componentDidMount() {
+    const { addExpression } = this.props;
+    if (prefs.expressions.length > 0) {
+      prefs.expressions.forEach(expression => {
+        addExpression(expression.input);
+      });
+    }
+  },
 
   shouldComponentUpdate(nextProps, nextState) {
     const { editing } = this.state;
@@ -220,11 +230,17 @@ Expressions.propTypes = {
 
 Expressions.displayName = "Expressions";
 
+function loadExpressions(state) {
+  const expressions = getExpressions(state);
+  prefs.expressions = expressions.toJS();
+  return expressions;
+}
+
 export default connect(
   state => ({
     pauseInfo: getPause(state),
-    expressions: getExpressions(state),
-    loadedObjects: getLoadedObjects(state),
+    expressions: loadExpressions(state),
+    loadedObjects: getLoadedObjects(state)
   }),
   dispatch => bindActionCreators(actions, dispatch),
 )(Expressions);

--- a/src/components/SecondaryPanes/Expressions.js
+++ b/src/components/SecondaryPanes/Expressions.js
@@ -4,7 +4,6 @@ import { connect } from "react-redux";
 import { bindActionCreators } from "redux";
 import ImPropTypes from "react-immutable-proptypes";
 import actions from "../../actions";
-import { prefs } from "../../utils/prefs";
 import { getExpressions, getLoadedObjects, getPause } from "../../selectors";
 const CloseButton = React.createFactory(
   require("../shared/Button/Close").default,
@@ -44,8 +43,16 @@ function getValue(expression) {
   };
 }
 
-class Expressions extends React.Component {
-  _input: null | any;
+const Expressions = React.createClass({
+  propTypes: {
+    expressions: ImPropTypes.list.isRequired,
+    addExpression: PropTypes.func.isRequired,
+    updateExpression: PropTypes.func.isRequired,
+    deleteExpression: PropTypes.func.isRequired,
+    evaluateExpressions: PropTypes.func.isRequired,
+    loadObjectProperties: PropTypes.func,
+    loadedObjects: ImPropTypes.map.isRequired
+  },
 
   state: {
     editing: null | Node,
@@ -71,12 +78,7 @@ class Expressions extends React.Component {
   }
 
   componentDidMount() {
-    const { addExpression } = this.props;
-    if (prefs.expressions.length > 0) {
-      prefs.expressions.forEach(expression => {
-        addExpression(expression.input);
-      });
-    }
+    this.props.evaluateExpressions();
   },
 
   shouldComponentUpdate(nextProps, nextState) {
@@ -230,16 +232,10 @@ Expressions.propTypes = {
 
 Expressions.displayName = "Expressions";
 
-function loadExpressions(state) {
-  const expressions = getExpressions(state);
-  prefs.expressions = expressions.toJS();
-  return expressions;
-}
-
 export default connect(
   state => ({
     pauseInfo: getPause(state),
-    expressions: loadExpressions(state),
+    expressions: getExpressions(state),
     loadedObjects: getLoadedObjects(state)
   }),
   dispatch => bindActionCreators(actions, dispatch),

--- a/src/components/SecondaryPanes/Expressions.js
+++ b/src/components/SecondaryPanes/Expressions.js
@@ -4,6 +4,7 @@ import { connect } from "react-redux";
 import { bindActionCreators } from "redux";
 import ImPropTypes from "react-immutable-proptypes";
 import actions from "../../actions";
+import { prefs } from "../../utils/prefs";
 import { getExpressions, getLoadedObjects, getPause } from "../../selectors";
 const CloseButton = React.createFactory(require("../shared/Button/Close").default);
 const ObjectInspector = React.createFactory(require("../shared/ObjectInspector"));
@@ -57,6 +58,15 @@ class Expressions extends React.Component {
 
     this.renderExpression = this.renderExpression.bind(this);
   }
+
+  componentDidMount() {
+    const { addExpression } = this.props;
+    if (prefs.expressions.length > 0) {
+      prefs.expressions.forEach(expression => {
+        addExpression(expression.input);
+      });
+    }
+  },
 
   shouldComponentUpdate(nextProps, nextState) {
     const { editing } = this.state;
@@ -211,10 +221,16 @@ Expressions.propTypes = {
 
 Expressions.displayName = "Expressions";
 
+function loadExpressions(state) {
+  const expressions = getExpressions(state);
+  prefs.expressions = expressions.toJS();
+  return expressions;
+}
+
 export default connect(
   state => ({
     pauseInfo: getPause(state),
-    expressions: getExpressions(state),
+    expressions: loadExpressions(state),
     loadedObjects: getLoadedObjects(state)
   }),
   dispatch => bindActionCreators(actions, dispatch)

--- a/src/components/SecondaryPanes/Expressions.js
+++ b/src/components/SecondaryPanes/Expressions.js
@@ -4,7 +4,6 @@ import { connect } from "react-redux";
 import { bindActionCreators } from "redux";
 import ImPropTypes from "react-immutable-proptypes";
 import actions from "../../actions";
-import { prefs } from "../../utils/prefs";
 import { getExpressions, getLoadedObjects, getPause } from "../../selectors";
 const CloseButton = React.createFactory(require("../shared/Button/Close").default);
 const ObjectInspector = React.createFactory(require("../shared/ObjectInspector"));
@@ -60,13 +59,8 @@ class Expressions extends React.Component {
   }
 
   componentDidMount() {
-    const { addExpression } = this.props;
-    if (prefs.expressions.length > 0) {
-      prefs.expressions.forEach(expression => {
-        addExpression(expression.input);
-      });
-    }
-  },
+    this.props.evaluateExpressions();
+  }
 
   shouldComponentUpdate(nextProps, nextState) {
     const { editing } = this.state;
@@ -213,6 +207,7 @@ class Expressions extends React.Component {
 Expressions.propTypes = {
   expressions: ImPropTypes.list.isRequired,
   addExpression: PropTypes.func.isRequired,
+  evaluateExpressions: PropTypes.func.isRequired,
   updateExpression: PropTypes.func.isRequired,
   deleteExpression: PropTypes.func.isRequired,
   loadObjectProperties: PropTypes.func,
@@ -221,16 +216,10 @@ Expressions.propTypes = {
 
 Expressions.displayName = "Expressions";
 
-function loadExpressions(state) {
-  const expressions = getExpressions(state);
-  prefs.expressions = expressions.toJS();
-  return expressions;
-}
-
 export default connect(
   state => ({
     pauseInfo: getPause(state),
-    expressions: loadExpressions(state),
+    expressions: getExpressions(state),
     loadedObjects: getLoadedObjects(state)
   }),
   dispatch => bindActionCreators(actions, dispatch)

--- a/src/reducers/expressions.js
+++ b/src/reducers/expressions.js
@@ -13,7 +13,6 @@ type ExpressionState = {
   expressions: I.List<Expression>,
 };
 
-
 const State = makeRecord(
   ({
     expressions: I.List(restoreExpressions()),
@@ -51,25 +50,48 @@ function update(state = State(), action: Action): Record<ExpressionState> {
   return state;
 }
 
+function restoreExpressions() {
+  const exprs = prefs.expressions;
+  if (exprs.length == 0) {
+    return;
+  }
+  return exprs;
+}
+
+function storeExpressions(state) {
+  prefs.expressions = state.getIn(["expressions"]).toJS();
+}
+
 function appendToList(state: State, path: string[], value: any) {
-  return state.updateIn(path, () => {
+  const newState = state.updateIn(path, () => {
     return state.getIn(path).push(value);
   });
+  storeExpressions(newState);
+  return newState;
 }
 
 function updateItemInList(
-  state: State, path: string[], key: string, value: any) {
-  return state.updateIn(path, () => {
+  state: State,
+  path: string[],
+  key: string,
+  value: any,
+) {
+  const newState = state.updateIn(path, () => {
     const list = state.getIn(path);
     const index = list.findIndex(e => e.input == key);
     return list.update(index, () => value);
   });
+  storeExpressions(newState);
+  return newState;
 }
 
 function deleteExpression(state: State, input: string) {
-  const index = getExpressions({ expressions: state })
-    .findKey(e => e.input == input);
-  return state.deleteIn(["expressions", index]);
+  const index = getExpressions({ expressions: state }).findKey(
+    e => e.input == input,
+  );
+  const newState = state.deleteIn(["expressions", index]);
+  storeExpressions(newState);
+  return newState;
 }
 
 type OuterState = { expressions: Record<ExpressionState> };

--- a/src/reducers/expressions.js
+++ b/src/reducers/expressions.js
@@ -28,13 +28,11 @@ function update(state = State(), action: Action): Record<ExpressionState> {
       });
     case constants.UPDATE_EXPRESSION:
       const key = action.expression.input;
-      const newState = updateItemInList(state, ["expressions"], key, {
+      return updateItemInList(state, ["expressions"], key, {
         input: action.input,
         value: null,
         updating: true
       });
-      persistExpressions(newState);
-      return newState;
     case constants.EVALUATE_EXPRESSION:
       if (action.status === "done") {
         return updateItemInList(state, ["expressions"], action.input, {
@@ -51,42 +49,25 @@ function update(state = State(), action: Action): Record<ExpressionState> {
   return state;
 }
 
-function restoreExpressions() {
-  const prefExpressions = prefs.expressions || [];
-  if (Object.keys(prefExpressions).length == 0) {
-    return;
-  }
-  return prefExpressions;
-}
-
-function persistExpressions(state: State) {
-  prefs.expressions = state.getIn(["expressions"]).toJS();
-}
-
 function appendToList(state: State, path: string[], value: any) {
-  const newState = state.updateIn(path, () => {
+  return state.updateIn(path, () => {
     return state.getIn(path).push(value);
   });
-  persistExpressions(newState);
-  return newState;
 }
 
 function updateItemInList(
   state: State, path: string[], key: string, value: any) {
-  const newState = state.updateIn(path, () => {
+  return state.updateIn(path, () => {
     const list = state.getIn(path);
     const index = list.findIndex(e => e.input == key);
     return list.update(index, () => value);
   });
-  return newState;
 }
 
 function deleteExpression(state: State, input: string) {
   const index = getExpressions({ expressions: state })
     .findKey(e => e.input == input);
-  const newState = state.deleteIn(["expressions", index]);
-  persistExpressions(newState);
-  return newState;
+  return state.deleteIn(["expressions", index]);
 }
 
 type OuterState = { expressions: Record<ExpressionState> };

--- a/src/reducers/expressions.js
+++ b/src/reducers/expressions.js
@@ -30,13 +30,11 @@ function update(state = State(), action: Action): Record<ExpressionState> {
       });
     case constants.UPDATE_EXPRESSION:
       const key = action.expression.input;
-      const newState = updateItemInList(state, ["expressions"], key, {
+      return updateItemInList(state, ["expressions"], key, {
         input: action.input,
         value: null,
         updating: true,
       });
-      persistExpressions(newState);
-      return newState;
     case constants.EVALUATE_EXPRESSION:
       if (action.status === "done") {
         return updateItemInList(state, ["expressions"], action.input, {
@@ -53,48 +51,25 @@ function update(state = State(), action: Action): Record<ExpressionState> {
   return state;
 }
 
-function restoreExpressions() {
-  const exprs = prefs.expressions;
-  if (exprs.length == 0) {
-    return;
-  }
-  return exprs;
-}
-
-function storeExpressions(state) {
-  prefs.expressions = state.getIn(["expressions"]).toJS();
-}
-
 function appendToList(state: State, path: string[], value: any) {
-  const newState = state.updateIn(path, () => {
+  return state.updateIn(path, () => {
     return state.getIn(path).push(value);
   });
-  storeExpressions(newState);
-  return newState;
 }
 
 function updateItemInList(
-  state: State,
-  path: string[],
-  key: string,
-  value: any,
-) {
-  const newState = state.updateIn(path, () => {
+  state: State, path: string[], key: string, value: any) {
+  return state.updateIn(path, () => {
     const list = state.getIn(path);
     const index = list.findIndex(e => e.input == key);
     return list.update(index, () => value);
   });
-  storeExpressions(newState);
-  return newState;
 }
 
 function deleteExpression(state: State, input: string) {
-  const index = getExpressions({ expressions: state }).findKey(
-    e => e.input == input,
-  );
-  const newState = state.deleteIn(["expressions", index]);
-  storeExpressions(newState);
-  return newState;
+  const index = getExpressions({ expressions: state })
+    .findKey(e => e.input == input);
+  return state.deleteIn(["expressions", index]);
 }
 
 type OuterState = { expressions: Record<ExpressionState> };

--- a/src/reducers/expressions.js
+++ b/src/reducers/expressions.js
@@ -30,11 +30,13 @@ function update(state = State(), action: Action): Record<ExpressionState> {
       });
     case constants.UPDATE_EXPRESSION:
       const key = action.expression.input;
-      return updateItemInList(state, ["expressions"], key, {
+      const newState = updateItemInList(state, ["expressions"], key, {
         input: action.input,
         value: null,
         updating: true,
       });
+      persistExpressions(newState);
+      return newState;
     case constants.EVALUATE_EXPRESSION:
       if (action.status === "done") {
         return updateItemInList(state, ["expressions"], action.input, {

--- a/src/reducers/expressions.js
+++ b/src/reducers/expressions.js
@@ -14,7 +14,7 @@ type ExpressionState = {
 }
 
 const State = makeRecord(({
-  expressions: I.List()
+  expressions: I.List(restoreExpressions())
 } : ExpressionState));
 
 function update(state = State(), action: Action): Record<ExpressionState> {
@@ -49,25 +49,43 @@ function update(state = State(), action: Action): Record<ExpressionState> {
   return state;
 }
 
+function restoreExpressions() {
+  const exprs = prefs.expressions;
+  if (exprs.length == 0) {
+    return;
+  }
+  return exprs;
+}
+
+function storeExpressions(state) {
+  prefs.expressions = state.getIn(["expressions"]).toJS();
+}
+
 function appendToList(state: State, path: string[], value: any) {
-  return state.updateIn(path, () => {
+  const newState = state.updateIn(path, () => {
     return state.getIn(path).push(value);
   });
+  storeExpressions(newState);
+  return newState;
 }
 
 function updateItemInList(
   state: State, path: string[], key: string, value: any) {
-  return state.updateIn(path, () => {
+  const newState = state.updateIn(path, () => {
     const list = state.getIn(path);
     const index = list.findIndex(e => e.input == key);
     return list.update(index, () => value);
   });
+  storeExpressions(newState);
+  return newState;
 }
 
 function deleteExpression(state: State, input: string) {
   const index = getExpressions({ expressions: state })
     .findKey(e => e.input == input);
-  return state.deleteIn(["expressions", index]);
+  const newState = state.deleteIn(["expressions", index]);
+  storeExpressions(newState);
+  return newState;
 }
 
 type OuterState = { expressions: Record<ExpressionState> };

--- a/src/utils/prefs.js
+++ b/src/utils/prefs.js
@@ -15,6 +15,7 @@ if (isDevelopment()) {
   pref("devtools.debugger.tabs", "[]");
   pref("devtools.debugger.pending-selected-location", "{}");
   pref("devtools.debugger.pending-breakpoints", "[]");
+  pref("devtools.debugger.expressions", "[]");
 }
 
 const prefs = new PrefsHelper("devtools", {
@@ -27,7 +28,8 @@ const prefs = new PrefsHelper("devtools", {
   endPanelCollapsed: ["Bool", "debugger.end-panel-collapsed"],
   tabs: ["Json", "debugger.tabs"],
   pendingSelectedLocation: ["Json", "debugger.pending-selected-location"],
-  pendingBreakpoints: ["Json", "debugger.pending-breakpoints"]
+  pendingBreakpoints: ["Json", "debugger.pending-breakpoints"],
+  expressions: ["Json", "debugger.expressions"]
 });
 
 module.exports = { prefs };

--- a/src/utils/prefs.js
+++ b/src/utils/prefs.js
@@ -13,7 +13,6 @@ if (isDevelopment()) {
   pref("devtools.debugger.start-panel-collapsed", false);
   pref("devtools.debugger.end-panel-collapsed", false);
   pref("devtools.debugger.tabs", "[]");
-  pref("devtools.debugger.expressions", "[]");
   pref("devtools.debugger.pending-selected-location", "{}");
   pref("devtools.debugger.pending-breakpoints", "[]");
   pref("devtools.debugger.expressions", "[]");

--- a/src/utils/prefs.js
+++ b/src/utils/prefs.js
@@ -13,6 +13,7 @@ if (isDevelopment()) {
   pref("devtools.debugger.start-panel-collapsed", false);
   pref("devtools.debugger.end-panel-collapsed", false);
   pref("devtools.debugger.tabs", "[]");
+  pref("devtools.debugger.expressions", "[]");
   pref("devtools.debugger.pending-selected-location", "{}");
   pref("devtools.debugger.pending-breakpoints", "[]");
   pref("devtools.debugger.expressions", "[]");


### PR DESCRIPTION
Associated Issue: #2290

### Summary of Changes

* Add prefs for expressions
* Add store and restore functions to the reducer
* Call `evaluateExpressions` from `componentDidMount` to evaluate if expressions exist

### Test Plan
- [x] Add an expressions
- [x] Refresh the debugger
- [x] Check if the expressions show up
- [x] And if the value is correct for the current frame

### Screenshots/Videos
![persist-expressions](https://cloud.githubusercontent.com/assets/792924/23901382/e4cb1ac6-08b4-11e7-982b-68ec12a029e0.gif)

