### PR TITLE
issue #2117: add module: noParse to ignore mocha

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -33,6 +33,11 @@ let webpackConfig = {
     alias: {
       "react-dom": "react-dom/dist/react-dom"
     }
+  },
+
+  module: {
+    // Ignore the prebuilt mocha lib file.
+    noParse: /mocha\/mocha\.js/i
   }
 };
 


### PR DESCRIPTION
Associated Issue: #2117

Fixes the warning about mocha.js being a prebuilt file during the webpack build.

### Summary of Changes

* add the module.noParse webpack config to ignore the prebuilt mocha.js file

### Test Plan

- [x] started integration tests on http://localhost:8000/integration/ (2 failing tests but I have the same result on the latest master, so I guess this is unrelated to my change)

### Screenshots

![image](https://cloud.githubusercontent.com/assets/1141550/25357311/a8c631ba-293d-11e7-80a2-fd3c600e9f60.png)

