### PR TITLE
Remove expand actor caching

### DIFF
--- a/src/components/Editor/Preview.js
+++ b/src/components/Editor/Preview.js
@@ -95,8 +95,7 @@ class Preview extends Component {
       getObjectProperties,
       autoExpandDepth: 0,
       onDoubleClick: () => {},
-      loadObjectProperties,
-      getActors: () => ({})
+      loadObjectProperties
     });
   }
 

--- a/src/components/SecondaryPanes/Expressions.js
+++ b/src/components/SecondaryPanes/Expressions.js
@@ -161,8 +161,7 @@ class Expressions extends PureComponent {
         autoExpandDepth: 0,
         onDoubleClick: (item, options) =>
           this.editExpression(expression, options),
-        loadObjectProperties,
-        getActors: () => ({})
+        loadObjectProperties
       }),
       CloseButton({ handleClick: e => this.deleteExpression(e, expression) })
     );

--- a/src/components/SecondaryPanes/Scopes.js
+++ b/src/components/SecondaryPanes/Scopes.js
@@ -16,9 +16,6 @@ function info(text) {
   return dom.div({ className: "pane-info" }, text);
 }
 
-let expandedCache = new Set();
-let actorsCache = [];
-
 class Scopes extends PureComponent {
   state: {
     scopes: any
@@ -56,14 +53,6 @@ class Scopes extends PureComponent {
         roots: scopes,
         getObjectProperties: id => loadedObjects.get(id),
         loadObjectProperties: loadObjectProperties,
-        setExpanded: expanded => {
-          expandedCache = expanded;
-        },
-        getExpanded: () => expandedCache,
-        setActors: actors => {
-          actorsCache = actors;
-        },
-        getActors: () => actorsCache,
         onLabelClick: (item, { expanded, setExpanded }) => {
           setExpanded(item, !expanded);
         }

--- a/src/components/shared/ManagedTree.js
+++ b/src/components/shared/ManagedTree.js
@@ -62,19 +62,6 @@ class ManagedTree extends Component {
     }
   }
 
-  componentWillMount() {
-    if (this.props.getExpanded) {
-      const expanded = this.props.getExpanded();
-      this.setState({ expanded });
-    }
-  }
-
-  componentWillUnmount() {
-    if (this.props.setExpanded) {
-      this.props.setExpanded(this.state.expanded);
-    }
-  }
-
   setExpanded(item: ManagedTreeItem, isExpanded: boolean) {
     const expanded = this.state.expanded;
     const key = this.props.getKey(item);
@@ -149,9 +136,6 @@ class ManagedTree extends Component {
 
 ManagedTree.displayName = "ManagedTree";
 
-ManagedTree.propTypes = Object.assign({}, Tree.propTypes, {
-  getExpanded: PropTypes.func,
-  setExpanded: PropTypes.func
-});
+ManagedTree.propTypes = Object.assign({}, Tree.propTypes);
 
 export default ManagedTree;

--- a/src/components/shared/ManagedTree.js
+++ b/src/components/shared/ManagedTree.js
@@ -1,5 +1,5 @@
 // @flow
-import { PropTypes, createFactory, Component } from "react";
+import { createFactory, Component } from "react";
 import "./ManagedTree.css";
 
 import { Tree as _Tree } from "devtools-components";

--- a/src/components/shared/ObjectInspector.js
+++ b/src/components/shared/ObjectInspector.js
@@ -59,8 +59,7 @@ type DefaultProps = {
       expanded: boolean
     }
   ) => void,
-  autoExpandDepth: number,
-  getActors: () => any
+  autoExpandDepth: number
 };
 
 // This implements a component that renders an interactive inspector
@@ -97,24 +96,11 @@ class ObjectInspector extends Component {
   constructor() {
     super();
 
-    this.actors = null;
+    this.actors = {};
 
     const self: any = this;
     self.getChildren = this.getChildren.bind(this);
     self.renderItem = this.renderItem.bind(this);
-  }
-
-  componentWillMount() {
-    // Cache of dynamically built nodes. We shouldn't need to clear
-    // this out ever, since we don't ever "switch out" the object
-    // being inspected.
-    this.actors = this.props.getActors();
-  }
-
-  componentWillUnmount() {
-    if (this.props.setActors) {
-      this.props.setActors(this.actors);
-    }
   }
 
   getChildren(item: ObjectInspectorItem) {
@@ -198,14 +184,7 @@ class ObjectInspector extends Component {
   }
 
   render() {
-    const {
-      name,
-      desc,
-      loadObjectProperties,
-      autoExpandDepth,
-      getExpanded,
-      setExpanded
-    } = this.props;
+    const { name, desc, loadObjectProperties, autoExpandDepth } = this.props;
 
     let roots = this.props.roots;
     if (!roots) {
@@ -227,8 +206,6 @@ class ObjectInspector extends Component {
           loadObjectProperties(item.contents.value);
         }
       },
-      getExpanded,
-      setExpanded,
       renderItem: this.renderItem
     });
   }
@@ -244,18 +221,13 @@ ObjectInspector.propTypes = {
   getObjectProperties: PropTypes.func.isRequired,
   loadObjectProperties: PropTypes.func.isRequired,
   onLabelClick: PropTypes.func.isRequired,
-  onDoubleClick: PropTypes.func.isRequired,
-  getExpanded: PropTypes.func,
-  setExpanded: PropTypes.func,
-  getActors: PropTypes.func.isRequired,
-  setActors: PropTypes.func
+  onDoubleClick: PropTypes.func.isRequired
 };
 
 ObjectInspector.defaultProps = {
   onLabelClick: () => {},
   onDoubleClick: () => {},
-  autoExpandDepth: 1,
-  getActors: () => ({})
+  autoExpandDepth: 1
 };
 
 export default ObjectInspector;

--- a/src/test/integration/tests/scopes-mutations.js
+++ b/src/test/integration/tests/scopes-mutations.js
@@ -93,40 +93,14 @@ module.exports = async function(ctx) {
   onPaused = waitForPaused(dbg);
   await resume(dbg);
   await onPaused;
-
   is(
-    getScopeNodeLabel(dbg, 6),
-    "lastName",
-    'The sixth element in the scope panel is still "lastName"'
+    getScopeNodeLabel(dbg, 2),
+    "<this>",
+    'The second element in the scope panel is "<this>"'
   );
   is(
-    getScopeNodeValue(dbg, 6),
-    '"Doe"',
-    'The "lastName" property is still "Doe", but it should be "Pierce"' +
-      "since it was changed in the script."
+    getScopeNodeLabel(dbg, 3),
+    "phonebook",
+    'The third element in the scope panel is "phonebook"'
   );
-
-  onPaused = waitForPaused(dbg);
-  await resume(dbg);
-  await onPaused;
-  is(
-    getScopeNodeLabel(dbg, 6),
-    "lastName",
-    'The sixth element in the scope panel is still "lastName"'
-  );
-  is(
-    getScopeNodeLabel(dbg, 7),
-    "__proto__",
-    'The seventh element in the scope panel is still "__proto__", ' +
-      'but it should be now "timezone", since it was added to the "sarah" object ' +
-      "in the script"
-  );
-  is(
-    getScopeNodeValue(dbg, 7),
-    "Object",
-    'The seventh element in the scope panel has the value "Object", ' +
-      'but it should be "PST"'
-  );
-
-  await resume(dbg);
 };

--- a/src/test/mochitest/browser_dbg-scopes-mutations.js
+++ b/src/test/mochitest/browser_dbg-scopes-mutations.js
@@ -83,38 +83,13 @@ add_task(async function() {
   await onPaused;
 
   is(
-    getScopeNodeLabel(dbg, 6),
-    "lastName",
-    'The sixth element in the scope panel is still "lastName"'
+    getScopeNodeLabel(dbg, 2),
+    "<this>",
+    'The second element in the scope panel is "<this>"'
   );
   is(
-    getScopeNodeValue(dbg, 6),
-    '"Doe"',
-    'The "lastName" property is still "Doe", but it should be "Pierce"' +
-      "since it was changed in the script."
+    getScopeNodeLabel(dbg, 3),
+    "phonebook",
+    'The third element in the scope panel is "phonebook"'
   );
-
-  onPaused = waitForPaused(dbg);
-  await resume(dbg);
-  await onPaused;
-  is(
-    getScopeNodeLabel(dbg, 6),
-    "lastName",
-    'The sixth element in the scope panel is still "lastName"'
-  );
-  is(
-    getScopeNodeLabel(dbg, 7),
-    "__proto__",
-    'The seventh element in the scope panel is still "__proto__", ' +
-      'but it should be now "timezone", since it was added to the "sarah" object ' +
-      "in the script"
-  );
-  is(
-    getScopeNodeValue(dbg, 7),
-    "Object",
-    'The seventh element in the scope panel has the value "Object", ' +
-      'but it should be "PST"'
-  );
-
-  await resume(dbg);
 });

--- a/src/test/mochitest/browser_dbg-scopes.js
+++ b/src/test/mochitest/browser_dbg-scopes.js
@@ -9,7 +9,7 @@ function getLabel(dbg, index) {
   return findElement(dbg, "scopeNode", index).innerText;
 }
 
-add_task(function* () {
+add_task(function*() {
   const dbg = yield initDebugger("doc-script-switching.html");
 
   toggleScopes(dbg);
@@ -27,5 +27,5 @@ add_task(function* () {
 
   yield stepOver(dbg);
   is(getLabel(dbg, 4), "foo()");
-  is(getLabel(dbg, 5), "prototype");
+  is(getLabel(dbg, 5), "Window");
 });

--- a/src/utils/object-inspector.js
+++ b/src/utils/object-inspector.js
@@ -216,10 +216,6 @@ function getChildren({ getObjectProperties, actors, item }) {
   // node would be a new instance every render.
   const key = item.path;
   if (actors && actors[key]) {
-    if (item.contents.value && item.contents.value.preview) {
-      actors[key] = updateActor(item, actors, key);
-    }
-
     return actors[key];
   }
 
@@ -240,21 +236,6 @@ function getChildren({ getObjectProperties, actors, item }) {
   }
   actors[key] = children;
   return children;
-}
-
-function updateActor(item, actors, key) {
-  const properties = item.contents.value.preview.ownProperties;
-  for (let pKey in properties) {
-    if (properties.hasOwnProperty(pKey)) {
-      const cacheObject = actors[key].filter(a => a.name == pKey)[0];
-      const cacheObjectIndex = actors[key].findIndex(a => a.name == pKey);
-      // Assign new values to the cache actor if it goes stale
-      if (cacheObject && cacheObject.contents.value != properties[pKey].value) {
-        actors[key][cacheObjectIndex].contents = properties[pKey];
-      }
-    }
-  }
-  return actors[key];
 }
 
 module.exports = {

--- a/src/utils/tests/object-inspector.js
+++ b/src/utils/tests/object-inspector.js
@@ -3,8 +3,7 @@ const expect = require("expect.js");
 const {
   makeNodesForProperties,
   isPromise,
-  getPromiseProperties,
-  getChildren
+  getPromiseProperties
 } = require("../object-inspector");
 
 const objProperties = {

--- a/src/utils/tests/object-inspector.js
+++ b/src/utils/tests/object-inspector.js
@@ -243,37 +243,4 @@ describe("promises", () => {
     const node = getPromiseProperties(promise);
     expect(node.contents.value.type).to.eql("3");
   });
-
-  it("update actors when necessary", () => {
-    const item = {
-      contents: {
-        value: {
-          preview: {
-            ownProperties: {
-              color: {
-                value: "red"
-              }
-            }
-          },
-          type: "object"
-        }
-      },
-      name: "car",
-      path: "Block/car"
-    };
-
-    let actors = new Object();
-    actors["Block/car"] = [
-      {
-        contents: {
-          value: "white"
-        },
-        name: "color",
-        path: "Block/car/color"
-      }
-    ];
-
-    const children = getChildren({ function() {}, actors, item });
-    expect(children[0].contents.value).to.eql("red");
-  });
 });


### PR DESCRIPTION
Associated Issue:

Based on discussions with @jasonLaster, we decided to take out all the expand and actor caching for now, due to various issues found. We would be looking at better ways to fix this interesting problem in the near future.
One noticeable change would be that during stepping the expand states of the scope tree is no longer maintained, the user would have to expand the scopes again ... this way we are guaranteed to have correct scope information.

### Summary of Changes

* Remove all the expand and actor caching across files

### Screenshots/Videos (OPTIONAL)

![image](https://cloud.githubusercontent.com/assets/792924/25759613/2b345754-31cb-11e7-92db-a33440de67c0.png)
