### PR TITLE
basic fix for broken function preview

### DIFF
--- a/src/components/shared/ObjectInspector.js
+++ b/src/components/shared/ObjectInspector.js
@@ -145,7 +145,7 @@ class ObjectInspector extends React.Component {
       objectValue = dom.span({ className: "unavailable" }, "(unavailable)");
     } else if (nodeIsFunction(item)) {
       objectValue = null;
-      label = previewFunction(item.contents.value);
+      label = previewFunction(item);
     } else if (nodeHasProperties(item) || nodeIsPrimitive(item)) {
       const object = item.contents.value;
       objectValue = Rep({ object, mode: MODE.TINY });

--- a/src/components/shared/previewFunction.js
+++ b/src/components/shared/previewFunction.js
@@ -11,7 +11,7 @@ function renderFunctionName(value) {
 }
 
 function renderParams(value) {
-  const { parameterNames } = value;
+  const { parameterNames = [] } = value;
   let params = parameterNames
     .filter(i => i)
     .map(param => dom.span({ className: "param" }, param));
@@ -27,7 +27,7 @@ function renderParen(paren) {
 }
 
 function previewFunction(value) {
-  return dom.div(
+  return dom.span(
     { className: "function-signature" },
     renderFunctionName(value),
     renderParen("("),


### PR DESCRIPTION
### Associated Issue
This fixes the broken function preview, a possible regression.

### Before
<img width="347" alt="screen shot 2017-04-10 at 10 16 31 pm" src="https://cloud.githubusercontent.com/assets/792924/24883349/68545028-1e3c-11e7-95e7-f1d49079ea06.png">



### After
<img width="397" alt="screen shot 2017-04-10 at 10 14 57 pm" src="https://cloud.githubusercontent.com/assets/792924/24883360/7a533c30-1e3c-11e7-844c-af178db3c684.png">


### Summary of Changes

* change `div` to `span`
* use `item` instead of `item.contents.value` to get the function details for preview
* If `parameterNames` does not exist the UI breaks

