### PR TITLE
Move parser fixtures to files

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,5 +2,6 @@ assets/*
 src/test/examples/**
 src/test/integration/**
 src/test/unit-sources/**
+src/utils/tests/fixtures/**
 src/test/mochitest/**
 bin/

--- a/package.json
+++ b/package.json
@@ -136,7 +136,8 @@
     ],
     "testPathIgnorePatterns": [
       "/node_modules/",
-      "<rootDir>/test/"
+      "<rootDir>/test/",
+      "<rootDir>/utils/tests/fixtures/"
     ],
     "transformIgnorePatterns": [
       "node_modules/(?!devtools-)"

--- a/src/utils/tests/fixtures/allSymbols.js
+++ b/src/utils/tests/fixtures/allSymbols.js
@@ -1,0 +1,31 @@
+const TIME = 60;
+let count = 0;
+
+function incrementCounter(counter) {
+  return counter++;
+}
+
+const sum = (a, b) => a + b;
+
+const Obj = {
+  foo: 1,
+  doThing() {
+    console.log("hey");
+  },
+  doOtherThing: function() {
+    return 42;
+  }
+};
+
+Obj.property = () => {};
+Obj.otherProperty = 1;
+
+class Ultra {
+  constructor() {
+    this.awesome = true;
+  }
+
+  beAwesome(person) {
+    console.log(`${person} is Awesome!`);
+  }
+}

--- a/src/utils/tests/fixtures/class.js
+++ b/src/utils/tests/fixtures/class.js
@@ -1,0 +1,13 @@
+class Test {
+  constructor() {
+    this.foo = "foo";
+  }
+
+  bar(a) {
+    console.log("bar", a);
+  }
+}
+
+class Test2 {}
+
+let expressiveClass = class {};

--- a/src/utils/tests/fixtures/expression.js
+++ b/src/utils/tests/fixtures/expression.js
@@ -1,0 +1,6 @@
+function expr() {
+  const obj = { a: { b: 2 } };
+  const obj2 = { c: { b: 3 } };
+  const foo = obj2.c.b;
+  return obj.a.b;
+}

--- a/src/utils/tests/fixtures/func.js
+++ b/src/utils/tests/fixtures/func.js
@@ -1,0 +1,9 @@
+function square(n) {
+  return n * n;
+}
+
+child = function() {};
+
+(function() {
+  2;
+})();

--- a/src/utils/tests/fixtures/math.js
+++ b/src/utils/tests/fixtures/math.js
@@ -1,0 +1,11 @@
+function math(n) {
+  function square(n) {
+    n * n;
+  }
+  const two = square(2);
+  const four = squaare(4);
+  return two * four;
+}
+
+var child = function() {};
+child2 = function() {};

--- a/src/utils/tests/fixtures/proto.js
+++ b/src/utils/tests/fixtures/proto.js
@@ -1,0 +1,14 @@
+const foo = function() {};
+
+const bar = () => {};
+
+const TodoView = Backbone.View.extend({
+  tagName: "li",
+  initialize: function() {},
+  doThing(b) {
+    console.log("hi", b);
+  },
+  render: function() {
+    return this;
+  }
+});

--- a/src/utils/tests/fixtures/resolveToken.js
+++ b/src/utils/tests/fixtures/resolveToken.js
@@ -1,0 +1,19 @@
+const a = 1;
+let b = 0;
+
+function getA() {
+  return a;
+}
+
+function setB(newB) {
+  b = newB;
+}
+
+const plusAB = (function(x, y) {
+  const obj = { x, y };
+  function insideClosure(alpha, beta) {
+    return alpha + beta + obj.x + obj.y;
+  }
+
+  return insideClosure;
+})(a, b);

--- a/src/utils/tests/fixtures/thisExpression.js
+++ b/src/utils/tests/fixtures/thisExpression.js
@@ -1,0 +1,11 @@
+class Test {
+  constructor() {
+    this.foo = {
+      a: "foobar"
+    };
+  }
+
+  bar() {
+    console.log(this.foo.a);
+  }
+}

--- a/src/utils/tests/fixtures/var.js
+++ b/src/utils/tests/fixtures/var.js
@@ -1,0 +1,4 @@
+var foo = 1;
+let bar = 2;
+const baz = 3;
+const a = 4, b = 5;


### PR DESCRIPTION
### Summary of Changes

* moved the fixtures to their own files
* had to change some source locations

WHY?

We're doing a lot of parsing already and that's going to keep happening. We are building a debugger after all. So, lets invest in our fixtures and move them to their own files so that they can be better organized and we can get syntax highlighting and other things for free.