### PR TITLE
Don't show undef

### DIFF
--- a/src/components/Editor/Preview.js
+++ b/src/components/Editor/Preview.js
@@ -33,7 +33,14 @@ class Preview extends Component {
   };
 
   componentDidMount() {
-    const { loadObjectProperties, loadedObjects, value } = this.props;
+    const {
+      loadObjectProperties,
+      loadedObjects,
+      value,
+      popoverTarget
+    } = this.props;
+
+    popoverTarget.classList.add("selected-token");
 
     if (!value || !value.type == "object") {
       return;
@@ -42,6 +49,11 @@ class Preview extends Component {
     if (value.actor && !loadedObjects.has(value.actor)) {
       loadObjectProperties(value);
     }
+  }
+
+  componentWillUnmount() {
+    const { popoverTarget } = this.props;
+    popoverTarget.classList.remove("selected-token");
   }
 
   getChildren(root, getObjectProperties) {

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -765,13 +765,12 @@ class Editor extends PureComponent {
     }
 
     const token = selectedToken.textContent;
-    selectedToken.classList.add("selected-token");
 
     const value = getExpressionValue(selectedExpression, {
       getExpression: this.props.getExpression
     });
 
-    if (!value) {
+    if (!value || value.type == "undefined") {
       return;
     }
 
@@ -780,7 +779,6 @@ class Editor extends PureComponent {
       expression: token,
       popoverTarget: selectedToken,
       onClose: () => {
-        selectedToken.classList.remove("selected-token");
         this.setState({
           selectedToken: null,
           selectedExpression: null

--- a/src/utils/editor/expression.js
+++ b/src/utils/editor/expression.js
@@ -65,10 +65,8 @@ export function previewExpression({
 
   if (variables.has(tokenText)) {
     let variableKey = variables.get(tokenText);
-    if (variableKey.contents) {
-      if (variableKey.contents.value.type === "undefined") {
-        return null;
-      }
+    if (!get(variableKey, "contents.value.type") == "undefined") {
+      return null;
     }
 
     return variables.get(tokenText);

--- a/src/utils/editor/expression.js
+++ b/src/utils/editor/expression.js
@@ -65,10 +65,12 @@ export function previewExpression({
 
   if (variables.has(tokenText)) {
     let variableKey = variables.get(tokenText);
-
-    if (variableKey.contents.value.type === "undefined") {
-      return null;
+    if (variableKey.contents) {
+      if (variableKey.contents.value.type === "undefined") {
+        return null;
+      }
     }
+
     return variables.get(tokenText);
   }
 

--- a/src/utils/editor/expression.js
+++ b/src/utils/editor/expression.js
@@ -64,6 +64,11 @@ export function previewExpression({
   }
 
   if (variables.has(tokenText)) {
+    let variableKey = variables.get(tokenText);
+
+    if (variableKey.contents.value.type === "undefined") {
+      return null;
+    }
     return variables.get(tokenText);
   }
 

--- a/src/utils/editor/expression.js
+++ b/src/utils/editor/expression.js
@@ -65,7 +65,7 @@ export function previewExpression({
 
   if (variables.has(tokenText)) {
     let variableKey = variables.get(tokenText);
-    if (!get(variableKey, "contents.value.type") == "undefined") {
+    if (get(variableKey, "contents.value.type") == "undefined") {
       return null;
     }
 


### PR DESCRIPTION
Associated Issue: #2691 

### Summary of Changes

 

- [x] Don't show undefined values of variables in current scope when debugger is paused
- [x] Add selected-token class to popoverTarget in `componentDidMount`
- [x] Remove selected-token class from popoverTarget in `componentWillUnmount`

### Test Plan
- [x] When paused in the debugger, hovering over an undefined variable, does not add highlighting class or the popup preview.
