### PR TITLE
Add a separate highlight animation for dark theme

### DIFF
--- a/src/components/Editor/Editor.css
+++ b/src/components/Editor/Editor.css
@@ -120,6 +120,15 @@ html[dir="rtl"] .editor-mount {
   100% { background-color: transparent; }
 }
 
+.theme-dark .highlight-line .CodeMirror-line {
+  animation: fade-highlight-out-dark 1.5s normal forwards;
+}
+
+@keyframes fade-highlight-out-dark {
+  0% { background-color: var(--theme-content-color3); }
+  100% { background-color: transparent; }
+}
+
 .welcomebox {
   width: calc(100% - 1px);
 


### PR DESCRIPTION
Associated Issue: #2447

### Summary of Changes

* Added _fade-highlight-out-dark_ animation for the dark theme. This sets the starting transition color to be a darker, blue-ish gray.

### Test Plan

- [x] Turned on function search and search modifiers
- [x] Searched for a function and clicked the name in the dropdown that appeared.

### Screenshots/Videos (OPTIONAL)

New color:
http://g.recordit.co/KEEn6tvCCX.gif