### PR TITLE
Save Search Modifiers as Prefs

### DIFF
--- a/assets/panel/prefs.js
+++ b/assets/panel/prefs.js
@@ -39,3 +39,6 @@ pref("devtools.debugger.tabs", "[]");
 pref("devtools.debugger.pending-selected-location", "{}");
 pref("devtools.debugger.pending-breakpoints", "[]");
 pref("devtools.debugger.expressions", "[]");
+pref("devtools.debugger.file-search-case-sensitive", true);
+pref("devtools.debugger.file-search-whole-word", false );
+pref("devtools.debugger.file-search-regex-match", false);

--- a/src/reducers/ui.js
+++ b/src/reducers/ui.js
@@ -99,10 +99,7 @@ function update(
         prefs.fileSearchRegexMatch = actionVal;
       }
 
-      return state.setIn(
-        ["fileSearchModifiers", action.modifier],
-        !state.getIn(["fileSearchModifiers", action.modifier])
-      );
+      return state.setIn(["fileSearchModifiers", action.modifier], actionVal);
     }
 
     case constants.SET_SYMBOL_SEARCH_TYPE: {

--- a/src/reducers/ui.js
+++ b/src/reducers/ui.js
@@ -43,9 +43,9 @@ export const State = makeRecord(
     fileSearchOn: false,
     fileSearchQuery: "",
     fileSearchModifiers: makeRecord({
-      caseSensitive: true,
-      wholeWord: false,
-      regexMatch: false
+      caseSensitive: prefs.fileSearchCaseSensitive,
+      wholeWord: prefs.fileSearchWholeWord,
+      regexMatch: prefs.fileSearchRegexMatch
     })(),
     projectSearchOn: false,
     symbolSearchOn: false,
@@ -85,6 +85,20 @@ function update(
     }
 
     case constants.TOGGLE_FILE_SEARCH_MODIFIER: {
+      const actionVal = !state.getIn(["fileSearchModifiers", action.modifier]);
+
+      if (action.modifier == "caseSensitive") {
+        prefs.fileSearchCaseSensitive = actionVal;
+      }
+
+      if (action.modifier == "wholeWord") {
+        prefs.fileSearchWholeWord = actionVal;
+      }
+
+      if (action.modifier == "regexMatch") {
+        prefs.fileSearchRegexMatch = actionVal;
+      }
+
       return state.setIn(
         ["fileSearchModifiers", action.modifier],
         !state.getIn(["fileSearchModifiers", action.modifier])

--- a/src/utils/prefs.js
+++ b/src/utils/prefs.js
@@ -17,6 +17,9 @@ if (isDevelopment()) {
   pref("devtools.debugger.pending-selected-location", "{}");
   pref("devtools.debugger.pending-breakpoints", "[]");
   pref("devtools.debugger.expressions", "[]");
+  pref("devtools.debugger.file-search-case-sensitive", true);
+  pref("devtools.debugger.file-search-whole-word", false);
+  pref("devtools.debugger.file-search-regex-match", false);
 }
 
 const prefs = new PrefsHelper("devtools", {
@@ -31,7 +34,10 @@ const prefs = new PrefsHelper("devtools", {
   tabs: ["Json", "debugger.tabs"],
   pendingSelectedLocation: ["Json", "debugger.pending-selected-location"],
   pendingBreakpoints: ["Json", "debugger.pending-breakpoints"],
-  expressions: ["Json", "debugger.expressions"]
+  expressions: ["Json", "debugger.expressions"],
+  fileSearchCaseSensitive: ["Bool", "debugger.file-search-case-sensitive"],
+  fileSearchWholeWord: ["Bool", "debugger.file-search-whole-word"],
+  fileSearchRegexMatch: ["Bool", "debugger.file-search-regex-match"]
 });
 
 module.exports = { prefs };


### PR DESCRIPTION
Associated Issue: #2850 

Summary of Changes

Preferences added for File Search options:
- Case-sensitive
- Regex
- Whole word

Test Plan

- Open the application and toggle the search options
- Go back/close application
- Open search options and the previously set values should be retained
