### PR TITLE
remove flash of 'not avaliable'

### DIFF
--- a/src/components/SecondaryPanes/Expressions.js
+++ b/src/components/SecondaryPanes/Expressions.js
@@ -121,9 +121,14 @@ const Expressions = React.createClass({
   renderExpression(expression) {
     const { loadObjectProperties, loadedObjects } = this.props;
     const { editing } = this.state;
-    const { input } = expression;
+    const { input, updating } = expression;
+
     if (editing == input) {
       return this.renderExpressionEditInput(expression);
+    }
+
+    if (updating) {
+      return;
     }
 
     const { value, path } = getValue(expression);


### PR DESCRIPTION
Associated Issue: #2347

### Summary of Changes

* Use the updating state passed in from the reducer

### Test Plan

- [x] Add an expression
- [x] Notice the 'not avaliable' does not flash before value shows

