### PR TITLE
Add search modifier tooltips

### DIFF
--- a/assets/panel/debugger.properties
+++ b/assets/panel/debugger.properties
@@ -517,6 +517,9 @@ symbolSearch.search.functionsPlaceholder=Search functions…
 symbolSearch.search.variablesPlaceholder=Search variables…
 symbolSearch.search.classesPlaceholder=Search classes…
 symbolSearch.search.key=O
+symbolSearch.searchModifier.regex=Regex
+symbolSearch.searchModifier.caseSensitive=Case sensitive
+symbolSearch.searchModifier.wholeWord=Whole word
 
 # LOCALIZATION NOTE (resumptionOrderPanelTitle): This is the text that appears
 # as a description in the notification panel popup, when multiple debuggers are

--- a/src/components/Editor/SearchBar.js
+++ b/src/components/Editor/SearchBar.js
@@ -512,7 +512,7 @@ const SearchBar = React.createClass({
     } = this.props;
     const { symbolSearchEnabled } = this.state;
 
-    function searchModBtn(modVal, className, svgName) {
+    function searchModBtn(modVal, className, svgName, tooltip) {
       return dom.button(
         {
           className: classnames(className, {
@@ -521,6 +521,7 @@ const SearchBar = React.createClass({
           }),
           onClick: () =>
             !symbolSearchEnabled ? toggleFileSearchModifier(modVal) : null,
+          title: tooltip,
         },
         Svg(svgName)
       );
@@ -528,9 +529,24 @@ const SearchBar = React.createClass({
 
     return dom.div(
       { className: "search-modifiers" },
-      searchModBtn("regexMatch", "regex-match-btn", "regex-match"),
-      searchModBtn("caseSensitive", "case-sensitive-btn", "case-match"),
-      searchModBtn("wholeWord", "whole-word-btn", "whole-word-match")
+      searchModBtn(
+        "regexMatch",
+        "regex-match-btn",
+        "regex-match",
+        L10N.getStr("symbolSearch.searchModifier.regex")
+      ),
+      searchModBtn(
+        "caseSensitive",
+        "case-sensitive-btn",
+        "case-match",
+        L10N.getStr("symbolSearch.searchModifier.caseSensitive")
+      ),
+      searchModBtn(
+        "wholeWord",
+        "whole-word-btn",
+        "whole-word-match",
+        L10N.getStr("symbolSearch.searchModifier.wholeWord")
+      )
     );
   },
 


### PR DESCRIPTION
Associated Issue: #2242  

### Summary of Changes

* Added tooltips to regex, case, and whole word match

Debugger's Testing doc
https://docs.google.com/document/d/1oBMRxV8A2ag2t22YsQOxTdEv0mXKzIg0tggJjRkU1S0/edit#.
Feel free to improve it!

### Screenshots/Videos (OPTIONAL)

![idb2uughip](https://cloud.githubusercontent.com/assets/12941622/24571466/6294e620-163f-11e7-928e-04ca6b4a423a.gif)
