### PR TITLE
add block statements to lexical scope determination

### DIFF
--- a/src/utils/parser/utils.js
+++ b/src/utils/parser/utils.js
@@ -239,7 +239,7 @@ function nodeContainsLocation({ node, location }) {
 }
 
 function isLexicalScope(path) {
-  return isFunction(path) || t.isProgram(path);
+  return t.isBlockStatement(path) || isFunction(path) || t.isProgram(path);
 }
 
 export function getSymbols(source: SourceText): SymbolDeclarations {

--- a/src/utils/tests/fixtures/resolveToken.js
+++ b/src/utils/tests/fixtures/resolveToken.js
@@ -17,3 +17,24 @@ const plusAB = (function(x, y) {
 
   return insideClosure;
 })(a, b);
+
+function withMultipleScopes() {
+  var outer = 1;
+  function innerScope() {
+    var inner = outer + 1;
+    return inner;
+  }
+
+  const fromIIFE = (function(toIIFE) {
+    return innerScope() + toIIFE;
+  })(1);
+
+  {
+    // random block
+    let x = outer + fromIIFE;
+    if (x) {
+      const y = x * x;
+      console.log(y);
+    }
+  }
+}

--- a/src/utils/tests/parser.js
+++ b/src/utils/tests/parser.js
@@ -233,6 +233,17 @@ describe("parser", () => {
         line: 3
       });
     });
+
+    it("finds variables in block scope", () => {
+      const scope = getClosestScope(getSourceText("resolveToken"), {
+        line: 34,
+        column: 13
+      });
+
+      var vars = getVariablesInLocalScope(scope);
+
+      expect(vars.map(v => v.name)).to.eql(["x"]);
+    });
   });
 
   describe("getVariablesInScope", () => {
@@ -253,6 +264,100 @@ describe("parser", () => {
         "four",
         "math",
         "child"
+      ]);
+    });
+
+    it("finds variables from multiple scopes", () => {
+      let vars;
+      const source = getSourceText("resolveToken");
+
+      vars = getVariablesInScope(
+        getClosestScope(source, {
+          line: 36,
+          column: 19
+        })
+      );
+
+      expect(vars).to.eql([
+        "this",
+        "arguments",
+        "y",
+        "x",
+        "innerScope",
+        "outer",
+        "fromIIFE",
+        "a",
+        "b",
+        "getA",
+        "setB",
+        "plusAB",
+        "withMultipleScopes"
+      ]);
+
+      vars = getVariablesInScope(
+        getClosestScope(source, {
+          line: 34,
+          column: 14
+        })
+      );
+
+      expect(vars).to.eql([
+        "this",
+        "arguments",
+        "x",
+        "innerScope",
+        "outer",
+        "fromIIFE",
+        "a",
+        "b",
+        "getA",
+        "setB",
+        "plusAB",
+        "withMultipleScopes"
+      ]);
+
+      vars = getVariablesInScope(
+        getClosestScope(source, {
+          line: 24,
+          column: 9
+        })
+      );
+
+      expect(vars).to.eql([
+        "this",
+        "arguments",
+        "inner",
+        "innerScope",
+        "outer",
+        "fromIIFE",
+        "a",
+        "b",
+        "getA",
+        "setB",
+        "plusAB",
+        "withMultipleScopes"
+      ]);
+
+      vars = getVariablesInScope(
+        getClosestScope(source, {
+          line: 28,
+          column: 33
+        })
+      );
+
+      expect(vars).to.eql([
+        "this",
+        "arguments",
+        "toIIFE",
+        "innerScope",
+        "outer",
+        "fromIIFE",
+        "a",
+        "b",
+        "getA",
+        "setB",
+        "plusAB",
+        "withMultipleScopes"
       ]);
     });
   });


### PR DESCRIPTION
Associated Issue: #2941 

Here's the Pull Request Doc
https://devtools-html.github.io/debugger.html/CONTRIBUTING.html#pull-requests

### Summary of Changes

* Adds `isBlockStatement` test to determine lexical scope to support `let`/`const` declarations
* Adds unit tests for retrieving variables within various scopes (`if`, simple block `{}`, IIFE, functions)

### Screenshots/Videos (OPTIONAL)

<img width="606" alt="image" src="https://cloud.githubusercontent.com/assets/788456/26207479/44ca23e2-3bad-11e7-88d0-f44492431a06.png">
