### PR TITLE
Default props bucket

### DIFF
--- a/src/components/shared/previewFunction.js
+++ b/src/components/shared/previewFunction.js
@@ -30,7 +30,7 @@ function previewFunction(value) {
   return dom.span(
     { className: "function-signature" },
     renderFunctionName(value),
-    renderParen("("),
+    renderParen(": function("),
     ...renderParams(value),
     renderParen(")")
   );

--- a/src/components/shared/previewFunction.js
+++ b/src/components/shared/previewFunction.js
@@ -30,7 +30,7 @@ function previewFunction(value) {
   return dom.span(
     { className: "function-signature" },
     renderFunctionName(value),
-    renderParen(": function("),
+    renderParen("("),
     ...renderParams(value),
     renderParen(")")
   );

--- a/src/test/integration/tests/editor-preview.js
+++ b/src/test/integration/tests/editor-preview.js
@@ -24,11 +24,11 @@ module.exports = async function(ctx) {
 
   invokeInTab(dbg, "toggleModel");
   await waitForPaused(dbg);
-  const el = dbg.win.cm.getWrapperElement()
+  const el = dbg.win.cm
+    .getWrapperElement()
     .querySelectorAll(".CodeMirror-line ")[50]
-    .querySelector(".cm-variable-2")
+    .querySelector(".cm-variable-2");
 
   mouseOverEl(dbg.win, el);
   assertPausedLocation(dbg, ctx, "long.js", 82);
-
 };

--- a/src/test/integration/utils/commands.js
+++ b/src/test/integration/utils/commands.js
@@ -1,4 +1,9 @@
-const { clickEl, rightClickEl, dblClickEl, mouseOverEl } = require("./mouse-events");
+const {
+  clickEl,
+  rightClickEl,
+  dblClickEl,
+  mouseOverEl
+} = require("./mouse-events");
 
 function info(msg) {
   console.log(`info: ${msg}\n`);

--- a/src/test/integration/utils/mocha.js
+++ b/src/test/integration/utils/mocha.js
@@ -7,7 +7,6 @@ const {
   waitForPaused
 } = require("./wait");
 
-
 const { type, pressKey } = require("./type");
 
 function info(msg) {
@@ -21,7 +20,7 @@ async function waitForTime(time) {
 }
 
 async function waitForElement(win, selector) {
-  return waitUntil(() => win.document.querySelector(selector))
+  return waitUntil(() => win.document.querySelector(selector));
 }
 
 async function debuggee(callback) {
@@ -63,8 +62,11 @@ function createDebuggerContext(iframe) {
   const win = iframe.contentWindow.window;
 
   const {
-    store, selectors, actions, client,
-    connection: { tabConnection: { threadClient, tabTarget }}
+    store,
+    selectors,
+    actions,
+    client,
+    connection: { tabConnection: { threadClient, tabTarget } }
   } = win.getGlobalsForTesting();
 
   return {
@@ -86,7 +88,7 @@ async function waitForLoad(iframe) {
 }
 
 async function waitForConnection(win) {
-  return
+  return;
 }
 
 async function createIframe() {
@@ -115,7 +117,7 @@ async function navigateToTab(iframe) {
 
   await waitForElement(win, ".tab");
   win.location = `/?firefox-tab=${tabId}`;
-  await waitForElement(win, ".debugger")
+  await waitForElement(win, ".debugger");
 }
 
 async function navigate(dbg, url) {

--- a/src/utils/object-inspector.js
+++ b/src/utils/object-inspector.js
@@ -54,7 +54,7 @@ function isPromise(item) {
 
 function isWindow(item) {
   const prototype = get(item, "prototype", undefined);
-  return (prototype.class = "WindowPrototype");
+  return prototype.class == "WindowPrototype";
 }
 
 function getPromiseProperties(item) {

--- a/src/utils/tests/object-inspector.js
+++ b/src/utils/tests/object-inspector.js
@@ -30,10 +30,10 @@ describe("object-inspector", () => {
       const nodes = makeNodesForProperties(objProperties, "root");
 
       const names = nodes.map(n => n.name);
-      expect(names).to.eql(["0", "length", "__proto__"]);
+      expect(names).to.eql(["0", "[default properties]", "__proto__"]);
 
       const paths = nodes.map(n => n.path);
-      expect(paths).to.eql(["root/0", "root/length", "root/__proto__"]);
+      expect(paths).to.eql(["root/0", "root/default", "root/__proto__"]);
     });
 
     it("excludes getters", () => {
@@ -106,8 +106,9 @@ describe("object-inspector", () => {
       expect(paths).to.eql(["root/bar", "root/__proto__"]);
     });
 
-    it("bucketing", () => {
-      let objProps = { ownProperties: {}, prototype: { class: "bla" } };
+    // For large arrays
+    it("numerical buckets", () => {
+      let objProps = { ownProperties: {}, prototype: { class: "Array" } };
       for (let i = 0; i < 331; i++) {
         objProps.ownProperties[i] = { value: {} };
       }
@@ -154,7 +155,7 @@ describe("object-inspector", () => {
       const paths = nodes.map(n => n.path);
 
       expect(names).to.eql([
-        "",
+        '""',
         "332217",
         '"needs-quotes"',
         "unquoted",

--- a/src/utils/tests/object-inspector.js
+++ b/src/utils/tests/object-inspector.js
@@ -19,7 +19,8 @@ const objProperties = {
   },
   prototype: {
     type: "object",
-    actor: "server2.conn1.child1/pausedobj618"
+    actor: "server2.conn1.child1/pausedobj618",
+    class: "bla"
   }
 };
 
@@ -41,6 +42,9 @@ describe("object-inspector", () => {
           ownProperties: {
             foo: { value: "foo" },
             bar: {}
+          },
+          prototype: {
+            class: "bla"
           }
         },
         "root"
@@ -49,8 +53,8 @@ describe("object-inspector", () => {
       const names = nodes.map(n => n.name);
       const paths = nodes.map(n => n.path);
 
-      expect(names).to.eql(["foo"]);
-      expect(paths).to.eql(["root/foo"]);
+      expect(names).to.eql(["foo", "__proto__"]);
+      expect(paths).to.eql(["root/foo", "root/__proto__"]);
     });
 
     it("sorts keys", () => {
@@ -62,6 +66,9 @@ describe("object-inspector", () => {
             11: { value: {} },
             2: { value: {} },
             _bar: { value: {} }
+          },
+          prototype: {
+            class: "bla"
           }
         },
         "root"
@@ -70,13 +77,14 @@ describe("object-inspector", () => {
       const names = nodes.map(n => n.name);
       const paths = nodes.map(n => n.path);
 
-      expect(names).to.eql(["1", "2", "11", "_bar", "bar"]);
+      expect(names).to.eql(["1", "2", "11", "_bar", "bar", "__proto__"]);
       expect(paths).to.eql([
         "root/1",
         "root/2",
         "root/11",
         "root/_bar",
-        "root/bar"
+        "root/bar",
+        "root/__proto__"
       ]);
     });
 
@@ -86,7 +94,7 @@ describe("object-inspector", () => {
           ownProperties: {
             bar: { value: {} }
           },
-          prototype: { value: {} }
+          prototype: { value: {}, class: "bla" }
         },
         "root"
       );
@@ -99,7 +107,7 @@ describe("object-inspector", () => {
     });
 
     it("bucketing", () => {
-      let objProps = { ownProperties: {} };
+      let objProps = { ownProperties: {}, prototype: { class: "bla" } };
       for (let i = 0; i < 331; i++) {
         objProps.ownProperties[i] = { value: {} };
       }
@@ -112,14 +120,16 @@ describe("object-inspector", () => {
         "[0..99]",
         "[100..199]",
         "[200..299]",
-        "[300..331]"
+        "[300..331]",
+        "__proto__"
       ]);
 
       expect(paths).to.eql([
         "root/bucket1",
         "root/bucket2",
         "root/bucket3",
-        "root/bucket4"
+        "root/bucket4",
+        "root/__proto__"
       ]);
     });
 
@@ -132,6 +142,9 @@ describe("object-inspector", () => {
             "needs-quotes": { value: {} },
             unquoted: { value: {} },
             "": { value: {} }
+          },
+          prototype: {
+            class: "WindowPrototype"
           }
         },
         "root"
@@ -140,12 +153,19 @@ describe("object-inspector", () => {
       const names = nodes.map(n => n.name);
       const paths = nodes.map(n => n.path);
 
-      expect(names).to.eql(['""', "332217", '"needs-quotes"', "unquoted"]);
+      expect(names).to.eql([
+        "",
+        "332217",
+        '"needs-quotes"',
+        "unquoted",
+        "__proto__"
+      ]);
       expect(paths).to.eql([
         "root/",
         "root/332217",
         "root/needs-quotes",
-        "root/unquoted"
+        "root/unquoted",
+        "root/__proto__"
       ]);
     });
   });


### PR DESCRIPTION
Associated Issue: #2280

### Summary of Changes

* Added  a function `makeDefaultPropsBucket` to render all the default properties under one `[default properties]` bucket
* Numerical bucketing are only used for rendering large array objects
* Updated the tests

### Test Plan

- [x] Add `this` as a watch expression
- [x] Inspect its properties
- [x] Add a large array to the watch expressions
- [x] Inspect its contents


### Screenshots/Videos
Before (example)
![image](https://cloud.githubusercontent.com/assets/792924/24918083/fe5ceac2-1ed6-11e7-83fa-6d6ca1f12ad3.png)

After (examples)
![screen shot 2017-04-11 at 4 53 38 pm](https://cloud.githubusercontent.com/assets/792924/24918230/9867b87c-1ed7-11e7-9167-36b127ff95ea.png)

this
![screen shot 2017-04-11 at 4 56 49 pm](https://cloud.githubusercontent.com/assets/792924/24918343/f8697b84-1ed7-11e7-887c-a93f2a0d9f34.png)
![screen shot 2017-04-11 at 4 59 32 pm](https://cloud.githubusercontent.com/assets/792924/24918437/53c9146c-1ed8-11e7-9337-baebc61f1a77.png)
