### PR TITLE
[WIP] Address some scope inconsistencies

### DIFF
--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -280,6 +280,10 @@ class Editor extends Component {
   }
 
   onMouseOver(e) {
+    const { target } = e;
+    if (!target.parentElement.closest(".CodeMirror-line")) {
+      return;
+    }
     this.previewSelectedToken(e);
   }
 


### PR DESCRIPTION
Associated Issue: #2536

### Summary of Changes

Previously, we would determine if a node was in scope by seeing if it's most local scope contained it. We now get all of the variables defined along the scope chain. So get all the variables in the narrowest scope up to the program. 

I tried to tidy up some of the parsing logic along the way so that it would be more consistent.

We now have more methods that are more specific to what we want to do:

+  getClosestPath,
+  getClosestScope,
+  getClosestExpression,
+  getVariablesInLocalScope,