### PR TITLE
Show dropdown when resizing with splitter

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -99,7 +99,8 @@ class App extends Component {
           startPanelCollapsed,
           endPanelCollapsed,
           horizontal,
-          endPanelSize
+          endPanelSize,
+          startPanelSize
         }),
         Editor({ horizontal, startPanelSize, endPanelSize }),
         !this.props.selectedSource ? WelcomeBox({ horizontal }) : null,


### PR DESCRIPTION
Minor bugfix

When left splitter (in LTR mode) is used to resize editor tabs were not being refreshed.

### Summary of changes

* Add `startPanelSize` property to `EditorTabs` so it gets refreshed when `startPanelSize` changes

### Screenshots

|  |  |
|---------|------|
|Before|![recored-2017-05-22_201258-opt](https://cloud.githubusercontent.com/assets/1755089/26314454/a4d96712-3f2b-11e7-8a88-68daafbecd9d.gif)|
|After|![recored-2017-05-18_233304-opt](https://cloud.githubusercontent.com/assets/1755089/26314475/b418f418-3f2b-11e7-94df-831186b6e5f1.gif)|

