### PR TITLE
Don't push bottom scroll bar off screen when search is opened for files that don't need to be prettyifyed

### DIFF
--- a/src/components/Editor/Editor.css
+++ b/src/components/Editor/Editor.css
@@ -15,6 +15,8 @@
   top: 30px;
   left: 0px;
   --editor-footer-height: 27px;
+  --editor-searchbar-height: 27px;
+  --editor-second-searchbar-height: 27px;
 }
 
 html[dir="rtl"] .editor-mount {
@@ -73,12 +75,7 @@ html[dir="rtl"] .editor-mount {
 
 .editor-wrapper .editor-mount {
   width: 100%;
-  height: calc(100% - var(--editor-footer-height));
   background-color: var(--theme-body-background);
-}
-
-.search-bar ~ .editor-mount {
-  height: calc(100% - 72px);
 }
 
 .CodeMirror-linenumber {

--- a/src/components/Editor/SearchBar.css
+++ b/src/components/Editor/SearchBar.css
@@ -2,11 +2,11 @@
 .search-bar {
   display: flex;
   flex-direction: column;
-  max-height: 50%;
 }
 
 .search-bar .search-field {
   padding-left: 7px;
+  height: var(--editor-searchbar-height);
 }
 
 .search-bar .close-btn {
@@ -23,7 +23,7 @@
   flex-shrink: 0;
   justify-content: space-between;
   width: calc(100% - 1px);
-  height: 27px;
+  height: var(--editor-second-searchbar-height);
   background-color: var(--theme-toolbar-background);
   border-bottom: 1px solid var(--theme-splitter-color);
   padding: 0 13px;


### PR DESCRIPTION
Associated Issue: #2424 

* Fixes Tabs from being masked by the search bar
* Stops the bottom scroll bar being pushed off by search bar
