### PR TITLE
Remove L10N setup from utils/tests/scopes.js

### DIFF
--- a/src/components/tests/WhyPaused.js
+++ b/src/components/tests/WhyPaused.js
@@ -3,8 +3,6 @@ import { shallow } from "enzyme";
 import WhyPaused from "../SecondaryPanes/WhyPaused.js";
 const fromJS = require("../../utils/fromJS");
 
-global.L10N = { getStr: () => "" };
-
 const WhyPausedComponent = React.createFactory(WhyPaused.WrappedComponent);
 
 describe("WhyPaused", () => {

--- a/src/utils/tests/scopes.js
+++ b/src/utils/tests/scopes.js
@@ -196,12 +196,6 @@ describe("scopes", () => {
         frame,
         isInterrupted: false
       });
-
-      global.L10N = { getStr: () => "" };
-    });
-
-    afterEach(function() {
-      delete global.L10N;
     });
 
     it("Returns variables from the outer scope", function() {


### PR DESCRIPTION
L10N is globally setup [here](https://github.com/devtools-html/debugger.html/blob/master/src/test/tests-setup.js#L27) so this is not required.

Associated Issue: #2728

### Summary of Changes

* Remove L10N setup from `utils/tests/scopes.js`
