### PR TITLE
(WIP) Show preview on hovering over false booleans

### DIFF
--- a/src/components/Editor/Preview.js
+++ b/src/components/Editor/Preview.js
@@ -155,10 +155,18 @@ class Preview extends Component {
     return this.renderSimplePreview(value);
   }
 
+  getPreviewType(value) {
+    if (typeof value == "boolean" || value.class === "Function") {
+      return "tooltip";
+    }
+
+    return "popover";
+  }
+
   render() {
     const { popoverTarget, onClose, value, expression } = this.props;
 
-    let type = value.class === "Function" ? "tooltip" : "popover";
+    let type = this.getPreviewType(value);
 
     return Popover(
       {

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -800,7 +800,7 @@ class Editor extends PureComponent {
       getExpression: this.props.getExpression
     });
 
-    if (value.type == "undefined") {
+    if (typeof value == "undefined" || value.type == "undefined") {
       return;
     }
 

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -800,7 +800,7 @@ class Editor extends PureComponent {
       getExpression: this.props.getExpression
     });
 
-    if (!value || value.type == "undefined") {
+    if (value.type == "undefined") {
       return;
     }
 

--- a/src/utils/editor/expression.js
+++ b/src/utils/editor/expression.js
@@ -84,7 +84,7 @@ export function getExpressionValue(
   { getExpression }: Object
 ) {
   const variableValue = get(selectedExpression, "contents.value");
-  if (variableValue) {
+  if (typeof variableValue === "boolean" || variableValue) {
     return variableValue;
   }
 


### PR DESCRIPTION
Associated Issue: #2692 

### Summary of Changes
This is a **work in progress**... the screenshot below shows the desired enhancement, however, this introduces a `TypeError` when hovering over functions (screenshot of error added after the animation).

* add type check so getExpression does not return undefined

### Tests
* All existing unit tests pass

### Screenshots/Videos
Action shot:

![action-shot](https://camo.githubusercontent.com/29e4c32e39f0abc6347920bee59ba91db1e6265e/687474703a2f2f672e7265636f726469742e636f2f395353433070535444632e676966)

Error:
![error](https://cloud.githubusercontent.com/assets/3654683/26081382/87e043bc-3998-11e7-86d1-fd39888dc96d.jpg)