### PR TITLE
[WIP] CodeFolding - hide fold markers unless hovering on the gutter

### DIFF
--- a/src/components/Editor/Editor.css
+++ b/src/components/Editor/Editor.css
@@ -156,3 +156,11 @@ html[dir="rtl"] .editor-mount {
   -moz-user-select: none;
   user-select: none;
 }
+
+.CodeMirror-guttermarker-subtle {
+  visibility: hidden;
+}
+
+.visible {
+  visibility: visible;
+}

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -156,6 +156,20 @@ class Editor extends Component {
     codeMirrorWrapper.addEventListener("mouseup", e => this.onMouseUp(e, ctx));
     codeMirrorWrapper.addEventListener("mouseover", e => this.onMouseOver(e));
 
+    const toggleFoldMarkerVisibility = e => {
+      if (node instanceof HTMLElement) {
+        node
+          .querySelectorAll(".CodeMirror-guttermarker-subtle")
+          .forEach(elem => {
+            elem.classList.toggle("visible");
+          });
+      }
+    };
+
+    const codeMirrorGutter = codeMirror.getGutterElement();
+    codeMirrorGutter.addEventListener("mouseleave", toggleFoldMarkerVisibility);
+    codeMirrorGutter.addEventListener("mouseenter", toggleFoldMarkerVisibility);
+
     if (!isFirefox()) {
       codeMirror.on("gutterContextMenu", (cm, line, eventName, event) =>
         this.onGutterContextMenu(event));


### PR DESCRIPTION
Associated Issue: #2588 

### Summary of Changes

* Add event listener on code mirror gutter to toggle visibility of fold marker

### Screenshots/Videos (OPTIONAL)
![curde_ver](https://cloud.githubusercontent.com/assets/1755089/24874000/b2d84182-1e40-11e7-8e9a-dc361c76b324.gif)

The problems here is `mouseenter` and `mouseleave` doesn't work as expected on gutter. I'm not sure why.

Let me know if you have any suggestions.