### PR TITLE
FunctionSearch - show index in summary, Fixes #2529

### DIFF
--- a/assets/panel/debugger.properties
+++ b/assets/panel/debugger.properties
@@ -146,7 +146,7 @@ sourceSearch.search.again.key=G
 
 # LOCALIZATION NOTE (sourceSearch.resultsSummary1): Shows a summary of
 # the number of matches for autocomplete
-sourceSearch.resultsSummary1=%d of %d results
+sourceSearch.resultsSummary1=%d results
 
 # LOCALIZATION NOTE (noMatchingStringsText): The text to display in the
 # global search results when there are no matching strings after filtering.

--- a/assets/panel/debugger.properties
+++ b/assets/panel/debugger.properties
@@ -239,7 +239,7 @@ callStack.expand=Expand Rows
 # for the summarizing the selected search result. e.g. 5 of 10 results.
 editor.searchResults=%d of %d results
 
-# LOCALIZATION NOTE (sourceSearch.singleResult):
+# LOCALIZATION NOTE (sourceSearch.singleResult): Copy shown when there is one result.
 editor.singleResult=1 result
 
 # LOCALIZATION NOTE (editor.noResults): Editor Search bar message

--- a/assets/panel/debugger.properties
+++ b/assets/panel/debugger.properties
@@ -239,6 +239,9 @@ callStack.expand=Expand Rows
 # for the summarizing the selected search result. e.g. 5 of 10 results.
 editor.searchResults=%d of %d results
 
+# LOCALIZATION NOTE (sourceSearch.singleResult):
+editor.singleResult=1 result
+
 # LOCALIZATION NOTE (editor.noResults): Editor Search bar message
 # for when no results found.
 editor.noResults=no results

--- a/assets/panel/debugger.properties
+++ b/assets/panel/debugger.properties
@@ -146,7 +146,7 @@ sourceSearch.search.again.key=G
 
 # LOCALIZATION NOTE (sourceSearch.resultsSummary1): Shows a summary of
 # the number of matches for autocomplete
-sourceSearch.resultsSummary1=%d results
+sourceSearch.resultsSummary1=%d of %d results
 
 # LOCALIZATION NOTE (noMatchingStringsText): The text to display in the
 # global search results when there are no matching strings after filtering.

--- a/src/components/Editor/SearchBar.js
+++ b/src/components/Editor/SearchBar.js
@@ -473,16 +473,18 @@ const SearchBar = React.createClass({
 
   // Renderers
   buildSummaryMsg() {
-    if (
-      this.state.symbolSearchEnabled &&
-      this.state.symbolSearchResults.length > 0
-    ) {
-      return L10N.getFormatStr(
-        "editor.searchResults",
-        this.state.selectedResultIndex + 1,
-        this.state.symbolSearchResults.length
-      );
+    if (this.state.symbolSearchEnabled) {
+      if (this.state.symbolSearchResults.length > 1) {
+        return L10N.getFormatStr(
+          "editor.searchResults",
+          this.state.selectedResultIndex + 1,
+          this.state.symbolSearchResults.length
+        );
+      } else if (this.state.symbolSearchResults.length === 1) {
+        return L10N.getFormatStr("editor.singleResult");
+      }
     }
+
     const { searchResults: { count, index }, query } = this.props;
 
     if (query.trim() == "") {

--- a/src/components/Editor/SearchBar.js
+++ b/src/components/Editor/SearchBar.js
@@ -473,9 +473,10 @@ const SearchBar = React.createClass({
 
   // Renderers
   buildSummaryMsg() {
-    if (this.state.symbolSearchEnabled) {
+    if (this.state.symbolSearchResults.length > 0) {
       return L10N.getFormatStr(
         "sourceSearch.resultsSummary1",
+        this.state.selectedResultIndex + 1,
         this.state.symbolSearchResults.length
       );
     }

--- a/src/components/Editor/SearchBar.js
+++ b/src/components/Editor/SearchBar.js
@@ -473,8 +473,10 @@ const SearchBar = React.createClass({
 
   // Renderers
   buildSummaryMsg() {
-    if (this.state.symbolSearchEnabled
-      && this.state.symbolSearchResults.length > 0) {
+    if (
+      this.state.symbolSearchEnabled &&
+      this.state.symbolSearchResults.length > 0
+    ) {
       return L10N.getFormatStr(
         "editor.searchResults",
         this.state.selectedResultIndex + 1,

--- a/src/components/Editor/SearchBar.js
+++ b/src/components/Editor/SearchBar.js
@@ -475,7 +475,7 @@ const SearchBar = React.createClass({
   buildSummaryMsg() {
     if (this.state.symbolSearchResults.length > 0) {
       return L10N.getFormatStr(
-        "sourceSearch.resultsSummary1",
+        "editor.searchResults",
         this.state.selectedResultIndex + 1,
         this.state.symbolSearchResults.length
       );

--- a/src/components/Editor/SearchBar.js
+++ b/src/components/Editor/SearchBar.js
@@ -473,7 +473,8 @@ const SearchBar = React.createClass({
 
   // Renderers
   buildSummaryMsg() {
-    if (this.state.symbolSearchResults.length > 0) {
+    if (this.state.symbolSearchEnabled
+      && this.state.symbolSearchResults.length > 0) {
       return L10N.getFormatStr(
         "editor.searchResults",
         this.state.selectedResultIndex + 1,


### PR DESCRIPTION
Associated Issue: #2529

### Summary of Changes

- Changed Summary message to `%d of %d results`

@wldcordeiro @jasonLaster  - What should be done for a `1 of 1 results` output?
