### PR TITLE
Convert shared components to es6 modules

### DIFF
--- a/src/components/shared/Autocomplete.js
+++ b/src/components/shared/Autocomplete.js
@@ -1,16 +1,24 @@
 // @flow
 
-import { Component, DOM as dom, PropTypes, createFactory } from "react";
+import {
+  Component,
+  DOM as dom,
+  PropTypes,
+  createFactory,
+  ReactDOM
+} from "react";
 import { filter } from "fuzzaldrin-plus";
 import classnames from "classnames";
 import { scrollList } from "../../utils/result-list";
 import Svg from "./Svg";
-
-const { findDOMNode } = require("react-dom");
-const SearchInput = createFactory(require("./SearchInput").default);
-const ResultList = createFactory(require("./ResultList").default);
+import { SearchInput as _SearchInput } from "./SearchInput";
+import { ResultList as _ResultList } from "./ResultList";
 
 import "./Autocomplete.css";
+
+const SearchInput = createFactory(_SearchInput);
+const ResultList = createFactory(_ResultList);
+
 type State = {
   inputValue: string,
   selectedIndex: number,
@@ -34,7 +42,7 @@ export default class Autocomplete extends Component {
 
   componentDidMount() {
     const endOfInput = this.state.inputValue.length;
-    const node = findDOMNode(this);
+    const node = ReactDOM.findDOMNode(this);
     if (node instanceof HTMLElement) {
       const searchInput = node.querySelector("input");
       if (searchInput instanceof HTMLInputElement) {

--- a/src/components/shared/Autocomplete.js
+++ b/src/components/shared/Autocomplete.js
@@ -1,22 +1,17 @@
 // @flow
 
-import {
-  Component,
-  DOM as dom,
-  PropTypes,
-  createFactory,
-  ReactDOM
-} from "react";
+import { Component, DOM as dom, PropTypes, createFactory } from "react";
+import ReactDOM from "../../../node_modules/react-dom/dist/react-dom";
 import { filter } from "fuzzaldrin-plus";
 import classnames from "classnames";
 import { scrollList } from "../../utils/result-list";
 import Svg from "./Svg";
-import { SearchInput as _SearchInput } from "./SearchInput";
-import { ResultList as _ResultList } from "./ResultList";
-
 import "./Autocomplete.css";
 
+import _SearchInput from "./SearchInput";
 const SearchInput = createFactory(_SearchInput);
+
+import _ResultList from "./ResultList";
 const ResultList = createFactory(_ResultList);
 
 type State = {

--- a/src/components/shared/ManagedTree.js
+++ b/src/components/shared/ManagedTree.js
@@ -1,7 +1,9 @@
 // @flow
 import { PropTypes, createFactory, Component } from "react";
-const Tree = createFactory(require("devtools-components").Tree);
-require("./ManagedTree.css");
+import { Tree as _Tree } from "devtools-components";
+import "./ManagedTree.css";
+
+const Tree = createFactory(_Tree);
 
 type ManagedTreeItem = {
   contents: Array<ManagedTreeItem>,

--- a/src/components/shared/ManagedTree.js
+++ b/src/components/shared/ManagedTree.js
@@ -1,8 +1,8 @@
 // @flow
 import { PropTypes, createFactory, Component } from "react";
-import { Tree as _Tree } from "devtools-components";
 import "./ManagedTree.css";
 
+import _Tree from "devtools-components";
 const Tree = createFactory(_Tree);
 
 type ManagedTreeItem = {

--- a/src/components/shared/ManagedTree.js
+++ b/src/components/shared/ManagedTree.js
@@ -2,7 +2,7 @@
 import { PropTypes, createFactory, Component } from "react";
 import "./ManagedTree.css";
 
-import _Tree from "devtools-components";
+import { Tree as _Tree } from "devtools-components";
 const Tree = createFactory(_Tree);
 
 type ManagedTreeItem = {

--- a/src/components/shared/ObjectInspector.js
+++ b/src/components/shared/ObjectInspector.js
@@ -1,7 +1,6 @@
 // @flow
 import { DOM as dom, PropTypes, createFactory, Component } from "react";
 import classnames from "classnames";
-import { ManagedTree as _ManagedTree } from "./ManagedTree";
 import Svg from "./Svg";
 import Rep from "./Rep";
 import previewFunction from "./previewFunction";
@@ -17,6 +16,7 @@ import {
   createNode
 } from "../../utils/object-inspector";
 
+import _ManagedTree from "./ManagedTree";
 const ManagedTree = createFactory(_ManagedTree);
 
 export type ObjectInspectorItemContentsValue = {

--- a/src/components/shared/ObjectInspector.js
+++ b/src/components/shared/ObjectInspector.js
@@ -1,7 +1,7 @@
 // @flow
 import { DOM as dom, PropTypes, createFactory, Component } from "react";
 import classnames from "classnames";
-const ManagedTree = createFactory(require("./ManagedTree").default);
+import { ManagedTree as _ManagedTree } from "./ManagedTree";
 import Svg from "./Svg";
 import Rep from "./Rep";
 import previewFunction from "./previewFunction";
@@ -16,6 +16,8 @@ import {
   getChildren,
   createNode
 } from "../../utils/object-inspector";
+
+const ManagedTree = createFactory(_ManagedTree);
 
 export type ObjectInspectorItemContentsValue = {
   actor: string,

--- a/src/components/shared/Svg.js
+++ b/src/components/shared/Svg.js
@@ -5,6 +5,6 @@
 
 import Svg from "../../../assets/images/Svg";
 
-require("./Svg.css");
+import "./Svg.css";
 
 export default Svg;


### PR DESCRIPTION
Associated Issue: #1884 

## Summary of Changes
Refactor the following files to use ES module syntax:
- ManagedTree
- Autocomplete
- ObjectInspector
- Svg
