### PR TITLE
Scoped expression evaluation

### DIFF
--- a/src/actions/expressions.js
+++ b/src/actions/expressions.js
@@ -89,6 +89,10 @@ export function deleteExpression(expression: Expression) {
 export function evaluateExpressions(frameId: frameIdType) {
   return async function({ dispatch, getState, client }: ThunkArgs) {
     const expressions = getExpressions(getState()).toJS();
+    if (!frameId) {
+      const selectedFrame = getSelectedFrame(getState())
+      frameId = selectedFrame ? selectedFrame.id : null;
+    }
     for (let expression of expressions) {
       await dispatch(evaluateExpression(expression, frameId));
     }

--- a/src/actions/expressions.js
+++ b/src/actions/expressions.js
@@ -90,7 +90,7 @@ export function evaluateExpressions(frameId: frameIdType) {
   return async function({ dispatch, getState, client }: ThunkArgs) {
     const expressions = getExpressions(getState()).toJS();
     if (!frameId) {
-      const selectedFrame = getSelectedFrame(getState())
+      const selectedFrame = getSelectedFrame(getState());
       frameId = selectedFrame ? selectedFrame.id : null;
     }
     for (let expression of expressions) {

--- a/src/actions/tests/expressions.js
+++ b/src/actions/tests/expressions.js
@@ -71,7 +71,7 @@ describe("expressions", () => {
 
     expect(selectors.getExpression(getState(), "foo").value).to.be(null);
     expect(selectors.getExpression(getState(), "bar").value).to.be(null);
-    await dispatch(actions.evaluateExpressions('boo'));
+    await dispatch(actions.evaluateExpressions("boo"));
 
     expect(selectors.getExpression(getState(), "foo").value).to.be("boo");
     expect(selectors.getExpression(getState(), "bar").value).to.be("boo");

--- a/src/actions/tests/expressions.js
+++ b/src/actions/tests/expressions.js
@@ -4,7 +4,11 @@ import { actions, selectors, createStore } from "../../utils/test-head";
 const mockThreadClient = {
   evaluate: (script, { frameId }) => {
     return new Promise((resolve, reject) => {
-      resolve("bla");
+      if (!frameId) {
+        resolve("bla");
+      } else {
+        resolve("boo");
+      }
     });
   }
 };
@@ -45,18 +49,31 @@ describe("expressions", () => {
     expect(selectors.getExpression(getState(), "bar").input).to.be("bar");
   });
 
-  it("should evaluate expressions", async () => {
+  it("should evaluate expressions global scope", async () => {
     const { dispatch, getState } = createStore(mockThreadClient);
-    const frameId = "baa";
 
     dispatch(actions.addExpression("foo"));
     dispatch(actions.addExpression("bar", { visible: false }));
 
     expect(selectors.getExpression(getState(), "foo").value).to.be(null);
     expect(selectors.getExpression(getState(), "bar").value).to.be(null);
-    await dispatch(actions.evaluateExpressions(frameId));
+    await dispatch(actions.evaluateExpressions());
 
     expect(selectors.getExpression(getState(), "foo").value).to.be("bla");
     expect(selectors.getExpression(getState(), "bar").value).to.be("bla");
+  });
+
+  it("should evaluate expressions in specific scope", async () => {
+    const { dispatch, getState } = createStore(mockThreadClient);
+
+    dispatch(actions.addExpression("foo"));
+    dispatch(actions.addExpression("bar", { visible: false }));
+
+    expect(selectors.getExpression(getState(), "foo").value).to.be(null);
+    expect(selectors.getExpression(getState(), "bar").value).to.be(null);
+    await dispatch(actions.evaluateExpressions('boo'));
+
+    expect(selectors.getExpression(getState(), "foo").value).to.be("boo");
+    expect(selectors.getExpression(getState(), "bar").value).to.be("boo");
   });
 });


### PR DESCRIPTION
Associated Issue: #2265

### Summary of Changes

* Get the frameId of the current selected scope
* Pass the frameId to `evaluateExpressions`
* Added tests

### Test Plan
- [x] Pause on  breakpoint
- [x] Add an expression
- [x] Select a different stack frame
- [x] Check the expression 
