### PR TITLE
Fix breakage in Chrome initialization logic

### DIFF
--- a/src/client/chrome.js
+++ b/src/client/chrome.js
@@ -4,13 +4,14 @@ const { setupCommands, clientCommands } = require("./chrome/commands");
 const { setupEvents, clientEvents, pageEvents } = require("./chrome/events");
 
 export async function onConnect(connection: any, actions: Object) {
-  const { connection: { Debugger, Runtime, Page }, clientType } = connection;
+  const { tabConnection, connTarget: { type } } = connection;
+  const { Debugger, Runtime, Page } = tabConnection;
 
   Debugger.enable();
   Debugger.setPauseOnExceptions({ state: "none" });
   Debugger.setAsyncCallStackDepth({ maxDepth: 0 });
 
-  if (clientType == "chrome") {
+  if (type == "chrome") {
     Page.frameNavigated(pageEvents.frameNavigated);
     Page.frameStartedLoading(pageEvents.frameStartedLoading);
     Page.frameStoppedLoading(pageEvents.frameStoppedLoading);
@@ -22,7 +23,7 @@ export async function onConnect(connection: any, actions: Object) {
   Debugger.resumed(clientEvents.resumed);
 
   setupCommands({ Debugger, Runtime, Page });
-  setupEvents({ actions, Page, clientType, Runtime });
+  setupEvents({ actions, Page, type, Runtime });
 }
 
 export { clientCommands, clientEvents };


### PR DESCRIPTION
Associated Issue: https://github.com/devtools-html/debugger.html/issues/2616

### Summary of Changes

* Trivial fix to update the initialization in chrome.js to correctly accommodate the parameters passed into `onConnect`.

### Test Plan

Just start up debugging against a Chrome tab. Before it would fail, now it works.
