### PR TITLE
Improve Editor rendering performance

### DIFF
--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -1,5 +1,5 @@
 // @flow
-import { DOM as dom, PropTypes, createFactory, Component } from "react";
+import { DOM as dom, PropTypes, createFactory, PureComponent } from "react";
 const ReactDOM = require("react-dom");
 import ImPropTypes from "react-immutable-proptypes";
 import { bindActionCreators } from "redux";
@@ -72,7 +72,7 @@ type EditorState = {
   selectedExpression: ?Object
 };
 
-class Editor extends Component {
+class Editor extends PureComponent {
   cbPanel: any;
   editor: any;
   pendingJumpLine: any;
@@ -124,7 +124,9 @@ class Editor extends Component {
     this.clearDebugLine(this.props.selectedFrame);
 
     if (!sourceText) {
-      this.showMessage("");
+      if (this.props.sourceText) {
+        this.showMessage("");
+      }
     } else if (!isTextForSource(sourceText)) {
       this.showMessage(sourceText.get("error") || L10N.getStr("loadingText"));
     } else if (this.props.sourceText !== sourceText) {

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -1,5 +1,5 @@
 // @flow
-import { DOM as dom, PropTypes, createFactory, PureComponent } from "react";
+import { DOM as dom, PropTypes, createFactory, Component } from "react";
 const ReactDOM = require("react-dom");
 import ImPropTypes from "react-immutable-proptypes";
 import { bindActionCreators } from "redux";
@@ -72,7 +72,7 @@ type EditorState = {
   selectedExpression: ?Object
 };
 
-class Editor extends PureComponent {
+class Editor extends Component {
   cbPanel: any;
   editor: any;
   pendingJumpLine: any;
@@ -220,6 +220,31 @@ class Editor extends PureComponent {
     shortcuts.off("CmdOrCtrl+Shift+B");
     shortcuts.off(`CmdOrCtrl+Shift+${searchAgainKey}`);
     shortcuts.off(`CmdOrCtrl+${searchAgainKey}`);
+  }
+
+  shouldComponentUpdate(nextProps, nextState) {
+    if (Object.keys(nextProps).length != Object.keys(this.props).length) {
+      return true;
+    }
+    if (Object.keys(nextState).length != Object.keys(this.state).length) {
+      return true;
+    }
+
+    let key;
+
+    for (key in nextProps) {
+      if (key != "getExpression" && nextProps[key] != this.props[key]) {
+        return true;
+      }
+    }
+
+    for (key in nextState) {
+      if (nextProps[key] != this.props[key]) {
+        return true;
+      }
+    }
+
+    return false;
   }
 
   componentDidUpdate(prevProps) {


### PR DESCRIPTION
This somewhat improves the performance issue in #2727.

Before this change, `Editor` was being re-rendered whenever any store state changed. For cases like the linked issue, where we were sending 500 actions to add source files to the list, this meant 500 re-renders, even though the contents didn't change.

One particularly-expensive operation is setting the text of the underlying text editor. Setting the message calls internal methods on that editor that need to measure DOM elements, causing lots of layout thrashing for every single change in the store.

### Summary of Changes

* Define `shouldComponentUpdate` for `Editor` so that it doesn't re-render if its props are shallow equal to the previous values. (Except for `getExpression`, which is re-bound every time and therefore never equal, even if it _means_ the same thing.)
* Prevent calling `Editor#showMessage` repeatedly with empty text. If it's already empty, then there's no need to do anything.

### Test Plan

- Open the file in #2727 in debugger.html
- Observe how long it takes for the sources to show up in the sidebar. It previously required 10+ seconds on my machine. Now it is down to around 2. 

### Next steps

While this removes the most costly render-thrashing component, the same problem is present in lots of other components. The `SourceTabs` and `ProjectSearch` components are also currently re-rendering even if their data hasn't changed. It looks like they can't easily be made `PureComponent`s because some of their props are generated dynamically so they aren't equal even when they have the same meaning.