### PR TITLE
Have firefox onConnect wait for newSources

### DIFF
--- a/src/client/firefox.js
+++ b/src/client/firefox.js
@@ -30,7 +30,7 @@ export async function onConnect(connection: any, actions: Object) {
   // bfcache) so explicity fire `newSource` events for all returned
   // sources.
   const sources = await clientCommands.fetchSources();
-  actions.newSources(sources);
+  await actions.newSources(sources);
 
   // If the threadClient is already paused, make sure to show a
   // paused state.

--- a/src/client/firefox/tests/onconnect.js
+++ b/src/client/firefox/tests/onconnect.js
@@ -1,0 +1,53 @@
+import { onConnect } from "../../firefox";
+
+const tabTarget = {
+  on: () => {}
+};
+
+const threadClient = {
+  addListener: () => {},
+  reconfigure: () => {},
+  getSources: () => {
+    return {
+      sources: [
+        {
+          id: "s.js",
+          url: "file:///tmp/s.js"
+        }
+      ]
+    };
+  },
+  getLastPausePacket: () => null
+};
+
+const debuggerClient = {};
+
+const actions = {
+  _sources: [],
+
+  newSources: function(sources) {
+    return new Promise(resolve => {
+      setTimeout(() => {
+        this._sources = sources;
+        resolve();
+      }, 0);
+    });
+  }
+};
+
+describe("firefox onConnect", () => {
+  it("wait for sources at startup", async () => {
+    await onConnect(
+      {
+        tabConnection: {
+          tabTarget,
+          threadClient,
+          debuggerClient
+        }
+      },
+      actions
+    );
+    expect(actions._sources.length).toEqual(1);
+    expect(actions._sources[0].url).toEqual("file:///tmp/s.js");
+  });
+});


### PR DESCRIPTION
This fixes a race where panel.js can report that the debugger has
started, but where getSources will still return null for a source that
does in fact exist.
See https://bugzilla.mozilla.org/show_bug.cgi?id=1364526
