### PR TITLE
Fix previewing scope params

### DIFF
--- a/src/utils/tests/parser.js
+++ b/src/utils/tests/parser.js
@@ -135,9 +135,40 @@ describe("parser", () => {
   });
 
   describe("getClosestScope", () => {
+    it("finds the scope at the beginning", () => {
+      const scope = getClosestScope(getSourceText("func"), {
+        line: 5,
+        column: 8
+      });
+
+      const node = scope.block;
+
+      expect(node.id).to.be(null);
+      expect(node.loc.start).to.eql({
+        line: 5,
+        column: 8
+      });
+      expect(node.type).to.be("FunctionExpression");
+    });
+
+    it("finds a scope given at the end", () => {
+      const scope = getClosestScope(getSourceText("func"), {
+        line: 9,
+        column: 1
+      });
+
+      const node = scope.block;
+      expect(node.id).to.be(null);
+      expect(node.loc.start).to.eql({
+        line: 7,
+        column: 1
+      });
+      expect(node.type).to.be("FunctionExpression");
+    });
+
     it("Can find the function declaration for square", () => {
       const scope = getClosestScope(getSourceText("func"), {
-        line: 2,
+        line: 1,
         column: 1
       });
 
@@ -155,14 +186,14 @@ describe("parser", () => {
     it("finds scope binding variables", () => {
       const scope = getClosestScope(getSourceText("math"), {
         line: 2,
-        column: 5
+        column: 2
       });
 
       var vars = getVariablesInLocalScope(scope);
-      expect(vars.map(v => v.name)).to.eql(["n", "square", "two", "four"]);
-      expect(vars[1].references[0].node.loc.start).to.eql({
-        column: 14,
-        line: 5
+      expect(vars.map(v => v.name)).to.eql(["n"]);
+      expect(vars[0].references[0].node.loc.start).to.eql({
+        column: 4,
+        line: 3
       });
     });
 


### PR DESCRIPTION
This fixes the algorithm for determing if a location is in scope by checking if it is at the start or end of a scope

<img width="328" alt="screen shot 2017-04-20 at 12 21 04 pm" src="https://cloud.githubusercontent.com/assets/254562/25241410/e119088a-25c3-11e7-88be-b5311b827956.png">
