### PR TITLE
Fix Outline CPU usage (and unrelated test failure)

### DIFF
--- a/src/components/Outline.js
+++ b/src/components/Outline.js
@@ -20,7 +20,7 @@ class Outline extends Component {
     this.state = {};
   }
 
-  componentWillUpdate({ sourceText }) {
+  componentWillReceiveProps({ sourceText }) {
     if (sourceText) {
       this.setSymbolDeclarations(sourceText);
     }
@@ -29,9 +29,11 @@ class Outline extends Component {
   async setSymbolDeclarations(sourceText: Record<SourceText>) {
     const symbolDeclarations = await getSymbols(sourceText.toJS());
 
-    this.setState({
-      symbolDeclarations
-    });
+    if (symbolDeclarations !== this.state.symbolDeclarations) {
+      this.setState({
+        symbolDeclarations
+      });
+    }
   }
 
   renderFunction(func) {


### PR DESCRIPTION
Associated Issue: #2731

The high CPU usage was due to an infinite loop. `componentWillUpdate` is called any time that props _or state_ are changed. So by triggering a process that will call `setState` inside of it, we then change the state and trigger it to happen again, ad infinitum. For this case, we only want to do the work if props are changing from above, so the correct callback to use is `componentWillReceiveProps`.

In running the tests, I found an unrelated failure that was already present on master. One of the unit tests needed a mocked `L10N` object, so I added it.

### Summary of Changes

* Changed callback that triggers symbol lookup from  `componentWillUpdate` to `componentWillReceiveProps` 
* Added a mock `L10N` object before test that requires it.

### Test Plan

- [x] Open debugger pointing to a window running a JavaScript application
- [x] Debug the debugger and start profiling JS execution
- [x] In the outline, select one of the js files to open it
- [x] Wait a few seconds
- [x] End the profile and check for JS activity. Should be minimal. OS-level stats should also show little to no CPU usage while the js file text is open but not being interacted with.
