### PR TITLE
Resize conditional breakpoint panel after splitbox is resized

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -90,7 +90,7 @@ class App extends Component {
 
   renderEditorPane() {
     const { startPanelCollapsed, endPanelCollapsed } = this.props;
-    const { horizontal, endPanelSize } = this.state;
+    const { horizontal, endPanelSize, startPanelSize } = this.state;
     return dom.div(
       { className: "editor-pane" },
       dom.div(
@@ -101,7 +101,7 @@ class App extends Component {
           horizontal,
           endPanelSize
         }),
-        Editor({ horizontal }),
+        Editor({ horizontal, startPanelSize, endPanelSize }),
         !this.props.selectedSource ? WelcomeBox({ horizontal }) : null,
         ProjectSearch()
       )

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -148,6 +148,13 @@ class Editor extends PureComponent {
     const { sourceText, selectedLocation } = nextProps;
     this.clearDebugLine(this.props.selectedFrame);
 
+    if (
+      nextProps.startPanelSize !== this.props.startPanelSize ||
+      nextProps.endPanelSize !== this.props.endPanelSize
+    ) {
+      this.editor.codeMirror.setSize();
+    }
+
     if (!sourceText) {
       if (this.props.sourceText) {
         this.showMessage("");
@@ -878,7 +885,9 @@ Editor.propTypes = {
     caseSensitive: PropTypes.bool.isRequired,
     regexMatch: PropTypes.bool.isRequired,
     wholeWord: PropTypes.bool.isRequired
-  }).isRequired
+  }).isRequired,
+  startPanelSize: PropTypes.number,
+  endPanelSize: PropTypes.number
 };
 
 Editor.contextTypes = {


### PR DESCRIPTION
Associated Issue: #2317

### Summary of Changes

* Add `startPanelSize` and `endPanelSize` property to `Editor` component.
* Refresh editor size when the size is changed

### Screenshots/Videos (OPTIONAL)
![resize](https://cloud.githubusercontent.com/assets/1755089/26117512/72a26d58-3a84-11e7-8899-3f96047361b7.gif)
