### PR TITLE
Convert components to ES modules

### DIFF
--- a/src/components/Editor/Breakpoint.js
+++ b/src/components/Editor/Breakpoint.js
@@ -1,7 +1,7 @@
 // @flow
 import { PropTypes, Component } from "react";
 import { isEnabled } from "devtools-config";
-const ReactDOM = require("react-dom");
+import ReactDOM from "../../../node_modules/react-dom/dist/react-dom";
 
 import classnames from "classnames";
 import Svg from "../shared/Svg";

--- a/src/components/Editor/ConditionalPanel.js
+++ b/src/components/Editor/ConditionalPanel.js
@@ -1,7 +1,7 @@
 // @flow
 import { DOM as dom } from "react";
+import ReactDOM from "../../../node_modules/react-dom/dist/react-dom";
 
-const ReactDOM = require("react-dom");
 import CloseButton from "../shared/Button/Close";
 import "./ConditionalPanel.css";
 

--- a/src/components/Editor/Preview.js
+++ b/src/components/Editor/Preview.js
@@ -1,26 +1,26 @@
 // @flow
 
-import React from "react";
+import React, { createFactory } from "react";
 import { connect } from "react-redux";
 import { bindActionCreators } from "redux";
 import { isEnabled } from "devtools-config";
 
-const ObjectInspector = React.createFactory(
-  require("../shared/ObjectInspector").default
-);
-const Popover = React.createFactory(require("../shared/Popover").default);
-const previewFunction = require("../shared/previewFunction").default;
+import _ObjectInspector from "../shared/ObjectInspector";
+const ObjectInspector = createFactory(_ObjectInspector);
 
+import _Popover from "../shared/Popover";
+const Popover = createFactory(_Popover);
+
+import previewFunction from "../shared/previewFunction";
 import { getLoadedObjects } from "../../selectors";
 import actions from "../../actions";
 import { getChildren } from "../../utils/object-inspector";
-
-const Rep = require("../shared/Rep").default;
-const { MODE } = require("devtools-reps");
+import Rep from "../shared/Rep";
+import { MODE } from "devtools-reps";
 
 const { DOM: dom, PropTypes, Component } = React;
 
-require("./Preview.css");
+import "./Preview.css";
 
 class Preview extends Component {
   componentDidMount() {

--- a/src/components/Editor/SearchBar.js
+++ b/src/components/Editor/SearchBar.js
@@ -1,9 +1,9 @@
 // @flow
 
 import { DOM as dom, PropTypes, createFactory, Component } from "react";
+import { findDOMNode } from "../../../node_modules/react-dom/dist/react-dom";
 import { connect } from "react-redux";
 import { bindActionCreators } from "redux";
-const { findDOMNode } = require("react-dom");
 import { isEnabled } from "devtools-config";
 import { filter } from "fuzzaldrin-plus";
 import Svg from "../shared/Svg";
@@ -29,9 +29,13 @@ import { getSymbols } from "../../utils/parser";
 import { scrollList } from "../../utils/result-list";
 import classnames from "classnames";
 import debounce from "lodash/debounce";
-const SearchInput = createFactory(require("../shared/SearchInput").default);
-const ResultList = createFactory(require("../shared/ResultList").default);
 import ImPropTypes from "react-immutable-proptypes";
+
+import _SearchInput from "../shared/SearchInput";
+const SearchInput = createFactory(_SearchInput);
+
+import _ResultList from "../shared/ResultList";
+const ResultList = createFactory(_ResultList);
 
 import type {
   FormattedSymbolDeclaration,

--- a/src/components/Editor/Tabs.js
+++ b/src/components/Editor/Tabs.js
@@ -14,15 +14,17 @@ import { getFilename, isPretty } from "../../utils/source";
 import classnames from "classnames";
 import actions from "../../actions";
 import CloseButton from "../shared/Button/Close";
-const PaneToggleButton = createFactory(
-  require("../shared/Button/PaneToggle").default
-);
 import Svg from "../shared/Svg";
-const Dropdown = createFactory(require("../shared/Dropdown").default);
 import { showMenu, buildMenu } from "devtools-launchpad";
 import debounce from "lodash/debounce";
 import { formatKeyShortcut } from "../../utils/text";
 import "./Tabs.css";
+
+import _PaneToggleButton from "../shared/Button/PaneToggle";
+const PaneToggleButton = createFactory(_PaneToggleButton);
+
+import _Dropdown from "../shared/Dropdown";
+const Dropdown = createFactory(_Dropdown);
 
 /*
  * Finds the hidden tabs by comparing the tabs' top offset.

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -1,18 +1,14 @@
 // @flow
 import { DOM as dom, PropTypes, createFactory, Component } from "react";
-const ReactDOM = require("react-dom");
+import ReactDOM from "../../../node_modules/react-dom/dist/react-dom";
 import ImPropTypes from "react-immutable-proptypes";
 import { bindActionCreators } from "redux";
 import { connect } from "react-redux";
 import classnames from "classnames";
 import debounce from "lodash/debounce";
 import { getMode } from "../../utils/source";
-
-const Footer = createFactory(require("./Footer").default);
-const SearchBar = createFactory(require("./SearchBar").default);
 import GutterMenu from "./GutterMenu";
 import EditorMenu from "./EditorMenu";
-const Preview = createFactory(require("./Preview").default);
 import { renderConditionalPanel } from "./ConditionalPanel";
 import { debugGlobal } from "devtools-launchpad";
 import { isEnabled } from "devtools-config";
@@ -31,10 +27,24 @@ import {
   getFileSearchQueryState,
   getFileSearchModifierState
 } from "../../selectors";
+
 import { makeLocationId } from "../../reducers/breakpoints";
 import actions from "../../actions";
-const Breakpoint = createFactory(require("./Breakpoint").default);
-const HitMarker = createFactory(require("./HitMarker").default);
+
+import _Footer from "./Footer";
+const Footer = createFactory(_Footer);
+
+import _SearchBar from "./SearchBar";
+const SearchBar = createFactory(_SearchBar);
+
+import _Preview from "./Preview";
+const Preview = createFactory(_Preview);
+
+import _Breakpoint from "./Breakpoint";
+const Breakpoint = createFactory(_Breakpoint);
+
+import _HitMarker from "./HitMarker";
+const HitMarker = createFactory(_HitMarker);
 
 import {
   getDocument,

--- a/src/components/SecondaryPanes/index.js
+++ b/src/components/SecondaryPanes/index.js
@@ -28,18 +28,24 @@ const Expressions = createFactory(_Expressions);
 import _SplitBox from "devtools-splitter";
 const SplitBox = createFactory(_SplitBox);
 
-const Scopes = isEnabled("chromeScopes")
-  ? createFactory(require("./ChromeScopes").default)
-  : createFactory(require("./Scopes").default);
-
 import _Frames from "./Frames";
 const Frames = createFactory(_Frames);
 
 import _EventListeners from "./EventListeners";
 const EventListeners = createFactory(_EventListeners);
 
-const Accordion = createFactory(require("../shared/Accordion").default);
-const CommandBar = createFactory(require("./CommandBar").default);
+import _Accordion from "../shared/Accordion";
+const Accordion = createFactory(_Accordion);
+
+import _CommandBar from "./CommandBar";
+const CommandBar = createFactory(_CommandBar);
+
+import _chromeScopes from "./ChromeScopes";
+import _Scopes from "./Scopes";
+
+const Scopes = isEnabled("chromeScopes")
+  ? createFactory(_chromeScopes)
+  : createFactory(_Scopes);
 
 import "./SecondaryPanes.css";
 

--- a/src/components/SecondaryPanes/index.js
+++ b/src/components/SecondaryPanes/index.js
@@ -16,8 +16,11 @@ import { isEnabled } from "devtools-config";
 import Svg from "../shared/Svg";
 import { prefs } from "../../utils/prefs";
 
-const WhyPaused = createFactory(require("./WhyPaused").default);
-const Breakpoints = createFactory(require("./Breakpoints").default);
+import _WhyPaused from "./WhyPaused";
+const WhyPaused = createFactory(_WhyPaused);
+
+import _Breakpoints from "./Breakpoints";
+const Breakpoints = createFactory(_Breakpoints);
 
 import _Expressions from "./Expressions";
 const Expressions = createFactory(_Expressions);
@@ -29,8 +32,12 @@ const Scopes = isEnabled("chromeScopes")
   ? createFactory(require("./ChromeScopes").default)
   : createFactory(require("./Scopes").default);
 
-const Frames = createFactory(require("./Frames").default);
-const EventListeners = createFactory(require("./EventListeners").default);
+import _Frames from "./Frames";
+const Frames = createFactory(_Frames);
+
+import _EventListeners from "./EventListeners";
+const EventListeners = createFactory(_EventListeners);
+
 const Accordion = createFactory(require("../shared/Accordion").default);
 const CommandBar = createFactory(require("./CommandBar").default);
 


### PR DESCRIPTION
Associated Issue: #1884 
## Summary of Changes
Refactor the following files to use ES module syntax:
- [x] SecondaryPanes/index.js
- [x] Editor/ConditionalPanel.js
- [x] Editor/SearchBar.js
- [x] Editor/index.js
- [x] Editor/Breakpoint.js
- [x] Editor/Preview.js
- [x] Editor/Tabs.js
