### PR TITLE
[SearchBar] Fix cursor for disabled search modifier

### DIFF
--- a/src/components/Editor/SearchBar.css
+++ b/src/components/Editor/SearchBar.css
@@ -66,6 +66,10 @@
   cursor: pointer;
 }
 
+.search-bottom-bar .search-modifiers button:hover {
+  background: var(--theme-toolbar-background-hover);
+}
+
 .search-bottom-bar .search-modifiers button:active {
   outline: none;
 }
@@ -80,6 +84,7 @@
 
 .search-bottom-bar .search-modifiers button.disabled svg {
   fill: var(--theme-comment-alt);
+  cursor: default;
 }
 
 .search-bottom-bar .search-type-toggles {


### PR DESCRIPTION
Cursor for disabled search modifier was not correct
![cursor](https://cloud.githubusercontent.com/assets/1755089/24333756/9a5fad1e-127b-11e7-99bb-ac5c6b75b7cc.gif)


### Summary of changes

* Change cursor of disabled search modifier to `default`.
* Add hover background for search modifier.

### Screenshots/Videos (OPTIONAL)

Hover style
![hover2](https://cloud.githubusercontent.com/assets/1755089/24333763/b28a9ee4-127b-11e7-8978-83012846aa7a.png)
