### PR TITLE
Update Gecko in CI Docker image to include devtools-source-map v0.3.0

### DIFF
--- a/bin/run-mochitests-docker
+++ b/bin/run-mochitests-docker
@@ -18,5 +18,5 @@ docker run -it \
   -v "/tmp/.X11-unix:/tmp/.X11-unix:rw" \
   -e "DISPLAY=unix$DISPLAY" \
   --ipc host \
-  jasonlaster11/local-mc12 \
+  jryans/debugger-gecko \
   /bin/bash -c "export SHELL=/bin/bash; touch devtools/client/debugger/new/test/mochitest/browser.ini && ./mach build && ./mach mochitest --subsuite devtools devtools/client/debugger/new/test/mochitest/"

--- a/bin/update-docker
+++ b/bin/update-docker
@@ -4,10 +4,14 @@ DOWNLOADS_PATH=${DOWNLOADS_PATH:-"$HOME/downloads"}
 
 mkdir -p $DOWNLOADS_PATH
 
-if [[ -e $DOWNLOADS_PATH/local-mc12.tar ]]; then
-  time docker load -i $DOWNLOADS_PATH/local-mc12.tar;
+# Using the first 8 chars of the Docker image hash for brevity
+if [[ -e $DOWNLOADS_PATH/gecko-b60ff65e.tar ]]; then
+  time docker load -i $DOWNLOADS_PATH/gecko-b60ff65e.tar;
 else
-  time docker pull jasonlaster11/local-mc12
+  # It appears the old Docker in CircleCI 1.0 doesn't support pulling a specific
+  # hash such as jryans/debugger-gecko@sha256:b60ff65ecf613774330979f108b70506508aad54dde815564c743da287f10b4b
+  # We should finish the upgrade to CircleCI 2.0 so that this can be less strange.
+  time docker pull jryans/debugger-gecko
   docker images
-  time docker save jasonlaster11/local-mc12 > $DOWNLOADS_PATH/local-mc12.tar
+  time docker save jryans/debugger-gecko > $DOWNLOADS_PATH/gecko-b60ff65e.tar
 fi


### PR DESCRIPTION
* Gecko in CI Docker image includes devtools-source-map v0.3.0, which will be needed to use source maps from the toolbox (upcoming work)
* Changed to referencing the Docker image repo by hash, which should avoid the need to create a new repo name for each update