### PR TITLE
Use source map service from toolbox in Firefox

### DIFF
--- a/assets/panel/moz.build
+++ b/assets/panel/moz.build
@@ -9,5 +9,4 @@ DevToolsModules(
     'panel.js',
     'parser-worker.js',
     'pretty-print-worker.js',
-    'source-map-worker.js'
 )

--- a/assets/panel/panel.js
+++ b/assets/panel/panel.js
@@ -30,6 +30,7 @@ DebuggerPanel.prototype = {
       threadClient: this.toolbox.threadClient,
       tabTarget: this.toolbox.target,
       debuggerClient: this.toolbox.target._client,
+      sourceMaps: this.toolbox.sourceMapService,
     });
 
     this._actions = actions;

--- a/bin/run-mochitests-docker
+++ b/bin/run-mochitests-docker
@@ -4,7 +4,6 @@ node ./bin/publish-assets
 
 docker run -it \
   -v `pwd`/assets/build/debugger.js:/gecko/devtools/client/debugger/new/debugger.js \
-  -v `pwd`/assets/build/source-map-worker.js:/gecko/devtools/client/debugger/new/source-map-worker.js \
   -v `pwd`/assets/build/pretty-print-worker.js:/gecko/devtools/client/debugger/new/pretty-print-worker.js \
   -v `pwd`/assets/build/parser-worker.js:/gecko/devtools/client/debugger/new/parser-worker.js \
   -v `pwd`/assets/build/integration-tests.js:/gecko/devtools/client/debugger/new/integration-tests.js \

--- a/circle-2.0.yml
+++ b/circle-2.0.yml
@@ -109,7 +109,6 @@ stages:
       #   command: |
       #       docker run -it \
       #         -v `pwd`/assets/build/debugger.js:/firefox/devtools/client/debugger/new/debugger.js \
-      #         -v `pwd`/assets/build/source-map-worker.js:/firefox/devtools/client/debugger/new/source-map-worker.js \
       #         -v `pwd`/assets/build/pretty-print-worker.js:/firefox/devtools/client/debugger/new/pretty-print-worker.js \
       #         -v `pwd`/assets/build/integration-tests.js:/firefox/devtools/client/debugger/new/integration-tests.js \
       #         -v `pwd`/assets/build/debugger.css:/firefox/devtools/client/debugger/new/debugger.css \

--- a/configs/application.json
+++ b/configs/application.json
@@ -1,8 +1,11 @@
 {
   "title": "Debugger",
   "environment": "development",
-  "baseWorkerURL": "http://localhost:8000/assets/build/",
-  "sourceMapWorkerURL": "http://localhost:8000/assets/build/source-map-worker.js",
+  "workers": {
+    "parserURL": "http://localhost:8000/assets/build/parser-worker.js",
+    "sourceMapURL": "http://localhost:8000/assets/build/source-map-worker.js",
+    "prettyPrintURL": "http://localhost:8000/assets/build/pretty-print-worker.js"
+  },
   "theme": "light",
   "logging": {
     "client": false,

--- a/configs/firefox-panel.json
+++ b/configs/firefox-panel.json
@@ -7,7 +7,6 @@
   },
   "workers": {
     "parserURL": "resource://devtools/client/debugger/new/parser-worker.js",
-    "sourceMapURL": "resource://devtools/client/debugger/new/source-map-worker.js",
     "prettyPrintURL": "resource://devtools/client/debugger/new/pretty-print-worker.js"
   },
   "features": {

--- a/src/actions/breakpoints.js
+++ b/src/actions/breakpoints.js
@@ -12,12 +12,6 @@ import constants from "../constants";
 import { PROMISE } from "../utils/redux/middleware/promise";
 import { getBreakpoint, getBreakpoints, getSource } from "../selectors";
 
-import {
-  getOriginalLocation,
-  getGeneratedLocation,
-  isOriginalId,
-} from "devtools-source-map";
-
 import type { ThunkArgs } from "./types";
 import type { Location } from "../types";
 
@@ -55,7 +49,7 @@ export function addBreakpoint(
   location: Location,
   { condition, getTextForLine }: addBreakpointOptions = {}
 ) {
-  return ({ dispatch, getState, client }: ThunkArgs) => {
+  return ({ dispatch, getState, client, sourceMaps }: ThunkArgs) => {
     if (_breakpointExists(getState(), location)) {
       return Promise.resolve();
     }
@@ -67,18 +61,21 @@ export function addBreakpoint(
       breakpoint: bp,
       condition: condition,
       [PROMISE]: (async function() {
-        if (isOriginalId(bp.location.sourceId)) {
+        if (sourceMaps.isOriginalId(bp.location.sourceId)) {
           const source = getSource(getState(), bp.location.sourceId);
-          location = await getGeneratedLocation(bp.location, source.toJS());
+          location = await sourceMaps.getGeneratedLocation(
+            bp.location,
+            source.toJS()
+          );
         }
 
         let { id, actualLocation, hitCount } = await client.setBreakpoint(
           location,
           bp.condition,
-          isOriginalId(bp.location.sourceId)
+          sourceMaps.isOriginalId(bp.location.sourceId)
         );
 
-        actualLocation = await getOriginalLocation(actualLocation);
+        actualLocation = await sourceMaps.getOriginalLocation(actualLocation);
 
         // If this breakpoint is being re-enabled, it already has a
         // text snippet.
@@ -187,7 +184,7 @@ export function setBreakpointCondition(
   { condition, getTextForLine }: addBreakpointOptions = {}
 ) {
   // location: Location, condition: string, { getTextForLine }) {
-  return ({ dispatch, getState, client }: ThunkArgs) => {
+  return ({ dispatch, getState, client, sourceMaps }: ThunkArgs) => {
     const bp = getBreakpoint(getState(), location);
     if (!bp) {
       return dispatch(addBreakpoint(location, { condition, getTextForLine }));
@@ -207,7 +204,7 @@ export function setBreakpointCondition(
         bp.id,
         location,
         condition,
-        isOriginalId(bp.location.sourceId)
+        sourceMaps.isOriginalId(bp.location.sourceId)
       ),
     });
   };

--- a/src/actions/navigation.js
+++ b/src/actions/navigation.js
@@ -1,5 +1,4 @@
 import constants from "../constants";
-import { clearSourceMaps } from "devtools-source-map";
 import { clearDocuments } from "../utils/editor";
 import { getSources } from "../reducers/sources";
 import { waitForMs } from "../utils/utils";
@@ -15,12 +14,14 @@ import { newSources } from "./sources";
  * @static
  */
 export function willNavigate(_, event) {
-  clearSourceMaps();
-  clearDocuments();
+  return async function({ dispatch, getState, client, sourceMaps }: ThunkArgs) {
+    await sourceMaps.clearSourceMaps();
+    clearDocuments();
 
-  return {
-    type: constants.NAVIGATE,
-    url: event.url,
+    dispatch({
+      type: constants.NAVIGATE,
+      url: event.url,
+    });
   };
 }
 

--- a/src/actions/pause.js
+++ b/src/actions/pause.js
@@ -42,9 +42,9 @@ export function resumed() {
  * @static
  */
 export function paused(pauseInfo: Pause) {
-  return async function({ dispatch, getState, client }: ThunkArgs) {
+  return async function({ dispatch, getState, client, sourceMaps }: ThunkArgs) {
     let { frames, why, loadedObjects } = pauseInfo;
-    frames = await updateFrameLocations(frames);
+    frames = await updateFrameLocations(frames, sourceMaps);
     const frame = frames[0];
 
     dispatch({

--- a/src/actions/types.js
+++ b/src/actions/types.js
@@ -27,6 +27,7 @@ export type ThunkArgs = {
   dispatch: () => Promise<any>,
   getState: () => any,
   client: any,
+  sourceMaps: any,
 };
 
 export type ActionType = Object | Function;

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -6,7 +6,7 @@ const { prefs } = require("../utils/prefs");
 const {
   bootstrapApp,
   bootstrapStore,
-  bootstrapWorker,
+  bootstrapWorkers,
 } = require("../utils/bootstrap");
 
 function loadFromPrefs(actions: Object) {
@@ -21,7 +21,7 @@ function getClient(connection: any) {
   return clientType == "firefox" ? firefox : chrome;
 }
 
-async function onConnect(connection: Object) {
+async function onConnect(connection: Object, services: Object) {
   // NOTE: the landing page does not connect to a JS process
   if (!connection) {
     return;
@@ -29,9 +29,9 @@ async function onConnect(connection: Object) {
 
   const client = getClient(connection);
   const commands = client.clientCommands;
-  const { store, actions, selectors } = bootstrapStore(commands);
+  const { store, actions, selectors } = bootstrapStore(commands, services);
 
-  bootstrapWorker();
+  bootstrapWorkers();
   await client.onConnect(connection, actions);
   await loadFromPrefs(actions);
 

--- a/src/components/Editor/EditorMenu.js
+++ b/src/components/Editor/EditorMenu.js
@@ -1,6 +1,6 @@
 const { showMenu } = require("../shared/menu");
 const { isEnabled } = require("devtools-config");
-const { isOriginalId, hasMappedSource } = require("devtools-source-map");
+const { isOriginalId } = require("devtools-source-map");
 const { copyToTheClipboard } = require("../../utils/clipboard");
 
 async function EditorMenu(
@@ -26,8 +26,6 @@ async function EditorMenu(
 
   event.stopPropagation();
   event.preventDefault();
-
-  const isMapped = await hasMappedSource(selectedLocation);
 
   const copySourceUrl = {
     id: "node-menu-copy-source",
@@ -67,9 +65,8 @@ async function EditorMenu(
 
   const menuOptions = [];
 
-  if (isMapped) {
-    menuOptions.push(jumpLabel);
-  }
+  // TODO: Find a new way to only add this for mapped sources?
+  menuOptions.push(jumpLabel);
 
   const textSelected = codeMirror.somethingSelected();
   if (isEnabled("watchExpressions") && textSelected) {

--- a/src/utils/pause.js
+++ b/src/utils/pause.js
@@ -1,16 +1,17 @@
 // @flow
-import { getOriginalLocation } from "devtools-source-map";
-
 import type { Pause, Frame } from "../types";
 
-export function updateFrameLocations(frames: Frame[]): Promise<Frame[]> {
+export function updateFrameLocations(
+  frames: Frame[],
+  sourceMaps: any
+): Promise<Frame[]> {
   if (!frames || frames.length == 0) {
     return Promise.resolve(frames);
   }
 
   return Promise.all(
     frames.map(frame => {
-      return getOriginalLocation(frame.location).then(loc => {
+      return sourceMaps.getOriginalLocation(frame.location).then(loc => {
         return Object.assign(frame, {
           location: loc,
         });

--- a/src/utils/teardown.js
+++ b/src/utils/teardown.js
@@ -1,9 +1,0 @@
-const { stopSourceMapWorker } = require("devtools-source-map");
-const { stopPrettyPrintWorker } = require("../utils/pretty-print");
-const { stopParserWorker } = require("../utils/parser");
-
-export function teardownWorkers() {
-  stopSourceMapWorker();
-  stopPrettyPrintWorker();
-  stopParserWorker();
-}

--- a/src/utils/test-head.js
+++ b/src/utils/test-head.js
@@ -1,11 +1,12 @@
 // @flow
 
 /**
- * Utils for mochitest
+ * Utils for Jest
  * @module utils/test-head
  */
 
 const { combineReducers } = require("redux");
+const sourceMaps = require("devtools-source-map");
 const reducers = require("../reducers");
 const actions = require("../actions").default;
 const selectors = require("../selectors");
@@ -21,7 +22,10 @@ function createStore(client: any, initialState: any = {}) {
   return configureStore({
     log: false,
     makeThunkArgs: args => {
-      return Object.assign({}, args, { client });
+      return Object.assign({}, args, {
+        client,
+        sourceMaps,
+      });
     },
   })(combineReducers(reducers), initialState);
 }


### PR DESCRIPTION
### Summary of Changes

* When used as a Firefox panel, the debugger gets a `sourceMapService` object from the toolbox, which manages the worker itself, etc. Those details are hidden from the debugger.
* When used in a tab, the debugger starts the source map worker like it did before.

### Test Plan

- [x] Verified source maps work when running in a tab
- [x] Verified source maps work when running as a panel