### PR TITLE
Fix broken source search

### DIFF
--- a/src/components/Editor/SearchBar.js
+++ b/src/components/Editor/SearchBar.js
@@ -470,7 +470,7 @@ class SearchBar extends Component {
   }
 
   onKeyUp(e: SyntheticKeyboardEvent) {
-    if (e.key !== "Enter" || e.key !== "F3") {
+    if (e.key !== "Enter" && e.key !== "F3") {
       return;
     }
 

--- a/src/components/ProjectSearch.js
+++ b/src/components/ProjectSearch.js
@@ -94,7 +94,7 @@ class ProjectSearch extends Component {
     return dom.div(
       { className: "search-container" },
       Autocomplete({
-        selectItem: result => {
+        selectItem: (e, result) => {
           this.props.selectSource(result.id);
           this.close();
         },

--- a/src/components/shared/Autocomplete.js
+++ b/src/components/shared/Autocomplete.js
@@ -87,7 +87,7 @@ export default class Autocomplete extends Component {
       e.preventDefault();
     } else if (e.key === "Enter") {
       if (searchResults.length) {
-        this.props.selectItem(searchResults[this.state.selectedIndex]);
+        this.props.selectItem(e, searchResults[this.state.selectedIndex]);
       } else {
         this.props.close(this.state.inputValue);
       }


### PR DESCRIPTION
On selecting the source from list, the source was not
being opened in the editor

- Fixes #2742 
- In search bar, on press enter, move to next result (previously broken)