### PR TITLE
Redux performance user timing middleware

### DIFF
--- a/configs/application.json
+++ b/configs/application.json
@@ -12,6 +12,9 @@
     "firefoxProxy": false,
     "actions": false
   },
+  "performance": {
+    "actions": false
+  },
   "features": {
     "chromeScopes": {
       "label": "Chrome Scopes",

--- a/configs/development.json
+++ b/configs/development.json
@@ -9,6 +9,9 @@
     "firefoxProxy": false,
     "actions": false
   },
+  "performance": {
+    "actions": false
+  },
   "workers": {
     "parserURL": "http://localhost:8000/assets/build/parser-worker.js",
     "sourceMapURL": "http://localhost:8000/assets/build/source-map-worker.js",

--- a/configs/local.sample.json
+++ b/configs/local.sample.json
@@ -4,6 +4,9 @@
   "logging": {
     "actions": false
   },
+  "performance": {
+    "actions": false
+  },
   "features": {
     "chromeScopes": {
       "label": "Chrome Scopes",

--- a/src/test/integration/utils/shared.js
+++ b/src/test/integration/utils/shared.js
@@ -7,9 +7,12 @@ const selectors = {
   breakpointItem: i => `.breakpoints-list .breakpoint:nth-child(${i})`,
   scopeNode: i => `.scopes-list .tree-node:nth-child(${i}) .object-label`,
   scopeValue: i => `.scopes-list .tree-node:nth-child(${i}) .object-value`,
-  expressionNode: i => `.expressions-list .tree-node:nth-child(${i}) .object-label`,
-  expressionValue: i => `.expressions-list .tree-node:nth-child(${i}) .object-value`,
-  expressionClose: i => `.expressions-list .expression-container:nth-child(${i}) .close-btn`,
+  expressionNode: i =>
+    `.expressions-list .tree-node:nth-child(${i}) .object-label`,
+  expressionValue: i =>
+    `.expressions-list .tree-node:nth-child(${i}) .object-value`,
+  expressionClose: i =>
+    `.expressions-list .expression-container:nth-child(${i}) .close-btn`,
   expressionNodes: ".expressions-list .tree-node",
   frame: i => `.frames ul li:nth-child(${i})`,
   frames: ".frames ul li",

--- a/src/utils/bootstrap.js
+++ b/src/utils/bootstrap.js
@@ -17,6 +17,7 @@ import App from "../components/App";
 export function bootstrapStore(client, services) {
   const createStore = configureStore({
     log: getValue("logging.actions"),
+    timing: getValue("performance.actions"),
     makeThunkArgs: (args, state) => {
       return Object.assign({}, args, { client }, services);
     }

--- a/src/utils/create-store.js
+++ b/src/utils/create-store.js
@@ -16,6 +16,7 @@ import { log } from "./redux/middleware/log";
 import { history } from "./redux/middleware/history";
 import { promise } from "./redux/middleware/promise";
 import { thunk } from "./redux/middleware/thunk";
+import { timing } from "./redux/middleware/timing";
 
 /**
  * @memberof utils/create-store
@@ -25,19 +26,8 @@ type ReduxStoreOptions = {
   makeThunkArgs?: Function,
   history?: Array<Object>,
   middleware?: Function[],
-  log?: boolean
-};
-
-const timing = store => next => action => {
-  performance.mark(`${action.type}_start`);
-  let result = next(action);
-  performance.mark(`${action.type}_end`);
-  performance.measure(
-    `${action.type}`,
-    `${action.type}_start`,
-    `${action.type}_end`
-  );
-  return result;
+  log?: boolean,
+  timing?: boolean
 };
 
 /**
@@ -57,7 +47,7 @@ const configureStore = (opts: ReduxStoreOptions = {}) => {
   const middleware = [
     thunk(opts.makeThunkArgs),
     promise,
-    timing,
+
     // Order is important: services must go last as they always
     // operate on "already transformed" actions. Actions going through
     // them shouldn't have any special fields like promises, they
@@ -75,6 +65,10 @@ const configureStore = (opts: ReduxStoreOptions = {}) => {
 
   if (opts.log) {
     middleware.push(log);
+  }
+
+  if (opts.timing) {
+    middleware.push(timing);
   }
 
   // Hook in the redux devtools browser extension if it exists

--- a/src/utils/create-store.js
+++ b/src/utils/create-store.js
@@ -28,6 +28,18 @@ type ReduxStoreOptions = {
   log?: boolean
 };
 
+const timing = store => next => action => {
+  performance.mark(`${action.type}_start`);
+  let result = next(action);
+  performance.mark(`${action.type}_end`);
+  performance.measure(
+    `${action.type}`,
+    `${action.type}_start`,
+    `${action.type}_end`
+  );
+  return result;
+};
+
 /**
  * This creates a dispatcher with all the standard middleware in place
  * that all code requires. It can also be optionally configured in
@@ -45,7 +57,7 @@ const configureStore = (opts: ReduxStoreOptions = {}) => {
   const middleware = [
     thunk(opts.makeThunkArgs),
     promise,
-
+    timing,
     // Order is important: services must go last as they always
     // operate on "already transformed" actions. Actions going through
     // them shouldn't have any special fields like promises, they

--- a/src/utils/redux/middleware/timing.js
+++ b/src/utils/redux/middleware/timing.js
@@ -4,11 +4,11 @@
  */
 
 const mark = window.performance && window.performance.mark
-  ? window.performance.mark
+  ? window.performance.mark.bind(window.performance)
   : () => {};
 
 const measure = window.performance && window.performance.measure
-  ? window.performance.measure
+  ? window.performance.measure.bind(window.performance)
   : () => {};
 
 export function timing(store) {

--- a/src/utils/redux/middleware/timing.js
+++ b/src/utils/redux/middleware/timing.js
@@ -1,0 +1,22 @@
+/**
+ * Redux middleware that sets performance markers for all actions such that they
+ * will appear in performance tooling under the User Timing API
+ */
+
+const mark = window.performance && window.performance.mark
+  ? window.performance.mark
+  : () => {};
+
+const measure = window.performance && window.performance.measure
+  ? window.performance.measure
+  : () => {};
+
+export function timing(store) {
+  return next => action => {
+    mark(`${action.type}_start`);
+    const result = next(action);
+    mark(`${action.type}_end`);
+    measure(`${action.type}`, `${action.type}_start`, `${action.type}_end`);
+    return result;
+  };
+}


### PR DESCRIPTION
### Summary of Changes

Logs User Timing into the performance timeline view

* created a timing middleware for Redux
* created a `performance.actions` config for turning on the timing middleware

### Test Plan

Example test plan:

- [x] Recording interactions using Chrome timeline view, see User Timing actions

### Screenshots/Videos (OPTIONAL)

![screen shot 2017-05-05 at 10 55 38 am](https://cloud.githubusercontent.com/assets/2134/25757999/a83847be-3181-11e7-9067-dcd2f3ef7f38.png)
