### PR TITLE
Converted PropTypes to flow types in EventListeners.js

### DIFF
--- a/src/components/SecondaryPanes/EventListeners.js
+++ b/src/components/SecondaryPanes/EventListeners.js
@@ -1,6 +1,6 @@
 // @flow
 import React from "react";
-const { DOM: dom, PropTypes, Component } = React;
+const { DOM: dom, Component } = React;
 import { bindActionCreators } from "redux";
 import { connect } from "react-redux";
 import actions from "../../actions";
@@ -8,8 +8,27 @@ import { getEventListeners, getBreakpoint } from "../../selectors";
 import CloseButton from "../shared/Button/Close";
 import "./EventListeners.css";
 
+import type { Breakpoint, Location, SourceId } from "debugger-html";
+
+type Listener = {
+  selector: string,
+  type: string,
+  sourceId: SourceId,
+  line: number,
+  breakpoint: ?Breakpoint
+};
+
 class EventListeners extends Component {
   renderListener: Function;
+
+  props: {
+    listeners: Array<Listener>,
+    selectSource: (SourceId, { line: number }) => any,
+    addBreakpoint: ({ sourceId: SourceId, line: number }) => any,
+    enableBreakpoint: Location => any,
+    disableBreakpoint: Location => any,
+    removeBreakpoint: Location => any
+  };
 
   constructor(...args) {
     super(...args);
@@ -74,15 +93,6 @@ class EventListeners extends Component {
     );
   }
 }
-
-EventListeners.propTypes = {
-  listeners: PropTypes.array.isRequired,
-  selectSource: PropTypes.func.isRequired,
-  addBreakpoint: PropTypes.func.isRequired,
-  enableBreakpoint: PropTypes.func.isRequired,
-  disableBreakpoint: PropTypes.func.isRequired,
-  removeBreakpoint: PropTypes.func.isRequired
-};
 
 EventListeners.displayName = "EventListeners";
 


### PR DESCRIPTION
### Summary of Changes

* Converted PropTypes to flow types in EventListeners.js

### Test Plan

`yarn flow` :trollface: 

### TODO
so I think we could extract `Listener` type so it could be used by selectors etc. Wasnt sure where it should be located though. Also what should be in fact `Listener` is now extended by me with `breakpoint` property, as that is what `mapStateToProps` returns (extended `Listener`) - so this should ideally become some composite type of `Listener` and `{ breakpoint: ?Breakpoint }`