### PR TITLE
[SearchBar] Check before scrolling to result in result-list

### DIFF
--- a/src/components/Editor/SearchBar.js
+++ b/src/components/Editor/SearchBar.js
@@ -163,7 +163,11 @@ class SearchBar extends Component {
       searchInput.focus();
     }
 
-    if (this.refs.resultList && this.refs.resultList.refs) {
+    if (
+      this.refs.resultList &&
+      this.refs.resultList.refs &&
+      this.state.symbolSearchResults.length > this.state.selectedResultIndex
+    ) {
       scrollList(this.refs.resultList.refs, this.state.selectedResultIndex);
     }
 

--- a/src/components/Editor/SearchBar.js
+++ b/src/components/Editor/SearchBar.js
@@ -163,11 +163,7 @@ class SearchBar extends Component {
       searchInput.focus();
     }
 
-    if (
-      this.refs.resultList &&
-      this.refs.resultList.refs &&
-      this.state.symbolSearchResults.length > this.state.selectedResultIndex
-    ) {
+    if (this.refs.resultList && this.refs.resultList.refs) {
       scrollList(this.refs.resultList.refs, this.state.selectedResultIndex);
     }
 

--- a/src/utils/result-list.js
+++ b/src/utils/result-list.js
@@ -1,6 +1,10 @@
 const { isFirefox } = require("devtools-config");
 
 function scrollList(resultList, index) {
+  if (!resultList.hasOwnProperty(index)) {
+    return;
+  }
+
   const resultEl = resultList[index];
 
   if (isFirefox()) {


### PR DESCRIPTION
Found a problem which can be fixed with a minor change
### STR
* Open TodoMVC example in browser
* Open `js/views/app-view.js` file in debugger.html
* Open function search in editor and enter `a`.
* Navigate to lower result by pressing `down` arrow key a few times
* Now enter `a` in function search to narrow the result

![search-bar](https://cloud.githubusercontent.com/assets/1755089/25095816/f8e80a70-23ba-11e7-9733-c7ca5b053567.gif)



### Summary of Changes

* check before scrolling list
