### PR TITLE
remove optimized away values

### DIFF
--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -801,7 +801,11 @@ class Editor extends PureComponent {
       getExpression: this.props.getExpression
     });
 
-    if (typeof value == "undefined" || value.type == "undefined") {
+    if (
+      typeof value == "undefined" ||
+      value.type == "undefined" ||
+      value.optimizedOut
+    ) {
       return;
     }
 


### PR DESCRIPTION
Associated Issue: #2908

### Summary of Changes

* Check for `optimizedOut` property on the value

### Test Plan

- [x] Pause on breakpoint
- [x] Hover over optimzed away value
