### PR TITLE
Fix #2814: previewing values in editor when paused

### DIFF
--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -850,7 +850,7 @@ Editor.contextTypes = {
   shortcuts: PropTypes.object
 };
 
-const expressionsSel = state => state.expressions;
+const expressionsSel = state => state.expressions.expressions;
 const getExpressionSel = createSelector(expressionsSel, expressions => input =>
   expressions.find(exp => exp.input == input));
 


### PR DESCRIPTION
There was a small typo in the selector used to query the expression values in the editor.

This PR fixes the problem but doesn't address how to automate preventing it from recurring. Writing an integration test for this seems like it would be quite tricky. Another path would be to get more Flow type coverage of these selectors, though that has been a bit tricky.

### Test steps

- Repro steps in #2814 should no longer reproduce

### Screenshot

<img width="569" alt="screen shot 2017-05-04 at 7 13 14 pm" src="https://cloud.githubusercontent.com/assets/8495/25730908/597c92f2-30fe-11e7-8dd1-26ffeda710df.png">
