### PR TITLE
Remove yarn version from docs and circle config

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ debugger.html is a hackable debugger for modern times, built from the ground up 
 > Or take a look at our detailed [getting started][getting-started] instructions.
 
 ```bash
-curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 0.19.1
+curl -o- -L https://yarnpkg.com/install.sh | bash -s
 git clone git@github.com:devtools-html/debugger.html.git
 
 cd debugger.html

--- a/bin/install-yarn
+++ b/bin/install-yarn
@@ -1,5 +1,0 @@
-if [[ ! -e ~/.yarn/bin/yarn || $(yarn --version) != "${YARN_VERSION}" ]]; then
-  echo "Installing Yarn $YARN_VERSION"
-  rm -rf ~/.yarn
-  curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version $YARN_VERSION
-fi

--- a/circle.yml
+++ b/circle.yml
@@ -33,7 +33,7 @@ dependencies:
     - ~/.cache/yarn
   override:
     - yarn install
-    - npm i -g flow-coverage-report
+    - yarn global add flow-coverage-report
     - ./bin/update-docker
 
 general:

--- a/circle.yml
+++ b/circle.yml
@@ -5,12 +5,9 @@ machine:
     - docker
   environment:
     DOWNLOADS_PATH: "$HOME/downloads"
-    YARN_PATH: "$HOME/.yarn"
-    YARN_VERSION: 0.19.1
-    PATH: "${PATH}:${HOME}/.yarn/bin:${HOME}/${CIRCLE_PROJECT_REPONAME}/node_modules/.bin"
+    PATH: "${PATH}:${HOME}/${CIRCLE_PROJECT_REPONAME}/node_modules/.bin"
   post:
     - mkdir -p $DOWNLOADS_PATH
-    - mkdir -p $YARN_PATH
 
 checkout:
   post:
@@ -31,12 +28,9 @@ test:
     - bash <(curl -s https://codecov.io/bash) -f $CIRCLE_TEST_REPORTS/jest-coverage/coverage-final.json
 
 dependencies:
-  pre:
-    - ./bin/install-yarn
   cache_directories:
     - ~/downloads
     - ~/.cache/yarn
-    - ~/.yarn
   override:
     - yarn install
     - npm i -g flow-coverage-report

--- a/circle.yml
+++ b/circle.yml
@@ -13,16 +13,16 @@ checkout:
   post:
     - cp configs/ci.json configs/local.json
 test:
-  override:
+  pre:
     - mkdir -p $CIRCLE_TEST_REPORTS/mocha
     - mkdir -p $CIRCLE_TEST_REPORTS/flow-coverage
     - mkdir -p $CIRCLE_TEST_REPORTS/jest-coverage
+  post:
     - yarn lint-css
     - yarn lint-js
     - yarn lint-md
     - yarn flow
     - ./bin/run-mochitests-docker
-  post:
     - yarn flow-coverage -- -t json -o $CIRCLE_TEST_REPORTS/flow-coverage
     - yarn check
     - bash <(curl -s https://codecov.io/bash) -f $CIRCLE_TEST_REPORTS/jest-coverage/coverage-final.json

--- a/circle.yml
+++ b/circle.yml
@@ -32,7 +32,8 @@ dependencies:
     - ~/downloads
     - ~/.cache/yarn
   override:
-    - yarn install
+    - yarn
+  post:
     - yarn global add flow-coverage-report
     - ./bin/update-docker
 

--- a/docs/getting-setup.md
+++ b/docs/getting-setup.md
@@ -55,7 +55,7 @@ Try this [first activity][first-activity] if you want to start debugging the deb
 This setup is for people on the DevTools team and DevTools wizards.
 
 ```bash
-curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 0.19.1
+curl -o- -L https://yarnpkg.com/install.sh | bash -s
 git clone git@github.com:devtools-html/debugger.html.git
 cd debugger.html
 yarn install


### PR DESCRIPTION
Associated Issue: #2475

### Summary of Changes

I don't believe we need to ensure a version of `yarn` anymore.  Now that the package has stabilized we can likely trust the latest stable version instead of a custom `0.19.1` version.

* removed yarn version requirements from circle ci config
* removed yarn version suggestions in docs

### Test Plan

- run this on circle
- try to pass local tests
