### PR TITLE
#2676- PaneToggle.css Change

### DIFF
--- a/src/components/shared/Button/PaneToggle.css
+++ b/src/components/shared/Button/PaneToggle.css
@@ -22,8 +22,17 @@
   margin-right: 5px;
 }
 
+html[dir="rtl"] .toggle-button-end {
+  margin-left: 5px;
+  margin-right: auto;
+}
+
 .toggle-button-start {
   margin-left: 5px;
+}
+
+html[dir="rtl"] .toggle-button-start {
+  margin-right: 5px;
 }
 
 html:not([dir="rtl"]) .toggle-button-end svg,

--- a/src/components/shared/Button/PaneToggle.css
+++ b/src/components/shared/Button/PaneToggle.css
@@ -18,21 +18,12 @@
 }
 
 .toggle-button-end {
-  margin-left: auto;
-  margin-right: 5px;
-}
-
-html[dir="rtl"] .toggle-button-end {
-  margin-left: 5px;
-  margin-right: auto;
+  margin-inline-end: 5px;
+  margin-inline-start: auto;
 }
 
 .toggle-button-start {
-  margin-left: 5px;
-}
-
-html[dir="rtl"] .toggle-button-start {
-  margin-right: 5px;
+  margin-inline-start: 5px;
 }
 
 html:not([dir="rtl"]) .toggle-button-end svg,


### PR DESCRIPTION
Associated Issue: #2676 

Summary of Changes

- Added RTL styling for .toggle-button-end & .toggle-button-start.

Test Plan

- Opened the app in RTL mode and tested the changes.
- Opened the app again in the usual LTR mode and tested for correctness.

Screenshot
![rtlchange](https://cloud.githubusercontent.com/assets/16179366/25551773/d1566658-2c4f-11e7-87de-6e300562c9ef.png)

