### PR TITLE
Fix DOM event properties not showing up in the OI

### DIFF
--- a/src/client/firefox/commands.js
+++ b/src/client/firefox/commands.js
@@ -182,13 +182,9 @@ function getProperties(grip: Grip): Promise<*> {
   return objClient.getPrototypeAndProperties().then(resp => {
     const { ownProperties, safeGetterValues } = resp;
     for (const name in safeGetterValues) {
-      const { getterValue } = safeGetterValues[name];
-      if (!ownProperties[name]) {
-        ownProperties[name] = { ...safeGetterValues[name] };
-      }
-      ownProperties[name].value = getterValue;
+      const { enumerable, writable, getterValue } = safeGetterValues[name];
+      ownProperties[name] = { enumerable, writable, value: getterValue };
     }
-
     return resp;
   });
 }

--- a/src/client/firefox/commands.js
+++ b/src/client/firefox/commands.js
@@ -181,13 +181,12 @@ function getProperties(grip: Grip): Promise<*> {
 
   return objClient.getPrototypeAndProperties().then(resp => {
     const { ownProperties, safeGetterValues } = resp;
-    for (let name in safeGetterValues) {
-      if (name in ownProperties) {
-        let { getterValue } = safeGetterValues[name];
-        ownProperties[name].value = getterValue;
-      } else {
-        ownProperties[name] = safeGetterValues[name];
+    for (const name in safeGetterValues) {
+      const { getterValue } = safeGetterValues[name];
+      if (!ownProperties[name]) {
+        ownProperties[name] = { ...safeGetterValues[name] };
       }
+      ownProperties[name].value = getterValue;
     }
 
     return resp;

--- a/src/client/firefox/tests/__snapshots__/commands.js.snap
+++ b/src/client/firefox/tests/__snapshots__/commands.js.snap
@@ -1,0 +1,66 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`firefox commands getProperties empty response 1`] = `
+Object {
+  "ownProperties": Object {},
+  "safeGetterValues": Object {},
+}
+`;
+
+exports[`firefox commands getProperties getter values 1`] = `
+Object {
+  "ownProperties": Object {
+    "foo": Object {
+      "value": "foo",
+    },
+    "obj": Object {
+      "enumerable": true,
+      "value": "getter",
+      "writable": false,
+    },
+  },
+  "safeGetterValues": Object {
+    "obj": Object {
+      "enumerable": true,
+      "getterValue": "getter",
+      "writable": false,
+    },
+  },
+}
+`;
+
+exports[`firefox commands getProperties new getter values 1`] = `
+Object {
+  "ownProperties": Object {
+    "foo": Object {
+      "value": "foo",
+    },
+    "obj": Object {
+      "enumerable": true,
+      "value": "getter",
+      "writable": false,
+    },
+  },
+  "safeGetterValues": Object {
+    "obj": Object {
+      "enumerable": true,
+      "getterValue": "getter",
+      "writable": false,
+    },
+  },
+}
+`;
+
+exports[`firefox commands getProperties simple properties 1`] = `
+Object {
+  "ownProperties": Object {
+    "foo": Object {
+      "value": "foo",
+    },
+    "obj": Object {
+      "value": "obj",
+    },
+  },
+  "safeGetterValues": Object {},
+}
+`;

--- a/src/client/firefox/tests/commands.js
+++ b/src/client/firefox/tests/commands.js
@@ -73,14 +73,17 @@ describe("firefox commands", () => {
           foo: { value: "foo" }
         },
         safeGetterValues: {
-          obj: { value: "getter" }
+          obj: { getterValue: "getter" }
         }
       });
 
       const expected = {
-        ownProperties: { foo: { value: "foo" }, obj: { value: "getter" } },
+        ownProperties: {
+          foo: { value: "foo" },
+          obj: { getterValue: "getter", value: "getter" }
+        },
         safeGetterValues: {
-          obj: { value: "getter" }
+          obj: { getterValue: "getter" }
         }
       };
 

--- a/src/client/firefox/tests/commands.js
+++ b/src/client/firefox/tests/commands.js
@@ -19,7 +19,7 @@ describe("firefox commands", () => {
 
       setupCommands({ threadClient });
       const props = await getProperties({});
-      expect(props).toEqual({ ownProperties: {}, safeGetterValues: {} });
+      expect(props).toMatchSnapshot();
     });
 
     it("simple properties", async () => {
@@ -32,14 +32,9 @@ describe("firefox commands", () => {
         safeGetterValues: {}
       });
 
-      const expected = {
-        ownProperties: { foo: { value: "foo" }, obj: { value: "obj" } },
-        safeGetterValues: {}
-      };
-
       setupCommands({ threadClient });
       const props = await getProperties({});
-      expect(props).toEqual(expected);
+      expect(props).toMatchSnapshot();
     });
 
     it("getter values", async () => {
@@ -50,20 +45,13 @@ describe("firefox commands", () => {
           foo: { value: "foo" }
         },
         safeGetterValues: {
-          obj: { getterValue: "getter" }
+          obj: { getterValue: "getter", enumerable: true, writable: false }
         }
       });
 
-      const expected = {
-        ownProperties: { foo: { value: "foo" }, obj: { value: "getter" } },
-        safeGetterValues: {
-          obj: { getterValue: "getter" }
-        }
-      };
-
       setupCommands({ threadClient });
       const props = await getProperties({});
-      expect(props).toEqual(expected);
+      expect(props).toMatchSnapshot();
     });
 
     it("new getter values", async () => {
@@ -73,23 +61,13 @@ describe("firefox commands", () => {
           foo: { value: "foo" }
         },
         safeGetterValues: {
-          obj: { getterValue: "getter" }
+          obj: { getterValue: "getter", enumerable: true, writable: false }
         }
       });
 
-      const expected = {
-        ownProperties: {
-          foo: { value: "foo" },
-          obj: { getterValue: "getter", value: "getter" }
-        },
-        safeGetterValues: {
-          obj: { getterValue: "getter" }
-        }
-      };
-
       setupCommands({ threadClient });
       const props = await getProperties({});
-      expect(props).toEqual(expected);
+      expect(props).toMatchSnapshot();
     });
   });
 });

--- a/src/test/mochitest/browser_dbg-scopes.js
+++ b/src/test/mochitest/browser_dbg-scopes.js
@@ -23,7 +23,7 @@ add_task(function*() {
 
   toggleNode(dbg, 4);
   yield waitForDispatch(dbg, "LOAD_OBJECT_PROPERTIES");
-  is(getLabel(dbg, 5), "length");
+  is(getLabel(dbg, 5), "arguments");
 
   yield stepOver(dbg);
   is(getLabel(dbg, 4), "foo()");


### PR DESCRIPTION
Associated Issue: #2849

### Summary of Changes

* Fix logic for copying Safe getter values
* Fix tests

### Test Plan

- [x] Break on Dom event
- [x] Click to view properties in scope pane

### Screenshots/Videos (OPTIONAL)
![image](https://cloud.githubusercontent.com/assets/792924/26710979/4d08d27a-4755-11e7-8722-43f578ce6651.png)

