### PR TITLE
Add right border to command bar in rtl mode

### DIFF
--- a/src/components/SecondaryPanes/CommandBar.css
+++ b/src/components/SecondaryPanes/CommandBar.css
@@ -10,6 +10,10 @@
   background-color: var(--theme-body-background);
 }
 
+html[dir="rtl"] .command-bar {
+  border-right: 1px solid var(--theme-splitter-color);
+}
+
 .theme-dark .command-bar {
   background-color: var(--theme-tab-toolbar-background);
 }


### PR DESCRIPTION
Closes #2676 

Second part of issue. Splitter appears to stop before command-bar.

### Summary of Changes

* Add right border to command bar in rtl mode

### Screenshots/Videos (OPTIONAL)
|Before|After|
|--------|------|
|![s1](https://cloud.githubusercontent.com/assets/1755089/25670806/80a91df4-304b-11e7-8e08-4a4d3ae6882a.png)|![s2](https://cloud.githubusercontent.com/assets/1755089/25670812/850e7a10-304b-11e7-8a0f-9fe9484fab21.png)|

