### PR TITLE
WIP: Adding to watch Expressions, commented mouseLeave

### DIFF
--- a/configs/development.json
+++ b/configs/development.json
@@ -23,6 +23,10 @@
       "label": "Watch Expressions",
       "enabled": true
     },
+    "previewWatch": {
+      "label": "Add watch expression from preview",
+      "enabled": true
+    },
     "chromeScopes": {
       "label": "Chrome Scopes",
       "enabled": false

--- a/src/components/Editor/Preview.css
+++ b/src/components/Editor/Preview.css
@@ -8,7 +8,6 @@
   min-height: inherit;
   max-height: 200px;
   overflow: auto;
-  box-shadow: 1px 2px 4px 1px var(--theme-toolbar-background-alt);
 }
 
 .popover .preview .header {
@@ -75,4 +74,33 @@
 .tooltip .gap {
   height: 4px;
   padding-top: 4px;
+}
+
+.add-to-expression-bar {
+  border: 1px solid var(--theme-splitter-color);
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-size: 14px;
+  line-height: 30px;
+  background: var(--theme-toolbar-background);
+  color: var(--theme-comment-alt);
+}
+
+.add-to-expression-bar .prompt {
+  padding-left: 3px;
+  width: 1em;
+}
+
+.add-to-expression-bar .expression-to-save-label {
+  width: calc(100% - 4em);
+}
+
+.add-to-expression-bar .expression-to-save-button {
+  font-size: 14px;
+  color: var(--theme-comment);
+  cursor: pointer;
 }

--- a/src/components/Editor/Preview.js
+++ b/src/components/Editor/Preview.js
@@ -9,6 +9,7 @@ const ObjectInspector = React.createFactory(
 );
 const Popover = React.createFactory(require("../shared/Popover").default);
 const previewFunction = require("../shared/previewFunction").default;
+const { addExpression } = actions;
 
 import { getLoadedObjects } from "../../selectors";
 import { getChildren } from "../../utils/object-inspector";
@@ -89,6 +90,24 @@ class Preview extends Component {
     });
   }
 
+  renderAddToExpressionBar(expression) {
+    return dom.div(
+      { className: "add-to-expression-bar" },
+      dom.div({ className: "prompt" }, "»"),
+      dom.div({ className: "expression-to-save-label" }, expression),
+      dom.div(
+        {
+          className: "expression-to-save-button",
+          onClick: event => {
+            console.log(expression);
+            addExpression(expression);
+          }
+        },
+        L10N.getStr("addWatchExpressionButton")
+      )
+    );
+  }
+
   renderPreview(expression, value) {
     const root = {
       name: expression,
@@ -101,7 +120,11 @@ class Preview extends Component {
     }
 
     if (value.type === "object") {
-      return this.renderObjectPreview(expression, root);
+      return dom.div(
+        {},
+        this.renderObjectPreview(expression, root),
+        this.renderAddToExpressionBar(expression, value)
+      );
     }
 
     return this.renderSimplePreview(value);

--- a/src/components/Editor/Preview.js
+++ b/src/components/Editor/Preview.js
@@ -3,15 +3,15 @@
 import React from "react";
 import { connect } from "react-redux";
 import { bindActionCreators } from "redux";
-import actions from "../../actions";
+
 const ObjectInspector = React.createFactory(
   require("../shared/ObjectInspector").default
 );
 const Popover = React.createFactory(require("../shared/Popover").default);
 const previewFunction = require("../shared/previewFunction").default;
-const { addExpression } = actions;
 
 import { getLoadedObjects } from "../../selectors";
+import actions from "../../actions";
 import { getChildren } from "../../utils/object-inspector";
 
 const Rep = require("../shared/Rep").default;
@@ -91,6 +91,7 @@ class Preview extends Component {
   }
 
   renderAddToExpressionBar(expression) {
+    const { addExpression } = this.props;
     return dom.div(
       { className: "add-to-expression-bar" },
       dom.div({ className: "prompt" }, "»"),
@@ -148,6 +149,7 @@ class Preview extends Component {
 
 Preview.propTypes = {
   loadObjectProperties: PropTypes.func,
+  addExpression: PropTypes.func,
   loadedObjects: PropTypes.object,
   selectedFrame: PropTypes.object,
   popoverTarget: PropTypes.object,

--- a/src/components/Editor/Preview.js
+++ b/src/components/Editor/Preview.js
@@ -3,6 +3,7 @@
 import React from "react";
 import { connect } from "react-redux";
 import { bindActionCreators } from "redux";
+import { isEnabled } from "devtools-config";
 
 const ObjectInspector = React.createFactory(
   require("../shared/ObjectInspector").default
@@ -91,6 +92,10 @@ class Preview extends Component {
   }
 
   renderAddToExpressionBar(expression) {
+    if (!isEnabled("previewWatch")) {
+      return null;
+    }
+
     const { addExpression } = this.props;
     return dom.div(
       { className: "add-to-expression-bar" },

--- a/src/components/shared/Popover.css
+++ b/src/components/shared/Popover.css
@@ -1,6 +1,7 @@
 .popover {
   position: fixed;
   z-index: 100;
+  box-shadow: 1px 2px 4px 1px var(--theme-toolbar-background-alt);
 }
 
 .popover .gap {

--- a/src/components/shared/Popover.js
+++ b/src/components/shared/Popover.js
@@ -70,7 +70,7 @@ class Popover extends Component {
     return dom.div(
       {
         className: classNames("popover", { up: dir === "up" }),
-        onMouseLeave,
+        // onMouseLeave,
         style: { top, left }
       },
       this.getChildren()

--- a/src/components/shared/Popover.js
+++ b/src/components/shared/Popover.js
@@ -70,7 +70,7 @@ class Popover extends Component {
     return dom.div(
       {
         className: classNames("popover", { up: dir === "up" }),
-        // onMouseLeave,
+        onMouseLeave,
         style: { top, left }
       },
       this.getChildren()


### PR DESCRIPTION
Associated Issue: #2578 

- Created UI as suggested
- Somehow [`addExpression`](https://github.com/devtools-html/debugger.html/compare/master...ruturajv:bug-2578-save-preview-to-watch-expressions?expand=1#diff-358af90c482e216b601199f75f64a27bR103) isn't working as I hoped, @jasonLaster @wldcordeiro  could you please check ?
- please ignore the mouseLeave comment

- regarding a comment on the mock, `input - updates preview`should the expression be listed in an input box and then user can play around with it to see preview changing ... and then add ?