### PR TITLE
Add hover effect to close-btn-big

### DIFF
--- a/src/components/shared/Button/Close.css
+++ b/src/components/shared/Button/Close.css
@@ -21,11 +21,13 @@
   display: block;
 }
 
+.close-btn-big:hover .close,
 .close-btn:hover .close {
   background: var(--theme-selection-background);
   border-radius: 2px;
 }
 
+.close-btn-big:hover .close path,
 .close-btn:hover .close path {
   fill: white;
 }
@@ -42,7 +44,7 @@
   display: inline-block;
   padding: 2px;
   text-align: center;
-  transition: all 0.25s easeinout;
+  transition: all 0.25s ease-in-out;
   line-height: 100%;
   width: 16px;
   height: 16px;


### PR DESCRIPTION
### Summary of Changes

* `close-btn-big` is used in file search and conditional breakpoint panel.
* Fix another typo in `transition-timing-function` property value

### Screenshots/Videos (OPTIONAL)
|File search|
|--------------|
|![no-hover-file-search](https://cloud.githubusercontent.com/assets/1755089/23908241/7221fa0e-08f9-11e7-9c81-c98f18ab80eb.png)|
|![hover-file-search](https://cloud.githubusercontent.com/assets/1755089/23908246/73a2a6bc-08f9-11e7-8dc6-fc6c0ddd4665.png)|
