### PR TITLE
Standardize prettier options

### DIFF
--- a/bin/prettier.js
+++ b/bin/prettier.js
@@ -6,7 +6,7 @@ const isWindows = /^win/.test(process.platform);
 const prettierCmd = path.resolve(__dirname, "../node_modules/.bin/" + (isWindows ? "prettier.cmd" : "prettier"));
 
 const args = [
-  "--trailing-comma=all",
+  "--trailing-comma=es5",
   "--bracket-spacing=true"
 ];
 


### PR DESCRIPTION
Fixes up `bin/prettier` options to match those in `package.json`.