### PR TITLE
Bug/2817 breakpoints nightly won't delete breakpoints

### DIFF
--- a/src/actions/breakpoints.js
+++ b/src/actions/breakpoints.js
@@ -14,15 +14,26 @@ import { getBreakpoint, getBreakpoints, getSource } from "../selectors";
 import type { ThunkArgs } from "./types";
 import type { Location } from "../types";
 
-type addBreakpointOptions = { condition: string, getTextForLine?: () => any };
+type addBreakpointOptions = {
+  condition: string,
+  disabled?: boolean,
+  getTextForLine?: () => any
+};
 
 function _breakpointExists(state, location: Location) {
   const currentBp = getBreakpoint(state, location);
   return currentBp && !currentBp.disabled;
 }
 
-function _getOrCreateBreakpoint(state, location, condition) {
-  return getBreakpoint(state, location) || { location, condition, text: "" };
+function _getOrCreateBreakpoint(state, location, condition, disabled = false) {
+  return (
+    getBreakpoint(state, location) || {
+      location,
+      condition,
+      disabled,
+      text: ""
+    }
+  );
 }
 
 /**
@@ -46,14 +57,19 @@ export function enableBreakpoint(location: Location) {
  */
 export function addBreakpoint(
   location: Location,
-  { condition, getTextForLine }: addBreakpointOptions = {}
+  { condition, getTextForLine, disabled }: addBreakpointOptions = {}
 ) {
   return ({ dispatch, getState, client, sourceMaps }: ThunkArgs) => {
     if (_breakpointExists(getState(), location)) {
       return Promise.resolve();
     }
 
-    const bp = _getOrCreateBreakpoint(getState(), location, condition);
+    const bp = _getOrCreateBreakpoint(
+      getState(),
+      location,
+      condition,
+      disabled
+    );
 
     return dispatch({
       type: "ADD_BREAKPOINT",

--- a/src/actions/breakpoints.js
+++ b/src/actions/breakpoints.js
@@ -16,7 +16,6 @@ import type { Location } from "../types";
 
 type addBreakpointOptions = {
   condition: string,
-  disabled?: boolean,
   getTextForLine?: () => any
 };
 
@@ -25,12 +24,11 @@ function _breakpointExists(state, location: Location) {
   return currentBp && !currentBp.disabled;
 }
 
-function _getOrCreateBreakpoint(state, location, condition, disabled = false) {
+function _getOrCreateBreakpoint(state, location, condition) {
   return (
     getBreakpoint(state, location) || {
       location,
       condition,
-      disabled,
       text: ""
     }
   );
@@ -57,19 +55,14 @@ export function enableBreakpoint(location: Location) {
  */
 export function addBreakpoint(
   location: Location,
-  { condition, getTextForLine, disabled }: addBreakpointOptions = {}
+  { condition, getTextForLine }: addBreakpointOptions = {}
 ) {
   return ({ dispatch, getState, client, sourceMaps }: ThunkArgs) => {
     if (_breakpointExists(getState(), location)) {
       return Promise.resolve();
     }
 
-    const bp = _getOrCreateBreakpoint(
-      getState(),
-      location,
-      condition,
-      disabled
-    );
+    const bp = _getOrCreateBreakpoint(getState(), location, condition);
 
     return dispatch({
       type: "ADD_BREAKPOINT",

--- a/src/actions/sources.js
+++ b/src/actions/sources.js
@@ -14,7 +14,7 @@ import { PROMISE } from "../utils/redux/middleware/promise";
 import assert from "../utils/assert";
 import { updateFrameLocations } from "../utils/pause";
 import { setSymbols } from "./ast";
-import { addBreakpoint, disableBreakpoint } from "./breakpoints";
+import { addBreakpoint } from "./breakpoints";
 
 import { prettyPrint } from "../utils/pretty-print";
 import { getPrettySourceURL } from "../utils/source";
@@ -62,10 +62,6 @@ async function checkPendingBreakpoint(
 
   if (sameSource && !bp) {
     await dispatch(addBreakpoint(location, { condition, disabled }));
-    // if (location.column && isEnabled("columnBreakpoints")) {
-    //  await dispatch(addBreakpoint(location, { condition, disabled }));
-    // } else {
-    // }
   }
 }
 

--- a/src/actions/sources.js
+++ b/src/actions/sources.js
@@ -61,10 +61,7 @@ async function checkPendingBreakpoint(
   const bp = getBreakpoint(state, location);
 
   if (sameSource && !bp) {
-    await dispatch(addBreakpoint(location, { condition }));
-    if (disabled) {
-      await dispatch(disableBreakpoint(location));
-    }
+    await dispatch(addBreakpoint(location, { condition, disabled }));
     // if (location.column && isEnabled("columnBreakpoints")) {
     //  await dispatch(addBreakpoint(location, { condition, disabled }));
     // } else {

--- a/src/actions/sources.js
+++ b/src/actions/sources.js
@@ -55,7 +55,8 @@ async function checkPendingBreakpoint(
 ) {
   const {
     location: { line, sourceUrl, column },
-    condition
+    condition,
+    disabled
   } = pendingBreakpoint;
   const sameSource = sourceUrl && sourceUrl === source.url;
   const location = { sourceId: source.id, sourceUrl, line, column };
@@ -63,9 +64,9 @@ async function checkPendingBreakpoint(
 
   if (sameSource && !bp) {
     if (location.column && isEnabled("columnBreakpoints")) {
-      await dispatch(addBreakpoint(location, { condition }));
+      await dispatch(addBreakpoint(location, { condition, disabled }));
     } else {
-      await dispatch(addBreakpoint(location, { condition }));
+      await dispatch(addBreakpoint(location, { condition, disabled }));
     }
   }
 }

--- a/src/actions/sources.js
+++ b/src/actions/sources.js
@@ -13,10 +13,8 @@ import defer from "../utils/defer";
 import { PROMISE } from "../utils/redux/middleware/promise";
 import assert from "../utils/assert";
 import { updateFrameLocations } from "../utils/pause";
-import { addBreakpoint } from "./breakpoints";
 import { setSymbols } from "./ast";
-
-import { isEnabled } from "devtools-config";
+import { addBreakpoint, disableBreakpoint } from "./breakpoints";
 
 import { prettyPrint } from "../utils/pretty-print";
 import { getPrettySourceURL } from "../utils/source";
@@ -63,11 +61,14 @@ async function checkPendingBreakpoint(
   const bp = getBreakpoint(state, location);
 
   if (sameSource && !bp) {
-    if (location.column && isEnabled("columnBreakpoints")) {
-      await dispatch(addBreakpoint(location, { condition, disabled }));
-    } else {
-      await dispatch(addBreakpoint(location, { condition, disabled }));
+    await dispatch(addBreakpoint(location, { condition }));
+    if (disabled) {
+      await dispatch(disableBreakpoint(location));
     }
+    // if (location.column && isEnabled("columnBreakpoints")) {
+    //  await dispatch(addBreakpoint(location, { condition, disabled }));
+    // } else {
+    // }
   }
 }
 

--- a/src/actions/tests/helpers/breakpoints.js
+++ b/src/actions/tests/helpers/breakpoints.js
@@ -1,14 +1,17 @@
 import { makeLocationId } from "../../../reducers/breakpoints";
 
-export const theMockedPendingBreakpoint = {
-  location: {
-    sourceUrl: "http://localhost:8000/examples/bar.js",
-    line: 5,
-    column: undefined
-  },
-  condition: "3",
-  disabled: false
-};
+export function mockPendingBreakpoint(overrides = {}) {
+  const { sourceUrl, line, column, condition, disabled } = overrides;
+  return {
+    location: {
+      sourceUrl: sourceUrl || "http://localhost:8000/examples/bar.js",
+      line: line || 5,
+      column: column || undefined
+    },
+    condition: condition || "3",
+    disabled: disabled || false
+  };
+}
 
 export function generateCorrectedBreakpoint(breakpoint, correctedLocation) {
   return Object.assign({}, breakpoint, { location: correctedLocation });

--- a/src/actions/tests/pending-breakpoints.js
+++ b/src/actions/tests/pending-breakpoints.js
@@ -2,26 +2,18 @@
 import {
   generatePendingBreakpoint,
   generateBreakpoint,
-  theMockedPendingBreakpoint,
+  mockPendingBreakpoint,
   simulateCorrectThreadClient,
   generateCorrectedBreakpoint,
   simpleMockThreadClient
 } from "./helpers/breakpoints.js";
 
+import { prefs } from "../../utils/prefs";
+
 jest.mock("../../utils/prefs", () => ({
   prefs: {
     expressions: [],
-    pendingBreakpoints: {
-      "http://localhost:8000/examples/bar.js:5:": {
-        location: {
-          sourceUrl: "http://localhost:8000/examples/bar.js",
-          line: 5,
-          column: undefined
-        },
-        condition: "3",
-        disabled: false
-      }
-    }
+    pendingBreakpoints: {}
   }
 }));
 
@@ -34,6 +26,13 @@ import {
 import { makePendingLocationId } from "../../reducers/breakpoints";
 
 describe("when adding breakpoints", () => {
+  const mockedPendingBreakpoint = mockPendingBreakpoint();
+
+  beforeEach(() => {
+    const id = makePendingLocationId(mockedPendingBreakpoint.location);
+    prefs.pendingBreakpoints = { [id]: mockedPendingBreakpoint };
+  });
+
   it("a corresponding pending breakpoint should be added", async () => {
     const { dispatch, getState } = createStore(simpleMockThreadClient);
     const bp = generateBreakpoint("foo");
@@ -86,6 +85,13 @@ describe("when adding breakpoints", () => {
 });
 
 describe("when changing an existing breakpoint", () => {
+  const mockedPendingBreakpoint = mockPendingBreakpoint();
+
+  beforeEach(() => {
+    const id = makePendingLocationId(mockedPendingBreakpoint.location);
+    prefs.pendingBreakpoints = { [id]: mockedPendingBreakpoint };
+  });
+
   it("updates corresponding pendingBreakpoint", async () => {
     const { dispatch, getState } = createStore(simpleMockThreadClient);
     const bp = generateBreakpoint("foo");
@@ -128,15 +134,22 @@ describe("when changing an existing breakpoint", () => {
 });
 
 describe("initializing when pending breakpoints exist in perfs", () => {
-  it("syncs pending breakpoints", async () => {
-    const { getState } = createStore(simpleMockThreadClient);
-    const id = makePendingLocationId(theMockedPendingBreakpoint.location);
-    const bps = selectors.getPendingBreakpoints(getState());
-    const bp = bps.get(id);
-    expect(bp).toEqual(generatePendingBreakpoint(theMockedPendingBreakpoint));
+  const mockedPendingBreakpoint = mockPendingBreakpoint();
+
+  beforeEach(() => {
+    const id = makePendingLocationId(mockedPendingBreakpoint.location);
+    prefs.pendingBreakpoints = { [id]: mockedPendingBreakpoint };
   });
 
-  it("readding breakpoints update existing pending breakpoints", async () => {
+  it("syncs pending breakpoints", async () => {
+    const { getState } = createStore(simpleMockThreadClient);
+    const id = makePendingLocationId(mockedPendingBreakpoint.location);
+    const bps = selectors.getPendingBreakpoints(getState());
+    const bp = bps.get(id);
+    expect(bp).toEqual(generatePendingBreakpoint(mockedPendingBreakpoint));
+  });
+
+  it("re-adding breakpoints update existing pending breakpoints", async () => {
     const { dispatch, getState } = createStore(simpleMockThreadClient);
     const bar = generateBreakpoint("bar.js");
 
@@ -155,9 +168,23 @@ describe("initializing when pending breakpoints exist in perfs", () => {
     const bps = selectors.getPendingBreakpoints(getState());
     expect(bps.size).toBe(2);
   });
-});
 
+  it("syncs pending breakpoints", async () => {
+    const id = makePendingLocationId(mockedPendingBreakpoint.location);
+    const { getState } = createStore(simpleMockThreadClient);
+    const bps = selectors.getPendingBreakpoints(getState());
+    const bp = bps.get(id);
+    expect(bp).toEqual(generatePendingBreakpoint(mockedPendingBreakpoint));
+  });
+});
 describe("adding sources", () => {
+  const mockedPendingBreakpoint = mockPendingBreakpoint();
+
+  beforeEach(() => {
+    const id = makePendingLocationId(mockedPendingBreakpoint.location);
+    prefs.pendingBreakpoints = { [id]: mockedPendingBreakpoint };
+  });
+
   it("corresponding breakpoints are added for a single source", async () => {
     const { dispatch, getState } = createStore(simpleMockThreadClient);
 
@@ -185,6 +212,13 @@ describe("adding sources", () => {
 });
 
 describe("invalid breakpoint location", () => {
+  const mockedPendingBreakpoint = mockPendingBreakpoint();
+
+  beforeEach(() => {
+    const id = makePendingLocationId(mockedPendingBreakpoint.location);
+    prefs.pendingBreakpoints = { [id]: mockedPendingBreakpoint };
+  });
+
   it("a corrected corresponding pending breakpoint is added", async () => {
     // setup
     const bp = generateBreakpoint("foo");

--- a/src/reducers/breakpoints.js
+++ b/src/reducers/breakpoints.js
@@ -110,13 +110,12 @@ function addBreakpoint(state, action) {
   const id = makeLocationId(action.breakpoint.location);
   if (action.status === "start") {
     const bp = state.breakpoints.get(id) || action.breakpoint;
-    const bpExists = !!state.breakpoints.get(id);
 
     const updatedState = state
       .setIn(
         ["breakpoints", id],
         updateObj(bp, {
-          disabled: bpExists ? false : action.breakpoint.disabled,
+          disabled: false,
           loading: true,
           // We want to do an OR here, but we can't because we need
           // empty strings to be truthy, i.e. an empty string is a valid
@@ -146,6 +145,7 @@ function addBreakpoint(state, action) {
       ["breakpoints", locationId],
       updateObj(bp, {
         id: breakpointId,
+        disabled: false,
         loading: false,
         text: text
       })

--- a/src/reducers/breakpoints.js
+++ b/src/reducers/breakpoints.js
@@ -109,13 +109,14 @@ function update(
 function addBreakpoint(state, action) {
   const id = makeLocationId(action.breakpoint.location);
   if (action.status === "start") {
-    let bp = state.breakpoints.get(id) || action.breakpoint;
+    const bp = state.breakpoints.get(id) || action.breakpoint;
+    const bpExists = !!state.breakpoints.get(id);
 
     const updatedState = state
       .setIn(
         ["breakpoints", id],
         updateObj(bp, {
-          disabled: false,
+          disabled: bpExists ? false : action.breakpoint.disabled,
           loading: true,
           // We want to do an OR here, but we can't because we need
           // empty strings to be truthy, i.e. an empty string is a valid
@@ -145,7 +146,6 @@ function addBreakpoint(state, action) {
       ["breakpoints", locationId],
       updateObj(bp, {
         id: breakpointId,
-        disabled: false,
         loading: false,
         text: text
       })

--- a/src/reducers/breakpoints.js
+++ b/src/reducers/breakpoints.js
@@ -148,7 +148,7 @@ function addBreakpoint(state, action) {
     }
 
     const locationId = makeLocationId(location);
-    const bp = state.breakpoints.get(locationId);
+    const bp = state.breakpoints.get(locationId) || action.breakpoint;
     const updatedState = state.setIn(
       ["breakpoints", locationId],
       updateObj(bp, {

--- a/src/reducers/breakpoints.js
+++ b/src/reducers/breakpoints.js
@@ -24,7 +24,7 @@ export type BreakpointsState = {
   breakpointsDisabled: false
 };
 
-export function initialState() {
+export function initialState(): Record<BreakpointsState> {
   return makeRecord(
     ({
       breakpoints: I.Map(),

--- a/src/reducers/breakpoints.js
+++ b/src/reducers/breakpoints.js
@@ -24,13 +24,15 @@ export type BreakpointsState = {
   breakpointsDisabled: false
 };
 
-export const State = makeRecord(
-  ({
-    breakpoints: I.Map(),
-    pendingBreakpoints: restorePendingBreakpoints(),
-    breakpointsDisabled: false
-  }: BreakpointsState)
-);
+export function initialState() {
+  return makeRecord(
+    ({
+      breakpoints: I.Map(),
+      pendingBreakpoints: restorePendingBreakpoints(),
+      breakpointsDisabled: false
+    }: BreakpointsState)
+  )();
+}
 
 // Return the first argument that is a string, or null if nothing is a
 // string.
@@ -67,7 +69,10 @@ function allBreakpointsDisabled(state) {
   return state.breakpoints.every(x => x.disabled);
 }
 
-function update(state: Record<BreakpointsState> = State(), action: Action) {
+function update(
+  state: Record<BreakpointsState> = initialState(),
+  action: Action
+) {
   switch (action.type) {
     case "ADD_BREAKPOINT": {
       const newState = addBreakpoint(state, action);

--- a/src/test/integration/tests/breakpoints.js
+++ b/src/test/integration/tests/breakpoints.js
@@ -23,12 +23,12 @@ async function removeBreakpoint(dbg, index) {
 
 async function disableBreakpoint(dbg, index) {
   toggleBreakpoint(dbg, index);
-  await waitForDispatch(dbg, "REMOVE_BREAKPOINT");
+  await waitForDispatch(dbg, "DISABLE_BREAKPOINT");
 }
 
 async function enableBreakpoint(dbg, index) {
   toggleBreakpoint(dbg, index);
-  await waitForDispatch(dbg, "ADD_BREAKPOINT");
+  await waitForDispatch(dbg, "ENABLE_BREAKPOINT");
 }
 
 async function toggleBreakpoints(dbg) {

--- a/src/test/mochitest/browser_dbg-breakpoints.js
+++ b/src/test/mochitest/browser_dbg-breakpoints.js
@@ -8,7 +8,7 @@ function toggleBreakpoint(dbg, index) {
 }
 
 function removeBreakpoint(dbg, index) {
-  return Task.spawn(function* () {
+  return Task.spawn(function*() {
     const bp = findElement(dbg, "breakpointItem", index);
     bp.querySelector(".close-btn").click();
     yield waitForDispatch(dbg, "REMOVE_BREAKPOINT");
@@ -16,21 +16,21 @@ function removeBreakpoint(dbg, index) {
 }
 
 function disableBreakpoint(dbg, index) {
-  return Task.spawn(function* () {
+  return Task.spawn(function*() {
     toggleBreakpoint(dbg, index);
-    yield waitForDispatch(dbg, "REMOVE_BREAKPOINT");
+    yield waitForDispatch(dbg, "DISABLE_BREAKPOINT");
   });
 }
 
 function enableBreakpoint(dbg, index) {
-  return Task.spawn(function* () {
+  return Task.spawn(function*() {
     toggleBreakpoint(dbg, index);
-    yield waitForDispatch(dbg, "ADD_BREAKPOINT");
+    yield waitForDispatch(dbg, "ENABLE_BREAKPOINT");
   });
 }
 
 function toggleBreakpoints(dbg) {
-  return Task.spawn(function* () {
+  return Task.spawn(function*() {
     clickElement(dbg, "toggleBreakpoints");
     yield waitForDispatch(dbg, "TOGGLE_BREAKPOINTS");
   });
@@ -47,7 +47,7 @@ function findBreakpoints(dbg) {
   return getBreakpoints(getState());
 }
 
-add_task(function* () {
+add_task(function*() {
   const dbg = yield initDebugger("doc-scripts.html");
 
   // Create two breakpoints
@@ -70,7 +70,7 @@ add_task(function* () {
 });
 
 // toggle all
-add_task(function* () {
+add_task(function*() {
   const dbg = yield initDebugger("doc-scripts.html");
 
   // Create two breakpoints


### PR DESCRIPTION
Associated Issue: #2817 

### Summary of Changes

* updated pending breakpoint tests to use jest instead of expectjs
* made initialState for breakpoints be the initialState for the update function in the breakpoints reducer, rather than using a stale copy from when the file was initialized
* wrote tests for the bug
* fixed bug

### Test Plan

This feature is unit / integration tested

Example test plan:

- [x] open panel
- [x] set a break point
- [x] disable breakpoint
- [x] reload panel

### Screenshots/Videos (OPTIONAL)

set breakpoint:

<img width="303" alt="screen shot 2017-05-23 at 6 34 13 pm" src="https://cloud.githubusercontent.com/assets/26968615/26364984/88005c70-3fe6-11e7-823b-07889421b13a.png">

disable breakpoint:

<img width="306" alt="screen shot 2017-05-23 at 6 34 35 pm" src="https://cloud.githubusercontent.com/assets/26968615/26364987/89caa614-3fe6-11e7-9029-e102a6c41f8b.png">

reload debugger:

<img width="301" alt="screen shot 2017-05-23 at 6 34 26 pm" src="https://cloud.githubusercontent.com/assets/26968615/26364990/8b283080-3fe6-11e7-91ac-025055f8ecbb.png">
