### PR TITLE
Added F3 hotkey for searching.

### DIFF
--- a/src/components/Editor/SearchBar.js
+++ b/src/components/Editor/SearchBar.js
@@ -477,7 +477,7 @@ class SearchBar extends Component {
   }
 
   onKeyUp(e: SyntheticKeyboardEvent) {
-    if (e.key != "Enter") {
+    if (e.key !== "Enter" || e.key !== "F3") {
       return;
     }
 


### PR DESCRIPTION
Associated Issue: #2641 

### Summary of Changes

* Added `F3` as a hotkey.

### Results

* Expecting `Enter` and `F3` to be used as a way to navigate search terms.