### PR TITLE
removed feature flag for search modifiers #2685

### DIFF
--- a/configs/application.json
+++ b/configs/application.json
@@ -33,10 +33,6 @@
       "label": "Code Folding",
       "enabled": false
     },
-    "searchModifiers": {
-      "label": "Search Modifiers",
-      "enabled": false
-    },
     "searchNav": {
       "label": "Search Navigation",
       "enabled": false

--- a/configs/ci.json
+++ b/configs/ci.json
@@ -15,10 +15,6 @@
     "codeCoverage": {
       "label": "Code Coverage",
       "enabled": true
-    },
-    "searchModifiers": {
-      "label": "Search Modifiers",
-      "enabled": true
     }
   },
   "chrome": {

--- a/configs/development.json
+++ b/configs/development.json
@@ -43,10 +43,6 @@
       "label": "Code Folding",
       "enabled": false
     },
-    "searchModifiers": {
-      "label": "Search Modifiers",
-      "enabled": true
-    },
     "searchNav": {
       "label": "Search Navigation",
       "enabled": false

--- a/configs/firefox-panel.json
+++ b/configs/firefox-panel.json
@@ -15,7 +15,6 @@
     "chromeScopes": { "enabled": false },
     "eventListeners": { "enabled": false },
     "codeCoverage": { "enabled": false },
-    "searchModifiers": { "enabled": true },
     "showSource": { "enabled": true   }
   }
 }

--- a/configs/local.sample.json
+++ b/configs/local.sample.json
@@ -25,10 +25,6 @@
       "label": "Code Folding",
       "enabled": false
     },
-    "searchModifiers": {
-      "label": "Search Modifiers",
-      "enabled": false
-    },
     "searchNav": {
       "label": "Search Navigation",
       "enabled": false

--- a/src/components/Editor/SearchBar.js
+++ b/src/components/Editor/SearchBar.js
@@ -4,7 +4,6 @@ import { DOM as dom, PropTypes, createFactory, Component } from "react";
 import { findDOMNode } from "../../../node_modules/react-dom/dist/react-dom";
 import { connect } from "react-redux";
 import { bindActionCreators } from "redux";
-import { isEnabled } from "devtools-config";
 import { filter } from "fuzzaldrin-plus";
 import Svg from "../shared/Svg";
 import actions from "../../actions";
@@ -550,10 +549,6 @@ class SearchBar extends Component {
   }
 
   renderSearchModifiers() {
-    if (!isEnabled("searchModifiers")) {
-      return;
-    }
-
     const { modifiers, toggleFileSearchModifier, symbolSearchOn } = this.props;
 
     function searchModBtn(modVal, className, svgName, tooltip) {
@@ -628,10 +623,6 @@ class SearchBar extends Component {
   }
 
   renderBottomBar() {
-    if (!isEnabled("searchModifiers")) {
-      return;
-    }
-
     return dom.div(
       { className: "search-bottom-bar" },
       this.renderSearchTypeToggle(),

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -11,7 +11,6 @@ import GutterMenu from "./GutterMenu";
 import EditorMenu from "./EditorMenu";
 import { renderConditionalPanel } from "./ConditionalPanel";
 import { debugGlobal } from "devtools-launchpad";
-import { isEnabled } from "devtools-config";
 import {
   getSourceText,
   getFileSearchState,
@@ -315,10 +314,6 @@ class Editor extends Component {
     const { query, searchModifiers } = this.props;
     const { editor: { codeMirror } } = this.editor;
     const ctx = { ed: this.editor, cm: codeMirror };
-
-    if (!searchModifiers) {
-      return;
-    }
 
     const direction = e.shiftKey ? "prev" : "next";
     traverseResults(e, ctx, query, direction, searchModifiers.toJS());
@@ -696,12 +691,7 @@ class Editor extends Component {
 
     if (searchOn) {
       subtractions.push(cssVars.searchbarHeight);
-
-      const secondSearchBarOn = isEnabled("searchModifiers");
-
-      if (secondSearchBarOn) {
-        subtractions.push(cssVars.secondSearchbarHeight);
-      }
+      subtractions.push(cssVars.secondSearchbarHeight);
     }
 
     return {


### PR DESCRIPTION
Associated Issue: #<issue number>

Here's the Pull Request Doc
https://devtools-html.github.io/debugger.html/CONTRIBUTING.html#pull-requests

### Summary of Changes

* removed all references to the searchModifiers flag 

### Test Plan

Open the debugger with no mention of searchModifiers in your config/local.json
Open a JS file and hit Ctrl+F. You should see functions and variables as check options in the left and in the right the regex, case sensitive and wholewords options.
