### PR TITLE
Convert remaining of reducers to ES modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "lint-fix": "yarn lint-js -- --fix",
     "test": "jest",
     "test-coverage": "yarn test -- --coverage",
-    "test-all": "yarn test; yarn lint",
+    "test-all": "yarn test; yarn lint; yarn flow",
     "firefox": "start-firefox --start --location https://devtools-html.github.io/debugger-examples/",
     "chrome": "start-chrome --location https://devtools-html.github.io/debugger-examples/",
     "copy-assets": "node bin/copy-assets --symlink",

--- a/src/reducers/async-requests.js
+++ b/src/reducers/async-requests.js
@@ -24,4 +24,4 @@ function update(state = initialState, action) {
   return state;
 }
 
-module.exports = update;
+export default update;

--- a/src/reducers/breakpoints.js
+++ b/src/reducers/breakpoints.js
@@ -58,7 +58,7 @@ function allBreakpointsDisabled(state) {
   return state.breakpoints.every(x => x.disabled);
 }
 
-export function update(state: any = State(), action: Action) {
+function update(state: any = State(), action: Action) {
   switch (action.type) {
     case "ADD_BREAKPOINT": {
       const newState = addBreakpoint(state, action);
@@ -257,3 +257,5 @@ export function getBreakpointsLoading(state: OuterState) {
 export function getPendingBreakpoints(state: OuterState) {
   return state.breakpoints.pendingBreakpoints;
 }
+
+export default update;

--- a/src/reducers/breakpoints.js
+++ b/src/reducers/breakpoints.js
@@ -58,7 +58,7 @@ function allBreakpointsDisabled(state) {
   return state.breakpoints.every(x => x.disabled);
 }
 
-function update(state: any = State(), action: Action) {
+function update(state: Record<BreakpointsState> = State(), action: Action) {
   switch (action.type) {
     case "ADD_BREAKPOINT": {
       const newState = addBreakpoint(state, action);

--- a/src/reducers/breakpoints.js
+++ b/src/reducers/breakpoints.js
@@ -8,11 +8,11 @@
  * @module reducers/breakpoints
  */
 
-const fromJS = require("../utils/fromJS");
-const { updateObj } = require("../utils/utils");
-const I = require("immutable");
-const makeRecord = require("../utils/makeRecord");
-const { prefs } = require("../utils/prefs");
+import fromJS from "../utils/fromJS";
+import { updateObj } from "../utils/utils";
+import * as I from "immutable";
+import makeRecord from "../utils/makeRecord";
+import { prefs } from "../utils/prefs";
 
 import type { Breakpoint, Location } from "../types";
 import type { Action } from "../actions/types";
@@ -24,7 +24,7 @@ export type BreakpointsState = {
   breakpointsDisabled: false
 };
 
-const State = makeRecord(
+export const State = makeRecord(
   ({
     breakpoints: I.Map(),
     pendingBreakpoints: restorePendingBreakpoints(),
@@ -50,7 +50,7 @@ function locationMoved(location, newLocation) {
   );
 }
 
-function makeLocationId(location: Location) {
+export function makeLocationId(location: Location) {
   return `${location.sourceId}:${location.line}`;
 }
 
@@ -58,7 +58,7 @@ function allBreakpointsDisabled(state) {
   return state.breakpoints.every(x => x.disabled);
 }
 
-function update(state = State(), action: Action) {
+export function update(state: any = State(), action: Action) {
   switch (action.type) {
     case "ADD_BREAKPOINT": {
       const newState = addBreakpoint(state, action);
@@ -229,43 +229,31 @@ function restorePendingBreakpoints() {
 
 type OuterState = { breakpoints: Record<BreakpointsState> };
 
-function getBreakpoint(state: OuterState, location: Location) {
+export function getBreakpoint(state: OuterState, location: Location) {
   return state.breakpoints.breakpoints.get(makeLocationId(location));
 }
 
-function getBreakpoints(state: OuterState) {
+export function getBreakpoints(state: OuterState) {
   return state.breakpoints.breakpoints;
 }
 
-function getBreakpointsForSource(state: OuterState, sourceId: string) {
+export function getBreakpointsForSource(state: OuterState, sourceId: string) {
   return state.breakpoints.breakpoints.filter(bp => {
     return bp.location.sourceId === sourceId;
   });
 }
 
-function getBreakpointsDisabled(state: OuterState): boolean {
+export function getBreakpointsDisabled(state: OuterState): boolean {
   return state.breakpoints.get("breakpointsDisabled");
 }
 
-function getBreakpointsLoading(state: OuterState) {
+export function getBreakpointsLoading(state: OuterState) {
   const breakpoints = getBreakpoints(state);
   const isLoading = !!breakpoints.valueSeq().filter(bp => bp.loading).first();
 
   return breakpoints.size > 0 && isLoading;
 }
 
-function getPendingBreakpoints(state: OuterState) {
+export function getPendingBreakpoints(state: OuterState) {
   return state.breakpoints.pendingBreakpoints;
 }
-
-module.exports = {
-  State,
-  update,
-  makeLocationId,
-  getBreakpoint,
-  getBreakpoints,
-  getBreakpointsForSource,
-  getBreakpointsDisabled,
-  getBreakpointsLoading,
-  getPendingBreakpoints
-};

--- a/src/reducers/coverage.js
+++ b/src/reducers/coverage.js
@@ -25,10 +25,7 @@ export const State = makeRecord(
   }: CoverageState)
 );
 
-export function update(
-  state: any = State(),
-  action: Action
-): Record<CoverageState> {
+function update(state: any = State(), action: Action): Record<CoverageState> {
   switch (action.type) {
     case constants.RECORD_COVERAGE:
       return state
@@ -53,3 +50,5 @@ export function getHitCountForSource(state: OuterState, sourceId: ?string) {
 export function getCoverageEnabled(state: OuterState) {
   return state.coverage.get("coverageOn");
 }
+
+export default update;

--- a/src/reducers/coverage.js
+++ b/src/reducers/coverage.js
@@ -25,7 +25,10 @@ export const State = makeRecord(
   }: CoverageState)
 );
 
-function update(state: any = State(), action: Action): Record<CoverageState> {
+function update(
+  state: Record<CoverageState> = State(),
+  action: Action
+): Record<CoverageState> {
   switch (action.type) {
     case constants.RECORD_COVERAGE:
       return state

--- a/src/reducers/coverage.js
+++ b/src/reducers/coverage.js
@@ -5,9 +5,9 @@
  * @module reducers/coverage
  */
 
-const makeRecord = require("../utils/makeRecord");
-const I = require("immutable");
-const fromJS = require("../utils/fromJS");
+import makeRecord from "../utils/makeRecord";
+import * as I from "immutable";
+import fromJS from "../utils/fromJS";
 
 import constants from "../constants";
 import type { Action } from "../actions/types";
@@ -18,14 +18,17 @@ export type CoverageState = {
   hitCount: Object
 };
 
-const State = makeRecord(
+export const State = makeRecord(
   ({
     coverageOn: false,
     hitCount: I.Map()
   }: CoverageState)
 );
 
-function update(state = State(), action: Action): Record<CoverageState> {
+export function update(
+  state: any = State(),
+  action: Action
+): Record<CoverageState> {
   switch (action.type) {
     case constants.RECORD_COVERAGE:
       return state
@@ -42,18 +45,11 @@ function update(state = State(), action: Action): Record<CoverageState> {
 // https://github.com/devtools-html/debugger.html/blob/master/src/reducers/sources.js#L179-L185
 type OuterState = { coverage: Record<CoverageState> };
 
-function getHitCountForSource(state: OuterState, sourceId: ?string) {
+export function getHitCountForSource(state: OuterState, sourceId: ?string) {
   const hitCount = state.coverage.get("hitCount");
   return hitCount.get(sourceId);
 }
 
-function getCoverageEnabled(state: OuterState) {
+export function getCoverageEnabled(state: OuterState) {
   return state.coverage.get("coverageOn");
 }
-
-module.exports = {
-  State,
-  update,
-  getHitCountForSource,
-  getCoverageEnabled
-};

--- a/src/reducers/event-listeners.js
+++ b/src/reducers/event-listeners.js
@@ -10,7 +10,7 @@ const initialState = {
   fetchingListeners: false
 };
 
-export function update(state = initialState, action, emit) {
+function update(state = initialState, action, emit) {
   switch (action.type) {
     case constants.UPDATE_EVENT_BREAKPOINTS:
       state.activeEventNames = action.eventNames;
@@ -34,3 +34,5 @@ export function update(state = initialState, action, emit) {
 export function getEventListeners(state) {
   return state.eventListeners.listeners;
 }
+
+export default update;

--- a/src/reducers/expressions.js
+++ b/src/reducers/expressions.js
@@ -19,7 +19,7 @@ export const State = makeRecord(
   }: ExpressionState)
 );
 
-export function update(
+function update(
   state: Record<ExpressionState> = State(),
   action: Action
 ): Record<ExpressionState> {
@@ -116,3 +116,5 @@ export function getVisibleExpressions(state: OuterState) {
 export function getExpression(state: OuterState, input: string) {
   return getExpressions(state).find(exp => exp.input == input);
 }
+
+export default update;

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -2,16 +2,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const expressions = require("./expressions");
-const eventListeners = require("./event-listeners");
-const sources = require("./sources");
-const breakpoints = require("./breakpoints");
-const asyncRequests = require("./async-requests");
-const pause = require("./pause");
-const ui = require("./ui");
-const coverage = require("./coverage");
+import expressions from "./expressions";
+import eventListeners from "./event-listeners";
+import sources from "./sources";
+import breakpoints from "./breakpoints";
+import asyncRequests from "./async-requests";
+import pause from "./pause";
+import ui from "./ui";
+import coverage from "./coverage";
 
-module.exports = {
+export default {
   expressions: expressions.update,
   eventListeners: eventListeners.update,
   sources: sources.update,

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -12,12 +12,12 @@ import ui from "./ui";
 import coverage from "./coverage";
 
 export default {
-  expressions: expressions.update,
-  eventListeners: eventListeners.update,
-  sources: sources.update,
-  breakpoints: breakpoints.update,
-  pause: pause.update,
+  expressions,
+  eventListeners,
+  sources,
+  breakpoints,
   asyncRequests,
-  ui: ui.update,
-  coverage: coverage.update
+  pause,
+  ui,
+  coverage
 };

--- a/src/reducers/pause.js
+++ b/src/reducers/pause.js
@@ -37,7 +37,10 @@ export const State = makeRecord(
   }: PauseState)
 );
 
-function update(state: any = State(), action: Action): Record<PauseState> {
+function update(
+  state: Record<PauseState> = State(),
+  action: Action
+): Record<PauseState> {
   switch (action.type) {
     case constants.PAUSED: {
       const { selectedFrameId, frames, loadedObjects, pauseInfo } = action;

--- a/src/reducers/pause.js
+++ b/src/reducers/pause.js
@@ -37,10 +37,7 @@ export const State = makeRecord(
   }: PauseState)
 );
 
-export function update(
-  state: any = State(),
-  action: Action
-): Record<PauseState> {
+function update(state: any = State(), action: Action): Record<PauseState> {
   switch (action.type) {
     case constants.PAUSED: {
       const { selectedFrameId, frames, loadedObjects, pauseInfo } = action;
@@ -189,3 +186,5 @@ export function getChromeScopes(state: OuterState) {
   const frame = getSelectedFrame(state);
   return frame ? frame.scopeChain : undefined;
 }
+
+export default update;

--- a/src/reducers/pause.js
+++ b/src/reducers/pause.js
@@ -3,10 +3,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const fromJS = require("../utils/fromJS");
-const makeRecord = require("../utils/makeRecord");
-const { prefs } = require("../utils/prefs");
-const I = require("immutable");
+import fromJS from "../utils/fromJS";
+import makeRecord from "../utils/makeRecord";
+import { prefs } from "../utils/prefs";
+import * as I from "immutable";
 
 import constants from "../constants";
 import type { Frame, Pause } from "../types";
@@ -24,7 +24,7 @@ type PauseState = {
   debuggeeUrl: string
 };
 
-const State = makeRecord(
+export const State = makeRecord(
   ({
     pause: undefined,
     isWaitingOnBreak: false,
@@ -37,7 +37,10 @@ const State = makeRecord(
   }: PauseState)
 );
 
-function update(state = State(), action: Action): Record<PauseState> {
+export function update(
+  state: any = State(),
+  action: Action
+): Record<PauseState> {
   switch (action.type) {
     case constants.PAUSED: {
       const { selectedFrameId, frames, loadedObjects, pauseInfo } = action;
@@ -135,39 +138,39 @@ function update(state = State(), action: Action): Record<PauseState> {
 // (right now) to type those wrapped functions.
 type OuterState = { pause: Record<PauseState> };
 
-function getPause(state: OuterState) {
+export function getPause(state: OuterState) {
   return state.pause.get("pause");
 }
 
-function getLoadedObjects(state: OuterState) {
+export function getLoadedObjects(state: OuterState) {
   return state.pause.get("loadedObjects");
 }
 
-function getLoadedObject(state: OuterState, objectId: string) {
+export function getLoadedObject(state: OuterState, objectId: string) {
   return getLoadedObjects(state).get(objectId);
 }
 
-function getObjectProperties(state: OuterState, parentId: string) {
+export function getObjectProperties(state: OuterState, parentId: string) {
   return getLoadedObjects(state).filter(obj => obj.get("parentId") == parentId);
 }
 
-function getIsWaitingOnBreak(state: OuterState) {
+export function getIsWaitingOnBreak(state: OuterState) {
   return state.pause.get("isWaitingOnBreak");
 }
 
-function getShouldPauseOnExceptions(state: OuterState) {
+export function getShouldPauseOnExceptions(state: OuterState) {
   return state.pause.get("shouldPauseOnExceptions");
 }
 
-function getShouldIgnoreCaughtExceptions(state: OuterState) {
+export function getShouldIgnoreCaughtExceptions(state: OuterState) {
   return state.pause.get("shouldIgnoreCaughtExceptions");
 }
 
-function getFrames(state: OuterState) {
+export function getFrames(state: OuterState) {
   return state.pause.get("frames");
 }
 
-function getSelectedFrame(state: OuterState) {
+export function getSelectedFrame(state: OuterState) {
   const selectedFrameId = state.pause.get("selectedFrameId");
   const frames = state.pause.get("frames");
   if (!frames) {
@@ -177,28 +180,12 @@ function getSelectedFrame(state: OuterState) {
   return frames.find(frame => frame.get("id") == selectedFrameId).toJS();
 }
 
-function getDebuggeeUrl(state: OuterState) {
+export function getDebuggeeUrl(state: OuterState) {
   return state.pause.get("debuggeeUrl");
 }
 
 // NOTE: currently only used for chrome
-function getChromeScopes(state: OuterState) {
+export function getChromeScopes(state: OuterState) {
   const frame = getSelectedFrame(state);
   return frame ? frame.scopeChain : undefined;
 }
-
-module.exports = {
-  State,
-  update,
-  getPause,
-  getChromeScopes,
-  getLoadedObjects,
-  getLoadedObject,
-  getObjectProperties,
-  getIsWaitingOnBreak,
-  getShouldPauseOnExceptions,
-  getShouldIgnoreCaughtExceptions,
-  getFrames,
-  getSelectedFrame,
-  getDebuggeeUrl
-};

--- a/src/reducers/sources.js
+++ b/src/reducers/sources.js
@@ -44,7 +44,7 @@ export const State = makeRecord(
   }: SourcesState)
 );
 
-export function update(
+function update(
   state: Record<SourcesState> = State(),
   action: Action
 ): Record<SourcesState> {
@@ -326,3 +326,5 @@ export function getPrettySource(state: OuterState, id: string) {
 
   return getSourceByURL(state, getPrettySourceURL(source.get("url")));
 }
+
+export default update;

--- a/src/reducers/tests/sources.js
+++ b/src/reducers/tests/sources.js
@@ -2,7 +2,7 @@
 declare var describe: (name: string, func: () => void) => void;
 declare var it: (desc: string, func: () => void) => void;
 
-import { State, update } from "../sources";
+import update, { State } from "../sources";
 import { foobar } from "../../test/fixtures";
 const fakeSources = foobar.sources.sources;
 import expect from "expect.js";

--- a/src/reducers/ui.js
+++ b/src/reducers/ui.js
@@ -48,7 +48,10 @@ export const State = makeRecord(
   }: UIState)
 );
 
-function update(state = State(), action: Action): Record<UIState> {
+function update(
+  state: Record<UIState> = State(),
+  action: Action
+): Record<UIState> {
   switch (action.type) {
     case constants.TOGGLE_PROJECT_SEARCH: {
       return state.set("projectSearchOn", action.value);

--- a/src/reducers/ui.js
+++ b/src/reducers/ui.js
@@ -5,8 +5,8 @@
  * @module reducers/ui
  */
 
-const makeRecord = require("../utils/makeRecord");
-const { prefs } = require("../utils/prefs");
+import makeRecord from "../utils/makeRecord";
+import { prefs } from "../utils/prefs";
 
 import constants from "../constants";
 import type { Action, panelPositionType } from "../actions/types";
@@ -30,7 +30,7 @@ export type UIState = {
   endPanelCollapsed: boolean
 };
 
-const State = makeRecord(
+export const State = makeRecord(
   ({
     fileSearchOn: false,
     fileSearchQuery: "",
@@ -106,30 +106,33 @@ function getSearchState(field: SearchFieldType, state: OuterState): boolean {
   return state.ui.get(field);
 }
 
-function getFileSearchQueryState(state: OuterState): string {
+export function getFileSearchQueryState(state: OuterState): string {
   return state.ui.get("fileSearchQuery");
 }
 
-function getFileSearchModifierState(
+export function getFileSearchModifierState(
   state: OuterState
 ): Record<fileSearchModifiersType> {
   return state.ui.get("fileSearchModifiers");
 }
 
 type SymbolSearchType = "functions" | "variables";
-function getSymbolSearchType(state: OuterState): SymbolSearchType {
+export function getSymbolSearchType(state: OuterState): SymbolSearchType {
   return state.ui.get("symbolSearchType");
 }
 
-const getProjectSearchState = getSearchState.bind(null, "projectSearchOn");
-const getFileSearchState = getSearchState.bind(null, "fileSearchOn");
-const getSymbolSearchState = getSearchState.bind(null, "symbolSearchOn");
+export const getProjectSearchState = getSearchState.bind(
+  null,
+  "projectSearchOn"
+);
+export const getFileSearchState = getSearchState.bind(null, "fileSearchOn");
+export const getSymbolSearchState = getSearchState.bind(null, "symbolSearchOn");
 
-function getShownSource(state: OuterState): boolean {
+export function getShownSource(state: OuterState): boolean {
   return state.ui.get("shownSource");
 }
 
-function getPaneCollapse(
+export function getPaneCollapse(
   state: OuterState,
   position: panelPositionType
 ): boolean {
@@ -140,15 +143,4 @@ function getPaneCollapse(
   return state.ui.get("endPanelCollapsed");
 }
 
-module.exports = {
-  State,
-  update,
-  getProjectSearchState,
-  getFileSearchState,
-  getFileSearchQueryState,
-  getFileSearchModifierState,
-  getSymbolSearchState,
-  getSymbolSearchType,
-  getShownSource,
-  getPaneCollapse
-};
+export default update;

--- a/src/utils/bootstrap.js
+++ b/src/utils/bootstrap.js
@@ -14,7 +14,7 @@ const {
 const { startParserWorker, stopParserWorker } = require("../utils/parser");
 
 const configureStore = require("./create-store");
-const reducers = require("../reducers");
+import reducers from "../reducers";
 const selectors = require("../selectors");
 
 const App = require("../components/App").default;

--- a/src/utils/test-head.js
+++ b/src/utils/test-head.js
@@ -7,7 +7,7 @@
 
 const { combineReducers } = require("redux");
 const sourceMaps = require("devtools-source-map");
-const reducers = require("../reducers");
+import reducers from "../reducers";
 const actions = require("../actions").default;
 const selectors = require("../selectors");
 import constants from "../constants";


### PR DESCRIPTION
Associated Issue: #1884 

### Summary of Changes

Converted following reducers to ES modules:
- async requests,
- breakpoints,
- coverage,
- index,
- pause,
- ui.

All reducers has been updated to export `update` reducer by default. This allowed to somewhat simplify main reducer (`reducers/index`).

Also, type definitions for `update` functions' `state` argument have been added.

Another small change is addition of `yarn flow` command to the `yarn test-all` one. Lack of the former in the latter proved to be somewhat inconvenient when I wanted to manually check if everything is fine - the shortest way was `yarn test-all && yarn flow`. I completely agree this change is unrelated to the topic of this PR and won't mind to revert it if it's a problem.