### PR TITLE
Resolve svg src warning in jest tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,7 +146,8 @@
     ],
     "setupTestFrameworkScriptFile": "<rootDir>/test/tests-framework.js",
     "moduleNameMapper": {
-      "\\.(css|svg)$": "<rootDir>/test/__mocks__/styleMock.js"
+      "\\.css$": "<rootDir>/test/__mocks__/styleMock.js",
+      "\\.svg$": "<rootDir>/test/__mocks__/svgMock.js"
     }
   }
 }

--- a/src/components/tests/__snapshots__/closeButton.js.snap
+++ b/src/components/tests/__snapshots__/closeButton.js.snap
@@ -17,7 +17,7 @@ ShallowWrapper {
         className="close"
         element="i"
         raw={false}
-        src={Object {}}
+        src="<svg></svg>"
     />
 </div>,
   "nodes": Array [
@@ -30,7 +30,7 @@ ShallowWrapper {
             className="close"
             element="i"
             raw={false}
-            src={Object {}}
+            src="<svg></svg>"
       />
 </div>,
   ],
@@ -85,7 +85,7 @@ ShallowWrapper {
                     className="close"
                     element="i"
                     raw={false}
-                    src={Object {}}
+                    src="<svg></svg>"
           />
 </div>,
         "_debugID": 4,
@@ -98,7 +98,7 @@ ShallowWrapper {
                     className="close"
                     element="i"
                     raw={false}
-                    src={Object {}}
+                    src="<svg></svg>"
           />
 </div>,
       },

--- a/src/test/__mocks__/svgMock.js
+++ b/src/test/__mocks__/svgMock.js
@@ -1,0 +1,1 @@
+module.exports = "<svg></svg>";


### PR DESCRIPTION
Resolve #2630 

* Update css|svg mock to apply to only css
* Add mock for svg