### PR TITLE
Fix symbol search shortcut

### DIFF
--- a/assets/panel/debugger.properties
+++ b/assets/panel/debugger.properties
@@ -132,6 +132,10 @@ blackboxCheckboxTooltip2=Toggle blackboxing
 # searching all the source files the debugger has seen.
 sources.search.key=CmdOrCtrl+P
 
+# LOCALIZATION NOTE (sources.search.key2): A second key shortcut to open the
+# search for searching all the source files the debugger has seen.
+sources.search.key2=CmdOrCtrl+O
+
 # LOCALIZATION NOTE (sources.noSourcesAvailable): Text shown when the debugger
 # does not have any sources.
 sources.noSourcesAvailable=This page has no sources

--- a/src/components/ProjectSearch.js
+++ b/src/components/ProjectSearch.js
@@ -54,7 +54,7 @@ class ProjectSearch extends Component {
     const shortcuts = this.context.shortcuts;
     const searchKeys = [
       L10N.getStr("sources.search.key"),
-      L10N.getStr("symbolSearch.search.key")
+      L10N.getStr("sources.search.key2")
     ];
     searchKeys.forEach(key => shortcuts.off(key, this.toggle));
     shortcuts.off("Escape", this.onEscape);
@@ -64,7 +64,7 @@ class ProjectSearch extends Component {
     const shortcuts = this.context.shortcuts;
     const searchKeys = [
       L10N.getStr("sources.search.key"),
-      L10N.getStr("symbolSearch.search.key")
+      L10N.getStr("sources.search.key2")
     ];
     searchKeys.forEach(key => shortcuts.on(key, this.toggle));
     shortcuts.on("Escape", this.onEscape);


### PR DESCRIPTION
we just broke the symbol shortcut, but it's an easy fix.