### PR TITLE
Fix Object Inspector toggling

### DIFF
--- a/src/components/SecondaryPanes/Scopes.js
+++ b/src/components/SecondaryPanes/Scopes.js
@@ -52,10 +52,7 @@ class Scopes extends PureComponent {
       scopeInspector = ObjectInspector({
         roots: scopes,
         getObjectProperties: id => loadedObjects.get(id),
-        loadObjectProperties: loadObjectProperties,
-        onLabelClick: (item, { expanded, setExpanded }) => {
-          setExpanded(item, !expanded);
-        }
+        loadObjectProperties: loadObjectProperties
       });
     }
 

--- a/src/components/shared/ObjectInspector.js
+++ b/src/components/shared/ObjectInspector.js
@@ -44,15 +44,6 @@ type ObjectInspectorItem = {
 };
 
 type DefaultProps = {
-  onLabelClick: (
-    item: ObjectInspectorItem,
-    params: {
-      depth: number,
-      focused: boolean,
-      expanded: boolean,
-      setExpanded: () => any
-    }
-  ) => void,
   onDoubleClick: (
     item: ObjectInspectorItem,
     params: {
@@ -170,16 +161,7 @@ class ObjectInspector extends Component {
       dom.span(
         {
           className: "object-label",
-          dir: "ltr",
-          onClick: event => {
-            event.stopPropagation();
-            this.props.onLabelClick(item, {
-              depth,
-              focused,
-              expanded,
-              setExpanded
-            });
-          }
+          dir: "ltr"
         },
         label
       ),
@@ -225,12 +207,10 @@ ObjectInspector.propTypes = {
   roots: PropTypes.array,
   getObjectProperties: PropTypes.func.isRequired,
   loadObjectProperties: PropTypes.func.isRequired,
-  onLabelClick: PropTypes.func.isRequired,
   onDoubleClick: PropTypes.func.isRequired
 };
 
 ObjectInspector.defaultProps = {
-  onLabelClick: () => {},
   onDoubleClick: () => {},
   autoExpandDepth: 1
 };


### PR DESCRIPTION
### Summary of Changes

* We had some issues where variables would not expand when you clicked on a label. The reason for that was that we had a special event handler for label clicks which was overriding the default.
* There are three components to look at when testing (Scopes, Expressions, Preview). The GIF below tests all three.


![](http://g.recordit.co/G5HrARFMGj.gif)