### PR TITLE
make sure we deselect sources

### DIFF
--- a/src/actions/sources.js
+++ b/src/actions/sources.js
@@ -190,10 +190,7 @@ export function selectSource(id: string, options: SelectSourceOptions = {}) {
 
     if (!source) {
       // If there is no source we deselect the current selected source
-      return dispatch({
-        type: constants.SELECT_SOURCE,
-        source: { id, url: null }
-      });
+      clearSelectedSource();
     }
 
     source = source.toJS();
@@ -209,6 +206,12 @@ export function selectSource(id: string, options: SelectSourceOptions = {}) {
       tabIndex: options.tabIndex,
       line: options.line
     });
+  };
+}
+
+export function clearSelectedSource() {
+  return ({ dispatch, getState, client }: ThunkArgs) => {
+    dispatch({ type: constants.CLEAR_SELECTED_SOURCE });
   };
 }
 

--- a/src/actions/types.js
+++ b/src/actions/types.js
@@ -119,7 +119,8 @@ type SourceAction =
         frames: Frame[]
       }
     }
-  | { type: "CLOSE_TAB", url: string };
+  | { type: "CLOSE_TAB", url: string, tabs: any }
+  | { type: "CLOSE_TABS", urls: Array<string>, tabs: any };
 
 export type panelPositionType = "start" | "end";
 

--- a/src/reducers/sources.js
+++ b/src/reducers/sources.js
@@ -114,14 +114,12 @@ function update(
       return state.set("pendingSelectedLocation", location);
 
     case "CLOSE_TAB":
-      availableTabs = removeSourceFromTabList(state.tabs, action.url);
-
-      return state.merge({ tabs: availableTabs });
+      prefs.tabs = action.tabs;
+      return state.merge({ tabs: action.tabs });
 
     case "CLOSE_TABS":
-      availableTabs = removeSourcesFromTabList(state.tabs, action.urls);
-
-      return state.merge({ tabs: availableTabs });
+      prefs.tabs = action.tabs;
+      return state.merge({ tabs: action.tabs });
 
     case "LOAD_SOURCE_TEXT":
       return _updateText(state, action);
@@ -184,13 +182,11 @@ function _updateText(state, action: any): Record<SourcesState> {
   );
 }
 
-function removeSourceFromTabList(tabs, url) {
-  const newTabs = tabs.filter(tab => tab != url);
-  prefs.tabs = newTabs;
-  return newTabs;
+export function removeSourceFromTabList(tabs, url) {
+  return tabs.filter(tab => tab != url);
 }
 
-function removeSourcesFromTabList(tabs, urls) {
+export function removeSourcesFromTabList(tabs, urls) {
   return urls.reduce((t, url) => removeSourceFromTabList(t, url), tabs);
 }
 

--- a/src/reducers/sources.js
+++ b/src/reducers/sources.js
@@ -182,11 +182,11 @@ function _updateText(state, action: any): Record<SourcesState> {
   );
 }
 
-export function removeSourceFromTabList(tabs, url) {
+export function removeSourceFromTabList(tabs: any, url: string) {
   return tabs.filter(tab => tab != url);
 }
 
-export function removeSourcesFromTabList(tabs, urls) {
+export function removeSourcesFromTabList(tabs: any, urls: Array<string>) {
   return urls.reduce((t, url) => removeSourceFromTabList(t, url), tabs);
 }
 
@@ -204,7 +204,7 @@ function restoreTabs() {
  * @memberof reducers/sources
  * @static
  */
-function updateTabList(state: OuterState, url: string, tabIndex?: number) {
+function updateTabList(state: OuterState, url: ?string, tabIndex?: number) {
   let tabs = state.sources.get("tabs");
 
   const urlIndex = tabs.indexOf(url);
@@ -233,20 +233,19 @@ function updateTabList(state: OuterState, url: string, tabIndex?: number) {
  */
 export function getNewSelectedSourceId(
   state: OuterState,
-  availableTabs
+  availableTabs: any
 ): string {
-  state = state.sources;
-  const selectedLocation = state.selectedLocation;
+  const selectedLocation = state.sources.selectedLocation;
   if (!selectedLocation) {
     return "";
   }
 
-  const selectedTab = state.sources.get(selectedLocation.sourceId);
+  const selectedTab = state.sources.sources.get(selectedLocation.sourceId);
 
   const selectedTabUrl = selectedTab ? selectedTab.get("url") : "";
 
   if (availableTabs.includes(selectedTabUrl)) {
-    const sources = state.sources;
+    const sources = state.sources.sources;
     if (!sources) {
       return "";
     }
@@ -262,12 +261,15 @@ export function getNewSelectedSourceId(
     return "";
   }
 
-  const tabUrls = state.tabs.toJS();
+  const tabUrls = state.sources.tabs.toJS();
   const leftNeighborIndex = Math.max(tabUrls.indexOf(selectedTabUrl) - 1, 0);
   const lastAvailbleTabIndex = availableTabs.size - 1;
   const newSelectedTabIndex = Math.min(leftNeighborIndex, lastAvailbleTabIndex);
   const availableTab = availableTabs.toJS()[newSelectedTabIndex];
-  const tabSource = getSourceByUrlInSources(state.sources, availableTab);
+  const tabSource = getSourceByUrlInSources(
+    state.sources.sources,
+    availableTab
+  );
 
   if (tabSource) {
     return tabSource.get("id");

--- a/src/reducers/sources.js
+++ b/src/reducers/sources.js
@@ -57,7 +57,6 @@ function update(
   state: Record<SourcesState> = State(),
   action: Action
 ): Record<SourcesState> {
-  let availableTabs = null;
   let location = null;
 
   switch (action.type) {

--- a/src/reducers/sources.js
+++ b/src/reducers/sources.js
@@ -75,11 +75,9 @@ function update(
     }
 
     case "SELECT_SOURCE":
-      const sourceUrl = action.source.url || "";
-
       location = {
         line: action.line,
-        url: sourceUrl
+        url: action.source.url
       };
 
       prefs.pendingSelectedLocation = location;
@@ -91,8 +89,20 @@ function update(
         })
         .set("pendingSelectedLocation", location)
         .merge({
-          tabs: updateTabList({ sources: state }, sourceUrl, action.tabIndex)
+          tabs: updateTabList(
+            { sources: state },
+            action.source.url,
+            action.tabIndex
+          )
         });
+
+    case "CLEAR_SELECTED_SOURCE":
+      location = { url: "" };
+      prefs.pendingSelectedLocation = location;
+
+      return state
+        .set("selectedLocation", { sourceId: "" })
+        .set("pendingSelectedLocation", location);
 
     case "SELECT_SOURCE_URL":
       location = {

--- a/src/reducers/sources.js
+++ b/src/reducers/sources.js
@@ -75,13 +75,15 @@ function update(
     }
 
     case "SELECT_SOURCE":
+      const sourceUrl = action.source.url || "";
+
       location = {
         line: action.line,
-        url: action.source.url
+        url: sourceUrl
       };
+
       prefs.pendingSelectedLocation = location;
 
-      const sourceUrl = action.source.url || "";
       return state
         .set("selectedLocation", {
           sourceId: action.source.id,
@@ -104,16 +106,12 @@ function update(
     case "CLOSE_TAB":
       availableTabs = removeSourceFromTabList(state.tabs, action.url);
 
-      return state.merge({ tabs: availableTabs }).set("selectedLocation", {
-        sourceId: getNewSelectedSourceId(state, availableTabs)
-      });
+      return state.merge({ tabs: availableTabs });
 
     case "CLOSE_TABS":
       availableTabs = removeSourcesFromTabList(state.tabs, action.urls);
 
-      return state.merge({ tabs: availableTabs }).set("selectedLocation", {
-        sourceId: getNewSelectedSourceId(state, availableTabs)
-      });
+      return state.merge({ tabs: availableTabs });
 
     case "LOAD_SOURCE_TEXT":
       return _updateText(state, action);
@@ -227,7 +225,11 @@ function updateTabList(state: OuterState, url: string, tabIndex?: number) {
  * @memberof reducers/sources
  * @static
  */
-function getNewSelectedSourceId(state: SourcesState, availableTabs): string {
+export function getNewSelectedSourceId(
+  state: OuterState,
+  availableTabs
+): string {
+  state = state.sources;
   const selectedLocation = state.selectedLocation;
   if (!selectedLocation) {
     return "";

--- a/src/selectors.js
+++ b/src/selectors.js
@@ -15,6 +15,8 @@ import * as coverage from "./reducers/coverage";
 module.exports = {
   getSource: sources.getSource,
   getNewSelectedSourceId: sources.getNewSelectedSourceId,
+  removeSourceFromTabList: sources.removeSourceFromTabList,
+  removeSourcesFromTabList: sources.removeSourcesFromTabList,
   getSourceByURL: sources.getSourceByURL,
   getSourceInSources: sources.getSourceInSources,
   getSources: sources.getSources,

--- a/src/selectors.js
+++ b/src/selectors.js
@@ -14,6 +14,7 @@ import * as coverage from "./reducers/coverage";
 
 module.exports = {
   getSource: sources.getSource,
+  getNewSelectedSourceId: sources.getNewSelectedSourceId,
   getSourceByURL: sources.getSourceByURL,
   getSourceInSources: sources.getSourceInSources,
   getSources: sources.getSources,


### PR DESCRIPTION
Associated Issue: #2715

WIP 
Todo - Fix issue causing failing test

### Summary of Changes

* Call the `selectSource` action on `closeTab/s` to select the next available tab
* If no source is found dispatch an action to trigger clearing of the currently loaded source
* export `getNewSelectedSourceId` 

### Test Plan
- [x] Select multiple sources from the source tree
- [x] After all the tab have been opened, refresh the debugger
- [x] After debugger reloads, close the selected tab
- [x] The source of the next selected tab should be loaded
- [x] Close all the tabs
- [x] The loaded source text should be removed

