### PR TITLE
Convert SecondaryPanes to ES6 classes

### DIFF
--- a/src/components/SecondaryPanes/Breakpoints.js
+++ b/src/components/SecondaryPanes/Breakpoints.js
@@ -1,5 +1,5 @@
 // @flow
-import { DOM as dom, PropTypes, createClass } from "react";
+import { DOM as dom, PropTypes, Component } from "react";
 import { connect } from "react-redux";
 import { bindActionCreators } from "redux";
 import ImPropTypes from "react-immutable-proptypes";
@@ -44,21 +44,12 @@ function renderSourceLocation(source, line) {
     ) : null;
 }
 
-const Breakpoints = createClass({
-  propTypes: {
-    breakpoints: ImPropTypes.map.isRequired,
-    enableBreakpoint: PropTypes.func.isRequired,
-    disableBreakpoint: PropTypes.func.isRequired,
-    selectSource: PropTypes.func.isRequired,
-    removeBreakpoint: PropTypes.func.isRequired
-  },
-
-  displayName: "Breakpoints",
+class Breakpoints extends Component {
 
   shouldComponentUpdate(nextProps, nextState) {
     const { breakpoints } = this.props;
     return breakpoints !== nextProps.breakpoints;
-  },
+  }
 
   handleCheckbox(breakpoint) {
     if (breakpoint.loading) {
@@ -70,18 +61,18 @@ const Breakpoints = createClass({
     } else {
       this.props.disableBreakpoint(breakpoint.location);
     }
-  },
+  }
 
   selectBreakpoint(breakpoint) {
     const sourceId = breakpoint.location.sourceId;
     const line = breakpoint.location.line;
     this.props.selectSource(sourceId, { line });
-  },
+  }
 
   removeBreakpoint(event, breakpoint) {
     event.stopPropagation();
     this.props.removeBreakpoint(breakpoint.location);
-  },
+  }
 
   renderBreakpoint(breakpoint) {
     const snippet = breakpoint.text || "";
@@ -120,7 +111,7 @@ const Breakpoints = createClass({
         handleClick: (ev) => this.removeBreakpoint(ev, breakpoint),
         tooltip: L10N.getStr("breakpoints.removeBreakpointTooltip")
       }));
-  },
+  }
 
   render() {
     const { breakpoints } = this.props;
@@ -133,7 +124,17 @@ const Breakpoints = createClass({
        }))
     );
   }
-});
+}
+
+Breakpoints.displayName = "Breakpoints";
+
+Breakpoints.propTypes = {
+  breakpoints: ImPropTypes.map.isRequired,
+  enableBreakpoint: PropTypes.func.isRequired,
+  disableBreakpoint: PropTypes.func.isRequired,
+  selectSource: PropTypes.func.isRequired,
+  removeBreakpoint: PropTypes.func.isRequired
+};
 
 function updateLocation(state, bp): LocalBreakpoint {
   const source = getSource(state, bp.location.sourceId);

--- a/src/components/SecondaryPanes/ChromeScopes.js
+++ b/src/components/SecondaryPanes/ChromeScopes.js
@@ -40,6 +40,9 @@ function createNode(name, path, contents) {
 
 class Scopes extends Component {
   objectCache: Object
+  getChildren: Function
+  onExpand: Function
+  renderItem: Function
 
   constructor(...args) {
     super(...args);
@@ -48,7 +51,6 @@ class Scopes extends Component {
     // this out ever, since we don't ever "switch out" the object
     // being inspected.
     this.objectCache = {};
-    this.state = {};
 
     this.getChildren = this.getChildren.bind(this);
     this.onExpand = this.onExpand.bind(this);

--- a/src/components/SecondaryPanes/ChromeScopes.js
+++ b/src/components/SecondaryPanes/ChromeScopes.js
@@ -1,6 +1,6 @@
 // @flow
 import {
-  DOM as dom, PropTypes, createClass, createFactory
+  DOM as dom, PropTypes, Component, createFactory
 } from "react";
 import ImPropTypes from "react-immutable-proptypes";
 import { bindActionCreators } from "redux";
@@ -38,23 +38,22 @@ function createNode(name, path, contents) {
   return { name, path, contents };
 }
 
-const Scopes = createClass({
-  propTypes: {
-    scopes: PropTypes.array,
-    loadedObjects: ImPropTypes.map,
-    loadObjectProperties: PropTypes.func,
-    pauseInfo: PropTypes.object
-  },
+class Scopes extends Component {
+  objectCache: Object
 
-  displayName: "Scopes",
+  constructor(...args) {
+    super(...args);
 
-  getInitialState() {
     // Cache of dynamically built nodes. We shouldn't need to clear
     // this out ever, since we don't ever "switch out" the object
     // being inspected.
     this.objectCache = {};
-    return {};
-  },
+    this.state = {};
+
+    this.getChildren = this.getChildren.bind(this);
+    this.onExpand = this.onExpand.bind(this);
+    this.renderItem = this.renderItem.bind(this);
+  }
 
   makeNodesForProperties(objProps, parentPath) {
     const { ownProperties, prototype } = objProps;
@@ -77,7 +76,7 @@ const Scopes = createClass({
     }
 
     return nodes;
-  },
+  }
 
   renderItem(item, depth, focused, _, expanded, { setExpanded }) {
     const notEnumberable = false;
@@ -108,11 +107,11 @@ const Scopes = createClass({
                objectValue ? ": " : ""),
       dom.span({ className: "object-value" }, objectValue || "")
     );
-  },
+  }
 
   getObjectProperties(item) {
     this.props.loadedObjects.get(item.contents.value.objectId);
-  },
+  }
 
   getChildren(item) {
     const obj = item.contents;
@@ -144,7 +143,7 @@ const Scopes = createClass({
       return [];
     }
     return [];
-  },
+  }
 
   onExpand(item) {
     const { loadObjectProperties } = this.props;
@@ -152,7 +151,7 @@ const Scopes = createClass({
     if (nodeHasProperties(item)) {
       loadObjectProperties(item.contents.value);
     }
-  },
+  }
 
   getRoots() {
     return this.props.scopes.map(scope => {
@@ -165,7 +164,7 @@ const Scopes = createClass({
         contents: { value: scope.object }
       };
     });
-  },
+  }
 
   render() {
     const { pauseInfo } = this.props;
@@ -196,7 +195,16 @@ const Scopes = createClass({
       })
   );
   }
-});
+}
+
+Scopes.propTypes = {
+  scopes: PropTypes.array,
+  loadedObjects: ImPropTypes.map,
+  loadObjectProperties: PropTypes.func,
+  pauseInfo: PropTypes.object
+};
+
+Scopes.displayName = "Scopes";
 
 export default connect(
   state => ({

--- a/src/components/SecondaryPanes/CommandBar.js
+++ b/src/components/SecondaryPanes/CommandBar.js
@@ -1,6 +1,6 @@
 // @flow
 import {
-  DOM as dom, PropTypes, createClass
+  DOM as dom, PropTypes, Component
 } from "react";
 
 const { findDOMNode } = require("react-dom");
@@ -96,35 +96,14 @@ function debugBtn(onClick, type, className, tooltip, disabled = false) {
   );
 }
 
-const CommandBar = createClass({
-  propTypes: {
-    sources: PropTypes.object,
-    selectedSource: PropTypes.object,
-    resume: PropTypes.func,
-    stepIn: PropTypes.func,
-    stepOut: PropTypes.func,
-    stepOver: PropTypes.func,
-    breakOnNext: PropTypes.func,
-    pause: ImPropTypes.map,
-    pauseOnExceptions: PropTypes.func,
-    shouldPauseOnExceptions: PropTypes.bool,
-    shouldIgnoreCaughtExceptions: PropTypes.bool,
-    isWaitingOnBreak: PropTypes.bool,
-  },
-
-  contextTypes: {
-    shortcuts: PropTypes.object
-  },
-
-  displayName: "CommandBar",
-
+class CommandBar extends Component {
   componentWillUnmount() {
     const shortcuts = this.context.shortcuts;
     COMMANDS.forEach((action) => shortcuts.off(getKey(action)));
     if (isMacOS) {
       COMMANDS.forEach((action) => shortcuts.off(getKeyForOS("WINNT", action)));
     }
-  },
+  }
 
   componentDidMount() {
     const shortcuts = this.context.shortcuts;
@@ -142,7 +121,7 @@ const CommandBar = createClass({
         (_, e) => this.handleEvent(e, action)
       ));
     }
-  },
+  }
 
   handleEvent(e, action) {
     e.preventDefault();
@@ -151,7 +130,7 @@ const CommandBar = createClass({
     this.props[action]();
     const button = findDOMNode(this).querySelector(`.${action}`);
     handlePressAnimation(button);
-  },
+  }
 
   renderStepButtons() {
     const isPaused = this.props.pause;
@@ -181,7 +160,7 @@ const CommandBar = createClass({
         isDisabled
       )
     ];
-  },
+  }
 
   renderPauseButton() {
     const { pause, breakOnNext, isWaitingOnBreak } = this.props;
@@ -211,7 +190,7 @@ const CommandBar = createClass({
       "active",
       L10N.getFormatStr("pauseButtonTooltip", formatKey("pause"))
     );
-  },
+  }
 
   /*
    * The pause on exception button has three states in this order:
@@ -247,7 +226,7 @@ const CommandBar = createClass({
       "all enabled",
       L10N.getStr("pauseOnExceptions")
     );
-  },
+  }
 
   render() {
     return (
@@ -259,7 +238,28 @@ const CommandBar = createClass({
       )
     );
   }
-});
+}
+
+CommandBar.propTypes = {
+  sources: PropTypes.object,
+  selectedSource: PropTypes.object,
+  resume: PropTypes.func,
+  stepIn: PropTypes.func,
+  stepOut: PropTypes.func,
+  stepOver: PropTypes.func,
+  breakOnNext: PropTypes.func,
+  pause: ImPropTypes.map,
+  pauseOnExceptions: PropTypes.func,
+  shouldPauseOnExceptions: PropTypes.bool,
+  shouldIgnoreCaughtExceptions: PropTypes.bool,
+  isWaitingOnBreak: PropTypes.bool,
+};
+
+CommandBar.contextTypes = {
+  shortcuts: PropTypes.object
+};
+
+CommandBar.displayName = "CommandBar";
 
 export default connect(
   state => {

--- a/src/components/SecondaryPanes/EventListeners.js
+++ b/src/components/SecondaryPanes/EventListeners.js
@@ -10,6 +10,8 @@ import "./EventListeners.css";
 
 class EventListeners extends Component {
 
+  renderListener: Function
+
   constructor(...args) {
     super(...args);
 

--- a/src/components/SecondaryPanes/EventListeners.js
+++ b/src/components/SecondaryPanes/EventListeners.js
@@ -1,6 +1,6 @@
 // @flow
 import React from "react";
-const { DOM: dom, PropTypes } = React;
+const { DOM: dom, PropTypes, Component } = React;
 import { bindActionCreators } from "redux";
 import { connect } from "react-redux";
 import actions from "../../actions";
@@ -8,17 +8,13 @@ import { getEventListeners, getBreakpoint } from "../../selectors";
 import CloseButton from "../shared/Button/Close";
 import "./EventListeners.css";
 
-const EventListeners = React.createClass({
-  propTypes: {
-    listeners: PropTypes.array.isRequired,
-    selectSource: PropTypes.func.isRequired,
-    addBreakpoint: PropTypes.func.isRequired,
-    enableBreakpoint: PropTypes.func.isRequired,
-    disableBreakpoint: PropTypes.func.isRequired,
-    removeBreakpoint: PropTypes.func.isRequired
-  },
+class EventListeners extends Component {
 
-  displayName: "EventListeners",
+  constructor(...args) {
+    super(...args);
+
+    this.renderListener = this.renderListener.bind(this);
+  }
 
   renderListener({ type, selector, line, sourceId, breakpoint }) {
     const checked = breakpoint && !breakpoint.disabled;
@@ -42,7 +38,7 @@ const EventListeners = React.createClass({
         handleClick: (ev) => this.removeBreakpoint(ev, breakpoint)
       }) : ""
     );
-  },
+  }
 
   handleCheckbox(breakpoint, location) {
     if (!breakpoint) {
@@ -58,12 +54,12 @@ const EventListeners = React.createClass({
     } else {
       this.props.disableBreakpoint(breakpoint.location);
     }
-  },
+  }
 
   removeBreakpoint(event, breakpoint) {
     event.stopPropagation();
     this.props.removeBreakpoint(breakpoint.location);
-  },
+  }
 
   render() {
     const { listeners } = this.props;
@@ -73,7 +69,18 @@ const EventListeners = React.createClass({
       listeners.map(this.renderListener)
     );
   }
-});
+}
+
+EventListeners.propTypes = {
+  listeners: PropTypes.array.isRequired,
+  selectSource: PropTypes.func.isRequired,
+  addBreakpoint: PropTypes.func.isRequired,
+  enableBreakpoint: PropTypes.func.isRequired,
+  disableBreakpoint: PropTypes.func.isRequired,
+  removeBreakpoint: PropTypes.func.isRequired
+};
+
+EventListeners.displayName = "EventListeners";
 
 export default connect(
   state => {

--- a/src/components/SecondaryPanes/Expressions.js
+++ b/src/components/SecondaryPanes/Expressions.js
@@ -42,6 +42,12 @@ function getValue(expression) {
 class Expressions extends React.Component {
   _input: (null|any)
 
+  state: {
+    editing: (null|Node)
+  }
+
+  renderExpression: Function
+
   constructor(...args) {
     super(...args);
 

--- a/src/components/SecondaryPanes/Expressions.js
+++ b/src/components/SecondaryPanes/Expressions.js
@@ -39,25 +39,18 @@ function getValue(expression) {
   };
 }
 
-const Expressions = React.createClass({
-  propTypes: {
-    expressions: ImPropTypes.list.isRequired,
-    addExpression: PropTypes.func.isRequired,
-    updateExpression: PropTypes.func.isRequired,
-    deleteExpression: PropTypes.func.isRequired,
-    loadObjectProperties: PropTypes.func,
-    loadedObjects: ImPropTypes.map.isRequired
-  },
+class Expressions extends React.Component {
+  _input: (null|any)
 
-  _input: (null: any),
+  constructor(...args) {
+    super(...args);
 
-  displayName: "Expressions",
-
-  getInitialState() {
-    return {
+    this.state = {
       editing: null
     };
-  },
+
+    this.renderExpression = this.renderExpression.bind(this);
+  }
 
   shouldComponentUpdate(nextProps, nextState) {
     const { editing } = this.state;
@@ -65,7 +58,7 @@ const Expressions = React.createClass({
     return expressions !== nextProps.expressions
       || loadedObjects !== nextProps.loadedObjects
       || editing !== nextState.editing;
-  },
+  }
 
   editExpression(expression, { depth }) {
     if (depth > 0) {
@@ -73,13 +66,13 @@ const Expressions = React.createClass({
     }
 
     this.setState({ editing: expression.input });
-  },
+  }
 
   deleteExpression(e, expression) {
     e.stopPropagation();
     const { deleteExpression } = this.props;
     deleteExpression(expression);
-  },
+  }
 
   inputKeyPress(e, expression) {
     if (e.key !== "Enter") {
@@ -97,7 +90,7 @@ const Expressions = React.createClass({
       value,
       expression
     );
-  },
+  }
 
   renderExpressionEditInput(expression) {
     return dom.span(
@@ -116,7 +109,7 @@ const Expressions = React.createClass({
         }
       )
     );
-  },
+  }
 
   renderExpression(expression) {
     const { loadObjectProperties, loadedObjects } = this.props;
@@ -151,13 +144,13 @@ const Expressions = React.createClass({
       }),
       CloseButton({ handleClick: e => this.deleteExpression(e, expression) }),
     );
-  },
+  }
 
   componentDidUpdate() {
     if (this._input) {
       this._input.focus();
     }
-  },
+  }
 
   renderNewExpressionInput() {
     const onKeyPress = e => {
@@ -184,7 +177,7 @@ const Expressions = React.createClass({
          onKeyPress
        })
     );
-  },
+  }
 
   render() {
     const { expressions } = this.props;
@@ -194,7 +187,18 @@ const Expressions = React.createClass({
       this.renderNewExpressionInput()
     );
   }
-});
+}
+
+Expressions.propTypes = {
+  expressions: ImPropTypes.list.isRequired,
+  addExpression: PropTypes.func.isRequired,
+  updateExpression: PropTypes.func.isRequired,
+  deleteExpression: PropTypes.func.isRequired,
+  loadObjectProperties: PropTypes.func,
+  loadedObjects: ImPropTypes.map.isRequired
+};
+
+Expressions.displayName = "Expressions";
 
 export default connect(
   state => ({

--- a/src/components/SecondaryPanes/Frames.js
+++ b/src/components/SecondaryPanes/Frames.js
@@ -40,6 +40,13 @@ function renderFrameLocation({ source, location }: Frame) {
 
 class Frames extends Component {
 
+  state: {
+    showAllFrames: boolean
+  }
+
+  renderFrame: Function
+  toggleFramesDisplay: Function
+
   constructor(...args) {
     super(...args);
 

--- a/src/components/SecondaryPanes/Frames.js
+++ b/src/components/SecondaryPanes/Frames.js
@@ -1,7 +1,7 @@
 // @flow
 
 import {
-  DOM as dom, PropTypes, createClass
+  DOM as dom, PropTypes, Component
 } from "react";
 import { bindActionCreators } from "redux";
 import { connect } from "react-redux";
@@ -38,14 +38,18 @@ function renderFrameLocation({ source, location }: Frame) {
   );
 }
 
-const Frames = createClass({
-  propTypes: {
-    frames: PropTypes.array,
-    selectedFrame: PropTypes.object,
-    selectFrame: PropTypes.func.isRequired
-  },
+class Frames extends Component {
 
-  displayName: "Frames",
+  constructor(...args) {
+    super(...args);
+
+    this.state = {
+      showAllFrames: false
+    };
+
+    this.renderFrame = this.renderFrame.bind(this);
+    this.toggleFramesDisplay = this.toggleFramesDisplay.bind(this);
+  }
 
   shouldComponentUpdate(nextProps, nextState) {
     const { frames, selectedFrame } = this.props;
@@ -53,17 +57,13 @@ const Frames = createClass({
     return frames !== nextProps.frames
       || selectedFrame !== nextProps.selectedFrame
       || showAllFrames !== nextState.showAllFrames;
-  },
-
-  getInitialState() {
-    return { showAllFrames: false };
-  },
+  }
 
   toggleFramesDisplay() {
     this.setState({
       showAllFrames: !this.state.showAllFrames
     });
-  },
+  }
 
   onContextMenu(event: SyntheticKeyboardEvent, frame: Frame) {
     const copySourceUrlLabel = L10N.getStr("copySourceUrl");
@@ -88,7 +88,7 @@ const Frames = createClass({
     }
 
     showMenu(event, menuOptions);
-  },
+  }
 
   renderFrame(frame: Frame) {
     const { selectedFrame } = this.props;
@@ -106,21 +106,21 @@ const Frames = createClass({
       renderFrameTitle(frame),
       renderFrameLocation(frame)
     );
-  },
+  }
 
   onMouseDown(e: SyntheticKeyboardEvent, frame: Frame, selectedFrame: Frame) {
     if (e.nativeEvent.which == 3 && selectedFrame.id != frame.id) {
       return;
     }
     this.props.selectFrame(frame);
-  },
+  }
 
   onKeyUp(event: SyntheticKeyboardEvent, frame: Frame, selectedFrame: Frame) {
     if (event.key != "Enter" || selectedFrame.id == frame.id) {
       return;
     }
     this.props.selectFrame(frame);
-  },
+  }
 
   renderFrames(frames: Frame[]) {
     const numFramesToShow =
@@ -128,7 +128,7 @@ const Frames = createClass({
     const framesToShow = frames.slice(0, numFramesToShow);
 
     return dom.ul({}, framesToShow.map(this.renderFrame));
-  },
+  }
 
   renderToggleButton(frames: Frame[]) {
     let buttonMessage = this.state.showAllFrames
@@ -142,7 +142,7 @@ const Frames = createClass({
       { className: "show-more", onClick: this.toggleFramesDisplay },
       buttonMessage
     );
-  },
+  }
 
   render() {
     const { frames } = this.props;
@@ -163,7 +163,15 @@ const Frames = createClass({
       this.renderToggleButton(frames)
     );
   }
-});
+}
+
+Frames.propTypes = {
+  frames: PropTypes.array,
+  selectedFrame: PropTypes.object,
+  selectFrame: PropTypes.func.isRequired
+};
+
+Frames.displayName = "Frames";
 
 function getSourceForFrame(state, frame) {
   return getSource(state, frame.location.sourceId);

--- a/src/components/SecondaryPanes/Scopes.js
+++ b/src/components/SecondaryPanes/Scopes.js
@@ -1,6 +1,6 @@
 // @flow
 import {
-  DOM as dom, PropTypes, createClass, createFactory
+  DOM as dom, PropTypes, Component, createFactory
 } from "react";
 import { bindActionCreators } from "redux";
 import { connect } from "react-redux";
@@ -18,27 +18,24 @@ function info(text) {
 let expandedCache = new Set();
 let actorsCache = [];
 
-const Scopes = createClass({
-  propTypes: {
-    pauseInfo: ImPropTypes.map,
-    loadedObjects: ImPropTypes.map,
-    loadObjectProperties: PropTypes.func,
-    selectedFrame: PropTypes.object
-  },
+class Scopes extends Component {
 
-  displayName: "Scopes",
+  constructor(props, ...args) {
+    const { pauseInfo, selectedFrame } = props;
+
+    super(props, ...args);
+
+    this.state = {
+      scopes: getScopes(pauseInfo, selectedFrame)
+    };
+  }
 
   shouldComponentUpdate(nextProps, nextState) {
     const { pauseInfo, selectedFrame, loadedObjects } = this.props;
     return pauseInfo !== nextProps.pauseInfo
       || selectedFrame !== nextProps.selectedFrame
       || loadedObjects !== nextProps.loadedObjects;
-  },
-
-  getInitialState() {
-    const { pauseInfo, selectedFrame } = this.props;
-    return { scopes: getScopes(pauseInfo, selectedFrame) };
-  },
+  }
 
   componentWillReceiveProps(nextProps) {
     const { pauseInfo, selectedFrame } = this.props;
@@ -50,7 +47,7 @@ const Scopes = createClass({
         scopes: getScopes(nextProps.pauseInfo, nextProps.selectedFrame)
       });
     }
-  },
+  }
 
   render() {
     const { pauseInfo, loadObjectProperties, loadedObjects } = this.props;
@@ -83,7 +80,16 @@ const Scopes = createClass({
         : info(L10N.getStr("scopes.notPaused"))
     );
   }
-});
+}
+
+Scopes.propTypes = {
+  pauseInfo: ImPropTypes.map,
+  loadedObjects: ImPropTypes.map,
+  loadObjectProperties: PropTypes.func,
+  selectedFrame: PropTypes.object
+};
+
+Scopes.displayName = "Scopes";
 
 export default connect(
   state => ({

--- a/src/components/SecondaryPanes/Scopes.js
+++ b/src/components/SecondaryPanes/Scopes.js
@@ -20,6 +20,10 @@ let actorsCache = [];
 
 class Scopes extends Component {
 
+  state: {
+    scopes: any
+  }
+
   constructor(props, ...args) {
     const { pauseInfo, selectedFrame } = props;
 

--- a/src/components/SecondaryPanes/index.js
+++ b/src/components/SecondaryPanes/index.js
@@ -1,5 +1,5 @@
 // @flow
-import { DOM as dom, PropTypes, createClass, createFactory } from "react";
+import { DOM as dom, PropTypes, Component, createFactory } from "react";
 import { connect } from "react-redux";
 import { bindActionCreators } from "redux";
 import ImPropTypes from "react-immutable-proptypes";
@@ -48,22 +48,7 @@ function debugBtn(onClick, type, className, tooltip) {
   );
 }
 
-const SecondaryPanes = createClass({
-  propTypes: {
-    evaluateExpressions: PropTypes.func.isRequired,
-    pauseData: ImPropTypes.map,
-    horizontal: PropTypes.bool,
-    breakpoints: ImPropTypes.map.isRequired,
-    breakpointsDisabled: PropTypes.bool,
-    breakpointsLoading: PropTypes.bool,
-    toggleAllBreakpoints: PropTypes.func.isRequired
-  },
-
-  contextTypes: {
-    shortcuts: PropTypes.object
-  },
-
-  displayName: "SecondaryPanes",
+class SecondaryPanes extends Component {
 
   renderBreakpointsToggle() {
     const { toggleAllBreakpoints, breakpoints,
@@ -92,7 +77,7 @@ const SecondaryPanes = createClass({
       title: breakpointsDisabled ? L10N.getStr("breakpoints.enable") :
         L10N.getStr("breakpoints.disable")
     });
-  },
+  }
 
   watchExpressionHeaderButtons() {
     return [
@@ -106,7 +91,7 @@ const SecondaryPanes = createClass({
         L10N.getStr("watchExpressions.refreshButton")
       )
     ];
-  },
+  }
 
   getScopeItem() {
     const isPaused = () => !!this.props.pauseData;
@@ -120,7 +105,7 @@ const SecondaryPanes = createClass({
       },
       shouldOpen: isPaused
     };
-  },
+  }
 
   getWatchItem() {
     return { header: L10N.getStr("watchExpressions.header"),
@@ -128,7 +113,7 @@ const SecondaryPanes = createClass({
       component: Expressions,
       opened: true
     };
-  },
+  }
 
   getStartItems() {
     const scopesContent: any = this.props.horizontal ?
@@ -162,13 +147,13 @@ const SecondaryPanes = createClass({
     }
 
     return items.filter(item => item);
-  },
+  }
 
   renderHorizontalLayout() {
     return Accordion({
       items: this.getItems()
     });
-  },
+  }
 
   getEndItems() {
     const items: Array<SecondaryPanesItems> = [];
@@ -182,11 +167,11 @@ const SecondaryPanes = createClass({
     }
 
     return items;
-  },
+  }
 
   getItems() {
     return [...this.getStartItems(), ...this.getEndItems()];
-  },
+  }
 
   renderVerticalLayout() {
     return SplitBox({
@@ -198,7 +183,7 @@ const SecondaryPanes = createClass({
       startPanel: Accordion({ items: this.getStartItems() }),
       endPanel: Accordion({ items: this.getEndItems() })
     });
-  },
+  }
 
   render() {
     return dom.div(
@@ -210,7 +195,23 @@ const SecondaryPanes = createClass({
         this.renderHorizontalLayout() : this.renderVerticalLayout()
     );
   }
-});
+}
+
+SecondaryPanes.propTypes = {
+  evaluateExpressions: PropTypes.func.isRequired,
+  pauseData: ImPropTypes.map,
+  horizontal: PropTypes.bool,
+  breakpoints: ImPropTypes.map.isRequired,
+  breakpointsDisabled: PropTypes.bool,
+  breakpointsLoading: PropTypes.bool,
+  toggleAllBreakpoints: PropTypes.func.isRequired
+};
+
+SecondaryPanes.contextTypes = {
+  shortcuts: PropTypes.object
+};
+
+SecondaryPanes.displayName = "SecondaryPanes";
 
 export default connect(
   state => ({


### PR DESCRIPTION
Associated Issue: #1890

### Summary of Changes

* Updated the following components to use ES6 classes
  * BreakPoints
  * ChromeScopes
  * CommandBar
  * EventListeners
  * Expressions
  * Frames
  * Scopes
  * SecondaryPanels (index.js)

I haven't used Flow outside of this project so I made some assumptions on how to handle the errors that I saw (e.g. defining state and instance functions that are bound in the constructor).
