### PR TITLE
Converted PropTypes to flow types in SearchBar.js

### DIFF
--- a/src/actions/sources.js
+++ b/src/actions/sources.js
@@ -127,7 +127,7 @@ function loadSourceMap(generatedSource) {
   };
 }
 
-type SelectSourceOptions = { tabIndex?: number, line?: number };
+export type SelectSourceOptions = { tabIndex?: number, line?: number };
 
 /**
  * Deterministically select a source that has a given URL. This will

--- a/src/actions/types.js
+++ b/src/actions/types.js
@@ -30,6 +30,8 @@ export type ThunkArgs = {
   sourceMaps: any
 };
 
+export type Thunk = ThunkArgs => void;
+
 export type ActionType = Object | Function;
 
 /**

--- a/src/actions/types.js
+++ b/src/actions/types.js
@@ -30,7 +30,7 @@ export type ThunkArgs = {
   sourceMaps: any
 };
 
-export type Thunk = ThunkArgs => void;
+export type Thunk = ThunkArgs => any;
 
 export type ActionType = Object | Function;
 

--- a/src/actions/ui.js
+++ b/src/actions/ui.js
@@ -6,6 +6,7 @@ import {
   getFileSearchState
 } from "../selectors";
 import type { ThunkArgs } from "./types";
+import type { SymbolSearchType } from "../reducers/ui";
 
 export function toggleProjectSearch(toggleValue?: boolean) {
   return ({ dispatch, getState }: ThunkArgs) => {
@@ -48,7 +49,7 @@ export function toggleSymbolSearch(toggleValue: boolean) {
   };
 }
 
-export function setSelectedSymbolType(symbolType: "functions" | "variables") {
+export function setSelectedSymbolType(symbolType: SymbolSearchType) {
   return ({ dispatch, getState }: ThunkArgs) => {
     dispatch({
       type: constants.SET_SYMBOL_SEARCH_TYPE,

--- a/src/components/Editor/SearchBar.js
+++ b/src/components/Editor/SearchBar.js
@@ -33,7 +33,6 @@ import { SourceEditor } from "devtools-source-editor";
 import type { SourceRecord, SourceTextRecord } from "../../reducers/sources";
 import type { FileSearchModifiers, SymbolSearchType } from "../../reducers/ui";
 import type { SelectSourceOptions } from "../../actions/sources";
-import type { Thunk } from "../../actions/types";
 import type { SearchResults } from ".";
 
 import _SearchInput from "../shared/SearchInput";
@@ -81,20 +80,20 @@ class SearchBar extends Component {
   props: {
     editor?: SourceEditor,
     sourceText?: SourceTextRecord,
-    selectSource: (string, ?SelectSourceOptions) => Thunk,
+    selectSource: (string, ?SelectSourceOptions) => any,
     selectedSource?: SourceRecord,
     searchOn?: boolean,
-    toggleFileSearch: (?boolean) => Thunk,
+    toggleFileSearch: (?boolean) => any,
     searchResults: SearchResults,
     modifiers: FileSearchModifiers,
-    toggleFileSearchModifier: string => void,
+    toggleFileSearchModifier: string => any,
     symbolSearchOn: boolean,
     selectedSymbolType: SymbolSearchType,
-    toggleSymbolSearch: boolean => Thunk,
-    setSelectedSymbolType: SymbolSearchType => Thunk,
+    toggleSymbolSearch: boolean => any,
+    setSelectedSymbolType: SymbolSearchType => any,
     query: string,
-    setFileSearchQuery: string => void,
-    updateSearchResults: ({ count: number, index?: number }) => void
+    setFileSearchQuery: string => any,
+    updateSearchResults: ({ count: number, index?: number }) => any
   };
 
   constructor(props) {

--- a/src/components/Editor/SearchBar.js
+++ b/src/components/Editor/SearchBar.js
@@ -1,6 +1,6 @@
 // @flow
 
-import { DOM as dom, PropTypes, createFactory, Component } from "react";
+import { DOM as dom, createFactory, Component } from "react";
 import { findDOMNode } from "../../../node_modules/react-dom/dist/react-dom";
 import { connect } from "react-redux";
 import { bindActionCreators } from "redux";
@@ -28,7 +28,13 @@ import { getSymbols } from "../../utils/parser";
 import { scrollList } from "../../utils/result-list";
 import classnames from "classnames";
 import debounce from "lodash/debounce";
-import ImPropTypes from "react-immutable-proptypes";
+
+import { SourceEditor } from "devtools-source-editor";
+import type { SourceRecord, SourceTextRecord } from "../../reducers/sources";
+import type { FileSearchModifiers, SymbolSearchType } from "../../reducers/ui";
+import type { SelectSourceOptions } from "../../actions/sources";
+import type { Thunk } from "../../actions/types";
+import type { SearchResults } from ".";
 
 import _SearchInput from "../shared/SearchInput";
 const SearchInput = createFactory(_SearchInput);
@@ -57,7 +63,7 @@ function getShortcuts() {
 
 type ToggleSymbolSearchOpts = {
   toggle: boolean,
-  searchType: string
+  searchType: SymbolSearchType
 };
 
 type SearchBarState = {
@@ -71,6 +77,29 @@ import "./SearchBar.css";
 
 class SearchBar extends Component {
   state: SearchBarState;
+
+  props: {
+    editor?: SourceEditor,
+    sourceText?: SourceTextRecord,
+    selectSource: (string, ?SelectSourceOptions) => Thunk,
+    selectedSource?: SourceRecord,
+    searchOn?: boolean,
+    toggleFileSearch: (?boolean) => Thunk,
+    searchResults: SearchResults,
+    modifiers: FileSearchModifiers,
+    toggleFileSearchModifier: string => void,
+    symbolSearchOn: boolean,
+    selectedSymbolType: SymbolSearchType,
+    toggleSymbolSearch: boolean => Thunk,
+    setSelectedSymbolType: SymbolSearchType => Thunk,
+    query: string,
+    setFileSearchQuery: string => void,
+    updateSearchResults: ({ count: number, index?: number }) => void
+  };
+
+  context: {
+    shortcuts: Object
+  };
 
   constructor(props) {
     super(props);
@@ -675,34 +704,7 @@ class SearchBar extends Component {
   }
 }
 
-SearchBar.propTypes = {
-  editor: PropTypes.object,
-  sourceText: ImPropTypes.map,
-  selectSource: PropTypes.func.isRequired,
-  selectedSource: ImPropTypes.map,
-  searchOn: PropTypes.bool,
-  toggleFileSearch: PropTypes.func.isRequired,
-  searchResults: PropTypes.object.isRequired,
-  modifiers: ImPropTypes.recordOf({
-    caseSensitive: PropTypes.bool.isRequired,
-    regexMatch: PropTypes.bool.isRequired,
-    wholeWord: PropTypes.bool.isRequired
-  }).isRequired,
-  toggleFileSearchModifier: PropTypes.func.isRequired,
-  symbolSearchOn: PropTypes.bool.isRequired,
-  selectedSymbolType: PropTypes.string,
-  toggleSymbolSearch: PropTypes.func.isRequired,
-  setSelectedSymbolType: PropTypes.func.isRequired,
-  query: PropTypes.string.isRequired,
-  setFileSearchQuery: PropTypes.func.isRequired,
-  updateSearchResults: PropTypes.func.isRequired
-};
-
 SearchBar.displayName = "SearchBar";
-
-SearchBar.contextTypes = {
-  shortcuts: PropTypes.object
-};
 
 export default connect(
   state => {

--- a/src/components/Editor/SearchBar.js
+++ b/src/components/Editor/SearchBar.js
@@ -1,6 +1,6 @@
 // @flow
 
-import { DOM as dom, createFactory, Component } from "react";
+import { DOM as dom, createFactory, Component, PropTypes } from "react";
 import { findDOMNode } from "../../../node_modules/react-dom/dist/react-dom";
 import { connect } from "react-redux";
 import { bindActionCreators } from "redux";
@@ -95,10 +95,6 @@ class SearchBar extends Component {
     query: string,
     setFileSearchQuery: string => void,
     updateSearchResults: ({ count: number, index?: number }) => void
-  };
-
-  context: {
-    shortcuts: Object
   };
 
   constructor(props) {
@@ -705,6 +701,9 @@ class SearchBar extends Component {
 }
 
 SearchBar.displayName = "SearchBar";
+SearchBar.contextTypes = {
+  shortcuts: PropTypes.object
+};
 
 export default connect(
   state => {

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -72,24 +72,28 @@ import { getVisibleVariablesFromScope } from "../../utils/scopes";
 import { isFirefox } from "devtools-config";
 import "./Editor.css";
 
+import { SourceEditor } from "devtools-source-editor";
+
 const cssVars = {
   searchbarHeight: "var(--editor-searchbar-height)",
   secondSearchbarHeight: "var(--editor-second-searchbar-height)",
   footerHeight: "var(--editor-footer-height)"
 };
 
+export type SearchResults = {
+  index: number,
+  count: number
+};
+
 type EditorState = {
-  searchResults: {
-    index: number,
-    count: number
-  },
+  searchResults: SearchResults,
   selectedToken: ?Object,
   selectedExpression: ?Object
 };
 
 class Editor extends PureComponent {
   cbPanel: any;
-  editor: any;
+  editor: SourceEditor;
   pendingJumpLine: any;
   lastJumpLine: any;
   state: EditorState;

--- a/src/reducers/ui.js
+++ b/src/reducers/ui.js
@@ -12,19 +12,21 @@ import constants from "../constants";
 import type { Action, panelPositionType } from "../actions/types";
 import type { Record } from "../utils/makeRecord";
 
-type fileSearchModifiersType = {
+export type FileSearchModifiers = Record<{
   caseSensitive: boolean,
   wholeWord: boolean,
   regexMatch: boolean
-};
+}>;
+
+export type SymbolSearchType = "functions" | "variables";
 
 export type UIState = {
   fileSearchOn: boolean,
   fileSearchQuery: string,
-  fileSearchModifiers: Record<fileSearchModifiersType>,
+  fileSearchModifiers: FileSearchModifiers,
   projectSearchOn: boolean,
   symbolSearchOn: boolean,
-  symbolSearchType: "functions" | "variables",
+  symbolSearchType: SymbolSearchType,
   shownSource: string,
   startPanelCollapsed: boolean,
   endPanelCollapsed: boolean
@@ -115,11 +117,10 @@ export function getFileSearchQueryState(state: OuterState): string {
 
 export function getFileSearchModifierState(
   state: OuterState
-): Record<fileSearchModifiersType> {
+): FileSearchModifiers {
   return state.ui.get("fileSearchModifiers");
 }
 
-type SymbolSearchType = "functions" | "variables";
 export function getSymbolSearchType(state: OuterState): SymbolSearchType {
   return state.ui.get("symbolSearchType");
 }

--- a/src/utils/makeRecord.js
+++ b/src/utils/makeRecord.js
@@ -15,6 +15,7 @@ const I = require("immutable");
  * @static
  */
 export type Record<T: Object> = {
+  equals<A>(other: A): boolean,
   get<A>(key: $Keys<T>, notSetValue?: any): A,
   getIn<A>(keyPath: Array<any>, notSetValue?: any): A,
   set<A>(key: $Keys<T>, value: A): Record<T>,


### PR DESCRIPTION
* Converted PropTypes to flow types in `SearchBar.js`
* extracted few types in other files too, so they can be imported in `SearchBar.js`
* added `equals` method on `Record`'s type