### PR TITLE
remove the extra husky dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "flow-bin": "^0.41.0",
     "fuzzaldrin-plus": "^0.4.1",
     "glob": "^7.0.3",
-    "husky": "^0.13.1",
     "jest-junit-reporter": "^1.0.1",
     "lodash": "^4.17.4",
     "md5": "^2.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3248,7 +3248,7 @@ https-browserify@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-0.0.1.tgz#3f91365cabe60b77ed0ebba24b454e3e09d95a82"
 
-husky@^0.13.1:
+husky@^0.13.2:
   version "0.13.3"
   resolved "https://registry.yarnpkg.com/husky/-/husky-0.13.3.tgz#bc2066080badc8b8fe3516e881f5bc68a57052ff"
   dependencies:


### PR DESCRIPTION
Leaves the devDependency for husky at the more recent version.

Associated Issue: #2460

### Summary of Changes

* remove husy from package.json
* run `yarn` to generate a new `yarn.lock` file.

