### PR TITLE
adds hover styles and tooltips to search arrow buttons

### DIFF
--- a/assets/panel/debugger.properties
+++ b/assets/panel/debugger.properties
@@ -242,6 +242,14 @@ editor.singleResult=1 result
 # for when no results found.
 editor.noResults=no results
 
+# LOCALIZATION NOTE (editor.searchResults.nextResults): Editor Search bar
+# tooltip for traversing to the Next Result
+editor.searchResults.nextResult=Next Result
+
+# LOCALIZATION NOTE (editor.searchResults.prevResults): Editor Search bar
+# tooltip for traversing to the Previous Result
+editor.searchResults.prevResult=Previous Result
+
 # LOCALIZATION NOTE (editor.searchTypeToggleTitle): Search bar title for
 # toggling search type buttons(function search, variable search)
 editor.searchTypeToggleTitle=Search for:

--- a/src/components/shared/SearchInput.css
+++ b/src/components/shared/SearchInput.css
@@ -92,10 +92,18 @@
 .search-field .search-nav-buttons .nav-btn {
   display: flex;
   height: 100%;
-  border-radius: 50%;
+  background: transparent;
+  transition: all 0.25s ease-in-out;
+  border: 1px solid transparent;
+  justify-content: center;
+  padding-top: 4px;
 }
 
-.search-field .search-nav-buttons .nav-btn:hover path,
+.search-field .search-nav-buttons .nav-btn:hover {
+  cursor: pointer;
+  background: var(--theme-toolbar-background-hover);
+}
+
 .search-field .search-nav-buttons .nav-btn:active path {
   fill: var(--theme-comment-alt);
 }

--- a/src/components/shared/SearchInput.js
+++ b/src/components/shared/SearchInput.js
@@ -45,13 +45,13 @@ class SearchInput extends Component {
         handleNext,
         "arrow-down",
         classnames("nav-btn", "next"),
-        "Next Result"
+        L10N.getFormatStr("editor.searchResults.nextResult")
       ),
       arrowBtn(
         handlePrev,
         "arrow-up",
         classnames("nav-btn", "prev"),
-        "Previous Result"
+        L10N.getFormatStr("editor.searchResults.prevResult")
       )
     ];
   }

--- a/src/components/shared/SearchInput.js
+++ b/src/components/shared/SearchInput.js
@@ -5,6 +5,19 @@ import classnames from "classnames";
 import CloseButton from "./Button/Close";
 import "./SearchInput.css";
 
+const arrowBtn = (onClick, type, className, tooltip) => {
+  return dom.button(
+    {
+      onClick,
+      type,
+      className,
+      title: tooltip,
+      key: type
+    },
+    Svg(type)
+  );
+};
+
 class SearchInput extends Component {
   displayName: "SearchInput";
 
@@ -24,6 +37,25 @@ class SearchInput extends Component {
     return Svg("magnifying-glass");
   }
 
+  renderArrowButtons() {
+    const { handleNext, handlePrev } = this.props;
+
+    return [
+      arrowBtn(
+        handleNext,
+        "arrow-down",
+        classnames("nav-btn", "next"),
+        "Next Result"
+      ),
+      arrowBtn(
+        handlePrev,
+        "arrow-up",
+        classnames("nav-btn", "prev"),
+        "Previous Result"
+      )
+    ];
+  }
+
   renderNav() {
     if (!isEnabled("searchNav")) {
       return;
@@ -36,16 +68,7 @@ class SearchInput extends Component {
 
     return dom.div(
       { className: "search-nav-buttons" },
-      Svg("arrow-down", {
-        className: classnames("nav-btn", "next"),
-        onClick: handleNext,
-        title: "Next Result"
-      }),
-      Svg("arrow-up", {
-        className: classnames("nav-btn", "prev"),
-        onClick: handlePrev,
-        title: "Previous Result"
-      })
+      this.renderArrowButtons()
     );
   }
 


### PR DESCRIPTION
Associated Issue: [#2589](https://github.com/devtools-html/debugger.html/issues/2589)

### Summary of Changes

Adds hover styling to the up/down arrow navigation buttons in SeachInput Component. The following styles have been added:
  * `cursor: pointer` on hover
  * tooltip(s) on hover
  * adds `background` color and  `transition` change on hover to match behavior found in [CommandBar Buttons](https://github.com/devtools-html/debugger.html/blob/master/src/components/SecondaryPanes/CommandBar.css#L17-L34)

### Test Plan

- [x] cmd+f opens FileSearch
- [x] Type a search with multiple results
- [x] Hover cursor over arrow button(s)

### Screenshots/Videos (OPTIONAL)

![arrow-hover](https://cloud.githubusercontent.com/assets/10334352/25492636/844fab1c-2b28-11e7-999c-d8f4db61af1d.gif)

