### PR TITLE
Css fixes

### DIFF
--- a/src/components/SecondaryPanes/Expressions.css
+++ b/src/components/SecondaryPanes/Expressions.css
@@ -9,12 +9,6 @@
   color: var(--theme-body-color);
 }
 
-.input-expression::-webkit-input-placeholder {
-  text-align: center;
-  font-style: italic;
-  color: var(--theme-comment-alt);
-}
-
 .input-expression::placeholder {
   text-align: center;
   font-style: italic;

--- a/src/components/shared/Accordion.css
+++ b/src/components/shared/Accordion.css
@@ -59,7 +59,3 @@
   width: 16px;
   height: 16px;
 }
-
-.accordion .header-buttons button::-moz-focus-inner {
-  border: none;
-}

--- a/src/components/shared/SearchInput.css
+++ b/src/components/shared/SearchInput.css
@@ -62,10 +62,6 @@
   stroke: var(--theme-splitter-color);
 }
 
-.search-field ::-webkit-input-placeholder {
-  color: var(--theme-body-color-inactive);
-}
-
 .search-field input::placeholder {
   color: var(--theme-body-color-inactive);
 }


### PR DESCRIPTION
Remove vendor prefixes: #<2372>

### Summary of Changes

* Removed vendor specific prefixes in css files- for example webkit
* Add new line to file Accordion.css.(missed by accident during the commit)

### Test Plan

Sanity test:
Checked that UI is loading successfully on the Todo examples.

Example test plan:

- [x] Command-P opens the panel
- [x] Clicking “+” opens the panel
- [x] Clicking a source navigates to the source
- [x] Clicking "x" closes the panel

Here's the Debugger's Testing doc
https://docs.google.com/document/d/1oBMRxV8A2ag2t22YsQOxTdEv0mXKzIg0tggJjRkU1S0/edit#.
Feel free to improve it!

### Screenshots/Videos (OPTIONAL)
