### PR TITLE
Add scopes mutation integration tests

### DIFF
--- a/src/test/integration/runner.js
+++ b/src/test/integration/runner.js
@@ -133,6 +133,10 @@ describe("Tests", () => {
     await scopes(ctx);
   });
 
+  it("render the expected scopes when variable mutates while stepping", async function() {
+    await scopesMutations(ctx);
+  });
+
   // expected 0 to equal 2
   it("sources", async function() {
     await sources(ctx);

--- a/src/test/integration/tests/index.js
+++ b/src/test/integration/tests/index.js
@@ -19,6 +19,7 @@ module.exports = {
   prettyPrintPaused: require("./pretty-print-paused"),
   returnvalues: require("./returnvalues"),
   scopes: require("./scopes"),
+  scopesMutations: require("./scopes-mutations"),
   searching: require("./searching"),
   sources: require("./sources"),
   sourceMaps: require("./sourcemaps"),

--- a/src/test/integration/tests/scopes-mutations.js
+++ b/src/test/integration/tests/scopes-mutations.js
@@ -1,0 +1,132 @@
+const {
+  clickElement,
+  evalInTab,
+  findElement,
+  initDebugger,
+  invokeInTab,
+  resume,
+  stepOver,
+  waitForDispatch,
+  waitForPaused,
+  waitForTime
+} = require("../utils");
+
+function getScopeNodeLabel(dbg, index) {
+  return findElement(dbg, "scopeNode", index).innerText;
+}
+
+function getScopeNodeValue(dbg, index) {
+  return findElement(dbg, "scopeValue", index).innerText;
+}
+
+function expandNode(dbg, index) {
+  let onLoadProperties = onLoadObjectProperties(dbg);
+  clickElement(dbg, "scopeNode", index);
+  return onLoadProperties;
+}
+
+function toggleScopes(dbg) {
+  return findElement(dbg, "scopesHeader").click();
+}
+
+function onLoadObjectProperties(dbg) {
+  return waitForDispatch(dbg, "LOAD_OBJECT_PROPERTIES");
+}
+
+module.exports = async function(ctx) {
+  const { ok, is, info } = ctx;
+  console.log(">>> starting");
+  const dbg = await initDebugger("doc-script-mutate.html", "script-mutate");
+
+  toggleScopes(dbg);
+
+  let onPaused = waitForPaused(dbg);
+  invokeInTab(dbg, "mutate");
+  await onPaused;
+
+  is(
+    getScopeNodeLabel(dbg, 2),
+    "<this>",
+    'The second element in the scope panel is "<this>"'
+  );
+  is(
+    getScopeNodeLabel(dbg, 3),
+    "phonebook",
+    'The third element in the scope panel is "phonebook"'
+  );
+
+  // Expand `phonebook`
+  await expandNode(dbg, 3);
+  is(
+    getScopeNodeLabel(dbg, 4),
+    "S",
+    'The fourth element in the scope panel is "S"'
+  );
+
+  // Expand `S`
+  await expandNode(dbg, 4);
+  is(
+    getScopeNodeLabel(dbg, 5),
+    "sarah",
+    'The fifth element in the scope panel is "sarah"'
+  );
+  is(
+    getScopeNodeLabel(dbg, 6),
+    "serena",
+    'The sixth element in the scope panel is "serena"'
+  );
+
+  // Expand `sarah`
+  await expandNode(dbg, 5);
+  is(
+    getScopeNodeLabel(dbg, 6),
+    "lastName",
+    'The sixth element in the scope panel is now "lastName"'
+  );
+  is(
+    getScopeNodeValue(dbg, 6),
+    '"Doe"',
+    'The "lastName" element has the expected "Doe" value'
+  );
+
+  info("Resuming");
+  onPaused = waitForPaused(dbg);
+  await resume(dbg);
+  await onPaused;
+
+  is(
+    getScopeNodeLabel(dbg, 6),
+    "lastName",
+    'The sixth element in the scope panel is still "lastName"'
+  );
+  is(
+    getScopeNodeValue(dbg, 6),
+    '"Doe"',
+    'The "lastName" property is still "Doe", but it should be "Pierce"' +
+      "since it was changed in the script."
+  );
+
+  onPaused = waitForPaused(dbg);
+  await resume(dbg);
+  await onPaused;
+  is(
+    getScopeNodeLabel(dbg, 6),
+    "lastName",
+    'The sixth element in the scope panel is still "lastName"'
+  );
+  is(
+    getScopeNodeLabel(dbg, 7),
+    "__proto__",
+    'The seventh element in the scope panel is still "__proto__", ' +
+      'but it should be now "timezone", since it was added to the "sarah" object ' +
+      "in the script"
+  );
+  is(
+    getScopeNodeValue(dbg, 7),
+    "Object",
+    'The seventh element in the scope panel has the value "Object", ' +
+      'but it should be "PST"'
+  );
+
+  await resume(dbg);
+};

--- a/src/test/mochitest/browser.ini
+++ b/src/test/mochitest/browser.ini
@@ -12,6 +12,7 @@ support-files =
   examples/sourcemaps2/main.js
   examples/sourcemaps2/main.js.map
   examples/doc-scripts.html
+  examples/doc-script-mutate.html
   examples/doc-script-switching.html
   examples/doc-exceptions.html
   examples/doc-iframes.html
@@ -33,6 +34,7 @@ support-files =
   examples/simple1.js
   examples/simple2.js
   examples/frames.js
+  examples/script-mutate.js
   examples/script-switching-02.js
   examples/script-switching-01.js
   examples/times2.js
@@ -58,6 +60,7 @@ support-files =
 [browser_dbg-navigation.js]
 [browser_dbg-pretty-print.js]
 [browser_dbg-pretty-print-paused.js]
+[browser_dbg-scopes-mutations.js]
 [browser_dbg-searching.js]
 skip-if = true
 [browser_dbg-sourcemaps.js]

--- a/src/test/mochitest/browser_dbg-scopes-mutations.js
+++ b/src/test/mochitest/browser_dbg-scopes-mutations.js
@@ -1,0 +1,120 @@
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
+
+function getScopeNodeLabel(dbg, index) {
+  return findElement(dbg, "scopeNode", index).innerText;
+}
+
+function getScopeNodeValue(dbg, index) {
+  return findElement(dbg, "scopeValue", index).innerText;
+}
+
+function expandNode(dbg, index) {
+  let onLoadProperties = onLoadObjectProperties(dbg);
+  clickElement(dbg, "scopeNode", index);
+  return onLoadProperties;
+}
+
+function toggleScopes(dbg) {
+  return findElement(dbg, "scopesHeader").click();
+}
+
+function onLoadObjectProperties(dbg) {
+  return waitForDispatch(dbg, "LOAD_OBJECT_PROPERTIES");
+}
+
+add_task(async function() {
+  const dbg = await initDebugger("doc-script-mutate.html");
+
+  toggleScopes(dbg);
+
+  let onPaused = waitForPaused(dbg);
+  invokeInTab("mutate");
+  await onPaused;
+
+  is(
+    getScopeNodeLabel(dbg, 2),
+    "<this>",
+    'The second element in the scope panel is "<this>"'
+  );
+  is(
+    getScopeNodeLabel(dbg, 3),
+    "phonebook",
+    'The third element in the scope panel is "phonebook"'
+  );
+
+  // Expand `phonebook`
+  await expandNode(dbg, 3);
+  is(
+    getScopeNodeLabel(dbg, 4),
+    "S",
+    'The fourth element in the scope panel is "S"'
+  );
+
+  // Expand `S`
+  await expandNode(dbg, 4);
+  is(
+    getScopeNodeLabel(dbg, 5),
+    "sarah",
+    'The fifth element in the scope panel is "sarah"'
+  );
+  is(
+    getScopeNodeLabel(dbg, 6),
+    "serena",
+    'The sixth element in the scope panel is "serena"'
+  );
+
+  // Expand `sarah`
+  await expandNode(dbg, 5);
+  is(
+    getScopeNodeLabel(dbg, 6),
+    "lastName",
+    'The sixth element in the scope panel is now "lastName"'
+  );
+  is(
+    getScopeNodeValue(dbg, 6),
+    '"Doe"',
+    'The "lastName" element has the expected "Doe" value'
+  );
+
+  info("Resuming");
+  onPaused = waitForPaused(dbg);
+  await resume(dbg);
+  await onPaused;
+
+  is(
+    getScopeNodeLabel(dbg, 6),
+    "lastName",
+    'The sixth element in the scope panel is still "lastName"'
+  );
+  is(
+    getScopeNodeValue(dbg, 6),
+    '"Doe"',
+    'The "lastName" property is still "Doe", but it should be "Pierce"' +
+      "since it was changed in the script."
+  );
+
+  onPaused = waitForPaused(dbg);
+  await resume(dbg);
+  await onPaused;
+  is(
+    getScopeNodeLabel(dbg, 6),
+    "lastName",
+    'The sixth element in the scope panel is still "lastName"'
+  );
+  is(
+    getScopeNodeLabel(dbg, 7),
+    "__proto__",
+    'The seventh element in the scope panel is still "__proto__", ' +
+      'but it should be now "timezone", since it was added to the "sarah" object ' +
+      "in the script"
+  );
+  is(
+    getScopeNodeValue(dbg, 7),
+    "Object",
+    'The seventh element in the scope panel has the value "Object", ' +
+      'but it should be "PST"'
+  );
+
+  await resume(dbg);
+});

--- a/src/test/mochitest/examples/doc-script-mutate.html
+++ b/src/test/mochitest/examples/doc-script-mutate.html
@@ -1,0 +1,17 @@
+<!-- Any copyright is dedicated to the Public Domain.
+     http://creativecommons.org/publicdomain/zero/1.0/ -->
+<!doctype html>
+
+<html>
+  <head>
+    <meta charset="utf-8"/>
+    <title>Debugger test page - Mutate object</title>
+  </head>
+
+  <body>
+    <button onclick="mutate()">Click me!</button>
+
+    <script type="text/javascript" src="script-mutate.js"></script>
+  </body>
+
+</html>

--- a/src/test/mochitest/examples/script-mutate.js
+++ b/src/test/mochitest/examples/script-mutate.js
@@ -1,0 +1,20 @@
+/* Any copyright is dedicated to the Public Domain.
+   http://creativecommons.org/publicdomain/zero/1.0/ */
+function mutate() {
+  const phonebook = {
+    S: {
+      sarah: {
+        lastName: "Doe"
+      },
+      serena: {
+        lastName: "Williams"
+      }
+    }
+  };
+
+  debugger;
+  phonebook.S.sarah.lastName = "Pierce";
+  debugger;
+  phonebook.S.sarah.timezone = "PST";
+  debugger;
+}

--- a/src/test/mochitest/head.js
+++ b/src/test/mochitest/head.js
@@ -613,6 +613,7 @@ const selectors = {
   scopesHeader: ".scopes-pane ._header",
   breakpointItem: i => `.breakpoints-list .breakpoint:nth-child(${i})`,
   scopeNode: i => `.scopes-list .tree-node:nth-child(${i}) .object-label`,
+  scopeValue: i => `.scopes-list .tree-node:nth-child(${i}) .object-value`,
   frame: i => `.frames ul li:nth-child(${i})`,
   frames: ".frames ul li",
   gutter: i => `.CodeMirror-code *:nth-child(${i}) .CodeMirror-linenumber`,


### PR DESCRIPTION
Associated Issue: #2631

Add a WRT test and a mochitest one to test that the expanded scopes
__does not__ behave as expected when stepping over a code that mutates an object
in the scopes panel.
