### PR TITLE
Make source tab's UI and tests consistent in RTL mode

### DIFF
--- a/src/components/Editor/Tabs.css
+++ b/src/components/Editor/Tabs.css
@@ -78,6 +78,7 @@
 .source-tab .blackBox,
 .source-tab .prettyPrint {
   line-height: 0;
+  align-self: center;
 }
 
 .source-tab .blackBox svg {

--- a/src/components/Editor/Tabs.css
+++ b/src/components/Editor/Tabs.css
@@ -13,7 +13,7 @@
 
 .source-header .new-tab-btn {
   padding: 0px 4px;
-  margin-top: 8px;
+  margin-top: 4px;
   cursor: pointer;
   fill: var(--theme-comment);
   transition: 0.1s ease;
@@ -34,7 +34,7 @@
   border-top-left-radius: 2px;
   border-top-right-radius: 2px;
   display: inline-flex;
-  align-items: center;
+  align-items: flex-end;
   position: relative;
   transition: all 0.25s ease;
   min-width: 40px;
@@ -75,9 +75,9 @@
   fill: var(--theme-textbox-box-shadow);
 }
 
-.source-tab .blackBox {
+.source-tab .blackBox,
+.source-tab .prettyPrint {
   line-height: 0;
-  padding: 0 5px;
 }
 
 .source-tab .blackBox svg {
@@ -93,16 +93,13 @@
   white-space: nowrap;
   text-overflow: ellipsis;
   overflow: hidden;
-}
-
-.source-tab.pretty .filename {
-  padding-inline-start: 8px;
+  padding: 0 4px;
+  align-self: flex-start;
 }
 
 .source-tab .close-btn {
   visibility: hidden;
   line-height: 0;
-  margin-inline-start: 6px;
 }
 
 .source-tab.active .close-btn {

--- a/src/components/Editor/Tabs.css
+++ b/src/components/Editor/Tabs.css
@@ -90,6 +90,10 @@
   fill: var(--theme-textbox-box-shadow);
 }
 
+.theme-dark .source-tab .blackBox circle {
+  fill: var(--theme-body-color);
+}
+
 .source-tab .filename {
   white-space: nowrap;
   text-overflow: ellipsis;

--- a/src/components/shared/Dropdown.css
+++ b/src/components/shared/Dropdown.css
@@ -5,8 +5,8 @@
   box-shadow: 0 4px 4px 0 var(--search-overlays-semitransparent);
   max-height: 300px;
   position: absolute;
-  right: 8px;
-  top: 35px;
+  right: 0;
+  top: 23px;
   width: var(--width);
   z-index: 1000;
 }
@@ -28,7 +28,6 @@ html[dir="rtl"] .dropdown {
   border: none;
   padding: 0;
   font-weight: 100;
-  margin-top: 6px;
   font-size: 14px;
 }
 

--- a/src/components/stories/tabs.js
+++ b/src/components/stories/tabs.js
@@ -30,6 +30,8 @@ const tabs = {
 function TabsFactory(options, { dir = "ltr", theme = "light" } = {}) {
   const themeClass = `theme-${theme}`;
   document.body.parentNode.className = themeClass;
+  document.dir = dir;
+
   return dom.div(
     {
       className: `editor-pane ${themeClass}`,


### PR DESCRIPTION
Associated Issue: #2791 and #2858

### Summary of Changes

* Improved tab UI vertical alignments and spacing, including **special tabs with icons**.
* Improved Storybook's tab factory: now`document.dir` is configured according. (This one is important, because it was preventing styles from `postcss-bidirection` to apply, so tests weren't consistent.)
* Fixed dropdown alignment.

### Screenshots
![Special tabs LTR](https://cloud.githubusercontent.com/assets/5303585/25921919/a8e90100-35ad-11e7-8a7b-366a1d2ee652.png)

![Special tabs RTL](https://cloud.githubusercontent.com/assets/5303585/25921962/cf1db988-35ad-11e7-80e6-2d0dc50be746.png)

![Dropdown](https://cloud.githubusercontent.com/assets/5303585/25922006/f68f8e24-35ad-11e7-8831-2aa161697409.gif)