### PR TITLE
Fix close function in ProjectSearch

### DIFF
--- a/src/components/ProjectSearch.js
+++ b/src/components/ProjectSearch.js
@@ -80,8 +80,7 @@ class ProjectSearch extends Component {
   onEscape(shortcut, e) {
     if (this.props.searchOn) {
       e.preventDefault();
-      this.setState({ inputValue: "" });
-      this.props.toggleProjectSearch(false);
+      this.close();
     }
   }
 

--- a/src/components/ProjectSearch.js
+++ b/src/components/ProjectSearch.js
@@ -85,8 +85,8 @@ class ProjectSearch extends Component {
     }
   }
 
-  close(inputValue = "") {
-    this.setState({ inputValue });
+  close() {
+    this.setState({ inputValue: "" });
     this.props.toggleProjectSearch(false);
   }
 


### PR DESCRIPTION
Fixes #2396

This problem was caused because `close` function was passed down to `CloseButton` where it was being called with `SyntheticMouseEvent`. (`inputValue` parameter was object) 

### Summary of Changes

* Remove `inputValue` parameter from close function

### Screenshots/Videos (OPTIONAL)
![project-search](https://cloud.githubusercontent.com/assets/1755089/24071225/f52d8fc0-0bf2-11e7-8bf2-2d875dbe1abd.gif)
