### PR TITLE
Format Reference Errors

### DIFF
--- a/src/components/SecondaryPanes/Expressions.js
+++ b/src/components/SecondaryPanes/Expressions.js
@@ -28,7 +28,7 @@ function getValue(expression) {
 
   if (value.exception) {
     return {
-      path: expression.from,
+      path: value.from,
       value: value.exception
     };
   }
@@ -142,7 +142,11 @@ class Expressions extends PureComponent {
       return;
     }
 
-    const { value, path } = getValue(expression);
+    let { value, path } = getValue(expression);
+
+    if (value.class == "Error") {
+      value = { unavailable: true };
+    }
 
     const root = {
       name: expression.input,

--- a/src/components/shared/ObjectInspector.css
+++ b/src/components/shared/ObjectInspector.css
@@ -1,0 +1,3 @@
+.object-value .unavailable {
+  color: var(--theme-comment);
+}

--- a/src/components/shared/ObjectInspector.js
+++ b/src/components/shared/ObjectInspector.js
@@ -19,6 +19,8 @@ import {
 import _ManagedTree from "./ManagedTree";
 const ManagedTree = createFactory(_ManagedTree);
 
+import "./ObjectInspector.css";
+
 export type ObjectInspectorItemContentsValue = {
   actor: string,
   class: string,
@@ -124,9 +126,12 @@ class ObjectInspector extends Component {
   ) {
     let objectValue;
     let label = item.name;
+    const unavailable =
+      nodeIsPrimitive(item) &&
+      item.contents.value.hasOwnProperty("unavailable");
     if (nodeIsOptimizedOut(item)) {
       objectValue = dom.span({ className: "unavailable" }, "(optimized away)");
-    } else if (nodeIsMissingArguments(item)) {
+    } else if (nodeIsMissingArguments(item) || unavailable) {
       objectValue = dom.span({ className: "unavailable" }, "(unavailable)");
     } else if (nodeIsFunction(item)) {
       objectValue = null;

--- a/src/test/integration/tests/expressions.js
+++ b/src/test/integration/tests/expressions.js
@@ -67,7 +67,7 @@ module.exports = async function(ctx) {
 
   await addExpression(dbg, "f");
   is(getLabel(dbg, 1), "f");
-  is(getValue(dbg, 1), "ReferenceError");
+  is(getValue(dbg, 1), "(unavailable)");
 
   await editExpression(dbg, "oo");
   is(getLabel(dbg, 1), "foo()");

--- a/src/test/mochitest/browser_dbg-expressions.js
+++ b/src/test/mochitest/browser_dbg-expressions.js
@@ -47,7 +47,7 @@ add_task(function*() {
 
   yield addExpression(dbg, "f");
   is(getLabel(dbg, 1), "f");
-  is(getValue(dbg, 1), "ReferenceError");
+  is(getValue(dbg, 1), "(unavailable)");
 
   yield editExpression(dbg, "oo");
   is(getLabel(dbg, 1), "foo()");


### PR DESCRIPTION
Associated Issue: #2704 

Summary of Changes

* Modified Expressions.js to capture objects of exception type
* Modified ObjectInspector.js to capture unavailable objects

Test Plan

- Create watch for objects which wouldn't be available once the scope ends
- Once scope ends, the watched object must read "unavailable"

![screenshot from 2017-05-06 01-37-06](https://cloud.githubusercontent.com/assets/16179366/25773629/4945144c-3246-11e7-92d2-7cccac19b28b.png)
