### PR TITLE
Show message when there are no sources for a page (no files to debug)

### DIFF
--- a/assets/panel/debugger.properties
+++ b/assets/panel/debugger.properties
@@ -124,6 +124,10 @@ blackBoxCheckboxTooltip=Toggle black boxing
 # searching all the source files the debugger has seen.
 sources.search.key=P
 
+# LOCALIZATION NOTE (sources.noSourcesAvailable): Text shown when the debugger
+# does not have any sources.
+sources.noSourcesAvailable
+
 # LOCALIZATION NOTE (sources.searchAlt.key): Alternate key shortcut to open
 # the search for searching all the source files the debugger has seen.
 sources.searchAlt.key=O

--- a/src/components/Sources.css
+++ b/src/components/Sources.css
@@ -54,3 +54,11 @@
 .theme-dark .source-list .tree .node.focused {
   background-color: var(--theme-tab-toolbar-background);
 }
+
+.no-sources-message {
+  font-size: 12px;
+  color: var(--theme-comment-alt);
+  font-weight: lighter;
+  padding-top: 5px;
+  text-align: center;
+}

--- a/src/components/SourcesTree.js
+++ b/src/components/SourcesTree.js
@@ -240,7 +240,7 @@ class SourcesTree extends Component {
 
     const noSourcesMessage = dom.div({
       className: "no-sources-message"
-    }, "This page has no sources.");
+    }, L10N.getStr("sources.noSourcesAvailable"));
 
     if (isEmpty) {
       return noSourcesMessage;

--- a/src/components/SourcesTree.js
+++ b/src/components/SourcesTree.js
@@ -239,12 +239,12 @@ class SourcesTree extends Component {
     });
 
     const noSourcesMessage = dom.div({
-        className: "no-sources-message"
-      }, 'This page has no sources.');
+      className: "no-sources-message"
+    }, "This page has no sources.");
 
     if (isEmpty) {
       return noSourcesMessage;
-    } else {
+    }
     return dom.div({
       className: "sources-list",
       onKeyDown: e => {
@@ -253,7 +253,6 @@ class SourcesTree extends Component {
         }
       }
     }, tree);
-    }
   }
 }
 

--- a/src/components/SourcesTree.js
+++ b/src/components/SourcesTree.js
@@ -238,6 +238,13 @@ class SourcesTree extends Component {
       renderItem: this.renderItem
     });
 
+    const noSourcesMessage = dom.div({
+        className: "no-sources-message"
+      }, 'This page has no sources.');
+
+    if (isEmpty) {
+      return noSourcesMessage;
+    } else {
     return dom.div({
       className: "sources-list",
       onKeyDown: e => {
@@ -246,6 +253,7 @@ class SourcesTree extends Component {
         }
       }
     }, tree);
+    }
   }
 }
 

--- a/src/strings.json
+++ b/src/strings.json
@@ -31,6 +31,7 @@
   "sources.search": "%S to search",
   "sources.search.key": "P",
   "sources.searchAlt.key": "O",
+  "sources.noSourcesAvailable": "This page has no sources",
   "watchExpressions.header": "Watch Expressions",
   "watchExpressions.refreshButton": "Refresh",
   "welcome.search": "%S to search for sources",


### PR DESCRIPTION
Associated Issues: #2371 #2231 

### Summary of Changes
When a page doesn't have sources, show an indicative message "This page has no sources". Right now nothing is shown.

### Test Plan
- Go to https://devtools-html.github.io/debugger-examples/
- Attach debugger to that tab
- Check if there is a message "This page has no sources."
- Go to a page with sources
- Check that the tree loads normally

### Screenshots/Videos (OPTIONAL)

![debugger-html-no-sources-message](https://cloud.githubusercontent.com/assets/15914729/23967777/eb9ea48e-09c8-11e7-8c38-0ac8e2a0e66a.png)

