### PR TITLE
fix weird fromJS bug

### DIFF
--- a/src/utils/fromJS.js
+++ b/src/utils/fromJS.js
@@ -7,6 +7,21 @@
  */
 
 const Immutable = require("immutable");
+const isFunction = require("lodash/isFunction");
+
+// hasOwnProperty is defensive because it is possible that the
+// object that we're creating a map for has a `hasOwnProperty` field
+function hasOwnProperty(value, key) {
+  if (value.hasOwnProperty && isFunction(value.hasOwnProperty)) {
+    return value.hasOwnProperty(key);
+  }
+
+  if (value.prototype && value.prototype.hasOwnProperty) {
+    return value.prototype.hasOwnProperty(key);
+  }
+
+  return false;
+}
 
 /*
   creates an immutable map, where each of the value's
@@ -16,7 +31,7 @@ const Immutable = require("immutable");
   length confuses Immutable's internal algorithm.
 */
 function createMap(value) {
-  const hasLength = value.hasOwnProperty && value.hasOwnProperty("length");
+  const hasLength = hasOwnProperty(value, "length");
   const length = value.length;
 
   if (hasLength) {

--- a/src/utils/tests/fromJS.js
+++ b/src/utils/tests/fromJS.js
@@ -50,4 +50,25 @@ describe("fromJS", () => {
   it("supports objects without a prototype", () => {
     expect(() => fromJS(Object.create(null))).to.not.throwException();
   });
+
+  it("supports objects with `hasOwnProperty` fields", () => {
+    const value = {
+      lookupIterator: {
+        value: {},
+        writable: true
+      },
+
+      hasOwnProperty: {
+        value: {},
+        writable: true
+      },
+      arguments: {
+        value: {},
+        writable: false
+      }
+    };
+
+    const newMap = fromJS(value);
+    expect(newMap.getIn(["hasOwnProperty", "writable"])).to.equal(true);
+  });
 });


### PR DESCRIPTION

### Summary of Changes

* fixes a scary wtf bug in `fromJS` caused by a value that happens to have a `hasOwnProperty` field that we want to format. Note, this is one of the perils of building a product for JS in JS.

### Test Plan

* unit test the hell out of it