### PR TITLE
Convert actions to use ES6 import/exports

### DIFF
--- a/src/actions/breakpoints.js
+++ b/src/actions/breakpoints.js
@@ -8,15 +8,15 @@
  * @module actions/breakpoints
  */
 
-const constants = require("../constants");
-const { PROMISE } = require("../utils/redux/middleware/promise");
-const { getBreakpoint, getBreakpoints, getSource } = require("../selectors");
+import constants from "../constants";
+import { PROMISE } from "../utils/redux/middleware/promise";
+import { getBreakpoint, getBreakpoints, getSource } from "../selectors";
 
-const {
+import {
   getOriginalLocation,
   getGeneratedLocation,
   isOriginalId,
-} = require("devtools-source-map");
+} from "devtools-source-map";
 
 import type { ThunkArgs } from "./types";
 import type { Location } from "../types";
@@ -39,7 +39,7 @@ function _getOrCreateBreakpoint(state, location, condition) {
  * @memberof actions/breakpoints
  * @static
  */
-function enableBreakpoint(location: Location) {
+export function enableBreakpoint(location: Location) {
   return addBreakpoint(location);
 }
 
@@ -51,7 +51,7 @@ function enableBreakpoint(location: Location) {
  * @param {String} $1.condition Conditional breakpoint condition value
  * @param {Function} $1.getTextForLine Get the text to represent the line
  */
-function addBreakpoint(
+export function addBreakpoint(
   location: Location,
   { condition, getTextForLine }: addBreakpointOptions = {}
 ) {
@@ -99,7 +99,7 @@ function addBreakpoint(
  * @memberof actions/breakpoints
  * @static
  */
-function disableBreakpoint(location: Location) {
+export function disableBreakpoint(location: Location) {
   return _removeOrDisableBreakpoint(location, true);
 }
 
@@ -109,7 +109,7 @@ function disableBreakpoint(location: Location) {
  * @memberof actions/breakpoints
  * @static
  */
-function removeBreakpoint(location: Location) {
+export function removeBreakpoint(location: Location) {
   return _removeOrDisableBreakpoint(location);
 }
 
@@ -152,7 +152,7 @@ function _removeOrDisableBreakpoint(location, isDisabled) {
  * @memberof actions/breakpoints
  * @static
  */
-function toggleAllBreakpoints(shouldDisableBreakpoints: boolean) {
+export function toggleAllBreakpoints(shouldDisableBreakpoints: boolean) {
   return ({ dispatch, getState }: ThunkArgs) => {
     const breakpoints = getBreakpoints(getState());
     return dispatch({
@@ -182,7 +182,7 @@ function toggleAllBreakpoints(shouldDisableBreakpoints: boolean) {
  * @param {string} condition
  *        The condition to set on the breakpoint
  */
-function setBreakpointCondition(
+export function setBreakpointCondition(
   location: Location,
   { condition, getTextForLine }: addBreakpointOptions = {}
 ) {
@@ -212,12 +212,3 @@ function setBreakpointCondition(
     });
   };
 }
-
-module.exports = {
-  enableBreakpoint,
-  addBreakpoint,
-  disableBreakpoint,
-  removeBreakpoint,
-  toggleAllBreakpoints,
-  setBreakpointCondition,
-};

--- a/src/actions/coverage.js
+++ b/src/actions/coverage.js
@@ -1,8 +1,8 @@
 // @flow
-const constants = require("../constants");
+import constants from "../constants";
 import type { ThunkArgs } from "./types";
 
-function recordCoverage() {
+export function recordCoverage() {
   return async function({ dispatch, getState, client }: ThunkArgs) {
     const { coverage } = await client.recordCoverage();
 
@@ -12,7 +12,3 @@ function recordCoverage() {
     });
   };
 }
-
-module.exports = {
-  recordCoverage,
-};

--- a/src/actions/event-listeners.js
+++ b/src/actions/event-listeners.js
@@ -9,9 +9,9 @@
  * @module actions/event-listeners
  */
 
-const constants = require("../constants");
-const { reportException } = require("../utils/DevToolsUtils");
-const { getPause, getSourceByURL } = require("../selectors");
+import constants from "../constants";
+import { reportException } from "../utils/DevToolsUtils";
+import { getPause, getSourceByURL } from "../selectors";
 
 // delay is in ms
 const FETCH_EVENT_LISTENERS_DELAY = 200;
@@ -46,7 +46,7 @@ async function asPaused(state: any, client: any, func: any) {
  * @memberof actions/event-listeners
  * @static
  */
-function fetchEventListeners() {
+export function fetchEventListeners() {
   return ({ dispatch, getState, client }) => {
     // Make sure we"re not sending a batch of closely repeated requests.
     // This can easily happen whenever new sources are fetched.
@@ -154,7 +154,7 @@ async function _getDefinitionSite(threadClient, func) {
  * @static
  * @param {string} eventNames
  */
-function updateEventBreakpoints(eventNames) {
+export function updateEventBreakpoints(eventNames) {
   return dispatch => {
     setNamedTimeout("event-breakpoints-update", 0, () => {
       gThreadClient.pauseOnDOMEvents(eventNames, function() {
@@ -169,5 +169,3 @@ function updateEventBreakpoints(eventNames) {
     });
   };
 }
-
-module.exports = { updateEventBreakpoints, fetchEventListeners };

--- a/src/actions/expressions.js
+++ b/src/actions/expressions.js
@@ -1,9 +1,9 @@
 // @flow
 
-const constants = require("../constants");
-const { PROMISE } = require("../utils/redux/middleware/promise");
+import constants from "../constants";
+import { PROMISE } from "../utils/redux/middleware/promise";
 
-const { getExpressions, getSelectedFrame } = require("../selectors");
+import { getExpressions, getSelectedFrame } from "../selectors";
 
 import type { Expression } from "../types";
 import type { ThunkArgs } from "./types";
@@ -22,7 +22,7 @@ function expressionExists(expressions, input) {
  * @memberof actions/pause
  * @static
  */
-function addExpression(input: string) {
+export function addExpression(input: string) {
   return ({ dispatch, getState }: ThunkArgs) => {
     const expressions = getExpressions(getState());
     if (!input || expressionExists(expressions, input)) {
@@ -40,7 +40,7 @@ function addExpression(input: string) {
   };
 }
 
-function updateExpression(input: string, expression: Expression) {
+export function updateExpression(input: string, expression: Expression) {
   return ({ dispatch, getState }: ThunkArgs) => {
     if (!input || input == expression.input) {
       return;
@@ -65,7 +65,7 @@ function updateExpression(input: string, expression: Expression) {
  * @memberof actions/pause
  * @static
  */
-function deleteExpression(expression: Expression) {
+export function deleteExpression(expression: Expression) {
   return ({ dispatch }: ThunkArgs) => {
     dispatch({
       type: constants.DELETE_EXPRESSION,
@@ -80,7 +80,7 @@ function deleteExpression(expression: Expression) {
  * @param {number} selectedFrameId
  * @static
  */
-function evaluateExpressions(frameId: frameIdType) {
+export function evaluateExpressions(frameId: frameIdType) {
   return async function({ dispatch, getState, client }: ThunkArgs) {
     for (let expression of getExpressions(getState())) {
       await dispatch(evaluateExpression(expression, frameId));
@@ -102,10 +102,3 @@ function evaluateExpression(expression, frameId: frameIdType) {
     });
   };
 }
-
-module.exports = {
-  addExpression,
-  updateExpression,
-  deleteExpression,
-  evaluateExpressions,
-};

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -1,15 +1,15 @@
 // @flow
 
-const breakpoints = require("./breakpoints");
-const expressions = require("./expressions");
-const eventListeners = require("./event-listeners");
-const sources = require("./sources");
-const pause = require("./pause");
-const navigation = require("./navigation");
-const ui = require("./ui");
-const coverage = require("./coverage");
+import * as breakpoints from "./breakpoints";
+import * as expressions from "./expressions";
+import * as eventListeners from "./event-listeners";
+import * as sources from "./sources";
+import * as pause from "./pause";
+import * as navigation from "./navigation";
+import * as ui from "./ui";
+import * as coverage from "./coverage";
 
-module.exports = (Object.assign(
+export default Object.assign(
   navigation,
   breakpoints,
   expressions,
@@ -18,4 +18,4 @@ module.exports = (Object.assign(
   pause,
   ui,
   coverage
-): typeof breakpoints);
+);

--- a/src/actions/navigation.js
+++ b/src/actions/navigation.js
@@ -1,9 +1,9 @@
-const constants = require("../constants");
-const { clearSourceMaps } = require("devtools-source-map");
-const { clearDocuments } = require("../utils/editor");
-const { getSources } = require("../reducers/sources");
-const { waitForMs } = require("../utils/utils");
-const { newSources } = require("./sources");
+import constants from "../constants";
+import { clearSourceMaps } from "devtools-source-map";
+import { clearDocuments } from "../utils/editor";
+import { getSources } from "../reducers/sources";
+import { waitForMs } from "../utils/utils";
+import { newSources } from "./sources";
 
 /**
  * Redux actions for the navigation state
@@ -14,7 +14,7 @@ const { newSources } = require("./sources");
  * @memberof actions/navigation
  * @static
  */
-function willNavigate(_, event) {
+export function willNavigate(_, event) {
   clearSourceMaps();
   clearDocuments();
 
@@ -28,7 +28,7 @@ function willNavigate(_, event) {
  * @memberof actions/navigation
  * @static
  */
-function navigated() {
+export function navigated() {
   return async function({ dispatch, getState, client }: ThunkArgs) {
     await waitForMs(100);
     if (getSources(getState()).size == 0) {
@@ -37,8 +37,3 @@ function navigated() {
     }
   };
 }
-
-module.exports = {
-  willNavigate,
-  navigated,
-};

--- a/src/actions/pause.js
+++ b/src/actions/pause.js
@@ -1,11 +1,11 @@
 // @flow
-const constants = require("../constants");
-const { selectSource } = require("./sources");
-const { PROMISE } = require("../utils/redux/middleware/promise");
+import constants from "../constants";
+import { selectSource } from "./sources";
+import { PROMISE } from "../utils/redux/middleware/promise";
 
-const { getPause, getLoadedObject } = require("../selectors");
-const { updateFrameLocations } = require("../utils/pause");
-const { evaluateExpressions } = require("./expressions");
+import { getPause, getLoadedObject } from "../selectors";
+import { updateFrameLocations } from "../utils/pause";
+import { evaluateExpressions } from "./expressions";
 
 import type { Pause, Frame } from "../types";
 import type { ThunkArgs } from "./types";
@@ -23,7 +23,7 @@ type CommandType = { type: string };
  * @memberof actions/pause
  * @static
  */
-function resumed() {
+export function resumed() {
   return ({ dispatch, client }: ThunkArgs) => {
     // dispatch(evaluateExpressions(null));
 
@@ -41,7 +41,7 @@ function resumed() {
  * @memberof actions/pause
  * @static
  */
-function paused(pauseInfo: Pause) {
+export function paused(pauseInfo: Pause) {
   return async function({ dispatch, getState, client }: ThunkArgs) {
     let { frames, why, loadedObjects } = pauseInfo;
     frames = await updateFrameLocations(frames);
@@ -68,7 +68,7 @@ function paused(pauseInfo: Pause) {
  * @memberof actions/pause
  * @static
  */
-function pauseOnExceptions(
+export function pauseOnExceptions(
   shouldPauseOnExceptions: boolean,
   shouldIgnoreCaughtExceptions: boolean
 ) {
@@ -92,7 +92,7 @@ function pauseOnExceptions(
  * @memberof actions/pause
  * @static
  */
-function command({ type }: CommandType) {
+export function command({ type }: CommandType) {
   return ({ dispatch, client }: ThunkArgs) => {
     // execute debugger thread command e.g. stepIn, stepOver
     client[type]();
@@ -110,7 +110,7 @@ function command({ type }: CommandType) {
  * @static
  * @returns {Function} {@link command}
  */
-function stepIn() {
+export function stepIn() {
   return ({ dispatch, getState }: ThunkArgs) => {
     if (getPause(getState())) {
       return dispatch(command({ type: "stepIn" }));
@@ -124,7 +124,7 @@ function stepIn() {
  * @static
  * @returns {Function} {@link command}
  */
-function stepOver() {
+export function stepOver() {
   return ({ dispatch, getState }: ThunkArgs) => {
     if (getPause(getState())) {
       return dispatch(command({ type: "stepOver" }));
@@ -138,7 +138,7 @@ function stepOver() {
  * @static
  * @returns {Function} {@link command}
  */
-function stepOut() {
+export function stepOut() {
   return ({ dispatch, getState }: ThunkArgs) => {
     if (getPause(getState())) {
       return dispatch(command({ type: "stepOut" }));
@@ -152,7 +152,7 @@ function stepOut() {
  * @static
  * @returns {Function} {@link command}
  */
-function resume() {
+export function resume() {
   return ({ dispatch, getState }: ThunkArgs) => {
     if (getPause(getState())) {
       return dispatch(command({ type: "resume" }));
@@ -168,7 +168,7 @@ function resume() {
  * @memberof actions/pause
  * @static
  */
-function breakOnNext() {
+export function breakOnNext() {
   return ({ dispatch, client }: ThunkArgs) => {
     client.breakOnNext();
 
@@ -183,7 +183,7 @@ function breakOnNext() {
  * @memberof actions/pause
  * @static
  */
-function selectFrame(frame: Frame) {
+export function selectFrame(frame: Frame) {
   return ({ dispatch }: ThunkArgs) => {
     dispatch(evaluateExpressions(frame.id));
     dispatch(
@@ -200,7 +200,7 @@ function selectFrame(frame: Frame) {
  * @memberof actions/pause
  * @static
  */
-function loadObjectProperties(object: any) {
+export function loadObjectProperties(object: any) {
   return ({ dispatch, client, getState }: ThunkArgs) => {
     const objectId = object.actor || object.objectId;
 
@@ -215,17 +215,3 @@ function loadObjectProperties(object: any) {
     });
   };
 }
-
-module.exports = {
-  resumed,
-  paused,
-  pauseOnExceptions,
-  command,
-  stepIn,
-  stepOut,
-  stepOver,
-  resume,
-  breakOnNext,
-  selectFrame,
-  loadObjectProperties,
-};

--- a/src/actions/sources.js
+++ b/src/actions/sources.js
@@ -9,13 +9,13 @@
  * @module actions/sources
  */
 
-const defer = require("../utils/defer");
-const { PROMISE } = require("../utils/redux/middleware/promise");
-const assert = require("../utils/assert");
-const { updateFrameLocations } = require("../utils/pause");
-const { addBreakpoint } = require("./breakpoints");
+import defer from "../utils/defer";
+import { PROMISE } from "../utils/redux/middleware/promise";
+import assert from "../utils/assert";
+import { updateFrameLocations } from "../utils/pause";
+import { addBreakpoint } from "./breakpoints";
 
-const {
+import {
   getOriginalURLs,
   getOriginalSourceText,
   generatedToOriginalId,
@@ -24,16 +24,16 @@ const {
   getGeneratedLocation,
   isGeneratedId,
   applySourceMap,
-} = require("devtools-source-map");
+} from "devtools-source-map";
 
-const { prettyPrint } = require("../utils/pretty-print");
-const { getPrettySourceURL } = require("../utils/source");
+import { prettyPrint } from "../utils/pretty-print";
+import { getPrettySourceURL } from "../utils/source";
 
-const constants = require("../constants");
-const { prefs } = require("../utils/prefs");
-const { removeDocument } = require("../utils/editor");
+import constants from "../constants";
+import { prefs } from "../utils/prefs";
+import { removeDocument } from "../utils/editor";
 
-const {
+import {
   getSource,
   getSourceByURL,
   getSourceText,
@@ -41,7 +41,7 @@ const {
   getPendingSelectedLocation,
   getPendingBreakpoints,
   getFrames,
-} = require("../selectors");
+} from "../selectors";
 
 import type { Source, SourceText } from "../types";
 import type { ThunkArgs } from "./types";
@@ -79,7 +79,7 @@ function checkPendingBreakpoints(state, dispatch, source) {
  * @memberof actions/sources
  * @static
  */
-function newSource(source: Source) {
+export function newSource(source: Source) {
   return ({ dispatch, getState }: ThunkArgs) => {
     if (prefs.clientSourceMapsEnabled) {
       dispatch(loadSourceMap(source));
@@ -92,7 +92,7 @@ function newSource(source: Source) {
   };
 }
 
-function newSources(sources: Source[]) {
+export function newSources(sources: Source[]) {
   return ({ dispatch, getState }: ThunkArgs) => {
     sources
       .filter(source => !getSource(getState(), source.id))
@@ -141,7 +141,10 @@ type SelectSourceOptions = { tabIndex?: number, line?: number };
  * @memberof actions/sources
  * @static
  */
-function selectSourceURL(url: string, options: SelectSourceOptions = {}) {
+export function selectSourceURL(
+  url: string,
+  options: SelectSourceOptions = {}
+) {
   return ({ dispatch, getState }: ThunkArgs) => {
     const source = getSourceByURL(getState(), url);
     if (source) {
@@ -161,7 +164,7 @@ function selectSourceURL(url: string, options: SelectSourceOptions = {}) {
  * @memberof actions/sources
  * @static
  */
-function selectSource(id: string, options: SelectSourceOptions = {}) {
+export function selectSource(id: string, options: SelectSourceOptions = {}) {
   return ({ dispatch, getState, client }: ThunkArgs) => {
     if (!client) {
       // No connection, do nothing. This happens when the debugger is
@@ -195,7 +198,7 @@ function selectSource(id: string, options: SelectSourceOptions = {}) {
  * @memberof actions/sources
  * @static
  */
-function jumpToMappedLocation(sourceLocation: any) {
+export function jumpToMappedLocation(sourceLocation: any) {
   return async function({ dispatch, getState, client }: ThunkArgs) {
     if (!client) {
       return;
@@ -216,7 +219,7 @@ function jumpToMappedLocation(sourceLocation: any) {
  * @memberof actions/sources
  * @static
  */
-function closeTab(url: string) {
+export function closeTab(url: string) {
   removeDocument(url);
   return { type: constants.CLOSE_TAB, url };
 }
@@ -225,7 +228,7 @@ function closeTab(url: string) {
  * @memberof actions/sources
  * @static
  */
-function closeTabs(urls: string[]) {
+export function closeTabs(urls: string[]) {
   return ({ dispatch, getState, client }: ThunkArgs) => {
     urls.forEach(url => {
       const source = getSourceByURL(getState(), url);
@@ -250,7 +253,7 @@ function closeTabs(urls: string[]) {
  *          A promise that resolves to [aSource, prettyText] or rejects to
  *          [aSource, error].
  */
-function togglePrettyPrint(sourceId: string) {
+export function togglePrettyPrint(sourceId: string) {
   return ({ dispatch, getState, client }: ThunkArgs) => {
     const source = getSource(getState(), sourceId).toJS();
     let sourceText = getSourceText(getState(), sourceId);
@@ -301,7 +304,7 @@ function togglePrettyPrint(sourceId: string) {
  * @memberof actions/sources
  * @static
  */
-function loadSourceText(source: Source) {
+export function loadSourceText(source: Source) {
   return ({ dispatch, getState, client }: ThunkArgs) => {
     // Fetch the source text only once.
     let textInfo = getSourceText(getState(), source.id);
@@ -353,7 +356,7 @@ const FETCH_SOURCE_RESPONSE_DELAY = 200;
  * @returns {Promise}
  *         A promise that is resolved after source texts have been fetched.
  */
-function getTextForSources(actors: any[]) {
+export function getTextForSources(actors: any[]) {
   return ({ dispatch, getState }: ThunkArgs) => {
     let deferred = defer();
     let pending = new Set(actors);
@@ -419,16 +422,3 @@ function getTextForSources(actors: any[]) {
     return deferred.promise;
   };
 }
-
-module.exports = {
-  newSource,
-  newSources,
-  selectSource,
-  selectSourceURL,
-  jumpToMappedLocation,
-  closeTab,
-  closeTabs,
-  togglePrettyPrint,
-  loadSourceText,
-  getTextForSources,
-};

--- a/src/actions/tests/breakpoints.js
+++ b/src/actions/tests/breakpoints.js
@@ -1,6 +1,6 @@
-const { createStore, selectors, actions } = require("../../utils/test-head");
-const { Task } = require("../../utils/task");
-const expect = require("expect.js");
+import { createStore, selectors, actions } from "../../utils/test-head";
+import { Task } from "../../utils/task";
+import expect from "expect.js";
 
 const simpleMockThreadClient = {
   setBreakpoint: (location, condition) => {

--- a/src/actions/tests/sources.js
+++ b/src/actions/tests/sources.js
@@ -1,11 +1,11 @@
-const expect = require("expect.js");
-const { Task } = require("../../utils/task");
-const {
+import expect from "expect.js";
+import { Task } from "../../utils/task";
+import {
   actions,
   selectors,
   createStore,
   makeSource,
-} = require("../../utils/test-head");
+} from "../../utils/test-head";
 const {
   getSourceById,
   getSources,

--- a/src/actions/tests/ui.js
+++ b/src/actions/tests/ui.js
@@ -1,5 +1,5 @@
-const { createStore, selectors, actions } = require("../../utils/test-head");
-const expect = require("expect.js");
+import { createStore, selectors, actions } from "../../utils/test-head";
+import expect from "expect.js";
 
 const {
   getFileSearchState,

--- a/src/actions/ui.js
+++ b/src/actions/ui.js
@@ -1,13 +1,13 @@
 // @flow
-const constants = require("../constants");
-const {
+import constants from "../constants";
+import {
   getSource,
   getProjectSearchState,
   getFileSearchState,
-} = require("../selectors");
+} from "../selectors";
 import type { ThunkArgs } from "./types";
 
-function toggleProjectSearch(toggleValue?: boolean) {
+export function toggleProjectSearch(toggleValue?: boolean) {
   return ({ dispatch, getState }: ThunkArgs) => {
     if (toggleValue != null) {
       dispatch({
@@ -23,7 +23,7 @@ function toggleProjectSearch(toggleValue?: boolean) {
   };
 }
 
-function toggleFileSearch(toggleValue?: boolean) {
+export function toggleFileSearch(toggleValue?: boolean) {
   return ({ dispatch, getState }: ThunkArgs) => {
     if (toggleValue != null) {
       dispatch({
@@ -39,18 +39,18 @@ function toggleFileSearch(toggleValue?: boolean) {
   };
 }
 
-function setFileSearchQuery(query: string) {
+export function setFileSearchQuery(query: string) {
   return {
     type: constants.UPDATE_FILE_SEARCH_QUERY,
     query,
   };
 }
 
-function toggleFileSearchModifier(modifier: string) {
+export function toggleFileSearchModifier(modifier: string) {
   return { type: constants.TOGGLE_FILE_SEARCH_MODIFIER, modifier };
 }
 
-function showSource(sourceId: string) {
+export function showSource(sourceId: string) {
   return ({ dispatch, getState }: ThunkArgs) => {
     const source = getSource(getState(), sourceId);
     dispatch({
@@ -60,19 +60,10 @@ function showSource(sourceId: string) {
   };
 }
 
-function togglePaneCollapse(position: string, paneCollapsed: boolean) {
+export function togglePaneCollapse(position: string, paneCollapsed: boolean) {
   return {
     type: constants.TOGGLE_PANE,
     position,
     paneCollapsed,
   };
 }
-
-module.exports = {
-  toggleFileSearch,
-  setFileSearchQuery,
-  toggleFileSearchModifier,
-  toggleProjectSearch,
-  showSource,
-  togglePaneCollapse,
-};

--- a/src/utils/test-head.js
+++ b/src/utils/test-head.js
@@ -7,7 +7,7 @@
 
 const { combineReducers } = require("redux");
 const reducers = require("../reducers");
-const actions = require("../actions");
+const actions = require("../actions").default;
 const selectors = require("../selectors");
 const constants = require("../constants");
 


### PR DESCRIPTION
Associated Issue: #1884

### Summary of Changes

* modify the actions to use ES6 imports/exports

### Test Plan

- [x] Run the test suites
- [x] Test out basic features of debugger
  - add/remove/enable/disable breakpoints
  - toggle UI states
  - add watch expressions
  - etc
