### PR TITLE
Refactor Pending Breakpoints to fix reloading

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   node:
-    version: 7.0
+    version: 7.7.2
   services:
     - docker
   environment:

--- a/circle.yml
+++ b/circle.yml
@@ -20,7 +20,7 @@ test:
     - mkdir -p $CIRCLE_TEST_REPORTS/mocha
     - mkdir -p $CIRCLE_TEST_REPORTS/flow-coverage
     - mkdir -p $CIRCLE_TEST_REPORTS/jest-coverage
-    - node ./node_modules/.bin/jest --testResultsProcessor jest-junit-reporter --coverage --coverageDirectory=$CIRCLE_TEST_REPORTS/jest-coverage
+    - jest -i --testResultsProcessor jest-junit-reporter --coverage --coverageDirectory=$CIRCLE_TEST_REPORTS/jest-coverage
     - yarn license-check
     - yarn lint-css
     - yarn lint-js

--- a/flow-typed/debugger-html.js
+++ b/flow-typed/debugger-html.js
@@ -65,6 +65,20 @@ declare module "debugger-html" {
   };
 
   /**
+ * PendingBreakpoint
+ *
+ * @memberof types
+ * @static
+ */
+  declare type PendingBreakpoint = {
+    location: Location,
+    loading: boolean,
+    disabled: boolean,
+    text: string,
+    condition: ?string
+  };
+
+  /**
  * Frame ID
  *
  * @memberof types

--- a/package.json
+++ b/package.json
@@ -155,6 +155,7 @@
     ],
     "testPathIgnorePatterns": [
       "/node_modules/",
+      "/helpers/",
       "<rootDir>/test/",
       "<rootDir>/utils/tests/fixtures/"
     ],

--- a/src/actions/breakpoints.js
+++ b/src/actions/breakpoints.js
@@ -83,7 +83,6 @@ export function addBreakpoint(
         if (!text) {
           text = getTextForLine ? getTextForLine(actualLocation.line) : "";
         }
-
         return { id, actualLocation, text, hitCount };
       })()
     });
@@ -110,7 +109,7 @@ export function removeBreakpoint(location: Location) {
   return _removeOrDisableBreakpoint(location);
 }
 
-function _removeOrDisableBreakpoint(location, isDisabled) {
+function _removeOrDisableBreakpoint(location, isDisabled = false) {
   return ({ dispatch, getState, client }: ThunkArgs) => {
     let bp = getBreakpoint(getState(), location);
     if (!bp) {

--- a/src/actions/sources.js
+++ b/src/actions/sources.js
@@ -105,7 +105,7 @@ export function newSources(sources: Source[]) {
       source => !getSource(getState(), source.id)
     );
 
-    for (const source in filteredSources) {
+    for (let source of filteredSources) {
       await dispatch(newSource(source));
     }
   };

--- a/src/actions/sources.js
+++ b/src/actions/sources.js
@@ -75,8 +75,8 @@ async function checkPendingBreakpoints(state, dispatch, source) {
     return;
   }
 
-  const pendingBreakpointsList = pendingBreakpoints.valueSeq().toJS();
-  for (let pendingBreakpoint of pendingBreakpointsList) {
+  const pendingBreakpointsArray = pendingBreakpoints.valueSeq().toJS();
+  for (let pendingBreakpoint of pendingBreakpointsArray) {
     await checkPendingBreakpoint(state, dispatch, pendingBreakpoint, source);
   }
 }

--- a/src/actions/sources.js
+++ b/src/actions/sources.js
@@ -46,29 +46,38 @@ function checkSelectedSource(state, dispatch, source) {
   }
 }
 
-function checkPendingBreakpoints(state, dispatch, source) {
+async function checkPendingBreakpoint(
+  state,
+  dispatch,
+  pendingBreakpoint,
+  source
+) {
+  const {
+    location: { line, sourceUrl, column },
+    condition
+  } = pendingBreakpoint;
+  const sameSource = sourceUrl && sourceUrl === source.url;
+  const location = { sourceId: source.id, sourceUrl, line, column };
+  const bp = getBreakpoint(state, location);
+
+  if (sameSource && !bp) {
+    if (location.column && isEnabled("columnBreakpoints")) {
+      await dispatch(addBreakpoint(location, { condition }));
+    } else {
+      await dispatch(addBreakpoint(location, { condition }));
+    }
+  }
+}
+
+async function checkPendingBreakpoints(state, dispatch, source) {
   const pendingBreakpoints = getPendingBreakpoints(state);
+  if (!pendingBreakpoints) {
+    return;
+  }
 
-  if (pendingBreakpoints) {
-    pendingBreakpoints.forEach(pendingBreakpoint => {
-      const {
-        location: { line, sourceUrl, column },
-        condition
-      } = pendingBreakpoint;
-      const sameSource = sourceUrl && sourceUrl == source.url;
-
-      const location = { sourceId: source.id, sourceUrl, line, column };
-
-      const bp = getBreakpoint(state, location);
-
-      if (sameSource && !bp) {
-        if (location.column && isEnabled("columnBreakpoints")) {
-          dispatch(addBreakpoint(location, { condition }));
-        } else {
-          dispatch(addBreakpoint(location, { condition }));
-        }
-      }
-    });
+  const pendingBreakpointsList = pendingBreakpoints.valueSeq().toJS();
+  for (let pendingBreakpoint of pendingBreakpointsList) {
+    await checkPendingBreakpoint(state, dispatch, pendingBreakpoint, source);
   }
 }
 
@@ -78,23 +87,27 @@ function checkPendingBreakpoints(state, dispatch, source) {
  * @static
  */
 export function newSource(source: Source) {
-  return ({ dispatch, getState }: ThunkArgs) => {
+  return async ({ dispatch, getState }: ThunkArgs) => {
     if (prefs.clientSourceMapsEnabled) {
-      dispatch(loadSourceMap(source));
+      await dispatch(loadSourceMap(source));
     }
 
     dispatch({ type: constants.ADD_SOURCE, source });
 
     checkSelectedSource(getState(), dispatch, source);
-    checkPendingBreakpoints(getState(), dispatch, source);
+    await checkPendingBreakpoints(getState(), dispatch, source);
   };
 }
 
 export function newSources(sources: Source[]) {
-  return ({ dispatch, getState }: ThunkArgs) => {
-    sources
-      .filter(source => !getSource(getState(), source.id))
-      .forEach(source => dispatch(newSource(source)));
+  return async ({ dispatch, getState }: ThunkArgs) => {
+    const filteredSources = sources.filter(
+      source => !getSource(getState(), source.id)
+    );
+
+    for (const source in filteredSources) {
+      await dispatch(newSource(source));
+    }
   };
 }
 

--- a/src/actions/sources.js
+++ b/src/actions/sources.js
@@ -88,11 +88,11 @@ async function checkPendingBreakpoints(state, dispatch, source) {
  */
 export function newSource(source: Source) {
   return async ({ dispatch, getState }: ThunkArgs) => {
+    dispatch({ type: constants.ADD_SOURCE, source });
+
     if (prefs.clientSourceMapsEnabled) {
       await dispatch(loadSourceMap(source));
     }
-
-    dispatch({ type: constants.ADD_SOURCE, source });
 
     checkSelectedSource(getState(), dispatch, source);
     await checkPendingBreakpoints(getState(), dispatch, source);

--- a/src/actions/tests/breakpoints.js
+++ b/src/actions/tests/breakpoints.js
@@ -1,5 +1,32 @@
+// TODO: we would like to mock this in the local tests
+const theMockedPendingBreakpoint = {
+  location: {
+    sourceId: "bar",
+    sourceUrl: "http://todomvc.com/bar.js",
+    line: 5,
+    column: undefined
+  },
+  condition: "3",
+  disabled: false
+};
+
 import { createStore, selectors, actions } from "../../utils/test-head";
+import {
+  makePendingLocationId,
+  makeLocationId
+} from "../../reducers/breakpoints";
 import expect from "expect.js";
+
+const slidingMockThreadClient = {
+  setBreakpoint: (location, condition) => {
+    return new Promise((resolve, reject) => {
+      const actualLocation = Object.assign({}, location, {
+        line: location.line + 2
+      });
+      resolve({ id: makeLocationId(location), actualLocation, condition });
+    });
+  }
+};
 
 const simpleMockThreadClient = {
   setBreakpoint: (location, condition) => {
@@ -24,11 +51,40 @@ const simpleMockThreadClient = {
 describe("breakpoints", () => {
   it("should add a breakpoint", async () => {
     const { dispatch, getState } = createStore(simpleMockThreadClient);
+    const loc1 = { sourceId: "a", line: 5 };
 
-    await dispatch(actions.addBreakpoint({ sourceId: "a", line: 5 }));
-    await dispatch(actions.addBreakpoint({ sourceId: "b", line: 6 }));
+    await dispatch(actions.addBreakpoint(loc1));
+    const bps = selectors.getBreakpoints(getState());
+    const bp = selectors.getBreakpoint(getState(), loc1);
+    expect(bps.size).to.be(1);
+    expect(bp.location).to.eql(loc1);
+  });
 
-    expect(selectors.getBreakpoints(getState()).size).to.be(2);
+  it("should not re-add a breakpoint", async () => {
+    const { dispatch, getState } = createStore(simpleMockThreadClient);
+    const loc1 = { sourceId: "a", line: 5 };
+
+    await dispatch(actions.addBreakpoint(loc1));
+    let bps = selectors.getBreakpoints(getState());
+    const bp = selectors.getBreakpoint(getState(), loc1);
+    expect(bps.size).to.be(1);
+    expect(bp.location).to.eql(loc1);
+
+    await dispatch(actions.addBreakpoint(loc1));
+    bps = selectors.getBreakpoints(getState());
+    expect(bps.size).to.be(1);
+  });
+
+  it("when the user adds a sliding breakpoint, a corresponding pending breakpoint should be added", async () => {
+    const { dispatch, getState } = createStore(slidingMockThreadClient);
+    const location = { sourceId: "a", line: 5 };
+    const slidLocation = { sourceId: "a", line: 7 };
+
+    await dispatch(actions.addBreakpoint(location));
+    const bps = selectors.getBreakpoints(getState());
+    const bp = selectors.getBreakpoint(getState(), slidLocation);
+    expect(bps.size).to.be(1);
+    expect(bp.location).to.eql(slidLocation);
   });
 
   it("should remove a breakpoint", async () => {

--- a/src/actions/tests/helpers/breakpoints.js
+++ b/src/actions/tests/helpers/breakpoints.js
@@ -1,0 +1,57 @@
+import { makeLocationId } from "../../../reducers/breakpoints";
+
+export const theMockedPendingBreakpoint = {
+  location: {
+    sourceId: "bar",
+    sourceUrl: "http://todomvc.com/bar.js",
+    line: 5,
+    column: undefined
+  },
+  condition: "3",
+  disabled: false
+};
+
+function generateCorrectingThreadClient(offset = 0) {
+  return {
+    setBreakpoint: (location, condition) => {
+      return new Promise((resolve, reject) => {
+        const actualLocation = Object.assign({}, location, {
+          line: location.line + offset
+        });
+        resolve({ id: makeLocationId(location), actualLocation, condition });
+      });
+    }
+  };
+}
+
+/* in some cases, a breakpoint may be added, but the source will respond
+ * with a different breakpoint location. This is due to the breakpoint being
+ * added between functions, or somewhere that doesnt make sense. This function
+ * simulates that behavior.
+ * */
+export function simulateCorrectThreadClient(offset, location) {
+  const correctedThreadClient = generateCorrectingThreadClient(offset);
+  const offsetLine = { line: location.line + offset };
+  const correctedLocation = Object.assign({}, location, offsetLine);
+  return { correctedThreadClient, correctedLocation };
+}
+
+export const simpleMockThreadClient = {
+  setBreakpoint: (location, condition) => {
+    return new Promise((resolve, reject) => {
+      resolve({ id: "hi", actualLocation: location });
+    });
+  },
+
+  removeBreakpoint: id => {
+    return new Promise((resolve, reject) => {
+      resolve({ status: "done" });
+    });
+  },
+
+  setBreakpointCondition: (id, location, condition, noSliding) => {
+    return new Promise((resolve, reject) => {
+      resolve({ sourceId: "a", line: 5 });
+    });
+  }
+};

--- a/src/actions/tests/helpers/breakpoints.js
+++ b/src/actions/tests/helpers/breakpoints.js
@@ -17,11 +17,14 @@ export function generateCorrectedBreakpoint(breakpoint, correctedLocation) {
 function generateCorrectingThreadClient(offset = 0) {
   return {
     setBreakpoint: (location, condition) => {
-      return new Promise((resolve, reject) => {
-        const actualLocation = Object.assign({}, location, {
-          line: location.line + offset
-        });
-        resolve({ id: makeLocationId(location), actualLocation, condition });
+      const actualLocation = Object.assign({}, location, {
+        line: location.line + offset
+      });
+
+      return Promise.resolve({
+        id: makeLocationId(location),
+        actualLocation,
+        condition
       });
     }
   };
@@ -66,21 +69,11 @@ export function generatePendingBreakpoint(breakpoint) {
 }
 
 export const simpleMockThreadClient = {
-  setBreakpoint: (location, _condition) => {
-    return new Promise((resolve, reject) => {
-      resolve({ id: "hi", actualLocation: location });
-    });
-  },
+  setBreakpoint: (location, _condition) =>
+    Promise.resolve({ id: "hi", actualLocation: location }),
 
-  removeBreakpoint: _id => {
-    return new Promise((resolve, reject) => {
-      resolve({ status: "done" });
-    });
-  },
+  removeBreakpoint: _id => Promise.resolve({ status: "done" }),
 
-  setBreakpointCondition: (_id, _location, _condition, _noSliding) => {
-    return new Promise((resolve, reject) => {
-      resolve({ sourceId: "a", line: 5 });
-    });
-  }
+  setBreakpointCondition: (_id, _location, _condition, _noSliding) =>
+    Promise.resolve({ sourceId: "a", line: 5 })
 };

--- a/src/actions/tests/helpers/breakpoints.js
+++ b/src/actions/tests/helpers/breakpoints.js
@@ -2,14 +2,17 @@ import { makeLocationId } from "../../../reducers/breakpoints";
 
 export const theMockedPendingBreakpoint = {
   location: {
-    sourceId: "bar",
-    sourceUrl: "http://todomvc.com/bar.js",
+    sourceUrl: "http://localhost:8000/examples/bar.js",
     line: 5,
     column: undefined
   },
   condition: "3",
   disabled: false
 };
+
+export function generateCorrectedBreakpoint(breakpoint, correctedLocation) {
+  return Object.assign({}, breakpoint, { location: correctedLocation });
+}
 
 function generateCorrectingThreadClient(offset = 0) {
   return {
@@ -36,20 +39,46 @@ export function simulateCorrectThreadClient(offset, location) {
   return { correctedThreadClient, correctedLocation };
 }
 
+export function generateBreakpoint(filename) {
+  return {
+    location: {
+      sourceUrl: `http://localhost:8000/examples/${filename}`,
+      sourceId: filename,
+      line: 5
+    },
+    condition: null,
+    disabled: false
+  };
+}
+
+export function generatePendingBreakpoint(breakpoint) {
+  const {
+    location: { sourceUrl, line, column },
+    condition,
+    disabled
+  } = breakpoint;
+
+  return {
+    location: { sourceUrl, line, column },
+    condition,
+    disabled
+  };
+}
+
 export const simpleMockThreadClient = {
-  setBreakpoint: (location, condition) => {
+  setBreakpoint: (location, _condition) => {
     return new Promise((resolve, reject) => {
       resolve({ id: "hi", actualLocation: location });
     });
   },
 
-  removeBreakpoint: id => {
+  removeBreakpoint: _id => {
     return new Promise((resolve, reject) => {
       resolve({ status: "done" });
     });
   },
 
-  setBreakpointCondition: (id, location, condition, noSliding) => {
+  setBreakpointCondition: (_id, _location, _condition, _noSliding) => {
     return new Promise((resolve, reject) => {
       resolve({ sourceId: "a", line: 5 });
     });

--- a/src/actions/tests/pending-breakpoints.js
+++ b/src/actions/tests/pending-breakpoints.js
@@ -245,4 +245,17 @@ describe("pending breakpoints", () => {
     bps = selectors.getBreakpoints(getState());
     expect(bps.size).to.be(1);
   });
+
+  it("when a sources are added, corresponding breakpoints are added as well", async () => {
+    const { dispatch, getState } = createStore(simpleMockThreadClient);
+
+    let bps = selectors.getBreakpoints(getState());
+    expect(bps.size).to.be(0);
+
+    const source1 = makeSource("bar.js");
+    const source2 = makeSource("foo.js");
+    await dispatch(actions.newSources([source1, source2]));
+    bps = selectors.getBreakpoints(getState());
+    expect(bps.size).to.be(1);
+  });
 });

--- a/src/actions/tests/pending-breakpoints.js
+++ b/src/actions/tests/pending-breakpoints.js
@@ -49,14 +49,14 @@ describe("when adding breakpoints", () => {
   describe("adding and deleting breakpoints", () => {
     let breakpoint1;
     let breakpoint2;
-    let breakpointId1;
-    let breakpointId2;
+    let breakpointLocationId1;
+    let breakpointLocationId2;
 
     beforeEach(() => {
       breakpoint1 = generateBreakpoint("foo");
       breakpoint2 = generateBreakpoint("foo2");
-      breakpointId1 = makePendingLocationId(breakpoint1.location);
-      breakpointId2 = makePendingLocationId(breakpoint2.location);
+      breakpointLocationId1 = makePendingLocationId(breakpoint1.location);
+      breakpointLocationId2 = makePendingLocationId(breakpoint2.location);
     });
 
     it("add a corresponding pendingBreakpoint for each addition", async () => {
@@ -65,10 +65,10 @@ describe("when adding breakpoints", () => {
       await dispatch(actions.addBreakpoint(breakpoint2.location));
 
       const pendingBps = selectors.getPendingBreakpoints(getState());
-      expect(pendingBps.get(breakpointId1)).to.eql(
+      expect(pendingBps.get(breakpointLocationId1)).to.eql(
         generatePendingBreakpoint(breakpoint1)
       );
-      expect(pendingBps.get(breakpointId2)).to.eql(
+      expect(pendingBps.get(breakpointLocationId2)).to.eql(
         generatePendingBreakpoint(breakpoint2)
       );
     });
@@ -80,8 +80,8 @@ describe("when adding breakpoints", () => {
       await dispatch(actions.removeBreakpoint(breakpoint1.location));
 
       const pendingBps = selectors.getPendingBreakpoints(getState());
-      expect(pendingBps.has(breakpointId1)).not.to.be(true);
-      expect(pendingBps.has(breakpointId2)).to.be(true);
+      expect(pendingBps.has(breakpointLocationId1)).not.to.be(true);
+      expect(pendingBps.has(breakpointLocationId2)).to.be(true);
     });
   });
 });

--- a/src/actions/tests/pending-breakpoints.js
+++ b/src/actions/tests/pending-breakpoints.js
@@ -1,0 +1,248 @@
+// TODO: we would like to mock this in the local tests
+const theMockedPendingBreakpoint = {
+  location: {
+    sourceUrl: "http://localhost:8000/examples/bar.js",
+    line: 5,
+    column: undefined
+  },
+  condition: "3",
+  disabled: false
+};
+
+jest.mock("../../utils/prefs", () => ({
+  prefs: {
+    expressions: [],
+    pendingBreakpoints: {
+      "http://localhost:8000/examples/bar.js:5:": {
+        location: {
+          sourceUrl: "http://localhost:8000/examples/bar.js",
+          line: 5,
+          column: undefined
+        },
+        condition: "3",
+        disabled: false
+      }
+    }
+  }
+}));
+
+import {
+  createStore,
+  selectors,
+  actions,
+  makeSource
+} from "../../utils/test-head";
+import {
+  makeLocationId,
+  makePendingLocationId
+} from "../../reducers/breakpoints";
+import expect from "expect.js";
+
+function generateBreakpoint(filename) {
+  return {
+    location: {
+      sourceUrl: `http://localhost:8000/examples/${filename}`,
+      sourceId: filename,
+      line: 5
+    },
+    condition: null,
+    disabled: false
+  };
+}
+
+function generatePendingBreakpoint(breakpoint) {
+  const {
+    location: { sourceUrl, line, column },
+    condition,
+    disabled
+  } = breakpoint;
+
+  return {
+    location: { sourceUrl, line, column },
+    condition,
+    disabled
+  };
+}
+
+function slideMockBp(bp) {
+  const slidBp = Object.assign({}, bp);
+  slidBp.location.line = bp.location.line + 2;
+  return slidBp;
+}
+
+const slidingMockThreadClient = {
+  setBreakpoint: (location, condition) => {
+    return new Promise((resolve, reject) => {
+      const actualLocation = Object.assign({}, location, {
+        line: location.line + 2
+      });
+      resolve({ id: makeLocationId(location), actualLocation, condition });
+    });
+  }
+};
+
+const simpleMockThreadClient = {
+  setBreakpoint: (location, condition) => {
+    return new Promise((resolve, reject) => {
+      resolve({ id: "hi", actualLocation: location });
+    });
+  },
+
+  removeBreakpoint: id => {
+    return new Promise((resolve, reject) => {
+      resolve({ status: "done" });
+    });
+  },
+
+  setBreakpointCondition: (id, location, condition, noSliding) => {
+    return new Promise((resolve, reject) => {
+      resolve({ sourceId: "a", line: 5 });
+    });
+  }
+};
+
+describe("pending breakpoints", () => {
+  it("when the user adds a breakpoint, a corresponding pending breakpoint should be added", async () => {
+    const { dispatch, getState } = createStore(simpleMockThreadClient);
+    const bp = generateBreakpoint("foo");
+    const id = makePendingLocationId(bp.location);
+
+    await dispatch(actions.addBreakpoint(bp.location));
+    const pendingBps = selectors.getPendingBreakpoints(getState());
+    expect(pendingBps.size).to.be(2);
+    expect(pendingBps.get(id)).to.eql(generatePendingBreakpoint(bp));
+  });
+
+  it("when the user adds a sliding breakpoint, a corresponding pending breakpoint should be added", async () => {
+    const { dispatch, getState } = createStore(slidingMockThreadClient);
+    const bp = generateBreakpoint("foo");
+    await dispatch(actions.addBreakpoint(bp.location));
+    const pendingBps = selectors.getPendingBreakpoints(getState());
+
+    const slidBp = slideMockBp(bp);
+    const newId = makePendingLocationId(slidBp.location);
+
+    const bps = selectors.getPendingBreakpoints(getState());
+    const newBp = pendingBps.get(newId);
+    expect(newBp).to.eql(generatePendingBreakpoint(slidBp));
+  });
+
+  describe("when two or more breakpoints are added", () => {
+    let breakpoint1;
+    let breakpoint2;
+    let breakpointId1;
+    let breakpointId2;
+
+    beforeEach(() => {
+      breakpoint1 = generateBreakpoint("foo");
+      breakpoint2 = generateBreakpoint("foo2");
+      breakpointId1 = makePendingLocationId(breakpoint1.location);
+      breakpointId2 = makePendingLocationId(breakpoint2.location);
+    });
+
+    it("adds a corresponding pendingBreakpoint for each new addition", async () => {
+      const { dispatch, getState } = createStore(simpleMockThreadClient);
+      await dispatch(actions.addBreakpoint(breakpoint1.location));
+      await dispatch(actions.addBreakpoint(breakpoint2.location));
+
+      const pendingBps = selectors.getPendingBreakpoints(getState());
+      expect(pendingBps.get(breakpointId1)).to.eql(
+        generatePendingBreakpoint(breakpoint1)
+      );
+      expect(pendingBps.get(breakpointId2)).to.eql(
+        generatePendingBreakpoint(breakpoint2)
+      );
+    });
+
+    it("removes a corresponding pending breakpoint for each deletion", async () => {
+      const { dispatch, getState } = createStore(simpleMockThreadClient);
+      await dispatch(actions.addBreakpoint(breakpoint1.location));
+      await dispatch(actions.addBreakpoint(breakpoint2.location));
+      await dispatch(actions.removeBreakpoint(breakpoint1.location));
+
+      const pendingBps = selectors.getPendingBreakpoints(getState());
+      expect(pendingBps.has(breakpointId1)).not.to.be(true);
+      expect(pendingBps.has(breakpointId2)).to.be(true);
+    });
+  });
+
+  it("when the user disables a breakpoint, the corresponding pending breakpoint is also disabled", async () => {
+    const { dispatch, getState } = createStore(simpleMockThreadClient);
+    const bp = generateBreakpoint("foo");
+    const id = makePendingLocationId(bp.location);
+
+    await dispatch(actions.addBreakpoint(bp.location));
+    await dispatch(actions.disableBreakpoint(bp.location));
+    const bps = selectors.getPendingBreakpoints(getState());
+    const breakpoint = bps.get(id);
+    expect(breakpoint.disabled).to.be(true);
+  });
+
+  it("when the user updates a breakpoint, the corresponding pending breakpoints is updated", async () => {
+    const { dispatch, getState } = createStore(simpleMockThreadClient);
+    const bp = generateBreakpoint("foo");
+    const id = makePendingLocationId(bp.location);
+
+    await dispatch(actions.addBreakpoint(bp.location));
+    await dispatch(
+      actions.setBreakpointCondition(bp.location, { condition: "2" })
+    );
+    const bps = selectors.getPendingBreakpoints(getState());
+    const breakpoint = bps.get(id);
+    expect(breakpoint.condition).to.be("2");
+  });
+
+  it("when the user updates a breakpoint, the corresponding pending breakpoints are not removed", async () => {
+    const { dispatch, getState } = createStore(simpleMockThreadClient);
+    const bp = generateBreakpoint("foo");
+    const id = makePendingLocationId(bp.location);
+
+    await dispatch(actions.addBreakpoint(bp.location));
+    await dispatch(
+      actions.setBreakpointCondition(bp.location, { condition: "2" })
+    );
+    const bps = selectors.getPendingBreakpoints(getState());
+    const breakpoint = bps.get(id);
+    expect(breakpoint.condition).to.be("2");
+  });
+
+  it("when the debugger opens, it adds pending breakpoints", async () => {
+    const { getState } = createStore(simpleMockThreadClient);
+    const id = makePendingLocationId(theMockedPendingBreakpoint.location);
+    const bps = selectors.getPendingBreakpoints(getState());
+    const bp = bps.get(id);
+    expect(bp).to.eql(generatePendingBreakpoint(theMockedPendingBreakpoint));
+  });
+
+  it("when a bp is added, where there is a corresponding pending breakpoint we update it", async () => {
+    const { dispatch, getState } = createStore(simpleMockThreadClient);
+    const bar = generateBreakpoint("bar.js");
+
+    await dispatch(actions.addBreakpoint(bar.location));
+
+    const bps = selectors.getPendingBreakpoints(getState());
+    expect(bps.size).to.be(1);
+  });
+
+  it("when a bp is added, it does not remove the other pending breakpoints", async () => {
+    const { dispatch, getState } = createStore(simpleMockThreadClient);
+    const bp = generateBreakpoint("foo.js");
+
+    await dispatch(actions.addBreakpoint(bp.location));
+
+    const bps = selectors.getPendingBreakpoints(getState());
+    expect(bps.size).to.be(2);
+  });
+
+  it("when a source is added, corresponding breakpoints are added as well", async () => {
+    const { dispatch, getState } = createStore(simpleMockThreadClient);
+
+    let bps = selectors.getBreakpoints(getState());
+    expect(bps.size).to.be(0);
+
+    const source = makeSource("bar.js");
+    await dispatch(actions.newSource(source));
+    bps = selectors.getBreakpoints(getState());
+    expect(bps.size).to.be(1);
+  });
+});

--- a/src/actions/tests/sources.js
+++ b/src/actions/tests/sources.js
@@ -12,9 +12,6 @@ const {
   getSourceText,
   getSourceTabs
 } = selectors;
-import fromJS from "../../utils/fromJS";
-import I from "immutable";
-import { makePendingBreakpoint } from "../../reducers/breakpoints";
 
 const threadClient = {
   sourceContents: function(sourceId) {
@@ -42,10 +39,10 @@ const threadClient = {
 process.on("unhandledRejection", (reason, p) => {});
 
 describe("sources", () => {
-  it("should add sources to state", () => {
+  it("should add sources to state", async () => {
     const { dispatch, getState } = createStore();
-    dispatch(actions.newSource(makeSource("base.js")));
-    dispatch(actions.newSource(makeSource("jquery.js")));
+    await dispatch(actions.newSource(makeSource("base.js")));
+    await dispatch(actions.newSource(makeSource("jquery.js")));
 
     expect(getSources(getState()).size).to.equal(2);
     const base = getSource(getState(), "base.js");
@@ -54,29 +51,29 @@ describe("sources", () => {
     expect(jquery.get("id")).to.equal("jquery.js");
   });
 
-  it("should select a source", () => {
+  it("should select a source", async () => {
     // Note that we pass an empty client in because the action checks
     // if it exists.
     const { dispatch, getState } = createStore(threadClient);
 
-    dispatch(actions.newSource(makeSource("foo.js")));
+    await dispatch(actions.newSource(makeSource("foo.js")));
     dispatch(actions.selectSource("foo.js"));
     expect(getSelectedSource(getState()).get("id")).to.equal("foo.js");
   });
 
-  it("should automatically select a pending source", () => {
+  it("should automatically select a pending source", async () => {
     const { dispatch, getState } = createStore(threadClient);
     const baseSource = makeSource("base.js");
     dispatch(actions.selectSourceURL(baseSource.url));
 
     expect(getSelectedSource(getState())).to.be(undefined);
-    dispatch(actions.newSource(baseSource));
+    await dispatch(actions.newSource(baseSource));
     expect(getSelectedSource(getState()).get("url")).to.be(baseSource.url);
   });
 
-  it("should open a tab for the source", () => {
+  it("should open a tab for the source", async () => {
     const { dispatch, getState } = createStore(threadClient);
-    dispatch(actions.newSource(makeSource("foo.js")));
+    await dispatch(actions.newSource(makeSource("foo.js")));
     dispatch(actions.selectSource("foo.js"));
 
     const tabs = getSourceTabs(getState());
@@ -84,11 +81,11 @@ describe("sources", () => {
     expect(tabs.get(0)).to.equal("http://localhost:8000/examples/foo.js");
   });
 
-  it("should select previous tab on tab closed", () => {
+  it("should select previous tab on tab closed", async () => {
     const { dispatch, getState } = createStore(threadClient);
-    dispatch(actions.newSource(makeSource("foo.js")));
-    dispatch(actions.newSource(makeSource("bar.js")));
-    dispatch(actions.newSource(makeSource("baz.js")));
+    await dispatch(actions.newSource(makeSource("foo.js")));
+    await dispatch(actions.newSource(makeSource("bar.js")));
+    await dispatch(actions.newSource(makeSource("baz.js")));
     dispatch(actions.selectSource("foo.js"));
     dispatch(actions.selectSource("bar.js"));
     dispatch(actions.selectSource("baz.js"));
@@ -97,11 +94,11 @@ describe("sources", () => {
     expect(getSourceTabs(getState()).size).to.be(2);
   });
 
-  it("should select next tab on tab closed if no previous tab", () => {
+  it("should select next tab on tab closed if no previous tab", async () => {
     const { dispatch, getState } = createStore(threadClient);
-    dispatch(actions.newSource(makeSource("foo.js")));
-    dispatch(actions.newSource(makeSource("bar.js")));
-    dispatch(actions.newSource(makeSource("baz.js")));
+    await dispatch(actions.newSource(makeSource("foo.js")));
+    await dispatch(actions.newSource(makeSource("bar.js")));
+    await dispatch(actions.newSource(makeSource("baz.js")));
     dispatch(actions.selectSource("foo.js"));
     dispatch(actions.selectSource("bar.js"));
     dispatch(actions.selectSource("baz.js"));
@@ -154,9 +151,9 @@ describe("sources", () => {
 });
 
 describe("closing tabs", () => {
-  it("closing a tab", () => {
+  it("closing a tab", async () => {
     const { dispatch, getState } = createStore(threadClient);
-    dispatch(actions.newSource(makeSource("foo.js")));
+    await dispatch(actions.newSource(makeSource("foo.js")));
     dispatch(actions.selectSource("foo.js"));
     dispatch(actions.closeTab("http://localhost:8000/examples/foo.js"));
 
@@ -164,10 +161,10 @@ describe("closing tabs", () => {
     expect(getSourceTabs(getState()).size).to.be(0);
   });
 
-  it("closing the inactive tab", () => {
+  it("closing the inactive tab", async () => {
     const { dispatch, getState } = createStore(threadClient);
-    dispatch(actions.newSource(makeSource("foo.js")));
-    dispatch(actions.newSource(makeSource("bar.js")));
+    await dispatch(actions.newSource(makeSource("foo.js")));
+    await dispatch(actions.newSource(makeSource("bar.js")));
     dispatch(actions.selectSource("foo.js"));
     dispatch(actions.selectSource("bar.js"));
     dispatch(actions.closeTab("http://localhost:8000/examples/foo.js"));
@@ -176,9 +173,9 @@ describe("closing tabs", () => {
     expect(getSourceTabs(getState()).size).to.be(1);
   });
 
-  it("closing the only tab", () => {
+  it("closing the only tab", async () => {
     const { dispatch, getState } = createStore(threadClient);
-    dispatch(actions.newSource(makeSource("foo.js")));
+    await dispatch(actions.newSource(makeSource("foo.js")));
     dispatch(actions.selectSource("foo.js"));
     dispatch(actions.closeTab("http://localhost:8000/examples/foo.js"));
 
@@ -186,10 +183,10 @@ describe("closing tabs", () => {
     expect(getSourceTabs(getState()).size).to.be(0);
   });
 
-  it("closing the active tab", () => {
+  it("closing the active tab", async () => {
     const { dispatch, getState } = createStore(threadClient);
-    dispatch(actions.newSource(makeSource("foo.js")));
-    dispatch(actions.newSource(makeSource("bar.js")));
+    await dispatch(actions.newSource(makeSource("foo.js")));
+    await dispatch(actions.newSource(makeSource("bar.js")));
     dispatch(actions.selectSource("foo.js"));
     dispatch(actions.selectSource("bar.js"));
     dispatch(actions.closeTab("http://localhost:8000/examples/bar.js"));
@@ -198,11 +195,11 @@ describe("closing tabs", () => {
     expect(getSourceTabs(getState()).size).to.be(1);
   });
 
-  it("closing many inactive tabs", () => {
+  it("closing many inactive tabs", async () => {
     const { dispatch, getState } = createStore({});
-    dispatch(actions.newSource(makeSource("foo.js")));
-    dispatch(actions.newSource(makeSource("bar.js")));
-    dispatch(actions.newSource(makeSource("bazz.js")));
+    await dispatch(actions.newSource(makeSource("foo.js")));
+    await dispatch(actions.newSource(makeSource("bar.js")));
+    await dispatch(actions.newSource(makeSource("bazz.js")));
     dispatch(actions.selectSource("foo.js"));
     dispatch(actions.selectSource("bar.js"));
     dispatch(actions.selectSource("bazz.js"));
@@ -217,11 +214,11 @@ describe("closing tabs", () => {
     expect(getSourceTabs(getState()).size).to.be(1);
   });
 
-  it("closing many tabs including the active tab", () => {
+  it("closing many tabs including the active tab", async () => {
     const { dispatch, getState } = createStore({});
-    dispatch(actions.newSource(makeSource("foo.js")));
-    dispatch(actions.newSource(makeSource("bar.js")));
-    dispatch(actions.newSource(makeSource("bazz.js")));
+    await dispatch(actions.newSource(makeSource("foo.js")));
+    await dispatch(actions.newSource(makeSource("bar.js")));
+    await dispatch(actions.newSource(makeSource("bazz.js")));
     dispatch(actions.selectSource("foo.js"));
     dispatch(actions.selectSource("bar.js"));
     dispatch(actions.selectSource("bazz.js"));
@@ -236,10 +233,10 @@ describe("closing tabs", () => {
     expect(getSourceTabs(getState()).size).to.be(1);
   });
 
-  it("closing all the tabs", () => {
+  it("closing all the tabs", async () => {
     const { dispatch, getState } = createStore({});
-    dispatch(actions.newSource(makeSource("foo.js")));
-    dispatch(actions.newSource(makeSource("bar.js")));
+    await dispatch(actions.newSource(makeSource("foo.js")));
+    await dispatch(actions.newSource(makeSource("bar.js")));
     dispatch(actions.selectSource("foo.js"));
     dispatch(actions.selectSource("bar.js"));
     dispatch(

--- a/src/actions/tests/sources.js
+++ b/src/actions/tests/sources.js
@@ -12,6 +12,9 @@ const {
   getSourceText,
   getSourceTabs
 } = selectors;
+import fromJS from "../../utils/fromJS";
+import I from "immutable";
+import { makePendingBreakpoint } from "../../reducers/breakpoints";
 
 const threadClient = {
   sourceContents: function(sourceId) {

--- a/src/client/firefox/commands.js
+++ b/src/client/firefox/commands.js
@@ -97,6 +97,7 @@ function onNewBreakpoint(
 ): BreakpointResult {
   const bpClient = res[1];
   let actualLocation = res[0].actualLocation;
+
   bpClients[bpClient.actor] = bpClient;
 
   // Firefox only returns `actualLocation` if it actually changed,
@@ -105,6 +106,7 @@ function onNewBreakpoint(
   actualLocation = actualLocation
     ? {
         sourceId: actualLocation.source.actor,
+        sourceUrl: location.sourceUrl,
         line: actualLocation.line,
         column: actualLocation.column
       }

--- a/src/reducers/breakpoints.js
+++ b/src/reducers/breakpoints.js
@@ -57,9 +57,10 @@ export function makeLocationId(location: Location) {
 }
 
 export function makePendingLocationId(location: Location) {
-  let { sourceUrl, line, column } = location;
-  column = column || "";
-  return `${sourceUrl}:${line}:${column}`;
+  const { sourceUrl, line, column } = location;
+  const sourceUrlString = sourceUrl || "";
+  const columnString = column || "";
+  return `${sourceUrlString}:${line}:${columnString}`;
 }
 
 function allBreakpointsDisabled(state) {
@@ -241,7 +242,7 @@ export function makePendingBreakpoint(bp: any) {
   return { condition, disabled, location };
 }
 
-function setPendingBreakpoints(state) {
+function setPendingBreakpoints(state: any) {
   prefs.pendingBreakpoints = state.pendingBreakpoints;
 }
 

--- a/src/test/mochitest/browser_dbg-sources.js
+++ b/src/test/mochitest/browser_dbg-sources.js
@@ -11,11 +11,11 @@ function* waitForSourceCount(dbg, i) {
   });
 }
 
-add_task(function* () {
+add_task(function*() {
   const dbg = yield initDebugger("doc-sources.html");
   const { selectors: { getSelectedSource }, getState } = dbg;
 
-  yield waitForSources(dbg, "simple1");
+  yield waitForSources(dbg, "simple1", "simple2", "nested-source", "long.js");
 
   // Expand nodes and make sure more sources appear.
   is(findAllElements(dbg, "sourceNodes").length, 2);
@@ -27,15 +27,21 @@ add_task(function* () {
   is(findAllElements(dbg, "sourceNodes").length, 8);
 
   // Select a source.
-  ok(!findElementWithSelector(dbg, ".sources-list .focused"),
-     "Source is not focused");
+  ok(
+    !findElementWithSelector(dbg, ".sources-list .focused"),
+    "Source is not focused"
+  );
   const selected = waitForDispatch(dbg, "SELECT_SOURCE");
   clickElement(dbg, "sourceNode", 4);
   yield selected;
-  ok(findElementWithSelector(dbg, ".sources-list .focused"),
-     "Source is focused");
-  ok(getSelectedSource(getState()).get("url").includes("nested-source.js"),
-     "The right source is selected");
+  ok(
+    findElementWithSelector(dbg, ".sources-list .focused"),
+    "Source is focused"
+  );
+  ok(
+    getSelectedSource(getState()).get("url").includes("nested-source.js"),
+    "The right source is selected"
+  );
 
   // Make sure new sources appear in the list.
   ContentTask.spawn(gBrowser.selectedBrowser, null, function() {
@@ -45,16 +51,20 @@ add_task(function* () {
   });
 
   yield waitForSourceCount(dbg, 9);
-  is(findElement(dbg, "sourceNode", 7).textContent,
-     "math.min.js",
-     "The dynamic script exists");
+  is(
+    findElement(dbg, "sourceNode", 7).textContent,
+    "math.min.js",
+    "The dynamic script exists"
+  );
 
   // Make sure named eval sources appear in the list.
   ContentTask.spawn(gBrowser.selectedBrowser, null, function() {
     content.eval("window.evaledFunc = function() {} //# sourceURL=evaled.js");
   });
   yield waitForSourceCount(dbg, 11);
-  is(findElement(dbg, "sourceNode", 2).textContent,
-     "evaled.js",
-     "The eval script exists");
+  is(
+    findElement(dbg, "sourceNode", 2).textContent,
+    "evaled.js",
+    "The eval script exists"
+  );
 });

--- a/src/test/tests-setup.js
+++ b/src/test/tests-setup.js
@@ -1,5 +1,4 @@
 global.Worker = require("workerjs");
-
 global.L10N = { getStr: () => {} };
 
 const path = require("path");

--- a/src/types.js
+++ b/src/types.js
@@ -30,6 +30,7 @@ export type Mode =
 
 export type {
   Breakpoint,
+  PendingBreakpoint,
   Frame,
   Grip,
   LoadedObject,


### PR DESCRIPTION
Associated Issue: #2817


### Summary of Changes

* Refactor how pending breakpoints are stored and updated in the reducer
* add lots of tests
* update checkPendingBreakpoints

