### PR TITLE
OutlineView style the list of functions

### DIFF
--- a/src/components/Outline.css
+++ b/src/components/Outline.css
@@ -1,0 +1,8 @@
+.outline-list {
+  list-style-type: "-";
+}
+
+.outline-list__element {
+  color: blue;
+  padding-left: 0.5rem;
+}

--- a/src/components/Outline.js
+++ b/src/components/Outline.js
@@ -8,6 +8,7 @@ import { getSelectedSource, getSourceText } from "../selectors";
 import { isEnabled } from "devtools-config";
 import { getSymbols } from "../utils/parser";
 import "./Outline.css";
+import previewFunction from "./shared/previewFunction";
 
 import type { Record } from "../utils/makeRecord";
 import type { SourceText } from "debugger-html";
@@ -37,7 +38,13 @@ class Outline extends Component {
   }
 
   renderFunction(func) {
-    return dom.li({ key: func.id }, func.value);
+    return dom.li(
+      {
+        key: func.id,
+        className: "outline-list__element"
+      },
+      previewFunction(func)
+    );
   }
 
   renderFunctions() {
@@ -60,7 +67,7 @@ class Outline extends Component {
 
     return dom.div(
       { className: "outline" },
-      dom.ul({}, this.renderFunctions())
+      dom.ul({ className: "outline-list" }, this.renderFunctions())
     );
   }
 }

--- a/src/components/Outline.js
+++ b/src/components/Outline.js
@@ -37,11 +37,18 @@ class Outline extends Component {
     }
   }
 
+  selectItem(location) {
+    const selectedSourceId = this.props.selectedSource.get("id");
+    const startLine = location.start.line;
+    this.props.selectSource(selectedSourceId, { line: startLine });
+  }
+
   renderFunction(func) {
     return dom.li(
       {
         key: func.id,
-        className: "outline-list__element"
+        className: "outline-list__element",
+        onClick: () => this.selectItem(func.location)
       },
       previewFunction(func)
     );
@@ -57,7 +64,7 @@ class Outline extends Component {
 
     return functions
       .filter(func => func.value != "anonymous")
-      .map(this.renderFunction);
+      .map(func => this.renderFunction(func));
   }
 
   render() {
@@ -73,6 +80,7 @@ class Outline extends Component {
 }
 
 Outline.propTypes = {
+  selectSource: PropTypes.func.isRequired,
   selectedSource: PropTypes.object
 };
 
@@ -84,7 +92,8 @@ export default connect(
     const sourceId = selectedSource ? selectedSource.get("id") : null;
 
     return {
-      sourceText: getSourceText(state, sourceId)
+      sourceText: getSourceText(state, sourceId),
+      selectedSource
     };
   },
   dispatch => bindActionCreators(actions, dispatch)

--- a/src/components/Outline.js
+++ b/src/components/Outline.js
@@ -27,6 +27,7 @@ class Outline extends Component {
     }
   }
 
+  // TODO: move this logic out of the component and into a reducer
   async setSymbolDeclarations(sourceText: Record<SourceText>) {
     const symbolDeclarations = await getSymbols(sourceText.toJS());
 
@@ -38,9 +39,10 @@ class Outline extends Component {
   }
 
   selectItem(location) {
-    const selectedSourceId = this.props.selectedSource.get("id");
+    const { selectedSource, selectSource } = this.props;
+    const selectedSourceId = selectedSource.get("id");
     const startLine = location.start.line;
-    this.props.selectSource(selectedSourceId, { line: startLine });
+    selectSource(selectedSourceId, { line: startLine });
   }
 
   renderFunction(func) {

--- a/src/components/Sources.js
+++ b/src/components/Sources.js
@@ -46,7 +46,7 @@ class Sources extends Component {
       { className: "sources-panel" },
       dom.div({ className: "sources-header" }, this.renderShortcut()),
       SourcesTree({ sources, selectSource }),
-      Outline({})
+      Outline({ selectSource })
     );
   }
 }

--- a/src/components/shared/previewFunction.js
+++ b/src/components/shared/previewFunction.js
@@ -6,13 +6,19 @@ import flatten from "lodash/flatten";
 
 import "./previewFunction.css";
 
-function renderFunctionName(value) {
-  const name = value.userDisplayName || value.displayName || value.name || "";
+function getFunctionName(func) {
+  return (
+    func.userDisplayName || func.displayName || func.name || func.value || ""
+  );
+}
+
+function renderFunctionName(func) {
+  const name = getFunctionName(func);
   return dom.span({ className: "function-name" }, name);
 }
 
-function renderParams(value) {
-  const { parameterNames = [] } = value;
+function renderParams(func) {
+  const { parameterNames = [] } = func;
   let params = parameterNames
     .filter(i => i)
     .map(param => dom.span({ className: "param" }, param));
@@ -28,12 +34,12 @@ function renderParen(paren) {
   return dom.span({ className: "paren" }, paren);
 }
 
-function previewFunction(value) {
+function previewFunction(func) {
   return dom.span(
     { className: "function-signature" },
-    renderFunctionName(value),
+    renderFunctionName(func),
     renderParen("("),
-    ...renderParams(value),
+    ...renderParams(func),
     renderParen(")")
   );
 }

--- a/src/components/tests/Outline.js
+++ b/src/components/tests/Outline.js
@@ -8,6 +8,7 @@ import devtoolsConfig from "devtools-config";
 const OutlineComponent = React.createFactory(Outline.WrappedComponent);
 
 const sourcesToJs = fromJS({ text: "sources to js" });
+const selectSource = jest.genMockFunction();
 const sourceText = {
   root: "some text here",
   toJS: function() {
@@ -39,7 +40,7 @@ describe("Outline", () => {
   });
 
   it("should render a list of functions when properties change", async () => {
-    const component = shallow(new OutlineComponent());
+    const component = shallow(new OutlineComponent({ selectSource }));
 
     component.setProps({ sourceText });
 
@@ -48,7 +49,7 @@ describe("Outline", () => {
   });
 
   it("should render ignore anonimous functions", async () => {
-    const component = shallow(new OutlineComponent());
+    const component = shallow(new OutlineComponent({ selectSource }));
     symbolDeclarations.functions[1] = {
       id: "anonymous:25",
       value: "anonymous"

--- a/src/components/tests/Outline.js
+++ b/src/components/tests/Outline.js
@@ -16,6 +16,14 @@ const sourceText = {
   }
 };
 
+function generateFuncLocation(startLine) {
+  return {
+    start: {
+      line: startLine
+    }
+  };
+}
+
 describe("Outline", () => {
   var symbolDeclarations, symbolsPromise;
 
@@ -25,8 +33,16 @@ describe("Outline", () => {
 
     symbolDeclarations = {
       functions: [
-        { id: "my_example_function1:21", value: "my_example_function1" },
-        { id: "my_example_function2:22", value: "my_example_function2" }
+        {
+          id: "my_example_function1:21",
+          value: "my_example_function1",
+          location: generateFuncLocation(20)
+        },
+        {
+          id: "my_example_function2:22",
+          value: "my_example_function2",
+          location: generateFuncLocation(25)
+        }
       ]
     };
 
@@ -59,5 +75,27 @@ describe("Outline", () => {
 
     await symbolsPromise;
     expect(component).toMatchSnapshot();
+  });
+
+  it("should select a line of code in the current file on click", async () => {
+    const component = shallow(new OutlineComponent({ selectSource }));
+    const sourceId = "id";
+    const selectedSource = {
+      get: () => sourceId
+    };
+    const startLine = 12;
+
+    symbolDeclarations.functions[0] = {
+      id: "my_example_function1:21",
+      value: "my_example_function1",
+      location: generateFuncLocation(startLine)
+    };
+
+    component.setProps({ sourceText, selectedSource });
+
+    await symbolsPromise;
+    const listItem = component.find("li").first();
+    listItem.simulate("click");
+    expect(selectSource).toHaveBeenCalledWith(sourceId, { line: startLine });
   });
 });

--- a/src/components/tests/__snapshots__/Outline.js.snap
+++ b/src/components/tests/__snapshots__/Outline.js.snap
@@ -31,6 +31,7 @@ ShallowWrapper {
       "_compositeType": 0,
       "_context": Object {},
       "_currentElement": <Outline
+        selectSource={[Function]}
         sourceText={
                 Object {
                         "root": "some text here",
@@ -45,6 +46,7 @@ ShallowWrapper {
         "_reactInternalInstance": [Circular],
         "context": Object {},
         "props": Object {
+          "selectSource": [Function],
           "sourceText": Object {
             "root": "some text here",
             "toJS": [Function],
@@ -91,6 +93,7 @@ ShallowWrapper {
           >
                     <li
                               className="outline-list__element"
+                              onClick={[Function]}
                     >
                               <span
                                         className="function-signature"
@@ -114,6 +117,7 @@ ShallowWrapper {
                     </li>
                     <li
                               className="outline-list__element"
+                              onClick={[Function]}
                     >
                               <span
                                         className="function-signature"
@@ -146,6 +150,7 @@ ShallowWrapper {
           >
                     <li
                               className="outline-list__element"
+                              onClick={[Function]}
                     >
                               <span
                                         className="function-signature"
@@ -169,6 +174,7 @@ ShallowWrapper {
                     </li>
                     <li
                               className="outline-list__element"
+                              onClick={[Function]}
                     >
                               <span
                                         className="function-signature"
@@ -204,6 +210,7 @@ ShallowWrapper {
   },
   "root": [Circular],
   "unrendered": <Outline
+    selectSource={[Function]}
     sourceText={
         Object {
             "root": "some text here",
@@ -245,6 +252,7 @@ ShallowWrapper {
       "_compositeType": 0,
       "_context": Object {},
       "_currentElement": <Outline
+        selectSource={[Function]}
         sourceText={
                 Object {
                         "root": "some text here",
@@ -259,6 +267,7 @@ ShallowWrapper {
         "_reactInternalInstance": [Circular],
         "context": Object {},
         "props": Object {
+          "selectSource": [Function],
           "sourceText": Object {
             "root": "some text here",
             "toJS": [Function],
@@ -305,6 +314,7 @@ ShallowWrapper {
           >
                     <li
                               className="outline-list__element"
+                              onClick={[Function]}
                     >
                               <span
                                         className="function-signature"
@@ -337,6 +347,7 @@ ShallowWrapper {
           >
                     <li
                               className="outline-list__element"
+                              onClick={[Function]}
                     >
                               <span
                                         className="function-signature"
@@ -372,6 +383,7 @@ ShallowWrapper {
   },
   "root": [Circular],
   "unrendered": <Outline
+    selectSource={[Function]}
     sourceText={
         Object {
             "root": "some text here",

--- a/src/components/tests/__snapshots__/Outline.js.snap
+++ b/src/components/tests/__snapshots__/Outline.js.snap
@@ -11,13 +11,17 @@ ShallowWrapper {
   "node": <div
     className="outline"
 >
-    <ul />
+    <ul
+        className="outline-list"
+    />
 </div>,
   "nodes": Array [
     <div
       className="outline"
 >
-      <ul />
+      <ul
+            className="outline-list"
+      />
 </div>,
   ],
   "options": Object {},
@@ -82,12 +86,54 @@ ShallowWrapper {
         "_currentElement": <div
           className="outline"
 >
-          <ul>
-                    <li>
-                              my_example_function1
+          <ul
+                    className="outline-list"
+          >
+                    <li
+                              className="outline-list__element"
+                    >
+                              <span
+                                        className="function-signature"
+                              >
+                                        <span
+                                                  className="function-name"
+                                        >
+                                                  my_example_function1
+                                        </span>
+                                        <span
+                                                  className="paren"
+                                        >
+                                                  (
+                                        </span>
+                                        <span
+                                                  className="paren"
+                                        >
+                                                  )
+                                        </span>
+                              </span>
                     </li>
-                    <li>
-                              my_example_function2
+                    <li
+                              className="outline-list__element"
+                    >
+                              <span
+                                        className="function-signature"
+                              >
+                                        <span
+                                                  className="function-name"
+                                        >
+                                                  my_example_function2
+                                        </span>
+                                        <span
+                                                  className="paren"
+                                        >
+                                                  (
+                                        </span>
+                                        <span
+                                                  className="paren"
+                                        >
+                                                  )
+                                        </span>
+                              </span>
                     </li>
           </ul>
 </div>,
@@ -95,12 +141,54 @@ ShallowWrapper {
         "_renderedOutput": <div
           className="outline"
 >
-          <ul>
-                    <li>
-                              my_example_function1
+          <ul
+                    className="outline-list"
+          >
+                    <li
+                              className="outline-list__element"
+                    >
+                              <span
+                                        className="function-signature"
+                              >
+                                        <span
+                                                  className="function-name"
+                                        >
+                                                  my_example_function1
+                                        </span>
+                                        <span
+                                                  className="paren"
+                                        >
+                                                  (
+                                        </span>
+                                        <span
+                                                  className="paren"
+                                        >
+                                                  )
+                                        </span>
+                              </span>
                     </li>
-                    <li>
-                              my_example_function2
+                    <li
+                              className="outline-list__element"
+                    >
+                              <span
+                                        className="function-signature"
+                              >
+                                        <span
+                                                  className="function-name"
+                                        >
+                                                  my_example_function2
+                                        </span>
+                                        <span
+                                                  className="paren"
+                                        >
+                                                  (
+                                        </span>
+                                        <span
+                                                  className="paren"
+                                        >
+                                                  )
+                                        </span>
+                              </span>
                     </li>
           </ul>
 </div>,
@@ -137,13 +225,17 @@ ShallowWrapper {
   "node": <div
     className="outline"
 >
-    <ul />
+    <ul
+        className="outline-list"
+    />
 </div>,
   "nodes": Array [
     <div
       className="outline"
 >
-      <ul />
+      <ul
+            className="outline-list"
+      />
 </div>,
   ],
   "options": Object {},
@@ -208,9 +300,31 @@ ShallowWrapper {
         "_currentElement": <div
           className="outline"
 >
-          <ul>
-                    <li>
-                              my_example_function1
+          <ul
+                    className="outline-list"
+          >
+                    <li
+                              className="outline-list__element"
+                    >
+                              <span
+                                        className="function-signature"
+                              >
+                                        <span
+                                                  className="function-name"
+                                        >
+                                                  my_example_function1
+                                        </span>
+                                        <span
+                                                  className="paren"
+                                        >
+                                                  (
+                                        </span>
+                                        <span
+                                                  className="paren"
+                                        >
+                                                  )
+                                        </span>
+                              </span>
                     </li>
           </ul>
 </div>,
@@ -218,9 +332,31 @@ ShallowWrapper {
         "_renderedOutput": <div
           className="outline"
 >
-          <ul>
-                    <li>
-                              my_example_function1
+          <ul
+                    className="outline-list"
+          >
+                    <li
+                              className="outline-list__element"
+                    >
+                              <span
+                                        className="function-signature"
+                              >
+                                        <span
+                                                  className="function-name"
+                                        >
+                                                  my_example_function1
+                                        </span>
+                                        <span
+                                                  className="paren"
+                                        >
+                                                  (
+                                        </span>
+                                        <span
+                                                  className="paren"
+                                        >
+                                                  )
+                                        </span>
+                              </span>
                     </li>
           </ul>
 </div>,

--- a/src/components/tests/__snapshots__/Outline.js.snap
+++ b/src/components/tests/__snapshots__/Outline.js.snap
@@ -32,6 +32,11 @@ ShallowWrapper {
       "_context": Object {},
       "_currentElement": <Outline
         selectSource={[Function]}
+        selectedSource={
+                Object {
+                        "get": [Function],
+                      }
+        }
         sourceText={
                 Object {
                         "root": "some text here",
@@ -47,6 +52,9 @@ ShallowWrapper {
         "context": Object {},
         "props": Object {
           "selectSource": [Function],
+          "selectedSource": Object {
+            "get": [Function],
+          },
           "sourceText": Object {
             "root": "some text here",
             "toJS": [Function],
@@ -60,7 +68,7 @@ ShallowWrapper {
                 "id": "my_example_function1:21",
                 "location": Object {
                   "start": Object {
-                    "line": 20,
+                    "line": 21,
                   },
                 },
                 "value": "my_example_function1",
@@ -69,7 +77,7 @@ ShallowWrapper {
                 "id": "my_example_function2:22",
                 "location": Object {
                   "start": Object {
-                    "line": 25,
+                    "line": 22,
                   },
                 },
                 "value": "my_example_function2",
@@ -221,6 +229,11 @@ ShallowWrapper {
   "root": [Circular],
   "unrendered": <Outline
     selectSource={[Function]}
+    selectedSource={
+        Object {
+            "get": [Function],
+          }
+    }
     sourceText={
         Object {
             "root": "some text here",
@@ -263,6 +276,11 @@ ShallowWrapper {
       "_context": Object {},
       "_currentElement": <Outline
         selectSource={[Function]}
+        selectedSource={
+                Object {
+                        "get": [Function],
+                      }
+        }
         sourceText={
                 Object {
                         "root": "some text here",
@@ -278,6 +296,9 @@ ShallowWrapper {
         "context": Object {},
         "props": Object {
           "selectSource": [Function],
+          "selectedSource": Object {
+            "get": [Function],
+          },
           "sourceText": Object {
             "root": "some text here",
             "toJS": [Function],
@@ -291,13 +312,18 @@ ShallowWrapper {
                 "id": "my_example_function1:21",
                 "location": Object {
                   "start": Object {
-                    "line": 20,
+                    "line": 21,
                   },
                 },
                 "value": "my_example_function1",
               },
               Object {
                 "id": "anonymous:25",
+                "location": Object {
+                  "start": Object {
+                    "line": 25,
+                  },
+                },
                 "value": "anonymous",
               },
             ],
@@ -399,6 +425,11 @@ ShallowWrapper {
   "root": [Circular],
   "unrendered": <Outline
     selectSource={[Function]}
+    selectedSource={
+        Object {
+            "get": [Function],
+          }
+    }
     sourceText={
         Object {
             "root": "some text here",

--- a/src/components/tests/__snapshots__/Outline.js.snap
+++ b/src/components/tests/__snapshots__/Outline.js.snap
@@ -58,10 +58,20 @@ ShallowWrapper {
             "functions": Array [
               Object {
                 "id": "my_example_function1:21",
+                "location": Object {
+                  "start": Object {
+                    "line": 20,
+                  },
+                },
                 "value": "my_example_function1",
               },
               Object {
                 "id": "my_example_function2:22",
+                "location": Object {
+                  "start": Object {
+                    "line": 25,
+                  },
+                },
                 "value": "my_example_function2",
               },
             ],
@@ -279,6 +289,11 @@ ShallowWrapper {
             "functions": Array [
               Object {
                 "id": "my_example_function1:21",
+                "location": Object {
+                  "start": Object {
+                    "line": 20,
+                  },
+                },
                 "value": "my_example_function1",
               },
               Object {

--- a/src/test/integration/utils/shared.js
+++ b/src/test/integration/utils/shared.js
@@ -7,9 +7,12 @@ const selectors = {
   breakpointItem: i => `.breakpoints-list .breakpoint:nth-child(${i})`,
   scopeNode: i => `.scopes-list .tree-node:nth-child(${i}) .object-label`,
   scopeValue: i => `.scopes-list .tree-node:nth-child(${i}) .object-value`,
-  expressionNode: i => `.expressions-list .tree-node:nth-child(${i}) .object-label`,
-  expressionValue: i => `.expressions-list .tree-node:nth-child(${i}) .object-value`,
-  expressionClose: i => `.expressions-list .expression-container:nth-child(${i}) .close-btn`,
+  expressionNode: i =>
+    `.expressions-list .tree-node:nth-child(${i}) .object-label`,
+  expressionValue: i =>
+    `.expressions-list .tree-node:nth-child(${i}) .object-value`,
+  expressionClose: i =>
+    `.expressions-list .expression-container:nth-child(${i}) .close-btn`,
   expressionNodes: ".expressions-list .tree-node",
   frame: i => `.frames ul li:nth-child(${i})`,
   frames: ".frames ul li",


### PR DESCRIPTION
Associated Issue: #2562 

### Summary of Changes
This is the styling ticket for the OutlineList view, which introduces a function list for a given file

- style the list of functions
- jump to the source location 

### Test Plan
How to test:

- After starting the app and navigating to localhost:8000, click on the "settings" in the sidebar, and make sure that the "Source Outline" feature is enabled. 
- launch a browser and open a debugger from localhost:8000
- click through the source tree until you reach a .js file
- you should see an outline at the bottom

this needs a few more things like integrations tests

Here's the Debugger's Testing doc
https://docs.google.com/document/d/1oBMRxV8A2ag2t22YsQOxTdEv0mXKzIg0tggJjRkU1S0/edit#.
Feel free to improve it!

### Screenshots/Videos (OPTIONAL)

<img width="244" alt="screen shot 2017-05-09 at 6 27 12 pm" src="https://cloud.githubusercontent.com/assets/26968615/25861477/270cdd3c-34e5-11e7-9dd9-9154a3e0f917.png">
