### PR TITLE
Bring editor preview to foreground

### DIFF
--- a/src/components/shared/Popover.css
+++ b/src/components/shared/Popover.css
@@ -1,6 +1,6 @@
 .popover {
   position: fixed;
-  z-index: 4;
+  z-index: 100;
 }
 
 .popover-gap {


### PR DESCRIPTION
Previously masked by conditional breakpoint, right panel

Associated Issue: #2397 

### Screenshots

![2](https://cloud.githubusercontent.com/assets/7821757/24079705/37d70880-0cb4-11e7-9cdf-5a4e686d80ce.jpg)
---------
![1](https://cloud.githubusercontent.com/assets/7821757/24079709/3d9eb22c-0cb4-11e7-8321-38703f5616f0.jpg)
---------
![3](https://cloud.githubusercontent.com/assets/7821757/24079715/50ef3b94-0cb4-11e7-923b-76e379d51bef.jpg)

