### PR TITLE
[ObjectInspector] Vertically align variable keys when inspecting objects

### DIFF
--- a/src/components/shared/ObjectInspector.js
+++ b/src/components/shared/ObjectInspector.js
@@ -139,7 +139,7 @@ class ObjectInspector extends Component {
           "default-property": isDefault(item)
         }),
         style: {
-          marginLeft: nodeIsPrimitive(item) ? depth * 15 + 15 : depth * 15
+          marginLeft: depth * 15 + (nodeIsPrimitive(item) ? 15 : 0)
         },
         onClick: e => {
           e.stopPropagation();

--- a/src/components/shared/ObjectInspector.js
+++ b/src/components/shared/ObjectInspector.js
@@ -138,7 +138,9 @@ class ObjectInspector extends Component {
           focused,
           "default-property": isDefault(item)
         }),
-        style: { marginLeft: depth * 15 },
+        style: {
+          marginLeft: nodeIsPrimitive(item) ? depth * 15 + 15 : depth * 15
+        },
         onClick: e => {
           e.stopPropagation();
           setExpanded(item, !expanded);


### PR DESCRIPTION
Associated Issue: #3063

### Summary of Changes
In the `ObjectInspector` component I added a check if `item` is primitive, and if true, increase the left margin by 15px.

### Test Plan
 - [x] yarn test-all
 - [x] visual inspection (LTR)
 - [ ] visual inspection (RTL): Having trouble with this setting.

### Screenshots
#### Before:
![Before](https://camo.githubusercontent.com/2f27424bca6fd99f551047256b8b40e615a27710/68747470733a2f2f7368697075736572636f6e74656e742e636f6d2f37333330663661326538366433366663656630613863316361623937646233362f53637265656e25323053686f74253230323031372d30362d3032253230617425323031312e30312e3432253230414d2e706e67)

---
#### After:
![After-Light](https://cloud.githubusercontent.com/assets/3654683/26757211/500d723a-4883-11e7-878e-78085c530fcd.jpg)
![After-Dark](https://cloud.githubusercontent.com/assets/3654683/26757214/5fe5932c-4883-11e7-9ab5-ec26e01cd29e.jpg)

