### PR TITLE
Add code folding to the editor

### DIFF
--- a/configs/application.json
+++ b/configs/application.json
@@ -29,6 +29,10 @@
       "label": "Code Coverage",
       "enabled": false
     },
+    "codeFolding": {
+      "label": "Code Folding",
+      "enabled": false
+    },
     "searchModifiers": {
       "label": "Search Modifiers",
       "enabled": false

--- a/configs/development.json
+++ b/configs/development.json
@@ -35,6 +35,10 @@
       "label": "Code Coverage",
       "enabled": false
     },
+    "codeFolding": {
+      "label": "Code Folding",
+      "enabled": false
+    },
     "searchModifiers": {
       "label": "Search Modifiers",
       "enabled": true

--- a/configs/local.sample.json
+++ b/configs/local.sample.json
@@ -21,6 +21,10 @@
       "label": "Code Coverage",
       "enabled": false
     },
+    "codeFolding": {
+      "label": "Code Folding",
+      "enabled": false
+    },
     "searchModifiers": {
       "label": "Search Modifiers",
       "enabled": false

--- a/src/components/Editor/Breakpoint.js
+++ b/src/components/Editor/Breakpoint.js
@@ -1,5 +1,6 @@
 // @flow
 import { PropTypes, Component } from "react";
+import { isEnabled } from "devtools-config";
 const ReactDOM = require("react-dom");
 
 import classnames from "classnames";
@@ -11,7 +12,8 @@ ReactDOM.render(Svg("breakpoint"), breakpointSvg);
 function makeMarker(isDisabled: boolean) {
   const bp = breakpointSvg.cloneNode(true);
   bp.className = classnames("editor new-breakpoint", {
-    "breakpoint-disabled": isDisabled
+    "breakpoint-disabled": isDisabled,
+    "folding-enabled": isEnabled("codeFolding")
   });
 
   return bp;

--- a/src/components/Editor/Editor.css
+++ b/src/components/Editor/Editor.css
@@ -84,6 +84,9 @@ html[dir="rtl"] .editor-mount {
 .CodeMirror-linenumber {
   font-size: 11px;
   line-height: 14px;
+}
+
+.folding-enabled .CodeMirror-linenumber {
   text-align: left;
   padding: 0 0 0 2px;
 }

--- a/src/components/Editor/Editor.css
+++ b/src/components/Editor/Editor.css
@@ -51,7 +51,7 @@ html[dir="rtl"] .editor-mount {
   height: 14px;
   position: absolute;
   top: 0px;
-  right: -4px;
+  right: -16px;
 }
 
 .new-breakpoint.has-condition svg {
@@ -80,6 +80,8 @@ html[dir="rtl"] .editor-mount {
 .CodeMirror-linenumber {
   font-size: 11px;
   line-height: 14px;
+  text-align: left;
+  padding: 0 0 0 2px;
 }
 
 /* set the linenumber white when there is a breakpoint */
@@ -87,8 +89,8 @@ html[dir="rtl"] .editor-mount {
   color: white;
 }
 
-/* move the breakpoint below the linenumber */
-.new-breakpoint .CodeMirror-gutter-elt:last-child {
+/* move the breakpoint below the other gutter elements */
+.new-breakpoint .CodeMirror-gutter-elt:nth-child(2) {
   z-index: 0;
 }
 

--- a/src/components/Editor/Editor.css
+++ b/src/components/Editor/Editor.css
@@ -51,6 +51,10 @@ html[dir="rtl"] .editor-mount {
   height: 14px;
   position: absolute;
   top: 0px;
+  right: -4px;
+}
+
+.editor.new-breakpoint.folding-enabled svg {
   right: -16px;
 }
 

--- a/src/components/Editor/codemirror-mozilla.css
+++ b/src/components/Editor/codemirror-mozilla.css
@@ -190,13 +190,15 @@ selector in floating-scrollbar-light.css across all platforms. */
 }
 
 .CodeMirror-foldgutter {
-  width: 16px; /* Same as breakpoints gutter above */
+  width: 10px;
 }
 
 .CodeMirror-foldgutter-open,
 .CodeMirror-foldgutter-folded {
   color: #555;
   cursor: pointer;
+  line-height: 1;
+  padding: 0 1px;
 }
 
 .CodeMirror-foldgutter-open:after {

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -399,7 +399,9 @@ const Editor = React.createClass({
       return this.closeConditionalPanel(line);
     }
 
-    this.toggleBreakpoint(line);
+    if (gutter !== "CodeMirror-foldgutter") {
+      this.toggleBreakpoint(line);
+    }
   },
 
   onGutterContextMenu(event) {

--- a/src/utils/editor/index.js
+++ b/src/utils/editor/index.js
@@ -96,14 +96,20 @@ function traverseResults(e, ctx, query, dir, modifiers) {
 function createEditor() {
   return new SourceEditor({
     mode: "javascript",
+    foldGutter: true,
     readOnly: true,
     lineNumbers: true,
     theme: "mozilla",
     lineWrapping: false,
     matchBrackets: true,
     showAnnotationRuler: true,
-    enableCodeFolding: false,
-    gutters: ["breakpoints", "hit-markers"],
+    enableCodeFolding: true,
+    gutters: [
+      "breakpoints",
+      "hit-markers",
+      "CodeMirror-linenumbers",
+      "CodeMirror-foldgutter",
+    ],
     value: " ",
     extraKeys: {
       // Override code mirror keymap to avoid conflicts with split console.

--- a/src/utils/editor/index.js
+++ b/src/utils/editor/index.js
@@ -1,3 +1,4 @@
+const { isEnabled } = require("devtools-config");
 const { isPretty, isJavaScript } = require("../source");
 const { isOriginalId } = require("devtools-source-map");
 const buildQuery = require("./build-query");
@@ -96,7 +97,7 @@ function traverseResults(e, ctx, query, dir, modifiers) {
 function createEditor() {
   return new SourceEditor({
     mode: "javascript",
-    foldGutter: true,
+    foldGutter: isEnabled("codeFolding"),
     readOnly: true,
     lineNumbers: true,
     theme: "mozilla",

--- a/src/utils/editor/index.js
+++ b/src/utils/editor/index.js
@@ -103,12 +103,11 @@ function createEditor() {
     lineWrapping: false,
     matchBrackets: true,
     showAnnotationRuler: true,
-    enableCodeFolding: true,
     gutters: [
       "breakpoints",
       "hit-markers",
       "CodeMirror-linenumbers",
-      "CodeMirror-foldgutter",
+      "CodeMirror-foldgutter"
     ],
     value: " ",
     extraKeys: {

--- a/src/utils/editor/index.js
+++ b/src/utils/editor/index.js
@@ -95,6 +95,12 @@ function traverseResults(e, ctx, query, dir, modifiers) {
 }
 
 function createEditor() {
+  const gutters = ["breakpoints", "hit-markers", "CodeMirror-linenumbers"];
+
+  if (isEnabled("codeFolding")) {
+    gutters.push("CodeMirror-foldgutter");
+  }
+
   return new SourceEditor({
     mode: "javascript",
     foldGutter: isEnabled("codeFolding"),
@@ -104,12 +110,7 @@ function createEditor() {
     lineWrapping: false,
     matchBrackets: true,
     showAnnotationRuler: true,
-    gutters: [
-      "breakpoints",
-      "hit-markers",
-      "CodeMirror-linenumbers",
-      "CodeMirror-foldgutter"
-    ],
+    gutters,
     value: " ",
     extraKeys: {
       // Override code mirror keymap to avoid conflicts with split console.

--- a/src/utils/editor/source-editor.js
+++ b/src/utils/editor/source-editor.js
@@ -16,6 +16,10 @@ require("codemirror/mode/elm/elm");
 require("codemirror/mode/clojure/clojure");
 require("../../components/Editor/codemirror-mozilla.css");
 require("codemirror/addon/search/searchcursor");
+require("codemirror/addon/fold/foldcode");
+require("codemirror/addon/fold/brace-fold");
+require("codemirror/addon/fold/indent-fold");
+require("codemirror/addon/fold/foldgutter");
 
 import type { Mode, AlignOpts } from "../../types";
 
@@ -27,6 +31,7 @@ type SourceEditorOpts = {
   enableCodeFolding: boolean,
   extraKeys: Object,
   gutters: string[],
+  foldGutter: boolean,
   lineNumbers: boolean,
   lineWrapping: boolean,
   matchBrackets: boolean,


### PR DESCRIPTION
Associated Issue: #2465 

### Summary of Changes

* Adds code folding to the editor

### Test Plan

- [x] Open a document
- [x] Click the folding indicators in the gutter
- [x] Note that clicking the indicator doesn't add/remove breakpoints

### Screenshots/Videos

![code-fold](https://cloud.githubusercontent.com/assets/580982/24380574/4e17e08c-1309-11e7-86eb-66e7633956e3.gif)

