### PR TITLE
[Breakpoints] Needs polishing in alignment

### DIFF
--- a/src/components/SecondaryPanes/Breakpoints.css
+++ b/src/components/SecondaryPanes/Breakpoints.css
@@ -1,3 +1,7 @@
+.breakpoints-toggle {
+  margin: 2px 3px;
+}
+
 .breakpoints-list * {
   -moz-user-select: none;
   user-select: none;
@@ -53,6 +57,7 @@ html .breakpoints-list .breakpoint.paused {
 
 .breakpoints-list .breakpoint-checkbox {
   margin-inline-start: 0;
+  vertical-align: -2px;
 }
 
 .breakpoints-list .breakpoint-label {
@@ -85,8 +90,9 @@ html .breakpoints-list .breakpoint.paused {
 
 .breakpoint .close-btn {
   position: absolute;
-  offset-inline-end: 16px;
-  top: 12px;
+  offset-inline-end: 13px;
+  offset-inline-start: auto;
+  top: 9px;
 }
 
 .breakpoint .close {


### PR DESCRIPTION
Associated Issue: #2841 

### Summary of Changes

* The "remove breakpoint" button (X) is now aligned vertically.
* The "remove breakpoint" button (X) is now aligned with the checkbox above it.
* When breakpoints are added, the "Breakpoint" title bar will not get a height larger than the other titles.
* The checkbox for each item is now aligned with the file name.

### Test Plan

Tested how the breakpoints menu looks on Firefox, Chrome and Edge on Windows 10.
Verified the functionality of all the items in it still work as expected (enable/disable breakpoints, remove breakpoints and clicking the file name).

### Screenshots/Videos (OPTIONAL)
![image](https://cloud.githubusercontent.com/assets/881668/25912061/b326475c-35be-11e7-87d6-b4c2bff1ea92.png)
