### PR TITLE
Fix call stack logos styling

### DIFF
--- a/src/components/SecondaryPanes/Frames.css
+++ b/src/components/SecondaryPanes/Frames.css
@@ -75,6 +75,10 @@
   color: white;
 }
 
+.frames ul li.selected i.annotation-logo svg path {
+  fill: white;
+}
+
 :root.theme-light .frames ul li.selected .location,
 :root.theme-firebug .frames ul li.selected .location,
 :root.theme-dark .frames ul li.selected .location {
@@ -101,7 +105,8 @@
 
 .annotation-logo {
   width: 12px;
-  margin-left: 2px;
+  margin-left: 3px;
+  line-height: 8px;
 }
 
 :root.theme-dark .annotation-logo svg path {


### PR DESCRIPTION
Associated Issue: #2659 

### Summary of Changes

* updated line-height for call stack logos
* applied white color to logo when the frame is selected

### Screenshot
![49c3fdd2-25c3-11e7-9257-2388ce6e8a72](https://cloud.githubusercontent.com/assets/9111111/25224863/5d6c6e40-25dd-11e7-9305-e0002cd0c565.png)



