### PR TITLE
(WIP) Switch shared/Popover from PropTypes to flow props

### DIFF
--- a/src/components/shared/Popover.js
+++ b/src/components/shared/Popover.js
@@ -7,7 +7,7 @@ const BracketArrow = createFactory(_BracketArrow);
 
 import "./Popover.css";
 
-export type Props = {
+type Props = {
   target?: Object,
   children?: Object,
   onMouseLeave?: Function,

--- a/src/components/shared/Popover.js
+++ b/src/components/shared/Popover.js
@@ -1,4 +1,5 @@
-import { DOM as dom, PropTypes, createFactory, Component } from "react";
+/* @flow */
+import { DOM as dom, createFactory, Component } from "react";
 import ReactDOM from "../../../node_modules/react-dom/dist/react-dom";
 import classNames from "classnames";
 import _BracketArrow from "./BracketArrow";
@@ -6,7 +7,19 @@ const BracketArrow = createFactory(_BracketArrow);
 
 import "./Popover.css";
 
+export type Props = {
+  target?: Object,
+  children?: Object,
+  onMouseLeave?: Function,
+  type?: string
+};
+
 class Popover extends Component {
+  state: {
+    left: number,
+    top: number
+  };
+
   constructor() {
     super();
     this.state = {
@@ -14,6 +27,8 @@ class Popover extends Component {
       top: 0
     };
   }
+
+  props: Props;
 
   componentDidMount() {
     const { type } = this.props;
@@ -142,13 +157,6 @@ class Popover extends Component {
     return this.renderPopover();
   }
 }
-
-Popover.propTypes = {
-  target: PropTypes.object,
-  children: PropTypes.object,
-  onMouseLeave: PropTypes.func,
-  type: PropTypes.string
-};
 
 Popover.defaultProps = {
   onMouseLeave: () => {},


### PR DESCRIPTION
Associated Issue: #2804 

### Summary of Changes
convert from PropTypes to props using [codemod-proptypes-to-flow](https://github.com/billyvg/codemod-proptypes-to-flow)

### Test Plan
 - [x] yarn test-all
 - [x] hover over variables works
 - [ ] yarn flow: getting many Flow errors (shown below in screenshot), I would be most grateful for a bit of guidance on how to resolve them :)

### Screenshots
![iterm2002](https://cloud.githubusercontent.com/assets/3654683/26466492/e4649b4e-415c-11e7-8e37-3abc6c0aa754.jpg)
![iterm2003](https://cloud.githubusercontent.com/assets/3654683/26466496/e6a58ec2-415c-11e7-9aaf-edcbe68335f3.jpg)



