### PR TITLE
Fix BP conditional check

### DIFF
--- a/src/components/SecondaryPanes/Breakpoints.js
+++ b/src/components/SecondaryPanes/Breakpoints.js
@@ -75,7 +75,7 @@ class Breakpoints extends Component {
     const line = breakpoint.location.line;
     const isCurrentlyPaused = breakpoint.isCurrentlyPaused;
     const isDisabled = breakpoint.disabled;
-    const isConditional = breakpoint.condition !== null;
+    const isConditional = !!breakpoint.condition;
 
     return dom.div(
       {


### PR DESCRIPTION
I've been seeing yellow borders for BPs when they're not conditional for some time and have forgotten to make an issue :/

<img width="587" alt="screen shot 2017-04-07 at 4 10 19 pm" src="https://cloud.githubusercontent.com/assets/254562/24818094/17ce0176-1bad-11e7-8bc6-7c9aa8120c4d.png">
