### PR TITLE
Convert sources reducer to ES modules

### DIFF
--- a/src/reducers/sources.js
+++ b/src/reducers/sources.js
@@ -8,10 +8,10 @@
  * @module reducers/sources
  */
 
-const I = require("immutable");
-const makeRecord = require("../utils/makeRecord");
-const { getPrettySourceURL } = require("../utils/source");
-const { prefs } = require("../utils/prefs");
+import * as I from "immutable";
+import makeRecord from "../utils/makeRecord";
+import { getPrettySourceURL } from "../utils/source";
+import { prefs } from "../utils/prefs";
 
 import type { Source, Location } from "../types";
 import type { Action } from "../actions/types";
@@ -34,7 +34,7 @@ export type SourcesState = {
   tabs: I.List<any>
 };
 
-const State = makeRecord(
+export const State = makeRecord(
   ({
     sources: I.Map(),
     selectedLocation: undefined,
@@ -44,7 +44,7 @@ const State = makeRecord(
   }: SourcesState)
 );
 
-function update(state = State(), action: Action): Record<SourcesState> {
+export function update(state = State() : SourcesState, action: Action): Record<SourcesState> {
   let availableTabs = null;
   let location = null;
 
@@ -270,33 +270,33 @@ function getNewSelectedSourceId(state: SourcesState, availableTabs): string {
 // (right now) to type those wrapped functions.
 type OuterState = { sources: Record<SourcesState> };
 
-function getSource(state: OuterState, id: string) {
+export function getSource(state: OuterState, id: string) {
   return state.sources.sources.get(id);
 }
 
-function getSourceByURL(state: OuterState, url: string) {
+export function getSourceByURL(state: OuterState, url: string) {
   return state.sources.sources.find(source => source.get("url") == url);
 }
 
-function getSourceById(state: OuterState, id: string) {
+export function getSourceById(state: OuterState, id: string) {
   return state.sources.sources.find(source => source.get("id") == id);
 }
 
-function getSources(state: OuterState) {
+export function getSources(state: OuterState) {
   return state.sources.sources;
 }
 
-function getSourceText(state: OuterState, id: ?string) {
+export function getSourceText(state: OuterState, id: ?string) {
   if (id) {
     return state.sources.sourcesText.get(id);
   }
 }
 
-function getSourceTabs(state: OuterState) {
+export function getSourceTabs(state: OuterState) {
   return state.sources.tabs.filter(tab => getSourceByURL(state, tab));
 }
 
-function getSelectedSource(state: OuterState) {
+export function getSelectedSource(state: OuterState) {
   const selectedLocation = state.sources.selectedLocation;
   if (!selectedLocation) {
     return;
@@ -307,15 +307,15 @@ function getSelectedSource(state: OuterState) {
   );
 }
 
-function getSelectedLocation(state: OuterState) {
+export function getSelectedLocation(state: OuterState) {
   return state.sources.selectedLocation;
 }
 
-function getPendingSelectedLocation(state: OuterState) {
+export function getPendingSelectedLocation(state: OuterState) {
   return state.sources.pendingSelectedLocation;
 }
 
-function getPrettySource(state: OuterState, id: string) {
+export function getPrettySource(state: OuterState, id: string) {
   const source = getSource(state, id);
   if (!source) {
     return;
@@ -323,18 +323,3 @@ function getPrettySource(state: OuterState, id: string) {
 
   return getSourceByURL(state, getPrettySourceURL(source.get("url")));
 }
-
-module.exports = {
-  State,
-  update,
-  getSource,
-  getSourceByURL,
-  getSourceById,
-  getSources,
-  getSourceText,
-  getSourceTabs,
-  getSelectedSource,
-  getSelectedLocation,
-  getPendingSelectedLocation,
-  getPrettySource
-};

--- a/src/reducers/sources.js
+++ b/src/reducers/sources.js
@@ -44,7 +44,10 @@ export const State = makeRecord(
   }: SourcesState)
 );
 
-export function update(state = State(), action: Action): Record<SourcesState> {
+export function update(
+  state: any = State(),
+  action: Action
+): Record<SourcesState> {
   let availableTabs = null;
   let location = null;
 

--- a/src/reducers/sources.js
+++ b/src/reducers/sources.js
@@ -45,7 +45,7 @@ export const State = makeRecord(
 );
 
 export function update(
-  state: any = State(),
+  state: Record<SourcesState> = State(),
   action: Action
 ): Record<SourcesState> {
   let availableTabs = null;

--- a/src/reducers/sources.js
+++ b/src/reducers/sources.js
@@ -44,7 +44,7 @@ export const State = makeRecord(
   }: SourcesState)
 );
 
-export function update(state = State() : SourcesState, action: Action): Record<SourcesState> {
+export function update(state = State(), action: Action): Record<SourcesState> {
   let availableTabs = null;
   let location = null;
 

--- a/src/reducers/tests/sources.js
+++ b/src/reducers/tests/sources.js
@@ -2,10 +2,10 @@
 declare var describe: (name: string, func: () => void) => void;
 declare var it: (desc: string, func: () => void) => void;
 
-const { State, update } = require("../sources");
-const { foobar } = require("../../test/fixtures");
+import { State, update } from "../sources";
+import { foobar } from "../../test/fixtures";
 const fakeSources = foobar.sources.sources;
-const expect = require("expect.js");
+import expect from "expect.js";
 
 describe("sources reducer", () => {
   it("should work", () => {


### PR DESCRIPTION
Associated Issue: #1884 

### Summary of Changes

* update sources reducer to use ES modules
* update sources reducer test to use ES modules
* set sources reducer's state argument's state to `any` to silence Flow error

Note about last point:
Without it Flow complained about missing annotation after addition of 
`export` statement.  After setting it to `SourcesState` it complained 
about unrecognized methods, which I suspect come from Immutable. 
Since this PR isn't about type-checking, I left it at `any`, as suggested
in [this comment](https://github.com/devtools-html/debugger.html/issues/1884#issuecomment-280710019).