### PR TITLE
Tweak close-btn styles

### DIFF
--- a/src/components/Editor/Tabs.css
+++ b/src/components/Editor/Tabs.css
@@ -99,10 +99,3 @@
 .source-tab:hover .close-btn {
   visibility: visible;
 }
-
-.source-tab .close-btn .close {
-  padding: 0;
-  margin-top: 0;
-  display: inline-flex;
-  justify-content: center;
-}

--- a/src/components/SecondaryPanes/Breakpoints.css
+++ b/src/components/SecondaryPanes/Breakpoints.css
@@ -90,9 +90,9 @@ html .breakpoints-list .breakpoint.paused {
 }
 
 .breakpoint .close {
-  display: none;
+  visibility: hidden;
 }
 
 .breakpoint:hover .close {
-  display: block;
+  visibility: visible;
 }

--- a/src/components/shared/Button/Close.css
+++ b/src/components/shared/Button/Close.css
@@ -6,13 +6,13 @@
   cursor: pointer;
   width: 14px;
   height: 14px;
-  padding: 2px;
-  text-align: center;
-  margin-top: 2px;
-  line-height: 7px;
   transition: all 0.25s ease-in-out;
   border: 1px solid transparent;
   border-radius: 2px;
+  padding: 0;
+  margin-top: 0;
+  display: inline-flex;
+  justify-content: center;
 }
 
 .close-btn .close svg {
@@ -23,39 +23,26 @@
   display: block;
 }
 
-.close-btn-big:hover .close,
 .close-btn:hover .close {
   background: var(--theme-selection-background);
 }
 
-.close-btn-big:hover .close path,
 .close-btn:hover .close path {
   fill: white;
 }
 
-.close-btn-big {
+.close-btn.big {
   padding: 11px;
   margin-right: 7px;
   width: 27px;
   height: 40px;
 }
 
-.close-btn-big .close {
-  cursor: pointer;
-  display: inline-block;
-  padding: 2px;
-  text-align: center;
-  transition: all 0.25s ease-in-out;
-  line-height: 100%;
+.close-btn.big .close {
   width: 16px;
   height: 16px;
 }
 
-.close-btn-big .close svg {
+.close-btn.big .close svg {
   width: 9px;
-  height: 9px;
-}
-
-.close-btn-big .close:hover {
-  border-radius: 2px;
 }

--- a/src/components/shared/Button/Close.js
+++ b/src/components/shared/Button/Close.js
@@ -11,7 +11,7 @@ type CloseButtonType = {
 
 function CloseButton({ handleClick, buttonClass, tooltip }: CloseButtonType) {
   return dom.div({
-    className: buttonClass ? `close-btn-${buttonClass}` : "close-btn",
+    className: buttonClass ? `close-btn ${buttonClass}` : "close-btn",
     onClick: handleClick,
     title: tooltip
   },


### PR DESCRIPTION
### Summary of Changes

* Move `close-btn` styles to `Close.css`
* Change `.close-btn-big` to `.close-btn.big` to avoid duplication of CSS
* Use flex box for all close buttons
* Change `display: none` in `Breakpoint.css` to `visibility: hidden` to make it work with flexbox (conflicts with `display: inline-flex`)

### Screenshots/Videos (OPTIONAL)

|Conditional Breakpoint panel|
|-----|
|![big-btn](https://cloud.githubusercontent.com/assets/1755089/24049538/668d6d3a-0b52-11e7-9fd7-f980d0efb887.png)|
|![big-after](https://cloud.githubusercontent.com/assets/1755089/24049548/6c4c0e02-0b52-11e7-82fe-39c2b49d1be8.png)|

