### PR TITLE
Convert to ES modules

### DIFF
--- a/src/utils/result-list.js
+++ b/src/utils/result-list.js
@@ -1,4 +1,4 @@
-const { isFirefox } = require("devtools-config");
+import { isFirefox } from "devtools-config";
 
 function scrollList(resultList, index) {
   if (!resultList.hasOwnProperty(index)) {
@@ -64,7 +64,4 @@ function handleKeyDown(e: SyntheticKeyboardEvent) {
   }
 }
 
-module.exports = {
-  scrollList,
-  handleKeyDown
-};
+export { scrollList, handleKeyDown };

--- a/src/utils/source.js
+++ b/src/utils/source.js
@@ -5,8 +5,8 @@
  * @module utils/source
  */
 
-const { endTruncateStr } = require("./utils");
-const { basename } = require("../utils/path");
+import { endTruncateStr } from "./utils";
+import { basename } from "../utils/path";
 
 import type { Source, SourceText } from "../types";
 
@@ -143,7 +143,7 @@ function getMode(sourceText: SourceText) {
   return { name: "text" };
 }
 
-module.exports = {
+export {
   isJavaScript,
   isPretty,
   getPrettySourceURL,

--- a/src/utils/sources-tree.js
+++ b/src/utils/sources-tree.js
@@ -5,10 +5,10 @@
  * @module utils/sources-tree
  */
 
-const { parse } = require("url");
+import { parse } from "url";
 import assert from "./DevToolsUtils";
-const { isPretty } = require("./source");
-const merge = require("lodash/merge");
+import { isPretty } from "./source";
+import merge from "lodash/merge";
 
 const IGNORED_URLS = ["debugger eval code", "XStringBundle"];
 
@@ -388,7 +388,7 @@ function getDirectories(sourceUrl: string, sourceTree: any) {
   }
 }
 
-module.exports = {
+export {
   createNode,
   nodeHasChildren,
   createParentMap,

--- a/src/utils/task.js
+++ b/src/utils/task.js
@@ -45,4 +45,4 @@ const Task = {
   }
 };
 
-module.exports = { Task };
+export { Task };

--- a/src/utils/text.js
+++ b/src/utils/text.js
@@ -4,8 +4,9 @@
  * Utils for keyboard command strings
  * @module utils/text
  */
+import { Services } from "devtools-modules";
+const { appinfo } = Services;
 
-const { Services: { appinfo } } = require("devtools-modules");
 const isMacOS = appinfo.OS === "Darwin";
 
 /**
@@ -35,6 +36,4 @@ function formatKeyShortcut(shortcut: string): string {
   );
 }
 
-module.exports = {
-  formatKeyShortcut
-};
+export { formatKeyShortcut };

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -83,7 +83,7 @@ function filterDuplicates(list: Object[], predicate: duplicatesPredicate) {
   return pairs.filter(predicate).map(([prev, item]) => item).concat(lastItem);
 }
 
-module.exports = {
+export {
   handleError,
   promisify,
   endTruncateStr,

--- a/src/utils/worker.js
+++ b/src/utils/worker.js
@@ -50,7 +50,4 @@ function workerHandler(publicInterface) {
   };
 }
 
-module.exports = {
-  workerTask,
-  workerHandler
-};
+export { workerTask, workerHandler };


### PR DESCRIPTION
Associated Issue: #1884

## Refactor the following files to ES module syntax:
- [x] utils/utils.js
- [x] utils/worker.js
- [x] utils/text.js
- [x] utils/task.js
- [x] utils/sources-tree.js
- [x] utils/source.js
- [x] utils/result-list.js