### PR TITLE
accommodate objects without a prototype (fixes #2407)

### DIFF
--- a/src/utils/fromJS.js
+++ b/src/utils/fromJS.js
@@ -16,7 +16,7 @@ const Immutable = require("immutable");
   length confuses Immutable's internal algorithm.
 */
 function createMap(value) {
-  const hasLength = value.hasOwnProperty("length");
+  const hasLength = value.hasOwnProperty && value.hasOwnProperty("length");
   const length = value.length;
 
   if (hasLength) {
@@ -50,7 +50,7 @@ function fromJS(value: any): any {
   if (Array.isArray(value)) {
     return createList(value);
   }
-  if (value && value.constructor.meta) {
+  if (value && value.constructor && value.constructor.meta) {
     // This adds support for tcomb objects which are native JS objects
     // but are not "plain", so the above checks fail. Since they
     // behave the same we can use the same constructors, but we need

--- a/src/utils/tests/fromJS.js
+++ b/src/utils/tests/fromJS.js
@@ -46,4 +46,8 @@ describe("fromJS", () => {
     expect(iItems.getIn([0, "type"])).to.equal("null");
     expect(iItems.size).to.equal(10);
   });
+
+  it("supports objects without a prototype", () => {
+    expect(() => fromJS(Object.create(null))).to.not.throwException();
+  });
 });


### PR DESCRIPTION
Associated Issue: #2407

### Summary of Changes

* ensure *value.constructor* before *dereferencing value.constructor.meta*
* ensure *value.hasOwnProperty* before calling it

### Test Plan

- [x] In qbrt, I set a breakpoint in an application, triggered it, and confirmed that debugger.html broke there.
- [x] In debugger.html, I wrote a unit test, confirmed that it failed without the changes, and then confirmed that it passed with the changes.
