### PR TITLE
Convert Editor/Breakpoint.js to ES6 class

### DIFF
--- a/src/components/Editor/Breakpoint.js
+++ b/src/components/Editor/Breakpoint.js
@@ -16,12 +16,7 @@ function makeMarker(isDisabled: boolean) {
   return bp;
 }
 
-const Breakpoint = React.createClass({
-  propTypes: {
-    breakpoint: PropTypes.object.isRequired,
-    editor: PropTypes.object.isRequired,
-  },
-  displayName: "Breakpoint",
+class Breakpoint extends Component {
   addBreakpoint() {
     const bp = this.props.breakpoint;
     const line = bp.location.line - 1;
@@ -37,22 +32,22 @@ const Breakpoint = React.createClass({
     } else {
       this.props.editor.removeLineClass(line, "line", "has-condition");
     }
-  },
+  }
   shouldComponentUpdate(nextProps: any) {
     return this.props.editor !== nextProps.editor ||
       this.props.breakpoint.disabled !== nextProps.breakpoint.disabled ||
       this.props.breakpoint.condition !== nextProps.breakpoint.condition;
-  },
+  }
   componentDidMount() {
     if (!this.props.editor) {
       return;
     }
 
     this.addBreakpoint();
-  },
+  }
   componentDidUpdate() {
     this.addBreakpoint();
-  },
+  }
   componentWillUnmount() {
     if (!this.props.editor) {
       return;
@@ -64,10 +59,17 @@ const Breakpoint = React.createClass({
     this.props.editor.setGutterMarker(line, "breakpoints", null);
     this.props.editor.removeLineClass(line, "line", "new-breakpoint");
     this.props.editor.removeLineClass(line, "line", "has-condition");
-  },
+  }
   render() {
     return null;
-  },
-});
+  }
+}
+
+Breakpoint.propTypes = {
+  breakpoint: PropTypes.object.isRequired,
+  editor: PropTypes.object.isRequired,
+};
+
+Breakpoint.displayName = "Breakpoint";
 
 module.exports = Breakpoint;

--- a/src/components/Editor/Breakpoint.js
+++ b/src/components/Editor/Breakpoint.js
@@ -1,13 +1,11 @@
 // @flow
-const React = require("react");
-const ReactDOM = require("react-dom");
+import { DOM as dom, PropTypes, Component } from "react";
 
-const { PropTypes } = React;
-const classnames = require("classnames");
-const Svg = require("../shared/Svg");
+import classnames from "classnames";
+import Svg from "../shared/Svg";
 
 const breakpointSvg = document.createElement("div");
-ReactDOM.render(Svg("breakpoint"), breakpointSvg);
+dom.render(Svg("breakpoint"), breakpointSvg);
 
 function makeMarker(isDisabled: boolean) {
   const bp = breakpointSvg.cloneNode(true);

--- a/src/components/Editor/Breakpoint.js
+++ b/src/components/Editor/Breakpoint.js
@@ -20,8 +20,8 @@ function makeMarker(isDisabled: boolean) {
 class Breakpoint extends Component {
   addBreakpoint: Function;
 
-  constructor(props) {
-    super(props);
+  constructor() {
+    super();
     this.addBreakpoint = this.addBreakpoint.bind(this);
   }
 

--- a/src/components/Editor/Breakpoint.js
+++ b/src/components/Editor/Breakpoint.js
@@ -71,4 +71,4 @@ Breakpoint.propTypes = {
 
 Breakpoint.displayName = "Breakpoint";
 
-module.exports = Breakpoint;
+export default Breakpoint;

--- a/src/components/Editor/Breakpoint.js
+++ b/src/components/Editor/Breakpoint.js
@@ -1,10 +1,12 @@
 // @flow
-import { DOM as dom, PropTypes, Component } from "react";
+import { PropTypes, Component } from "react";
+const ReactDOM = require("react-dom");
 
 import classnames from "classnames";
 import Svg from "../shared/Svg";
 
-const breakpointSvg = dom.div(Svg("breakpoint"));
+const breakpointSvg = document.createElement("div");
+ReactDOM.render(Svg("breakpoint"), breakpointSvg);
 
 function makeMarker(isDisabled: boolean) {
   const bp = breakpointSvg.cloneNode(true);
@@ -16,6 +18,13 @@ function makeMarker(isDisabled: boolean) {
 }
 
 class Breakpoint extends Component {
+  addBreakpoint: Function;
+
+  constructor(props) {
+    super(props);
+    this.addBreakpoint = this.addBreakpoint.bind(this);
+  }
+
   addBreakpoint() {
     const bp = this.props.breakpoint;
     const line = bp.location.line - 1;

--- a/src/components/Editor/Breakpoint.js
+++ b/src/components/Editor/Breakpoint.js
@@ -4,8 +4,7 @@ import { DOM as dom, PropTypes, Component } from "react";
 import classnames from "classnames";
 import Svg from "../shared/Svg";
 
-const breakpointSvg = document.createElement("div");
-dom.render(Svg("breakpoint"), breakpointSvg);
+const breakpointSvg = dom.div(Svg("breakpoint"));
 
 function makeMarker(isDisabled: boolean) {
   const bp = breakpointSvg.cloneNode(true);

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -36,7 +36,7 @@ const {
 } = require("../../selectors");
 const { makeLocationId } = require("../../reducers/breakpoints");
 const actions = require("../../actions").default;
-const Breakpoint = React.createFactory(require("./Breakpoint"));
+const Breakpoint = React.createFactory(require("./Breakpoint").default);
 const HitMarker = React.createFactory(require("./HitMarker"));
 
 const {


### PR DESCRIPTION
Associated Issue: #1890 

# Summary of Changes
- Breakpoint.js
  - Convert to class syntax
  - Convert require statements to import syntax
