### PR TITLE
Fix secondary pane toggle button in vertical mode

### DIFF
--- a/src/components/WelcomeBox.css
+++ b/src/components/WelcomeBox.css
@@ -22,6 +22,11 @@ html .welcomebox .toggle-button-end {
   bottom: 0;
 }
 
+html[dir="rtl"] .welcomebox .toggle-button-end {
+  left: 0;
+  right: auto;
+}
+
 html .welcomebox .toggle-button-end.collapsed {
   bottom: 1px;
 }

--- a/src/components/WelcomeBox.css
+++ b/src/components/WelcomeBox.css
@@ -16,7 +16,12 @@
 }
 
 html .welcomebox .toggle-button-end {
-  bottom: 11px;
   position: absolute;
   top: auto;
+  right: 0;
+  bottom: 0;
+}
+
+html .welcomebox .toggle-button-end.collapsed {
+  bottom: 1px;
 }

--- a/src/components/WelcomeBox.css
+++ b/src/components/WelcomeBox.css
@@ -15,16 +15,12 @@
   z-index: 100;
 }
 
-html .welcomebox .toggle-button-end {
+.welcomebox .toggle-button-end {
   position: absolute;
   top: auto;
-  right: 0;
   bottom: 0;
-}
-
-html[dir="rtl"] .welcomebox .toggle-button-end {
-  left: 0;
-  right: auto;
+  offset-inline-end: 0;
+  offset-inline-start: auto;
 }
 
 html .welcomebox .toggle-button-end.collapsed {

--- a/src/components/shared/Button/PaneToggle.css
+++ b/src/components/shared/Button/PaneToggle.css
@@ -3,6 +3,11 @@
   transform: translate(0, 2px);
   transition: transform 0.25s ease-in-out;
   cursor: pointer;
+  padding: 5px 2px;
+}
+
+.toggle-button-start.vertical,
+.toggle-button-end.vertical {
   padding: 4px 2px;
 }
 

--- a/src/components/shared/Button/PaneToggle.css
+++ b/src/components/shared/Button/PaneToggle.css
@@ -35,10 +35,6 @@ html .toggle-button-end.vertical svg {
   transform: rotate(-90deg);
 }
 
-.toggle-button-end.vertical {
-  margin-bottom: 2px;
-}
-
 .toggle-button-start.collapsed,
 .toggle-button-end.collapsed {
   transform: rotate(180deg);


### PR DESCRIPTION
Associated Issue: #2792

Also fixes vertical alignment in both horizontal and vertical toggle buttons.

### Test Plan
- [x] [Horizontal mode] Toggle button in a file
- [x]  [Horizontal mode] Toggle button in welcome box
- [x]  [Vertical mode] Toggle button in a file
- [x]  [Vertical mode] Toggle button in a file
- [x] Firefox
- [x] Chrome

### Screenshots
Pretty consistent now! 😎

![screencast 2017-05-07 at 2 37 19 am](https://cloud.githubusercontent.com/assets/5303585/25778251/53503398-32cf-11e7-9664-a346fbb599b5.gif)
