### PR TITLE
[WIP] Reduce unnecessary re-layout in editor when switching frames

### DIFF
--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -674,14 +674,16 @@ class Editor extends PureComponent {
       this.editor.replaceDocument(doc);
       return doc;
     }
-    this.editor.editor.operation(() => {
-      doc = this.editor.createDocument();
-      setDocument(selectedLocation.sourceId, doc);
-      this.editor.replaceDocument(doc);
+    if (this.editor.editor) {
+      this.editor.editor.operation(() => {
+        doc = this.editor.createDocument();
+        setDocument(selectedLocation.sourceId, doc);
+        this.editor.replaceDocument(doc);
 
-      this.setText(sourceText.get("text"));
-      this.editor.setMode(getMode(sourceText.toJS()));
-    });
+        this.setText(sourceText.get("text"));
+        this.editor.setMode(getMode(sourceText.toJS()));
+      });
+    }
   }
 
   renderHighlightLines() {

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -674,13 +674,14 @@ class Editor extends PureComponent {
       this.editor.replaceDocument(doc);
       return doc;
     }
+    this.editor.editor.operation(() => {
+      doc = this.editor.createDocument();
+      setDocument(selectedLocation.sourceId, doc);
+      this.editor.replaceDocument(doc);
 
-    doc = this.editor.createDocument();
-    setDocument(selectedLocation.sourceId, doc);
-    this.editor.replaceDocument(doc);
-
-    this.setText(sourceText.get("text"));
-    this.editor.setMode(getMode(sourceText.toJS()));
+      this.setText(sourceText.get("text"));
+      this.editor.setMode(getMode(sourceText.toJS()));
+    });
   }
 
   renderHighlightLines() {


### PR DESCRIPTION
(This is WIP to show a partial solution. Not done and tests don't pass.)

I noticed that things feel a little sluggish any time we need to switch what file the editor is showing. This happens when you select a different file in the sources tree. But it's especially noticeable if you're paused in the debugger and click on a stack frame in a different file.

So I decided to try and figure out why, and whether we can do anything about it.

## The problem

If we profile switching between frames in different files, we can see a nice big relayout thrashing problem:

<img width="1485" alt="screen shot 2017-05-10 at 8 36 49 pm" src="https://cloud.githubusercontent.com/assets/8495/25930427/523ce09a-35c3-11e7-9b4b-c1315785a8e0.png">

That huge purple waterfall represents the majority of the time spent switching frames, about 240ms doing style calculation and re-layout. And all of it is within CodeMirror. It's a bunch of small things like updating the line number width, checking gutter spacing, and measuring the maximum line width. But while each one is cheap, many of the editor's measurements force previous style updates to be calculated by the browser, so we re-layout the same DOM tree a bunch of times. And we're doing each operation several times because we call several CodeMirror methods and each one triggers the same set of DOM measurements and updates.

The CodeMirror DOM measurements/updates are triggered from two places in our code:

- The first ~160ms comes in `Editor#showSourceText` (called by the editor's `componentWillReceiveProps`) where we're swapping out the old file's source for the new one. In that method, we call several methods on the CodeMirror instance and each of them triggers some recalculations, several of them being redundant.
- The last ~80ms comes in `Editor#highlightLine` (called by the editor's `componentDidUpdate`) where we call a CodeMirror method to make sure the desired line is visible in the editor.

(In the screenshot above, the highlighted event is the dividing line. All the events above it are caused by `showSourceText`, all the ones below are from `highlightLine`.)

## The (partial) solution

CodeMirror has an API to batch multiple method calls into a single "operation", so that layout updates are deferred and only run once at the end of the operation. By grouping all of the changes we want to make to the editor instance into one operation, we could avoid a lot of useless intermediate layout updates and reduce the slowness.

Unfortunately, grouping all the editor changes is a bit tricky since they're currently spread across two React lifecycle methods that execute at slightly different times. 

So I have started by just grouping all the changes in `showSourceText` into one operation. This is a simple change that buys us some improvement:

<img width="1485" alt="screen shot 2017-05-10 at 8 42 48 pm" src="https://cloud.githubusercontent.com/assets/8495/25930851/dfead18e-35c5-11e7-9eaa-35403cc82dee.png">

As before, the highlighted line is the last relayout triggered by `showSourceText`. Notice that there are far fewer recalculation and relayout lines, and that the total time spent in that method has been reduced from ~160ms to ~100ms. (The horizontal scale is different so that's not visually obvious, sorry.)

## What's left

After the change above, which groups all the changes triggered by `componentWillReceiveProps`, there's still a separate ~80ms spent doing CodeMirror layout updates triggered by `componentDidUpdate` calling `highlightLine`. We could presumably save about that much more time if we could batch that change together into the single operation. But to do that we need to reorganize the editor changes so they're all triggered either in `componentWillReceiveProps` or `componentDidUpdate` rather than spread across both. This might be hard if:

- the component methods that make editor changes are called from other code so they need to keep working without batching too
- the component's `render` or other lifecycle methods depend on the current order of editor changes, so they can't just be triggered from a different place.

Also, even after we batch all the updates, that still leaves us with around 100ms spent doing one batch of layout updates for CodeMirror. That seems longish to me. So it's possible:

- We're still using the CodeMirror API in some inefficient way.
- Our CSS makes doing relayout of the CodeMirror instance extra expensive.
- CodeMirror's internals could be more careful about doing all measurements together, then applying all style changes together, to avoid making the browser do multiple relayouts. But I haven't looked at the CodeMirror code and I'm sure it's a justifiably hard problem, so that suggestion may just be my naiveté. 