### PR TITLE
(WIP) Refactor to es modules

### DIFF
--- a/src/feature.js
+++ b/src/feature.js
@@ -2,6 +2,6 @@
  * This module maps to the config/feature.js to enable
  * feature checking within the context of the debugger
  */
-const { feature } = require("devtools-config");
+import { feature } from "devtools-config";
 
-module.exports = feature;
+export default feature;

--- a/src/utils/DevToolsUtils.js
+++ b/src/utils/DevToolsUtils.js
@@ -1,4 +1,4 @@
-const assert = require("./assert");
+import assert from "./assert";
 
 function reportException(who, exception) {
   let msg = `${who} threw an exception: `;
@@ -9,4 +9,4 @@ function executeSoon(fn) {
   setTimeout(fn, 0);
 }
 
-module.exports = { reportException, executeSoon, assert };
+export { reportException, executeSoon, assert };

--- a/src/utils/DevToolsUtils.js
+++ b/src/utils/DevToolsUtils.js
@@ -1,12 +1,12 @@
 import assert from "./assert";
 
-function reportException(who, exception) {
+export function reportException(who, exception) {
   let msg = `${who} threw an exception: `;
   console.error(msg, exception);
 }
 
-function executeSoon(fn) {
+export function executeSoon(fn) {
   setTimeout(fn, 0);
 }
 
-export { reportException, executeSoon, assert };
+export default assert;

--- a/src/utils/assert.js
+++ b/src/utils/assert.js
@@ -1,9 +1,7 @@
 // @flow
 
-function assert(condition: boolean, message: string) {
+export default function assert(condition: boolean, message: string) {
   if (!condition) {
     throw new Error(`Assertion failure: ${message}`);
   }
 }
-
-module.exports = assert;

--- a/src/utils/bootstrap.js
+++ b/src/utils/bootstrap.js
@@ -1,23 +1,18 @@
-const React = require("react");
-const { bindActionCreators, combineReducers } = require("redux");
-const ReactDOM = require("react-dom");
-const { getValue, isFirefoxPanel } = require("devtools-config");
-const { renderRoot } = require("devtools-launchpad");
-const {
-  startSourceMapWorker,
-  stopSourceMapWorker
-} = require("devtools-source-map");
-const {
+import React from "react";
+import { bindActionCreators, combineReducers } from "redux";
+import ReactDOM from "../../node_modules/react-dom/dist/react-dom";
+import { getValue, isFirefoxPanel } from "devtools-config";
+import { renderRoot } from "devtools-launchpad";
+import { startSourceMapWorker, stopSourceMapWorker } from "devtools-source-map";
+import {
   startPrettyPrintWorker,
   stopPrettyPrintWorker
-} = require("../utils/pretty-print");
-const { startParserWorker, stopParserWorker } = require("../utils/parser");
-
-const configureStore = require("./create-store");
+} from "../utils/pretty-print";
+import { startParserWorker, stopParserWorker } from "../utils/parser";
+import configureStore from "./create-store";
 import reducers from "../reducers";
-const selectors = require("../selectors");
-
-const App = require("../components/App").default;
+import selectors from "../selectors";
+import App from "../components/App";
 
 export function bootstrapStore(client, services) {
   const createStore = configureStore({

--- a/src/utils/create-store.js
+++ b/src/utils/create-store.js
@@ -10,12 +10,12 @@
  * @module utils/create-store
  */
 
-const { createStore, applyMiddleware } = require("redux");
-const { waitUntilService } = require("./redux/middleware/wait-service");
-const { log } = require("./redux/middleware/log");
-const { history } = require("./redux/middleware/history");
-const { promise } = require("./redux/middleware/promise");
-const { thunk } = require("./redux/middleware/thunk");
+import { createStore, applyMiddleware } from "redux";
+import { waitUntilService } from "./redux/middleware/wait-service";
+import { log } from "./redux/middleware/log";
+import { history } from "./redux/middleware/history";
+import { promise } from "./redux/middleware/promise";
+import { thunk } from "./redux/middleware/thunk";
 
 /**
  * @memberof utils/create-store
@@ -73,4 +73,4 @@ const configureStore = (opts: ReduxStoreOptions = {}) => {
   return applyMiddleware(...middleware)(devtoolsExt(createStore));
 };
 
-module.exports = configureStore;
+export default configureStore;

--- a/src/utils/defer.js
+++ b/src/utils/defer.js
@@ -9,7 +9,7 @@ export type Defer = {
   promise: Promise<any>
 };
 
-function defer(): Defer {
+export default function defer(): Defer {
   let resolve: Resolve; // eslint-disable-line no-unused-vars
   let reject: Reject; // eslint-disable-line no-unused-vars
   const promise: Promise<any> = new Promise(function(
@@ -25,5 +25,3 @@ function defer(): Defer {
     promise
   };
 }
-
-module.exports = defer;

--- a/src/utils/editor/build-query.js
+++ b/src/utils/editor/build-query.js
@@ -1,5 +1,5 @@
 // @flow
-const escapeRegExp = require("lodash/escapeRegExp");
+import escapeRegExp from "lodash/escapeRegExp";
 
 import type { SearchModifiers } from "../../types";
 
@@ -42,7 +42,7 @@ function buildFlags(caseSensitive: boolean, isGlobal: boolean): ?RegExp$flags {
   return;
 }
 
-function buildQuery(
+export default function buildQuery(
   originalQuery: string,
   modifiers: SearchModifiers,
   { isGlobal = false, ignoreSpaces = false }: QueryOptions
@@ -71,5 +71,3 @@ function buildQuery(
 
   return new RegExp(query);
 }
-
-module.exports = buildQuery;

--- a/src/utils/editor/expression.js
+++ b/src/utils/editor/expression.js
@@ -1,9 +1,10 @@
 // @flow
 
 import { resolveToken as resolveTokenFromParser } from "../parser";
+import get from "lodash/get";
+
 import type { Expression, Frame, SourceText } from "../../types";
 import type { Record } from "../makeRecord";
-const get = require("lodash/get");
 
 export function getTokenLocation(codeMirror: any, tokenEl: HTMLElement) {
   const lineOffset = 1;

--- a/src/utils/editor/index.js
+++ b/src/utils/editor/index.js
@@ -1,16 +1,16 @@
-const { isEnabled } = require("devtools-config");
-const { isPretty, isJavaScript } = require("../source");
-const { isOriginalId } = require("devtools-source-map");
-const buildQuery = require("./build-query");
-const sourceDocumentUtils = require("./source-documents");
+import { isEnabled } from "devtools-config";
+import { isPretty, isJavaScript } from "../source";
+import { isOriginalId } from "devtools-source-map";
+import buildQuery from "./build-query";
+import * as sourceDocumentUtils from "./source-documents";
 const { getDocument } = sourceDocumentUtils;
 
 import * as expressionUtils from "./expression.js";
 
-const sourceSearchUtils = require("./source-search");
+import * as sourceSearchUtils from "./source-search";
 const { findNext, findPrev } = sourceSearchUtils;
 
-const { SourceEditor, SourceEditorUtils } = require("devtools-source-editor");
+import { SourceEditor, SourceEditorUtils } from "devtools-source-editor";
 
 function shouldShowPrettyPrint(selectedSource) {
   if (!selectedSource) {

--- a/src/utils/editor/source-documents.js
+++ b/src/utils/editor/source-documents.js
@@ -18,9 +18,4 @@ function clearDocuments() {
   sourceDocs = {};
 }
 
-module.exports = {
-  getDocument,
-  setDocument,
-  removeDocument,
-  clearDocuments
-};
+export { getDocument, setDocument, removeDocument, clearDocuments };

--- a/src/utils/editor/source-search.js
+++ b/src/utils/editor/source-search.js
@@ -1,7 +1,7 @@
 // @flow
 
-const buildQuery = require("./build-query");
-const findIndex = require("lodash/findIndex");
+import buildQuery from "./build-query";
+import findIndex from "lodash/findIndex";
 
 import type { SearchModifiers } from "../../types";
 
@@ -322,7 +322,7 @@ function countMatches(
   return match ? match.length : 0;
 }
 
-module.exports = {
+export {
   buildQuery,
   clearIndex,
   countMatches,

--- a/src/utils/pretty-print/index.js
+++ b/src/utils/pretty-print/index.js
@@ -2,7 +2,7 @@
 
 const { workerUtils: { WorkerDispatcher } } = require("devtools-utils");
 const { isJavaScript } = require("../source");
-const assert = require("../assert");
+import assert from "../assert";
 
 import type { Source, SourceText } from "../../types";
 

--- a/src/utils/pretty-print/worker.js
+++ b/src/utils/pretty-print/worker.js
@@ -1,7 +1,7 @@
 // @flow
 
-const prettyFast = require("pretty-fast");
-const assert = require("../assert");
+import prettyFast from "pretty-fast";
+import assert from "../assert";
 
 type Mappings = {
   _array: Mapping[]

--- a/src/utils/redux/middleware/history.js
+++ b/src/utils/redux/middleware/history.js
@@ -1,6 +1,6 @@
 // @flow
 
-const { isDevelopment } = require("devtools-config");
+import { isDevelopment } from "devtools-config";
 
 import type { ThunkArgs } from "../../../actions/types";
 
@@ -9,7 +9,7 @@ import type { ThunkArgs } from "../../../actions/types";
  * in logging object. Should only be used for tests, as it collects all
  * action information, which will cause memory bloat.
  */
-exports.history = (log: Object[] = []) => ({
+export const history = (log: Object[] = []) => ({
   dispatch,
   getState
 }: ThunkArgs) => {

--- a/src/utils/redux/middleware/log.js
+++ b/src/utils/redux/middleware/log.js
@@ -2,7 +2,7 @@
  * A middleware that logs all actions coming through the system
  * to the console.
  */
-function log({ dispatch, getState }) {
+export default function log({ dispatch, getState }) {
   return next => action => {
     const actionText = JSON.stringify(action, null, 2);
     const truncatedActionText = `${actionText.slice(0, 1000)}...`;
@@ -10,5 +10,3 @@ function log({ dispatch, getState }) {
     next(action);
   };
 }
-
-exports.log = log;

--- a/src/utils/redux/middleware/promise.js
+++ b/src/utils/redux/middleware/promise.js
@@ -4,14 +4,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const defer = require("../../defer");
-const toPairs = require("lodash/toPairs");
-const fromPairs = require("lodash/fromPairs");
-const { executeSoon } = require("../../DevToolsUtils");
+import defer from "../../defer";
+import toPairs from "lodash/toPairs";
+import fromPairs from "lodash/fromPairs";
+import { executeSoon } from "../../DevToolsUtils";
 
 import type { ThunkArgs } from "../../../actions/types";
 
-const PROMISE = (exports.PROMISE = "@@dispatch/promise");
 let seqIdVal = 1;
 
 function seqIdGen() {
@@ -68,4 +67,5 @@ function promiseMiddleware({ dispatch, getState }: ThunkArgs) {
   };
 }
 
-exports.promise = promiseMiddleware;
+export const PROMISE = "@@dispatch/promise";
+export { promiseMiddleware as promise };

--- a/src/utils/sources-tree.js
+++ b/src/utils/sources-tree.js
@@ -6,7 +6,7 @@
  */
 
 const { parse } = require("url");
-const { assert } = require("./DevToolsUtils");
+import assert from "./DevToolsUtils";
 const { isPretty } = require("./source");
 const merge = require("lodash/merge");
 

--- a/src/utils/test-head.js
+++ b/src/utils/test-head.js
@@ -5,14 +5,13 @@
  * @module utils/test-head
  */
 
-const { combineReducers } = require("redux");
-const sourceMaps = require("devtools-source-map");
+import { combineReducers } from "redux";
+import sourceMaps from "devtools-source-map";
 import reducers from "../reducers";
-const actions = require("../actions").default;
-const selectors = require("../selectors");
+import actions from "../actions";
+import selectors from "../selectors";
 import constants from "../constants";
-
-const configureStore = require("../utils/create-store");
+import configureStore from "../utils/create-store";
 
 /**
  * @memberof utils/test-head
@@ -67,7 +66,7 @@ function waitForState(store: any, predicate: any) {
   });
 }
 
-module.exports = {
+export {
   actions,
   constants,
   selectors,


### PR DESCRIPTION
Associated Issue: #1884 

## Summary of Changes

(WIP) Refactor the following files to use ES module syntax:
- utils
	- editor
		- [x] build-query.js
		- [x] expression.js
		- [ ] index.js
		- [x] source-documents.js
		- [x] source-search.js
	- redux
		- middleware
			- [x] history.js
			- [x] log.js
			- [x] promise.js
			- [ ] thunk.js
			- [ ] wait-service.js
	- pretty-print
		- [ ] worker.js
		- [ ] index.js
    - [x] DevToolsUtils.js
	- [x] assert.js
	- [ ] client.js
	- [x] create-store.js
	- [x] defer.js
	- [ ] dehydrate-state.js
	- [ ] editor.js
	- [ ] fromJS.js
	- [ ] log.js
	- [ ] makeRecord.js
	- [ ] path.js
	- [ ] pause.js
	- [ ] prefs.js
	- [x] test-head.js

- [x] src/feature.js
- [ ] src/main.js
