### PR TITLE
Fix NaN bug when toggling function search

### DIFF
--- a/src/components/Editor/SearchBar.js
+++ b/src/components/Editor/SearchBar.js
@@ -307,7 +307,8 @@ const SearchBar = React.createClass({
       { key: "value" }
     );
 
-    updateSearchResults({ count: symbolSearchResults.length });
+    // symbol search doesn't use index so we pass the default value
+    updateSearchResults({ count: symbolSearchResults.length, index: -1 });
     return this.setState({ symbolSearchResults });
   },
 


### PR DESCRIPTION
Associated Issue: #2467

### Summary of Changes

* Passed default necessary index value in symbolic search as prop.

### Test Plan

1) Command-F in Editor opens Search.
2) Choose function search and look for a function.
3) Click the function and watch it highlight.
4) Escape out of the search box and Command-F again.
5) Check upper right hand corner.

### Screenshots/Videos (OPTIONAL)

Before: http://g.recordit.co/VNsJHS8jhC.gif

![](http://g.recordit.co/HGeap5YXrC.gif)