### PR TITLE
Fix for the last closed tab not getting persisted

### DIFF
--- a/src/actions/sources.js
+++ b/src/actions/sources.js
@@ -40,6 +40,7 @@ import type { ThunkArgs } from "./types";
 // select it.
 function checkSelectedSource(state, dispatch, source) {
   const pendingLocation = getPendingSelectedLocation(state);
+  console.log("checkSelectedSource", pendingLocation, source);
   if (pendingLocation && pendingLocation.url === source.url) {
     dispatch(selectSource(source.id, { line: pendingLocation.line }));
   }

--- a/src/actions/sources.js
+++ b/src/actions/sources.js
@@ -40,7 +40,7 @@ import type { ThunkArgs } from "./types";
 // select it.
 function checkSelectedSource(state, dispatch, source) {
   const pendingLocation = getPendingSelectedLocation(state);
-  console.log("checkSelectedSource", pendingLocation, source);
+
   if (pendingLocation && pendingLocation.url === source.url) {
     dispatch(selectSource(source.id, { line: pendingLocation.line }));
   }

--- a/src/reducers/sources.js
+++ b/src/reducers/sources.js
@@ -105,8 +105,13 @@ function update(
       availableTabs = removeSourceFromTabList(state.tabs, action.url);
       const sourceId = getNewSelectedSourceId(state, availableTabs);
 
-      location = { url: getSourceUrlById(state, sourceId) };
-      prefs.pendingSelectedLocation = location;
+      if (sourceId) {
+        location = { url: getSourceUrlById(state, sourceId) };
+        prefs.pendingSelectedLocation = location;
+      } else {
+        location = undefined;
+        prefs.pendingSelectedLocation = {};
+      }
 
       return state
         .merge({ tabs: availableTabs })
@@ -138,8 +143,16 @@ function update(
     case "NAVIGATE":
       const source = getSelectedSource({ sources: state });
       const url = source && source.get("url");
-      prefs.pendingSelectedLocation = { url };
-      return State().set("pendingSelectedLocation", { url });
+      const tabs = getTabs({ sources: state });
+
+      if (url) {
+        prefs.pendingSelectedLocation = { url };
+        return State()
+          .set("pendingSelectedLocation", { url })
+          .set("tabs", tabs);
+      }
+
+      return State().set("pendingSelectedLocation", {}).set("tabs", tabs);
   }
 
   return state;

--- a/src/reducers/sources.js
+++ b/src/reducers/sources.js
@@ -103,12 +103,14 @@ function update(
 
     case "CLOSE_TAB":
       availableTabs = removeSourceFromTabList(state.tabs, action.url);
-      location = { sourceId: getNewSelectedSourceId(state, availableTabs) };
+      const sourceId = getNewSelectedSourceId(state, availableTabs);
+
+      location = { url: getSourceUrlById(state, sourceId) };
       prefs.pendingSelectedLocation = location;
 
       return state
         .merge({ tabs: availableTabs })
-        .set("selectedLocation", location)
+        .set("selectedLocation", { sourceId })
         .set("pendingSelectedLocation", location);
 
     case "CLOSE_TABS":
@@ -269,6 +271,10 @@ function getNewSelectedSourceId(state: SourcesState, availableTabs): string {
   }
 
   return "";
+}
+
+function getSourceUrlById(state: SourcesState, id: string): string {
+  return state.sources.find(source => source.get("id") == id).get("url");
 }
 
 // Selectors

--- a/src/reducers/sources.js
+++ b/src/reducers/sources.js
@@ -287,8 +287,8 @@ function getNewSelectedSourceId(state: SourcesState, availableTabs): string {
 }
 
 function getSourceUrlById(state: SourcesState, id: string): string {
-  const source = state.sources.find(source => source.get("id") == id);
-  return source ? source.get("url") : "";
+  const src = state.sources.find(source => source.get("id") == id);
+  return src ? src.get("url") : "";
 }
 
 // Selectors

--- a/src/reducers/sources.js
+++ b/src/reducers/sources.js
@@ -287,7 +287,11 @@ function getNewSelectedSourceId(state: SourcesState, availableTabs): string {
 }
 
 function getSourceUrlById(state: SourcesState, id: string): string {
-  return state.sources.find(source => source.get("id") == id).get("url");
+  const source = state.sources.find(source => source.get("id") == id);
+  if (source) {
+    return source.get("url");
+  }
+  return "";
 }
 
 // Selectors

--- a/src/reducers/sources.js
+++ b/src/reducers/sources.js
@@ -103,10 +103,13 @@ function update(
 
     case "CLOSE_TAB":
       availableTabs = removeSourceFromTabList(state.tabs, action.url);
+      location = { sourceId: getNewSelectedSourceId(state, availableTabs) };
+      prefs.pendingSelectedLocation = location;
 
-      return state.merge({ tabs: availableTabs }).set("selectedLocation", {
-        sourceId: getNewSelectedSourceId(state, availableTabs)
-      });
+      return state
+        .merge({ tabs: availableTabs })
+        .set("selectedLocation", location)
+        .set("pendingSelectedLocation", location);
 
     case "CLOSE_TABS":
       availableTabs = removeSourcesFromTabList(state.tabs, action.urls);

--- a/src/reducers/sources.js
+++ b/src/reducers/sources.js
@@ -288,10 +288,7 @@ function getNewSelectedSourceId(state: SourcesState, availableTabs): string {
 
 function getSourceUrlById(state: SourcesState, id: string): string {
   const source = state.sources.find(source => source.get("id") == id);
-  if (source) {
-    return source.get("url");
-  }
-  return "";
+  return source ? source.get("url") : "";
 }
 
 // Selectors

--- a/src/test/integration/runner.js
+++ b/src/test/integration/runner.js
@@ -107,8 +107,12 @@ describe("Tests", () => {
 
   // expected 2 to equal 1
   xit("source maps bogus", async () => await sourceMapsBogus(ctx));
-
-  xit("tabs", async () => await tabs(ctx));
+  xit("tabs - add tabs", async () => await tabs.addTabs(ctx));
+  xit("tabs - reload with tabs", async () => await tabs.reloadWithTabs(ctx));
+  xit(
+    "tabs - reload with no tabs",
+    async () => await tabs.reloadWithNoTabs(ctx)
+  );
 });
 
 mocha.run();

--- a/src/test/integration/runner.js
+++ b/src/test/integration/runner.js
@@ -107,12 +107,10 @@ describe("Tests", () => {
 
   // expected 2 to equal 1
   xit("source maps bogus", async () => await sourceMapsBogus(ctx));
-  xit("tabs - add tabs", async () => await tabs.addTabs(ctx));
-  xit("tabs - reload with tabs", async () => await tabs.reloadWithTabs(ctx));
-  xit(
-    "tabs - reload with no tabs",
-    async () => await tabs.reloadWithNoTabs(ctx)
-  );
+  it("tabs - add tabs", async () => await tabs.addTabs(ctx));
+  it("tabs - reload with tabs", async () => await tabs.reloadWithTabs(ctx));
+  it("tabs - reload with no tabs", async () =>
+    await tabs.reloadWithNoTabs(ctx));
 });
 
 mocha.run();

--- a/src/test/integration/runner.js
+++ b/src/test/integration/runner.js
@@ -108,7 +108,7 @@ describe("Tests", () => {
   // expected 2 to equal 1
   xit("source maps bogus", async () => await sourceMapsBogus(ctx));
 
-  it("tabs", async () => await tabs(ctx));
+  xit("tabs", async () => await tabs(ctx));
 });
 
 mocha.run();

--- a/src/test/integration/tests/tabs.js
+++ b/src/test/integration/tests/tabs.js
@@ -11,7 +11,7 @@ function countTabs(dbg) {
   return findElement(dbg, "sourceTabs").children.length;
 }
 
-module.exports = async function(ctx) {
+export async function addTabs(ctx) {
   const { ok, is, info, requestLongerTimeout } = ctx;
 
   let dbg = await initDebugger("doc-scripts.html", "simple1", "simple2");
@@ -29,9 +29,34 @@ module.exports = async function(ctx) {
   await reload(dbg, "simple1", "simple2");
   await waitForDispatch(dbg, "LOAD_SOURCE_TEXT");
   expect(countTabs(dbg)).to.equal(2);
+}
 
-  // Test closing and reloading the debugger
-  await closeTab(dbg, "simple1");
-  await closeTab(dbg, "simple2");
+export async function reloadWithTabs(ctx) {
+  const { ok, is, info, requestLongerTimeout } = ctx;
+
+  let dbg = await initDebugger("doc-scripts.html", "simple1", "simple2");
+
+  await selectSource(dbg, "simple1");
+  await selectSource(dbg, "simple2");
+  expect(countTabs(dbg)).to.equal(2);
+
+  // Test reloading the debugger
+  await reload(dbg, "simple1", "simple2");
+  await waitForDispatch(dbg, "LOAD_SOURCE_TEXT");
+  expect(countTabs(dbg)).to.equal(2);
+}
+
+export async function reloadWithNoTabs(ctx) {
+  const { ok, is, info, requestLongerTimeout } = ctx;
+
+  let dbg = await initDebugger("doc-scripts.html", "simple1", "simple2");
+
+  await selectSource(dbg, "simple1");
+  await selectSource(dbg, "simple2");
+  closeTab(dbg, "simple1");
+  closeTab(dbg, "simple2");
+
+  // Test reloading the debugger
+  dbg = await initDebugger("doc-scripts.html", "simple1", "simple2");
   expect(countTabs(dbg)).to.equal(0);
-};
+}

--- a/src/test/integration/tests/tabs.js
+++ b/src/test/integration/tests/tabs.js
@@ -4,6 +4,7 @@ const {
   selectSource,
   findElement,
   waitForDispatch
+  closeTab
 } = require("../utils");
 
 function countTabs(dbg) {
@@ -28,4 +29,9 @@ module.exports = async function(ctx) {
   await reload(dbg, "simple1", "simple2");
   await waitForDispatch(dbg, "LOAD_SOURCE_TEXT");
   expect(countTabs(dbg)).to.equal(2);
+
+  // Test closing and reloading the debugger
+  await closeTab(dbg, "simple1");
+  await closeTab(dbg "simple2");
+  expect(countTabs(dbg)).to.equal(0);
 };

--- a/src/test/integration/tests/tabs.js
+++ b/src/test/integration/tests/tabs.js
@@ -3,7 +3,7 @@ const {
   reload,
   selectSource,
   findElement,
-  waitForDispatch
+  waitForDispatch,
   closeTab
 } = require("../utils");
 
@@ -32,6 +32,6 @@ module.exports = async function(ctx) {
 
   // Test closing and reloading the debugger
   await closeTab(dbg, "simple1");
-  await closeTab(dbg "simple2");
+  await closeTab(dbg, "simple2");
   expect(countTabs(dbg)).to.equal(0);
 };

--- a/src/test/integration/utils/commands.js
+++ b/src/test/integration/utils/commands.js
@@ -40,10 +40,11 @@ const {
 * @return {Promise}
 * @static
 */
-async function closeTab(dbg, url) {
+function closeTab(dbg, url) {
   info("Closing tab: " + url);
-  dbg.actions.closeTab(url);
-  return waitForDispatch(dbg, "CLOSE_TAB");
+  const source = findSource(dbg, url);
+
+  dbg.actions.closeTab(source.url);
 }
 
 /**

--- a/src/test/integration/utils/commands.js
+++ b/src/test/integration/utils/commands.js
@@ -32,6 +32,21 @@ const {
 } = require("./wait");
 
 /**
+* Closes a tab
+*
+* @memberof mochitest/actions
+* @param {Object} dbg
+* @param {String} url
+* @return {Promise}
+* @static
+*/
+async function closeTab(dbg, url) {
+  info("Closing tab: " + url);
+  dbg.actions.closeTab(url);
+  return waitForDispatch(dbg, "CLOSE_TAB");
+}
+
+/**
  * Selects the source.
  *
  * @memberof mochitest/actions
@@ -234,6 +249,7 @@ function pauseTest() {
 }
 
 module.exports = {
+  closeTab,
   selectSource,
   stepOver,
   stepIn,

--- a/src/test/integration/utils/shared.js
+++ b/src/test/integration/utils/shared.js
@@ -7,9 +7,12 @@ const selectors = {
   breakpointItem: i => `.breakpoints-list .breakpoint:nth-child(${i})`,
   scopeNode: i => `.scopes-list .tree-node:nth-child(${i}) .object-label`,
   scopeValue: i => `.scopes-list .tree-node:nth-child(${i}) .object-value`,
-  expressionNode: i => `.expressions-list .tree-node:nth-child(${i}) .object-label`,
-  expressionValue: i => `.expressions-list .tree-node:nth-child(${i}) .object-value`,
-  expressionClose: i => `.expressions-list .expression-container:nth-child(${i}) .close-btn`,
+  expressionNode: i =>
+    `.expressions-list .tree-node:nth-child(${i}) .object-label`,
+  expressionValue: i =>
+    `.expressions-list .tree-node:nth-child(${i}) .object-value`,
+  expressionClose: i =>
+    `.expressions-list .expression-container:nth-child(${i}) .close-btn`,
   expressionNodes: ".expressions-list .tree-node",
   frame: i => `.frames ul li:nth-child(${i})`,
   frames: ".frames ul li",


### PR DESCRIPTION
Associated Issue: #2615 and maybe #2638

### Summary of Changes

* Make sure the `pendingSelectedLocation` is updated

### Test Plan

Tell us a little a bit about how you tested your patch.

Example test plan:

- [x] I had two files opened within the top tab bar.
- [x] I closed both of them (all file tabs closed,
- [x] I refreshed the page
- [x] The last file should be closed.

### Screenshots/Videos 
![persist-tabs-fix](https://cloud.githubusercontent.com/assets/792924/25346497/a7127e9c-290f-11e7-9599-46df17fa13ab.gif)

