### PR TITLE
[Frames] Show collapse row button when there are more than NUM_FRAMES_SHOWN frames

### DIFF
--- a/src/components/SecondaryPanes/Frames/index.js
+++ b/src/components/SecondaryPanes/Frames/index.js
@@ -150,7 +150,7 @@ class Frames extends Component {
       : L10N.getStr("callStack.expand");
 
     frames = collapseFrames(frames);
-    if (frames.length < NUM_FRAMES_SHOWN) {
+    if (frames.length <= NUM_FRAMES_SHOWN) {
       return null;
     }
 


### PR DESCRIPTION
Minor fix.

When callstack has `NUM_FRAMES_SHOWN` frames, `Collapse Rows` button does nothing.

| | |
|---|---|
|![recored-2017-06-03_222808-opt](https://cloud.githubusercontent.com/assets/1755089/26755580/99f4a39e-48ad-11e7-9a7b-fedd5526b486.gif)|![screenshot from 2017-06-03 22-25-31](https://cloud.githubusercontent.com/assets/1755089/26755582/9f9240fe-48ad-11e7-8237-0f2f4db8040b.png)|

