### PR TITLE
Docs: Changed git clone  to use https

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ debugger.html is a hackable debugger for modern times, built from the ground up 
 
 ```bash
 curl -o- -L https://yarnpkg.com/install.sh | bash -s
-git clone git@github.com:devtools-html/debugger.html.git
+git clone https://github.com/devtools-html/debugger.html.git
 
 cd debugger.html
 yarn

--- a/docs/getting-setup.md
+++ b/docs/getting-setup.md
@@ -11,7 +11,7 @@ Also, before you start, it's helpful to make sure you have node 7.
 We recommend, [nvm] for updating the latest node.
 
 ```bash
-git clone git@github.com:devtools-html/debugger.html.git
+git clone https://github.com/devtools-html/debugger.html.git
 cd debugger.html
 yarn install
 ```


### PR DESCRIPTION
Github's recommended method for cloning is HTTPS.
This avoids the need for ssh keys.

No Associated Issue

Here's the Pull Request Doc
https://devtools-html.github.io/debugger.html/CONTRIBUTING.html#pull-requests

### Summary of Changes

Updated the Quick Setup section of README and GETTING_SETUP to avoid error due to missing SSH/GPG Keys

### Test Plan
Single line markdown changes. 
Opened both documents and made sure they rendered properly in github and standalone. 


