### PR TITLE
Hidden tab shown when clicked from tree node

### DIFF
--- a/src/components/Editor/Tabs.js
+++ b/src/components/Editor/Tabs.js
@@ -252,10 +252,13 @@ class SourceTabs extends Component {
     if (!this.refs.sourceTabs) {
       return;
     }
-
-    const sourceTabs = this.props.sourceTabs;
+    const { selectedSource, sourceTabs, selectSource } = this.props;
     const sourceTabEls = this.refs.sourceTabs.children;
     const hiddenSourceTabs = getHiddenTabs(sourceTabs, sourceTabEls);
+
+    if (hiddenSourceTabs.indexOf(selectedSource) !== -1) {
+      return selectSource(selectedSource.get("id"), { tabIndex: 0 });
+    }
 
     this.setState({ hiddenSourceTabs });
   }


### PR DESCRIPTION
Resolve #2015

### Summary of Changes

* If hidden tab is requested, it is put at the first place.

### Screenshot
![tab](https://cloud.githubusercontent.com/assets/7821757/24993982/6fe55740-2046-11e7-9586-c412484b0b0c.gif)

