### PR TITLE
'Reveal in tree' should also work for tabs with pretty printed source 

### DIFF
--- a/src/components/Editor/Tabs.js
+++ b/src/components/Editor/Tabs.js
@@ -233,11 +233,11 @@ class SourceTabs extends Component {
       },
       { item: closeAllTabsMenuItem },
       { item: { type: "separator" } },
-      { item: copySourceUrl },
-      { item: showSourceMenuItem }
+      { item: copySourceUrl }
     ];
 
     if (!isPrettySource) {
+      items.push({ item: showSourceMenuItem });
       items.push({ item: prettyPrint });
     }
 


### PR DESCRIPTION
Associated Issue: #2553 

### Summary of Changes
* Hide `Reveal in Tree` menu item for pretty-printed tabs

### Test Plan
* Right click on pretty-printed tabs to see if `Reveal in Tree` menu item is gone.