### PR TITLE
Fix 2267

### DIFF
--- a/src/components/Editor/SearchBar.js
+++ b/src/components/Editor/SearchBar.js
@@ -402,7 +402,7 @@ const SearchBar = React.createClass({
   },
 
   // Handlers
-  selectResultItem(e: SyntheticEvent, item: SymbolDeclaration, index?: number) {
+  selectResultItem(e: SyntheticEvent, item: SymbolDeclaration) {
     const { selectSource, selectedSource } = this.props;
 
     if (selectedSource) {

--- a/src/components/Editor/SearchBar.js
+++ b/src/components/Editor/SearchBar.js
@@ -54,42 +54,6 @@ type ToggleSymbolSearchOpts = {
 
 require("./SearchBar.css");
 
-const keyDownHandlers = {
-  ArrowUp(event, searchResults, resultCount) {
-    const selectedResultIndex = Math.max(0, this.state.selectedResultIndex - 1);
-
-    this.setState({ selectedResultIndex });
-    this.onSelectResultItem(searchResults[selectedResultIndex]);
-
-    event.preventDefault();
-  },
-
-  ArrowDown(event, searchResults, resultCount) {
-    const newIndex = this.state.selectedResultIndex + 1;
-    const selectedResultIndex = Math.min(resultCount - 1, newIndex);
-
-    this.setState({ selectedResultIndex });
-    this.onSelectResultItem(searchResults[selectedResultIndex]);
-
-    event.preventDefault();
-  },
-
-  Enter(event, searchResults) {
-    if (searchResults.length) {
-      const resultItem = searchResults[this.state.selectedResultIndex];
-      this.selectResultItem(event, resultItem, 0);
-    }
-
-    this.closeSearch(event);
-    event.preventDefault();
-  },
-
-  Tab(event) {
-    this.closeSearch(event);
-    event.preventDefault();
-  }
-};
-
 const SearchBar = React.createClass({
   propTypes: {
     editor: PropTypes.object,
@@ -442,8 +406,10 @@ const SearchBar = React.createClass({
     const { selectSource, selectedSource } = this.props;
 
     if (selectedSource) {
-      selectSource(
-        selectedSource.get("id"), { line: item.location.start.line });
+      selectSource(selectedSource.get("id"), {
+        line: item.location.start.line,
+      });
+
       this.closeSearch(e);
     }
   },

--- a/src/components/Editor/SearchBar.js
+++ b/src/components/Editor/SearchBar.js
@@ -399,12 +399,14 @@ const SearchBar = React.createClass({
   },
 
   // Handlers
-  selectResultItem(item: FormattedSymbolDeclaration) {
+  selectResultItem(e: SyntheticEvent, item: SymbolDeclaration, index: number) {
     const { selectSource, selectedSource } = this.props;
     if (selectedSource) {
+      this.setState({ selectedResultIndex: index });
       selectSource(selectedSource.get("id"), {
         line: item.location.start.line,
       });
+      this.closeSearch(e);
     }
   },
 

--- a/src/components/Editor/SearchBar.js
+++ b/src/components/Editor/SearchBar.js
@@ -30,7 +30,10 @@ const SearchInput = createFactory(require("../shared/SearchInput").default);
 const ResultList = createFactory(require("../shared/ResultList").default);
 const ImPropTypes = require("react-immutable-proptypes");
 
-import type { FormattedSymbolDeclaration, SymbolDeclaration } from "../../utils/parser/utils";
+import type {
+  FormattedSymbolDeclaration,
+  SymbolDeclaration,
+} from "../../utils/parser/utils";
 
 function getShortcuts() {
   const searchAgainKey = L10N.getStr("sourceSearch.search.again.key");

--- a/src/components/Editor/SearchBar.js
+++ b/src/components/Editor/SearchBar.js
@@ -30,7 +30,7 @@ const SearchInput = createFactory(require("../shared/SearchInput").default);
 const ResultList = createFactory(require("../shared/ResultList").default);
 const ImPropTypes = require("react-immutable-proptypes");
 
-import type { FormattedSymbolDeclaration } from "../../utils/parser/utils";
+import type { FormattedSymbolDeclaration, SymbolDeclaration } from "../../utils/parser/utils";
 
 function getShortcuts() {
   const searchAgainKey = L10N.getStr("sourceSearch.search.again.key");
@@ -399,7 +399,7 @@ const SearchBar = React.createClass({
   },
 
   // Handlers
-  selectResultItem(e: SyntheticEvent, item: SymbolDeclaration, index: number) {
+  selectResultItem(e: SyntheticEvent, item: SymbolDeclaration, index?: number) {
     const { selectSource, selectedSource } = this.props;
     if (selectedSource) {
       this.setState({ selectedResultIndex: index });
@@ -457,7 +457,7 @@ const SearchBar = React.createClass({
       e.preventDefault();
     } else if (e.key === "Enter") {
       if (searchResults.length) {
-        this.selectResultItem(searchResults[this.state.selectedResultIndex]);
+        this.selectResultItem(e, searchResults[this.state.selectedResultIndex]);
       }
       this.closeSearch(e);
       e.preventDefault();

--- a/src/components/shared/ResultList.js
+++ b/src/components/shared/ResultList.js
@@ -30,7 +30,7 @@ const ResultList = createClass({
   renderListItem(item: ResultListItem, index: number) {
     return dom.li(
       {
-        onClick: () => this.props.selectItem(item),
+        onClick: e => this.props.selectItem(e, item, index),
         key: `${item.id}${item.value}${index}`,
         ref: index,
         title: item.value,


### PR DESCRIPTION
Associated Issue: #2267

### Summary of Changes

* On **selectResultItem** is now possible to pass the event as a parameter to close the result list

### Test Plan

- [x] Open a large file
- [x] Ctrl+f to find
- [x] Select **function** from filter
- [x] Enter the text **add**
- [x] Click on any item
- [x] The result list show close after the click
