### PR TITLE
Hide outline toggle button when outline is disabled

### DIFF
--- a/src/components/Sources.js
+++ b/src/components/Sources.js
@@ -8,6 +8,7 @@ import { formatKeyShortcut } from "../utils/text";
 import actions from "../actions";
 import Svg from "./shared/Svg";
 import { getSources } from "../selectors";
+import { isEnabled } from "devtools-config";
 import "./Sources.css";
 
 import _Outline from "./Outline";
@@ -45,32 +46,38 @@ class Sources extends Component {
     this.setState({ selectedPane });
   }
 
-  renderFooter() {
+  renderOutlineToggleButton() {
+    if (!isEnabled("outline")) {
+      return;
+    }
+
     const { selectedPane } = this.state;
     const showSourcesTooltip = L10N.getStr("sourcesPane.showSourcesTooltip");
     const showOutlineTooltip = L10N.getStr("sourcesPane.showOutlineTooltip");
+
     const isSourcesPaneSelected = selectedPane === "sources";
     const tooltip = isSourcesPaneSelected
       ? showOutlineTooltip
       : showSourcesTooltip;
     const type = isSourcesPaneSelected ? "showSources" : "showOutline";
 
+    return dom.button(
+      {
+        className: "action",
+        onClick: this.togglePane,
+        key: type,
+        title: tooltip
+      },
+      Svg(type)
+    );
+  }
+
+  renderFooter() {
     return dom.div(
       {
         className: "source-footer"
       },
-      dom.div(
-        { className: "commands" },
-        dom.button(
-          {
-            className: "action",
-            onClick: this.togglePane,
-            key: type,
-            title: tooltip
-          },
-          Svg(type)
-        )
-      )
+      dom.div({ className: "commands" }, this.renderOutlineToggleButton())
     );
   }
 


### PR DESCRIPTION
Associated Issue: #2993


### Summary of Changes

* Check if outline is enabled before displaying outline toggle button

### Screenshots

![no_outline](https://cloud.githubusercontent.com/assets/1755089/26365387/1b83b8c0-4005-11e7-8ee1-e6231a12a437.png)
