### PR TITLE
Re-add accordion focus inner style

### DIFF
--- a/src/components/shared/Accordion.css
+++ b/src/components/shared/Accordion.css
@@ -59,3 +59,7 @@
   width: 16px;
   height: 16px;
 }
+
+accordion .header-buttons button::-moz-focus-inner {        
+  border: none;
+}


### PR DESCRIPTION
In https://github.com/devtools-html/debugger.html/pull/2386 we accidentally removed a style that's not autoprefixed for button focus states

Associated Issue: #2419

