### PR TITLE
[SoucesTree] Show the host domain first when the debugger opens

### DIFF
--- a/src/actions/navigation.js
+++ b/src/actions/navigation.js
@@ -17,10 +17,14 @@ export function willNavigate(_, event) {
     await sourceMaps.clearSourceMaps();
     clearDocuments();
 
-    dispatch({
-      type: "NAVIGATE",
-      url: event.url
-    });
+    dispatch(navigate(event.url));
+  };
+}
+
+export function navigate(url) {
+  return {
+    type: "NAVIGATE",
+    url
   };
 }
 

--- a/src/actions/tests/navigation.js
+++ b/src/actions/tests/navigation.js
@@ -1,0 +1,9 @@
+import { createStore, selectors, actions } from "../../utils/test-head";
+import expect from "expect.js";
+describe("navigation", () => {
+  it("navigate sets the debuggeeUrl", () => {
+    const { dispatch, getState } = createStore();
+    dispatch(actions.navigate("http://test.com/foo"));
+    expect(selectors.getDebuggeeUrl(getState())).to.be("http://test.com/foo");
+  });
+});

--- a/src/client/firefox.js
+++ b/src/client/firefox.js
@@ -30,6 +30,7 @@ export async function onConnect(connection: any, actions: Object) {
   // bfcache) so explicity fire `newSource` events for all returned
   // sources.
   const sources = await clientCommands.fetchSources();
+  actions.navigate(tabTarget._form.url);
   await actions.newSources(sources);
 
   // If the threadClient is already paused, make sure to show a

--- a/src/client/firefox/tests/onconnect.js
+++ b/src/client/firefox/tests/onconnect.js
@@ -1,7 +1,10 @@
 import { onConnect } from "../../firefox";
 
 const tabTarget = {
-  on: () => {}
+  on: () => {},
+  _form: {
+    url: "url"
+  }
 };
 
 const threadClient = {
@@ -24,6 +27,7 @@ const debuggerClient = {};
 
 const actions = {
   _sources: [],
+  navigate: () => {},
 
   newSources: function(sources) {
     return new Promise(resolve => {

--- a/src/components/SourcesTree.js
+++ b/src/components/SourcesTree.js
@@ -121,6 +121,8 @@ class SourcesTree extends Component {
       return;
     }
 
+    // TODO: do not run this every time a source is clicked,
+    // only when a new source is added
     const next = Set(nextProps.sources.valueSeq());
     const prev = Set(this.props.sources.valueSeq());
     const newSet = next.subtract(prev);

--- a/src/components/SourcesTree.js
+++ b/src/components/SourcesTree.js
@@ -83,6 +83,11 @@ class SourcesTree extends Component {
   }
 
   componentWillReceiveProps(nextProps) {
+    if (this.props.debuggeeUrl != nextProps.debuggeeUrl) {
+      // Recreate tree because the sort order changed
+      this.setState(createTree(this.props.sources, nextProps.debuggeeUrl));
+      return;
+    }
     const { selectedSource } = this.props;
     if (
       nextProps.shownSource &&
@@ -117,6 +122,7 @@ class SourcesTree extends Component {
     }
 
     if (nextProps.sources.size === 0) {
+      // remove all sources
       this.setState(createTree(nextProps.sources, this.props.debuggeeUrl));
       return;
     }

--- a/src/test/mochitest/browser_dbg-sources.js
+++ b/src/test/mochitest/browser_dbg-sources.js
@@ -58,13 +58,32 @@ add_task(function*() {
   );
 
   // Make sure named eval sources appear in the list.
+});
+
+add_task(function*() {
+  const dbg = yield initDebugger("doc-sources.html");
+  const { selectors: { getSelectedSource }, getState } = dbg;
+
+  yield waitForSources(dbg, "simple1", "simple2", "nested-source", "long.js");
+
   ContentTask.spawn(gBrowser.selectedBrowser, null, function() {
     content.eval("window.evaledFunc = function() {} //# sourceURL=evaled.js");
   });
-  yield waitForSourceCount(dbg, 11);
+  yield waitForSourceCount(dbg, 3);
   is(
-    findElement(dbg, "sourceNode", 2).textContent,
+    findElement(dbg, "sourceNode", 3).textContent,
+    "(no domain)",
+    "the folder exists"
+  );
+
+  // work around: the folder is rendered at the bottom, so we close the
+  // root folder and open the (no domain) folder
+  clickElement(dbg, "sourceArrow", 3);
+  yield waitForSourceCount(dbg, 4);
+
+  is(
+    findElement(dbg, "sourceNode", 4).textContent,
     "evaled.js",
-    "The eval script exists"
+    "the eval script exists"
   );
 });

--- a/src/utils/sources-tree.js
+++ b/src/utils/sources-tree.js
@@ -207,10 +207,11 @@ function addToTree(tree: any, source: TmpSource, debuggeeUrl: string) {
       i === 0 ? debuggeeUrl : ""
     );
 
-    if (index >= 0 && children[index].name === part) {
+    const child = children.find(c => c.name === part);
+    if (child) {
       // A node with the same name already exists, simply traverse
       // into it.
-      subtree = children[index];
+      subtree = child;
     } else {
       // No node with this name exists, so insert a new one in the
       // place that is alphabetically sorted.
@@ -226,10 +227,10 @@ function addToTree(tree: any, source: TmpSource, debuggeeUrl: string) {
 
   // Overwrite the contents of the final node to store the source
   // there.
-  if (isDir) {
-    subtree.contents.unshift(createNode("(index)", source.get("url"), source));
-  } else {
+  if (!isDir) {
     subtree.contents = source;
+  } else if (!subtree.contents.find(c => c.name === "(index)")) {
+    subtree.contents.unshift(createNode("(index)", source.get("url"), source));
   }
 }
 


### PR DESCRIPTION
Associated Issue: #2448 

This seems to work.
But I'm still not sure why the navigate action removes all sources from the state.
