### PR TITLE
Hiding Expressions

### DIFF
--- a/src/actions/expressions.js
+++ b/src/actions/expressions.js
@@ -21,8 +21,7 @@ function expressionExists(expressions, input) {
  * @memberof actions/pause
  * @static
  */
-
-export function addExpression(input: string, { visible = true } = {}) {
+export function addExpression(input: string, { visible = true }: Object = {}) {
   return ({ dispatch, getState }: ThunkArgs) => {
     const expressions = getExpressions(getState());
     if (!input || expressionExists(expressions, input)) {

--- a/src/actions/expressions.js
+++ b/src/actions/expressions.js
@@ -22,12 +22,12 @@ function expressionExists(expressions, input) {
  * @static
  */
 export function addExpression(input: string, { visible = true }: Object = {}) {
-  return ({ dispatch, getState }: ThunkArgs) => {
+  return async ({ dispatch, getState }: ThunkArgs) => {
     const expressions = getExpressions(getState());
     if (!input || expressionExists(expressions, input)) {
       const expression = getExpression(getState(), input);
       if (!expression.visible && visible) {
-        dispatch(deleteExpression(expression));
+        await dispatch(deleteExpression(expression));
       } else {
         return;
       }

--- a/src/actions/expressions.js
+++ b/src/actions/expressions.js
@@ -22,9 +22,9 @@ function expressionExists(expressions, input) {
  * @memberof actions/pause
  * @static
  */
-export function addExpression(input: string) {
+export function addExpression(input: string, visible: boolean = true) {
   return ({ dispatch, getState }: ThunkArgs) => {
-    const expressions = getExpressions(getState());
+    const expressions = getExpressions(getState(), visible);
     if (!input || expressionExists(expressions, input)) {
       return;
     }
@@ -32,11 +32,12 @@ export function addExpression(input: string) {
     dispatch({
       type: constants.ADD_EXPRESSION,
       input,
+      visible,
     });
 
     const selectedFrame = getSelectedFrame(getState());
     const selectedFrameId = selectedFrame ? selectedFrame.id : null;
-    dispatch(evaluateExpression({ input }, selectedFrameId));
+    dispatch(evaluateExpression({ input, visible }, selectedFrameId));
   };
 }
 
@@ -80,9 +81,9 @@ export function deleteExpression(expression: Expression) {
  * @param {number} selectedFrameId
  * @static
  */
-export function evaluateExpressions(frameId: frameIdType) {
+export function evaluateExpressions(frameId: frameIdType, visible: boolean = true) {
   return async function({ dispatch, getState, client }: ThunkArgs) {
-    const expressions = getExpressions(getState()).toJS();
+    const expressions = getExpressions(getState(), visible).toJS();
     for (let expression of expressions) {
       await dispatch(evaluateExpression(expression, frameId));
     }
@@ -99,6 +100,7 @@ function evaluateExpression(expression, frameId: frameIdType) {
     return dispatch({
       type: constants.EVALUATE_EXPRESSION,
       input: expression.input,
+      visible: expression.visible == undefined ? true : expression.visible,
       [PROMISE]: client.evaluate(expression.input, { frameId }),
     });
   };

--- a/src/actions/expressions.js
+++ b/src/actions/expressions.js
@@ -82,7 +82,8 @@ export function deleteExpression(expression: Expression) {
  */
 export function evaluateExpressions(frameId: frameIdType) {
   return async function({ dispatch, getState, client }: ThunkArgs) {
-    for (let expression of getExpressions(getState())) {
+    const expressions = getExpressions(getState()).toJS();
+    for (let expression of expressions) {
       await dispatch(evaluateExpression(expression, frameId));
     }
   };

--- a/src/actions/types.js
+++ b/src/actions/types.js
@@ -183,6 +183,7 @@ type PauseAction =
       input: string,
       status: string,
       value: Object,
+      visible: boolean,
       "@@dispatch/promise": any,
     }
   | {

--- a/src/actions/types.js
+++ b/src/actions/types.js
@@ -177,6 +177,7 @@ type PauseAction =
       id: number,
       input: string,
       value: string,
+      visible: boolean,
     }
   | {
       type: "EVALUATE_EXPRESSION",
@@ -190,6 +191,7 @@ type PauseAction =
       type: "UPDATE_EXPRESSION",
       expression: Expression,
       input: string,
+      visible: boolean,
     }
   | {
       type: "DELETE_EXPRESSION",

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -321,6 +321,7 @@ const Editor = React.createClass({
 
     const displayedExpression = previewExpression({
       expression: expressionFromToken,
+      selectedFrame,
       variables,
       tokenText: token.textContent,
     });

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -314,7 +314,7 @@ const Editor = React.createClass({
     );
 
     if (expressionFromToken) {
-      addExpression(expressionFromToken.value);
+      addExpression(expressionFromToken.value, false);
     }
 
     const variables = getVisibleVariablesFromScope(pauseData, selectedFrame);
@@ -640,7 +640,7 @@ const Editor = React.createClass({
 
     let value = get(selectedExpression, "contents.value");
     if (!value) {
-      const exp = this.props.getExpression(selectedExpression.value);
+      const exp = this.props.getExpression(selectedExpression.value, false);
       value = get(exp, "value.result");
     }
 

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -314,7 +314,7 @@ const Editor = React.createClass({
     );
 
     if (expressionFromToken) {
-      addExpression(expressionFromToken.value, false);
+      addExpression(expressionFromToken.value, { visible: false });
     }
 
     const variables = getVisibleVariablesFromScope(pauseData, selectedFrame);
@@ -640,7 +640,7 @@ const Editor = React.createClass({
 
     let value = get(selectedExpression, "contents.value");
     if (!value) {
-      const exp = this.props.getExpression(selectedExpression.value, false);
+      const exp = this.props.getExpression(selectedExpression.value);
       value = get(exp, "value.result");
     }
 

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -272,6 +272,12 @@ const Editor = React.createClass({
     }
   },
 
+  onMouseUp(e, ctx) {
+    if (e.metaKey) {
+      this.previewSelectedToken(e, ctx);
+    }
+  },
+
   onScroll(e) {
     return this.setState({ selectedToken: null, selectedExpression: null });
   },

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -188,7 +188,7 @@ const Editor = React.createClass({
     shortcuts.on(`CmdOrCtrl+${searchAgainKey}`, this.onSearchAgain);
 
     updateDocument(this.editor, selectedSource, sourceText);
-    this.previewSelectedToken = debounce(this.previewSelectedToken, 100);
+    (this: any).previewSelectedToken = debounce(this.previewSelectedToken, 100);
   },
 
   componentWillUnmount() {

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -188,7 +188,7 @@ const Editor = React.createClass({
     shortcuts.on(`CmdOrCtrl+${searchAgainKey}`, this.onSearchAgain);
 
     updateDocument(this.editor, selectedSource, sourceText);
-    this.previewSelectedToken = debounce(this.previewSelectedToken, 50);
+    this.previewSelectedToken = debounce(this.previewSelectedToken, 100);
   },
 
   componentWillUnmount() {

--- a/src/components/SecondaryPanes/Expressions.js
+++ b/src/components/SecondaryPanes/Expressions.js
@@ -4,7 +4,11 @@ import { connect } from "react-redux";
 import { bindActionCreators } from "redux";
 import ImPropTypes from "react-immutable-proptypes";
 import actions from "../../actions";
-import { getExpressions, getLoadedObjects, getPause } from "../../selectors";
+import {
+  getVisibleExpressions,
+  getLoadedObjects,
+  getPause,
+} from "../../selectors";
 const CloseButton = React.createFactory(
   require("../shared/Button/Close").default
 );
@@ -223,7 +227,7 @@ Expressions.displayName = "Expressions";
 export default connect(
   state => ({
     pauseInfo: getPause(state),
-    expressions: getExpressions(state, true),
+    expressions: getVisibleExpressions(state),
     loadedObjects: getLoadedObjects(state),
   }),
   dispatch => bindActionCreators(actions, dispatch)

--- a/src/components/SecondaryPanes/Expressions.js
+++ b/src/components/SecondaryPanes/Expressions.js
@@ -223,7 +223,7 @@ Expressions.displayName = "Expressions";
 export default connect(
   state => ({
     pauseInfo: getPause(state),
-    expressions: getExpressions(state),
+    expressions: getExpressions(state, true),
     loadedObjects: getLoadedObjects(state),
   }),
   dispatch => bindActionCreators(actions, dispatch)

--- a/src/reducers/expressions.js
+++ b/src/reducers/expressions.js
@@ -102,3 +102,7 @@ type OuterState = { expressions: Record<ExpressionState> };
 export function getExpressions(state: OuterState) {
   return state.expressions.get("expressions");
 }
+
+export function getExpression(state: OuterState, input: string) {
+  return getExpressions(state).find(exp => exp.input == input);
+}

--- a/src/reducers/expressions.js
+++ b/src/reducers/expressions.js
@@ -9,6 +9,10 @@ import type { Expression } from "../types";
 import type { Action } from "../actions/types";
 import type { Record } from "../utils/makeRecord";
 
+const expressionType = visible => {
+  return visible ? "visible" : "hidden";
+};
+
 type ExpressionState = {
   expressions: List<Expression>,
 };
@@ -25,25 +29,39 @@ export function update(
 ): Record<ExpressionState> {
   switch (action.type) {
     case constants.ADD_EXPRESSION:
-      return appendToList(state, ["expressions"], {
-        input: action.input,
-        value: null,
-        updating: true,
-      });
+      return appendToList(
+        state,
+        ["expressions", expressionType(action.visible)],
+        {
+          input: action.input,
+          value: null,
+          updating: true,
+        },
+      );
     case constants.UPDATE_EXPRESSION:
       const key = action.expression.input;
-      return updateItemInList(state, ["expressions"], key, {
-        input: action.input,
-        value: null,
-        updating: true,
-      });
+      return updateItemInList(
+        state,
+        ["expressions", expressionType(action.visible)],
+        key,
+        {
+          input: action.input,
+          value: null,
+          updating: true,
+        },
+      );
     case constants.EVALUATE_EXPRESSION:
       if (action.status === "done") {
-        return updateItemInList(state, ["expressions"], action.input, {
-          input: action.input,
-          value: action.value,
-          updating: false,
-        });
+        return updateItemInList(
+          state,
+          ["expressions", expressionType(action.visible)],
+          action.input,
+          {
+            input: action.input,
+            value: action.value,
+            updating: false,
+          },
+        );
       }
       break;
     case constants.DELETE_EXPRESSION:
@@ -61,15 +79,17 @@ function restoreExpressions() {
   return exprs;
 }
 
-function storeExpressions(state) {
-  prefs.expressions = state.getIn(["expressions"]).toJS();
+function storeExpressions(state, path) {
+  if (path[1] == "visible") {
+    prefs.expressions = state.getIn(path).toJS();
+  }
 }
 
 function appendToList(state: State, path: string[], value: any) {
   const newState = state.updateIn(path, () => {
     return state.getIn(path).push(value);
   });
-  storeExpressions(newState);
+  storeExpressions(newState, path);
   return newState;
 }
 
@@ -84,25 +104,37 @@ function updateItemInList(
     const index = list.findIndex(e => e.input == key);
     return list.update(index, () => value);
   });
-  storeExpressions(newState);
+  storeExpressions(newState, path);
   return newState;
 }
 
-function deleteExpression(state: State, input: string) {
-  const index = getExpressions({ expressions: state }).findKey(
-    e => e.input == input
+function deleteExpression(
+  state: State,
+  input: string,
+  visible: boolean = true,
+) {
+  const index = getExpressions({ expressions: state }, visible).findKey(
+    e => e.input == input,
   );
-  const newState = state.deleteIn(["expressions", index]);
-  storeExpressions(newState);
+  const newState = state.deleteIn([
+    "expressions",
+    expressionType(visible),
+    index,
+  ]);
+  storeExpressions(newState, ["expressions", expressionType(visible)]);
   return newState;
 }
 
 type OuterState = { expressions: Record<ExpressionState> };
 
-export function getExpressions(state: OuterState) {
-  return state.expressions.get("expressions");
+export function getExpressions(state: OuterState, visible: boolean = true) {
+  return state.expressions.getIn(["expressions", expressionType(visible)]);
 }
 
-export function getExpression(state: OuterState, input: string) {
-  return getExpressions(state).find(exp => exp.input == input);
+export function getExpression(
+  state: OuterState,
+  input: string,
+  visible: boolean = true,
+) {
+  return getExpressions(state, visible).find(exp => exp.input == input);
 }

--- a/src/reducers/expressions.js
+++ b/src/reducers/expressions.js
@@ -9,9 +9,9 @@ import type { Expression } from "../types";
 import type { Action } from "../actions/types";
 import type { Record } from "../utils/makeRecord";
 
-const expressionType = visible => {
+function expressionType(visible) {
   return visible ? "visible" : "hidden";
-};
+}
 
 type ExpressionState = {
   expressions: List<Expression>,
@@ -36,7 +36,7 @@ export function update(
           input: action.input,
           value: null,
           updating: true,
-        },
+        }
       );
     case constants.UPDATE_EXPRESSION:
       const key = action.expression.input;
@@ -48,7 +48,7 @@ export function update(
           input: action.input,
           value: null,
           updating: true,
-        },
+        }
       );
     case constants.EVALUATE_EXPRESSION:
       if (action.status === "done") {
@@ -60,7 +60,7 @@ export function update(
             input: action.input,
             value: action.value,
             updating: false,
-          },
+          }
         );
       }
       break;
@@ -111,10 +111,10 @@ function updateItemInList(
 function deleteExpression(
   state: State,
   input: string,
-  visible: boolean = true,
+  visible: boolean = true
 ) {
   const index = getExpressions({ expressions: state }, visible).findKey(
-    e => e.input == input,
+    e => e.input == input
   );
   const newState = state.deleteIn([
     "expressions",
@@ -134,7 +134,7 @@ export function getExpressions(state: OuterState, visible: boolean = true) {
 export function getExpression(
   state: OuterState,
   input: string,
-  visible: boolean = true,
+  visible: boolean = true
 ) {
   return getExpressions(state, visible).find(exp => exp.input == input);
 }

--- a/src/reducers/expressions.js
+++ b/src/reducers/expressions.js
@@ -105,14 +105,14 @@ function deleteExpression(state: State, input: string) {
 
 type OuterState = { expressions: Record<ExpressionState> };
 
-export function getExpressions(state: OuterState, visible: boolean = true) {
-  const expressions = state.expressions.get("expressions");
-  return visible ? expressions.filter(e => e.visible) : expressions;
+export function getExpressions(state: OuterState) {
+  return state.expressions.get("expressions");
 }
 
-export function getExpression(
-  state: OuterState,
-  input: string,
-) {
+export function getVisibleExpressions(state: OuterState) {
+  return state.expressions.get("expressions").filter(e => e.visible);
+}
+
+export function getExpression(state: OuterState, input: string) {
   return getExpressions(state).find(exp => exp.input == input);
 }

--- a/src/selectors.js
+++ b/src/selectors.js
@@ -55,4 +55,5 @@ module.exports = {
   getPaneCollapse: ui.getPaneCollapse,
 
   getExpressions: expressions.getExpressions,
+  getExpression: expressions.getExpression,
 };

--- a/src/selectors.js
+++ b/src/selectors.js
@@ -55,5 +55,6 @@ module.exports = {
   getPaneCollapse: ui.getPaneCollapse,
 
   getExpressions: expressions.getExpressions,
+  getVisibleExpressions: expressions.getVisibleExpressions,
   getExpression: expressions.getExpression,
 };

--- a/src/types.js
+++ b/src/types.js
@@ -9,6 +9,7 @@ export type SearchModifiers = {
 export type Expression = {
   value: Object,
   input: string,
+  visible: boolean,
 };
 
 export type Mode =


### PR DESCRIPTION
Associated Issue: #2219

### Summary of Changes

* As a follow up from #2421, including changes.
* Refactor of the reducers to support separate states for `hidden` and `visible` expressions.
* Persisting only `visible` expressions.
* Adding the `visible` argument to expression actions. e.g `addExpression(value, visible)` . If the visible argument is not passed, it defaults to `true`, creating a visible expression. Passing in `false` creates a hidden expression.

### Test Plan

- [x] add and remove expressions from the watch expressions list.
- [x] break on exceptions and preview member expressions
- [x] not that they don't get added to the watch expressions list

