### PR TITLE
Simplify function names

### DIFF
--- a/src/components/SecondaryPanes/Frames.js
+++ b/src/components/SecondaryPanes/Frames.js
@@ -6,6 +6,7 @@ import { connect } from "react-redux";
 import actions from "../../actions";
 import { endTruncateStr } from "../../utils/utils";
 import { getFilename } from "../../utils/source";
+import simplifyDisplayName from "../../utils/function";
 import get from "lodash/get";
 
 const { getFrames, getSelectedFrame, getSource } = require("../../selectors");
@@ -25,7 +26,9 @@ import "./Frames.css";
 const NUM_FRAMES_SHOWN = 7;
 
 function renderFrameTitle({ displayName }: Frame) {
-  return dom.div({ className: "title" }, endTruncateStr(displayName, 40));
+  const simplifiedDisplaName = simplifyDisplayName(displayName);
+  const truncatedDisplayName = endTruncateStr(simplifiedDisplaName, 40);
+  return dom.div({ className: "title" }, truncatedDisplayName);
 }
 
 function renderFrameLocation({ source, location, library }: LocalFrame) {

--- a/src/utils/function.js
+++ b/src/utils/function.js
@@ -1,0 +1,25 @@
+// Decodes an anonymous naming scheme that
+// spider monkey implements based on "Naming Anonymous JavaScript Functions"
+// http://johnjbarton.github.io/nonymous/index.html
+const objectProperty = /([\w\d]+)$/;
+const arrayProperty = /\[(.*?)\]$/;
+const functionProperty = /([\w\d]+)[\/\.<]*?$/;
+const annonymousProperty = /([\w\d]+)\(\^\)$/;
+
+export default function simplifyDisplayName(displayName) {
+  const scenarios = [
+    objectProperty,
+    arrayProperty,
+    functionProperty,
+    annonymousProperty
+  ];
+
+  for (let reg of scenarios) {
+    let match = reg.exec(displayName);
+    if (match) {
+      return match[1];
+    }
+  }
+
+  return displayName;
+}

--- a/src/utils/tests/function.js
+++ b/src/utils/tests/function.js
@@ -1,0 +1,42 @@
+import simplifyDisplayName from "../function";
+
+const cases = {
+  defaultCase: [["define", "define"]],
+
+  objectProperty: [
+    ["z.foz", "foz"],
+    ["z.foz/baz", "baz"],
+    ["z.foz/baz/y.bay", "bay"],
+    ["outer/x.fox.bax.nx", "nx"],
+    ["outer/fow.baw", "baw"],
+    ["fromYUI._attach", "_attach"],
+    ["Y.ClassNameManager</getClassName", "getClassName"],
+    ["orion.textview.TextView</addHandler", "addHandler"],
+    ["this.eventPool_.createObject", "createObject"]
+  ],
+
+  arrayProperty: [
+    ["this.eventPool_[createObject]", "createObject"],
+    ["jQuery.each(^)/jQuery.fn[o]", "o"],
+    ["viewport[get+D]", "get+D"],
+    ["arr[0]", "0"]
+  ],
+
+  functionProperty: [
+    ["fromYUI._attach/<.", "_attach"],
+    ["Y.ClassNameManager<", "ClassNameManager"],
+    ["fromExtJS.setVisible/cb<", "cb"],
+    ["fromDojo.registerWin/<", "registerWin"]
+  ],
+
+  annonymousProperty: [["jQuery.each(^)", "each"]]
+};
+
+describe("function names", () => {
+  Object.keys(cases).forEach(type => {
+    cases[type].forEach(([kase, expected]) => {
+      it(`${type} - ${kase}`, () =>
+        expect(simplifyDisplayName(kase)).toEqual(expected));
+    });
+  });
+});


### PR DESCRIPTION
### Summary of Changes

* This decodes Firefox's totally crazy interpretation of anonymous function names.
* **Why do decode the string, and not use babel** 
  * the string is a very clear spec with many rules, it is better than what we do w/ inference now
  * we don't want to load and parse every file we get in the call stack if we don't have to
* **will this work?** if the regex's fail to match we'll show the original. This code will not throw errors. (i think)

### Test Plan

You bet!

![screen shot 2017-04-08 at 6 09 57 pm](https://cloud.githubusercontent.com/assets/254562/24832852/53690700-1c87-11e7-8c38-890d6c9480ad.png)


### Screenshots/Videos (OPTIONAL)

![screen shot 2017-04-08 at 6 01 09 pm](https://cloud.githubusercontent.com/assets/254562/24832850/513305b2-1c87-11e7-8584-c7b20fe92e9d.png)
