### PR TITLE
Fix worker test failures

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -20,6 +20,7 @@ test:
     - mkdir -p $CIRCLE_TEST_REPORTS/mocha
     - mkdir -p $CIRCLE_TEST_REPORTS/flow-coverage
     - mkdir -p $CIRCLE_TEST_REPORTS/jest-coverage
+    - node ./node_modules/.bin/jest --testResultsProcessor jest-junit-reporter --coverage --coverageDirectory=$CIRCLE_TEST_REPORTS/jest-coverage
     - yarn lint-css
     - yarn lint-js
     - yarn lint-md

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "codemirror": "^5.1.0",
     "devtools-launchpad": "^0.0.61",
     "devtools-reps": "^0.5.0",
-    "devtools-source-map": "0.3.1",
+    "devtools-source-map": "0.3.3",
     "documentation": "^4.0.0-beta11",
     "eslint": "^3.12.0",
     "eslint-config-prettier": "^1.5.0",
@@ -123,8 +123,9 @@
       "node_modules/(?!devtools-)"
     ],
     "setupFiles": [
-      "<rootDir>/test/tests-boot.js"
+      "<rootDir>/test/tests-setup.js"
     ],
+    "setupTestFrameworkScriptFile": "<rootDir>/test/tests-framework.js",
     "moduleNameMapper": {
       "\\.(css|svg)$": "<rootDir>/test/__mocks__/styleMock.js"
     }

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -3,7 +3,11 @@
 const firefox = require("./firefox");
 const chrome = require("./chrome");
 const { prefs } = require("../utils/prefs");
-const { bootstrapApp, bootstrapStore } = require("../utils/bootstrap");
+const {
+  bootstrapApp,
+  bootstrapStore,
+  bootstrapWorker,
+} = require("../utils/bootstrap");
 
 function loadFromPrefs(actions: Object) {
   const { pauseOnExceptions, ignoreCaughtExceptions } = prefs;
@@ -26,6 +30,7 @@ async function onConnect(connection: Object) {
   const client = getClient(connection);
   const { store, actions, selectors } = bootstrapStore(client);
 
+  bootstrapWorker();
   await client.onConnect(connection, actions);
   await loadFromPrefs(actions);
 

--- a/src/main.js
+++ b/src/main.js
@@ -11,6 +11,7 @@ const {
 const { isFirefoxPanel } = require("devtools-config");
 
 const { onConnect } = require("./client");
+const { teardownWorkers } = require("./utils/teardown");
 
 if (!isFirefoxPanel()) {
   window.L10N = L10N;
@@ -19,9 +20,6 @@ if (!isFirefoxPanel()) {
 }
 
 if (isFirefoxPanel()) {
-  const sourceMap = require("devtools-source-map");
-  const prettyPrint = require("./utils/pretty-print");
-
   module.exports = {
     bootstrap: ({ threadClient, tabTarget, debuggerClient }: any) => {
       return onConnect({
@@ -31,8 +29,7 @@ if (isFirefoxPanel()) {
     },
     destroy: () => {
       unmountRoot(ReactDOM);
-      sourceMap.destroyWorker();
-      prettyPrint.destroyWorker();
+      teardownWorkers();
     },
   };
 } else {

--- a/src/test/tests-framework.js
+++ b/src/test/tests-framework.js
@@ -1,0 +1,28 @@
+const {
+  startSourceMapWorker,
+  stopSourceMapWorker,
+} = require("devtools-source-map");
+
+const {
+  startPrettyPrintWorker,
+  stopPrettyPrintWorker,
+} = require("../utils/pretty-print");
+
+const {
+  startParserWorker,
+  stopParserWorker,
+} = require("../utils/parser");
+
+const { getValue } = require("devtools-config");
+
+beforeAll(() => {
+  startSourceMapWorker(getValue("workers.sourceMapURL"));
+  startPrettyPrintWorker(getValue("workers.prettyPrintURL"));
+  startParserWorker(getValue("workers.parserURL"));
+});
+
+afterAll(() => {
+  stopSourceMapWorker();
+  stopPrettyPrintWorker();
+  stopParserWorker();
+});

--- a/src/test/tests-setup.js
+++ b/src/test/tests-setup.js
@@ -26,7 +26,7 @@ global.Worker = require("workerjs");
 
 const path = require("path");
 const getConfig = require("../../bin/getConfig");
-const setConfig = require("devtools-config").setConfig;
+const { setConfig } = require("devtools-config");
 
 const rootPath = path.join(__dirname, "../../");
 

--- a/src/utils/bootstrap.js
+++ b/src/utils/bootstrap.js
@@ -3,6 +3,9 @@ const { bindActionCreators, combineReducers } = require("redux");
 const ReactDOM = require("react-dom");
 const { getValue } = require("devtools-config");
 const { renderRoot } = require("devtools-launchpad");
+const { startSourceMapWorker } = require("devtools-source-map");
+const { startPrettyPrintWorker } = require("../utils/pretty-print");
+const { startParserWorker } = require("../utils/parser");
 
 const configureStore = require("./create-store");
 const reducers = require("../reducers");
@@ -42,4 +45,10 @@ export function bootstrapApp(connection, { store, actions }) {
   renderRoot(React, ReactDOM, App, store);
 
   return { store, actions, selectors };
+}
+
+export function bootstrapWorker() {
+  startSourceMapWorker(getValue("workers.sourceMapURL"));
+  startPrettyPrintWorker(getValue("workers.prettyPrintURL"));
+  startParserWorker(getValue("workers.parserURL"));
 }

--- a/src/utils/parser/index.js
+++ b/src/utils/parser/index.js
@@ -1,34 +1,17 @@
 // @flow
 
-const { workerUtils: { workerTask } } = require("devtools-modules");
-const { getValue } = require("devtools-config");
+const { workerUtils: { WorkerDispatcher } } = require("devtools-utils");
 
-let worker;
+const dispatcher = new WorkerDispatcher();
 
-function restartWorker() {
-  if (worker) {
-    worker.terminate();
-  }
-
-  worker = new Worker(getValue("workers.parserURL"));
-}
-
-restartWorker();
-
-function destroyWorker() {
-  if (worker) {
-    worker.terminate();
-    worker = null;
-  }
-}
-
-const getSymbols = workerTask(worker, "getSymbols");
-const getVariablesInScope = workerTask(worker, "getVariablesInScope");
-const getExpression = workerTask(worker, "getExpression");
+const getSymbols = dispatcher.task("getSymbols");
+const getVariablesInScope = dispatcher.task("getVariablesInScope");
+const getExpression = dispatcher.task("getExpression");
 
 module.exports = {
   getSymbols,
   getVariablesInScope,
   getExpression,
-  destroyWorker,
+  startParserWorker: dispatcher.start.bind(dispatcher),
+  stopParserWorker: dispatcher.stop.bind(dispatcher),
 };

--- a/src/utils/pretty-print/index.js
+++ b/src/utils/pretty-print/index.js
@@ -1,22 +1,13 @@
 // @flow
 
-const { getValue } = require("devtools-config");
-const { workerUtils: { workerTask } } = require("devtools-modules");
+const { workerUtils: { WorkerDispatcher } } = require("devtools-utils");
 const { isJavaScript } = require("../source");
 const assert = require("../assert");
 
 import type { Source, SourceText } from "../../types";
 
-let prettyPrintWorker = new Worker(getValue("workers.prettyPrintURL"));
-
-function destroyWorker() {
-  if (prettyPrintWorker != null) {
-    prettyPrintWorker.terminate();
-    prettyPrintWorker = null;
-  }
-}
-
-const _prettyPrint = workerTask(prettyPrintWorker, "prettyPrint");
+const dispatcher = new WorkerDispatcher();
+const _prettyPrint = dispatcher.task("prettyPrint");
 
 type PrettyPrintOpts = {
   source: Source,
@@ -42,5 +33,6 @@ async function prettyPrint({ source, sourceText, url }: PrettyPrintOpts) {
 
 module.exports = {
   prettyPrint,
-  destroyWorker,
+  startPrettyPrintWorker: dispatcher.start.bind(dispatcher),
+  stopPrettyPrintWorker: dispatcher.stop.bind(dispatcher),
 };

--- a/src/utils/teardown.js
+++ b/src/utils/teardown.js
@@ -1,0 +1,9 @@
+const { stopSourceMapWorker } = require("devtools-source-map");
+const { stopPrettyPrintWorker } = require("../utils/pretty-print");
+const { stopParserWorker } = require("../utils/parser");
+
+export function teardownWorkers() {
+  stopSourceMapWorker();
+  stopPrettyPrintWorker();
+  stopParserWorker();
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2055,19 +2055,26 @@ devtools-sham-modules@^0.0.18:
   version "0.0.18"
   resolved "https://registry.yarnpkg.com/devtools-sham-modules/-/devtools-sham-modules-0.0.18.tgz#0e2d89b164a4a642bd0948a4eb036aa72fc185ee"
 
-devtools-source-map@0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/devtools-source-map/-/devtools-source-map-0.3.1.tgz#2fadc21f0774cffdc73b5f2af1d82c6c871b5c21"
+devtools-source-map@0.3.3:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/devtools-source-map/-/devtools-source-map-0.3.3.tgz#0d71aa46e082b199b096ad08db03ce1b2b5e081e"
   dependencies:
     babel-plugin-transform-async-to-generator "^6.22.0"
     babel-plugin-transform-flow-strip-types "^6.22.0"
-    devtools-config "^0.0.12"
-    devtools-modules "^0.0.20"
+    devtools-utils "0.0.2"
     jest "^19.0.2"
     md5 "^2.2.1"
     regenerator-runtime "^0.10.3"
     source-map "^0.5.6"
     url "^0.11.0"
+
+devtools-utils@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/devtools-utils/-/devtools-utils-0.0.2.tgz#8e711f276920f75785cdd9ae061d7d45752c6d44"
+  dependencies:
+    babel-plugin-transform-flow-strip-types "^6.22.0"
+    babel-preset-stage-3 "^6.22.0"
+    jest "^19.0.2"
 
 diff@1.4.0, diff@^1.3.2:
   version "1.4.0"


### PR DESCRIPTION
### Summary of Changes

We were seeing `DebuggerConfig` errors in our unit tests because the new source map worker was using DebuggerConfig. The new version of the debugger bypasses that with a new explicit start/stop call to the workers.