### PR TITLE
Fix up Docker mapping to use latest files again

### DIFF
--- a/bin/run-mochitests-docker
+++ b/bin/run-mochitests-docker
@@ -3,18 +3,18 @@
 node ./bin/publish-assets
 
 docker run -it \
-  -v `pwd`/assets/build/debugger.js:/firefox/devtools/client/debugger/new/debugger.js \
-  -v `pwd`/assets/build/source-map-worker.js:/firefox/devtools/client/debugger/new/source-map-worker.js \
-  -v `pwd`/assets/build/pretty-print-worker.js:/firefox/devtools/client/debugger/new/pretty-print-worker.js \
-  -v `pwd`/assets/build/parser-worker.js:/firefox/devtools/client/debugger/new/parser-worker.js \
-  -v `pwd`/assets/build/integration-tests.js:/firefox/devtools/client/debugger/new/integration-tests.js \
-  -v `pwd`/assets/build/debugger.css:/firefox/devtools/client/debugger/new/debugger.css \
-  -v `pwd`/assets/build/panel/debugger.properties:/firefox/devtools/client/locales/en-US/debugger.properties \
-  -v `pwd`/assets/build/panel/prefs.js:/firefox/devtools/client/preferences/debugger.js \
-  -v `pwd`/assets/build/panel/panel.js:/firefox/devtools/client/debugger/new/panel.js \
-  -v `pwd`/assets/build/panel/index.html:/firefox/devtools/client/debugger/new/index.html \
-  -v `pwd`/assets/build/panel/moz.build:/firefox/devtools/client/debugger/new/moz.build \
-  -v `pwd`/assets/build/mochitest:/firefox/devtools/client/debugger/new/test/mochitest \
+  -v `pwd`/assets/build/debugger.js:/gecko/devtools/client/debugger/new/debugger.js \
+  -v `pwd`/assets/build/source-map-worker.js:/gecko/devtools/client/debugger/new/source-map-worker.js \
+  -v `pwd`/assets/build/pretty-print-worker.js:/gecko/devtools/client/debugger/new/pretty-print-worker.js \
+  -v `pwd`/assets/build/parser-worker.js:/gecko/devtools/client/debugger/new/parser-worker.js \
+  -v `pwd`/assets/build/integration-tests.js:/gecko/devtools/client/debugger/new/integration-tests.js \
+  -v `pwd`/assets/build/debugger.css:/gecko/devtools/client/debugger/new/debugger.css \
+  -v `pwd`/assets/build/panel/debugger.properties:/gecko/devtools/client/locales/en-US/debugger.properties \
+  -v `pwd`/assets/build/panel/prefs.js:/gecko/devtools/client/preferences/debugger.js \
+  -v `pwd`/assets/build/panel/panel.js:/gecko/devtools/client/debugger/new/panel.js \
+  -v `pwd`/assets/build/panel/index.html:/gecko/devtools/client/debugger/new/index.html \
+  -v `pwd`/assets/build/panel/moz.build:/gecko/devtools/client/debugger/new/moz.build \
+  -v `pwd`/assets/build/mochitest:/gecko/devtools/client/debugger/new/test/mochitest \
   -v "/tmp/.X11-unix:/tmp/.X11-unix:rw" \
   -e "DISPLAY=unix$DISPLAY" \
   --ipc host \


### PR DESCRIPTION
When I made the latest Docker image, I edited the name of the `WORKDIR` without realizing it needed to match the paths over here, so the mochitests weren't being run against the latest changes.

To make it easier to track these things, I created a tiny repo with the Docker stuff: https://github.com/devtools-html/debugger-docker. We might trash it soon if the approach changes, but seems useful to share for now.

The test run here should be broken for now (that's expected). Tomorrow we can look into adding fixes to make the tests pass again.