### PR TITLE
Fix tab height flusing with the header bug

### DIFF
--- a/src/components/Editor/Tabs.css
+++ b/src/components/Editor/Tabs.css
@@ -26,9 +26,7 @@
 
 .source-tabs {
   max-width: calc(100% - 80px);
-  align-self: flex-end;
-  display: flex;
-  margin-bottom: -1px;
+  align-self: flex-start;
 }
 
 .source-tab {
@@ -43,6 +41,7 @@
   overflow: hidden;
   padding: 5px;
   margin-inline-start: 3px;
+  margin-top: 4px;
 }
 
 .source-tab:hover {

--- a/src/components/Editor/Tabs.css
+++ b/src/components/Editor/Tabs.css
@@ -78,7 +78,7 @@
 
 .source-tab .blackBox {
   line-height: 0;
-  padding: 5px;
+  padding: 0 5px;
 }
 
 .source-tab .blackBox svg {

--- a/src/components/Editor/Tabs.css
+++ b/src/components/Editor/Tabs.css
@@ -26,21 +26,22 @@
 
 .source-tabs {
   max-width: calc(100% - 80px);
-  align-self: flex-start;
+  align-self: flex-end;
+  display: flex;
+  margin-bottom: -1px;
 }
 
 .source-tab {
   border: 1px solid transparent;
   border-top-left-radius: 2px;
   border-top-right-radius: 2px;
-  height: 30px;
   display: inline-flex;
   align-items: center;
   position: relative;
   transition: all 0.25s ease;
   min-width: 40px;
   overflow: hidden;
-  padding: 6px;
+  padding: 5px;
   margin-inline-start: 3px;
 }
 


### PR DESCRIPTION
Associated Issue: #2790

I've removed the fixed height and also decreased tab's `padding` in order to improve UI alignments. (see Firefox note). I think using a negative margin does the job very well for the expected visual here, hope that's not a problem. :)



## Screenshots
Styles are consistent among browsers.

### Firefox

Note: Please notice the tab height difference between the current debugger's tab (bottom) and my version (top).

<img width="935" alt="Firefox" src="https://cloud.githubusercontent.com/assets/5303585/25777107/60488cce-32a9-11e7-9aed-82f448c613f7.png">

### Chrome:
![screen shot 2017-05-06 at 22 15 18](https://cloud.githubusercontent.com/assets/5303585/25777111/8f275250-32a9-11e7-931c-89b438eabae9.png)

