### PR TITLE
Convert Accordion, ManagedTree, and ObjectInspector to ES6 classes

### DIFF
--- a/src/components/shared/Accordion.js
+++ b/src/components/shared/Accordion.js
@@ -1,5 +1,5 @@
 // @flow
-import { DOM as dom, PropTypes, createClass, createElement } from "react";
+import React, { DOM as dom, PropTypes, createElement } from "react";
 import Svg from "./Svg";
 
 import "./Accordion.css";
@@ -15,12 +15,26 @@ type AccordionItem = {
 
 type Props = { items: Array<Object> };
 
-const Accordion = createClass({
-  propTypes: { items: PropTypes.array.isRequired },
-  displayName: "Accordion",
-  getInitialState() {
-    return { opened: this.props.items.map(item => item.opened), created: [] };
-  },
+type AccordionState = {
+  opened: boolean[],
+  created: boolean[]
+};
+
+class Accordion extends React.Component {
+  state: AccordionState;
+
+  constructor(props: Props) {
+    super();
+
+    this.state = {
+      opened: props.items.map(item => item.opened),
+      created: []
+    };
+
+    const self: any = this;
+    self.renderContainer = this.renderContainer.bind(this);
+  }
+
   componentWillReceiveProps(nextProps: Props) {
     const newOpened = this.state.opened.map((isOpen, i) => {
       const { shouldOpen } = nextProps.items[i];
@@ -29,7 +43,8 @@ const Accordion = createClass({
     });
 
     this.setState({ opened: newOpened });
-  },
+  }
+
   handleHeaderClick(i: number) {
     const opened = [...this.state.opened];
     const created = [...this.state.created];
@@ -47,7 +62,8 @@ const Accordion = createClass({
     }
 
     this.setState({ opened, created });
-  },
+  }
+
   renderContainer(item: AccordionItem, i: number) {
     const { opened, created } = this.state;
     const containerClassName = `${item.header
@@ -74,13 +90,20 @@ const Accordion = createClass({
           )
         : null
     );
-  },
+  }
+
   render() {
     return dom.div(
       { className: "accordion" },
       this.props.items.map(this.renderContainer)
     );
   }
-});
+}
+
+Accordion.displayName = "Accordion";
+
+Accordion.propTypes = {
+  items: PropTypes.array.isRequired
+};
 
 export default Accordion;

--- a/src/components/shared/ManagedTree.js
+++ b/src/components/shared/ManagedTree.js
@@ -1,5 +1,5 @@
 // @flow
-import { createClass, PropTypes, createFactory } from "react";
+import React, { PropTypes, createFactory } from "react";
 const Tree = createFactory(require("devtools-modules").Tree);
 require("./ManagedTree.css");
 
@@ -23,25 +23,26 @@ type NextProps = {
   renderItem: () => any
 };
 
-type InitialState = {
+type ManagedTreeState = {
   expanded: any,
   focusedItem: ?ManagedTreeItem
 };
 
-let ManagedTree = createClass({
-  propTypes: Object.assign({}, Tree.propTypes, {
-    getExpanded: PropTypes.func,
-    setExpanded: PropTypes.func
-  }),
+class ManagedTree extends React.Component {
+  state: ManagedTreeState;
 
-  displayName: "ManagedTree",
+  constructor() {
+    super();
 
-  getInitialState(): InitialState {
-    return {
+    this.state = {
       expanded: new Set(),
       focusedItem: null
     };
-  },
+
+    const self: any = this;
+    self.setExpanded = this.setExpanded.bind(this);
+    self.focusItem = this.focusItem.bind(this);
+  }
 
   componentWillReceiveProps(nextProps: NextProps) {
     const listItems = nextProps.listItems;
@@ -57,20 +58,20 @@ let ManagedTree = createClass({
     ) {
       this.highlightItem(highlightItems);
     }
-  },
+  }
 
   componentWillMount() {
     if (this.props.getExpanded) {
       const expanded = this.props.getExpanded();
       this.setState({ expanded });
     }
-  },
+  }
 
   componentWillUnmount() {
     if (this.props.setExpanded) {
       this.props.setExpanded(this.state.expanded);
     }
-  },
+  }
 
   setExpanded(item: ManagedTreeItem, isExpanded: boolean) {
     const expanded = this.state.expanded;
@@ -87,14 +88,14 @@ let ManagedTree = createClass({
     } else if (!expanded && this.props.onCollapse) {
       this.props.onCollapse(item);
     }
-  },
+  }
 
   expandListItems(listItems: Array<ManagedTreeItem>) {
     const expanded = this.state.expanded;
     listItems.forEach(item => expanded.add(this.props.getKey(item)));
     this.focusItem(listItems[0]);
     this.setState({ expanded: expanded });
-  },
+  }
 
   highlightItem(highlightItems: Array<ManagedTreeItem>) {
     const expanded = this.state.expanded;
@@ -110,7 +111,7 @@ let ManagedTree = createClass({
         .findIndex(item => !expanded.has(this.props.getKey(item)));
       this.focusItem(highlightItems[index]);
     }
-  },
+  }
 
   focusItem(item: ManagedTreeItem) {
     if (!this.props.disabledFocus && this.state.focusedItem !== item) {
@@ -120,7 +121,7 @@ let ManagedTree = createClass({
         this.props.onFocus(item);
       }
     }
-  },
+  }
 
   render() {
     const { expanded, focusedItem } = this.state;
@@ -142,6 +143,13 @@ let ManagedTree = createClass({
 
     return Tree(props);
   }
+}
+
+ManagedTree.displayName = "ManagedTree";
+
+ManagedTree.propTypes = Object.assign({}, Tree.propTypes, {
+  getExpanded: PropTypes.func,
+  setExpanded: PropTypes.func
 });
 
 module.exports = ManagedTree;

--- a/src/components/shared/ObjectInspector.js
+++ b/src/components/shared/ObjectInspector.js
@@ -41,9 +41,25 @@ type ObjectInspectorItem = {
 };
 
 type DefaultProps = {
-  onLabelClick: any,
-  onDoubleClick: any,
-  autoExpandDepth: number
+  onLabelClick: (
+    item: ObjectInspectorItem,
+    params: {
+      depth: number,
+      focused: boolean,
+      expanded: boolean,
+      setExpanded: () => any
+    }
+  ) => void,
+  onDoubleClick: (
+    item: ObjectInspectorItem,
+    params: {
+      depth: number,
+      focused: boolean,
+      expanded: boolean
+    }
+  ) => void,
+  autoExpandDepth: number,
+  getActors: () => any
 };
 
 // This implements a component that renders an interactive inspector
@@ -73,51 +89,32 @@ type DefaultProps = {
 // fetched, and a primitive value that should be displayed with no
 // children.
 
-const ObjectInspector = React.createClass({
-  propTypes: {
-    autoExpandDepth: PropTypes.number,
-    name: PropTypes.string,
-    desc: PropTypes.object,
-    roots: PropTypes.array,
-    getObjectProperties: PropTypes.func.isRequired,
-    loadObjectProperties: PropTypes.func.isRequired,
-    onLabelClick: PropTypes.func.isRequired,
-    onDoubleClick: PropTypes.func.isRequired,
-    getExpanded: PropTypes.func,
-    setExpanded: PropTypes.func,
-    getActors: PropTypes.func.isRequired,
-    setActors: PropTypes.func
-  },
+class ObjectInspector extends React.Component {
+  static defaultProps: DefaultProps;
+  actors: any;
 
-  actors: (null: any),
+  constructor() {
+    super();
 
-  displayName: "ObjectInspector",
+    this.actors = null;
 
-  getInitialState() {
-    return {};
-  },
-
-  getDefaultProps(): DefaultProps {
-    return {
-      onLabelClick: () => {},
-      onDoubleClick: () => {},
-      autoExpandDepth: 1,
-      getActors: () => ({})
-    };
-  },
+    const self: any = this;
+    self.getChildren = this.getChildren.bind(this);
+    self.renderItem = this.renderItem.bind(this);
+  }
 
   componentWillMount() {
     // Cache of dynamically built nodes. We shouldn't need to clear
     // this out ever, since we don't ever "switch out" the object
     // being inspected.
     this.actors = this.props.getActors();
-  },
+  }
 
   componentWillUnmount() {
     if (this.props.setActors) {
       this.props.setActors(this.actors);
     }
-  },
+  }
 
   getChildren(item: ObjectInspectorItem) {
     const { getObjectProperties } = this.props;
@@ -128,7 +125,7 @@ const ObjectInspector = React.createClass({
       actors,
       item
     });
-  },
+  }
 
   renderItem(
     item: ObjectInspectorItem,
@@ -193,7 +190,7 @@ const ObjectInspector = React.createClass({
       dom.span({ className: "object-delimiter" }, objectValue ? ": " : ""),
       dom.span({ className: "object-value" }, objectValue || "")
     );
-  },
+  }
 
   render() {
     const {
@@ -230,6 +227,30 @@ const ObjectInspector = React.createClass({
       renderItem: this.renderItem
     });
   }
-});
+}
+
+ObjectInspector.displayName = "ObjectInspector";
+
+ObjectInspector.propTypes = {
+  autoExpandDepth: PropTypes.number,
+  name: PropTypes.string,
+  desc: PropTypes.object,
+  roots: PropTypes.array,
+  getObjectProperties: PropTypes.func.isRequired,
+  loadObjectProperties: PropTypes.func.isRequired,
+  onLabelClick: PropTypes.func.isRequired,
+  onDoubleClick: PropTypes.func.isRequired,
+  getExpanded: PropTypes.func,
+  setExpanded: PropTypes.func,
+  getActors: PropTypes.func.isRequired,
+  setActors: PropTypes.func
+};
+
+ObjectInspector.defaultProps = {
+  onLabelClick: () => {},
+  onDoubleClick: () => {},
+  autoExpandDepth: 1,
+  getActors: () => ({})
+};
 
 module.exports = ObjectInspector;


### PR DESCRIPTION
Associated Issue: #1890

Convert Accordion, ManagedTree, and ObjectInspector to ES6 classes