### PR TITLE
switch action types to exact object types

### DIFF
--- a/src/actions/ast.js
+++ b/src/actions/ast.js
@@ -48,7 +48,7 @@ export function setOutOfScopeLocations() {
       return dispatch(
         ({
           type: "OUT_OF_SCOPE_LOCATIONS",
-          locations: []
+          locations: undefined
         }: Action)
       );
     }

--- a/src/actions/ast.js
+++ b/src/actions/ast.js
@@ -13,7 +13,7 @@ import { PROMISE } from "../utils/redux/middleware/promise";
 import parser from "../utils/parser";
 
 import type { Source } from "debugger-html";
-import type { ThunkArgs } from "./types";
+import type { ThunkArgs, Action } from "./types";
 import type { AstLocation } from "../utils/parser";
 
 export function setSymbols(source: Source) {
@@ -29,11 +29,13 @@ export function setSymbols(source: Source) {
 
     const symbols = await parser.getSymbols(sourceText.toJS());
 
-    dispatch({
-      type: "SET_SYMBOLS",
-      source,
-      symbols
-    });
+    dispatch(
+      ({
+        type: "SET_SYMBOLS",
+        source,
+        symbols
+      }: Action)
+    );
   };
 }
 
@@ -43,10 +45,12 @@ export function setOutOfScopeLocations() {
     const sourceText = getSourceText(getState(), location.sourceId);
 
     if (!location.line || !sourceText) {
-      return dispatch({
-        type: "OUT_OF_SCOPE_LOCATIONS",
-        locations: null
-      });
+      return dispatch(
+        ({
+          type: "OUT_OF_SCOPE_LOCATIONS",
+          locations: []
+        }: Action)
+      );
     }
 
     const locations = await parser.getOutOfScopeLocations(
@@ -54,10 +58,12 @@ export function setOutOfScopeLocations() {
       location
     );
 
-    return dispatch({
-      type: "OUT_OF_SCOPE_LOCATIONS",
-      locations
-    });
+    return dispatch(
+      ({
+        type: "OUT_OF_SCOPE_LOCATIONS",
+        locations
+      }: Action)
+    );
   };
 }
 
@@ -68,9 +74,11 @@ export function clearSelection() {
       return;
     }
 
-    return dispatch({
-      type: "CLEAR_SELECTION"
-    });
+    return dispatch(
+      ({
+        type: "CLEAR_SELECTION"
+      }: Action)
+    );
   };
 }
 
@@ -84,35 +92,37 @@ export function setSelection(token: string, position: AstLocation) {
     const sourceText = getSelectedSourceText(getState());
     const selectedFrame = getSelectedFrame(getState());
 
-    await dispatch({
-      type: "SET_SELECTION",
-      [PROMISE]: (async function() {
-        const closestExpression = await parser.getClosestExpression(
-          sourceText.toJS(),
-          token,
-          position
-        );
+    await dispatch(
+      ({
+        type: "SET_SELECTION",
+        [PROMISE]: (async function() {
+          const closestExpression = await parser.getClosestExpression(
+            sourceText.toJS(),
+            token,
+            position
+          );
 
-        if (!closestExpression) {
-          return;
-        }
+          if (!closestExpression) {
+            return;
+          }
 
-        const { expression, location } = closestExpression;
+          const { expression, location } = closestExpression;
 
-        if (!expression) {
-          return;
-        }
+          if (!expression) {
+            return;
+          }
 
-        const { result } = await client.evaluate(expression, {
-          frameId: selectedFrame.id
-        });
+          const { result } = await client.evaluate(expression, {
+            frameId: selectedFrame.id
+          });
 
-        return {
-          expression,
-          result,
-          location
-        };
-      })()
-    });
+          return {
+            expression,
+            result,
+            location
+          };
+        })()
+      }: Action)
+    );
   };
 }

--- a/src/actions/expressions.js
+++ b/src/actions/expressions.js
@@ -4,7 +4,7 @@ import { PROMISE } from "../utils/redux/middleware/promise";
 import { getExpression, getExpressions, getSelectedFrame } from "../selectors";
 
 import type { Expression } from "../types";
-import type { ThunkArgs } from "./types";
+import type { ThunkArgs, Action } from "./types";
 
 type frameIdType = string | null;
 
@@ -29,19 +29,23 @@ export function addExpression(input: string, { visible = true }: Object = {}) {
 
     // Lets make the expression visible
     if (expression) {
-      return dispatch({
-        type: "UPDATE_EXPRESSION",
-        expression,
-        input,
-        visible: true
-      });
+      return dispatch(
+        ({
+          type: "UPDATE_EXPRESSION",
+          expression,
+          input,
+          visible: true
+        }: Action)
+      );
     }
 
-    dispatch({
-      type: "ADD_EXPRESSION",
-      input,
-      visible
-    });
+    dispatch(
+      ({
+        type: "ADD_EXPRESSION",
+        input,
+        visible
+      }: Action)
+    );
 
     const selectedFrame = getSelectedFrame(getState());
     const selectedFrameId = selectedFrame ? selectedFrame.id : null;
@@ -55,12 +59,14 @@ export function updateExpression(input: string, expression: Expression) {
       return;
     }
 
-    dispatch({
-      type: "UPDATE_EXPRESSION",
-      expression,
-      input: input,
-      visible: expression.visible
-    });
+    dispatch(
+      ({
+        type: "UPDATE_EXPRESSION",
+        expression,
+        input,
+        visible: expression.visible
+      }: Action)
+    );
 
     const selectedFrame = getSelectedFrame(getState());
     const selectedFrameId = selectedFrame ? selectedFrame.id : null;
@@ -77,10 +83,12 @@ export function updateExpression(input: string, expression: Expression) {
  */
 export function deleteExpression(expression: Expression) {
   return ({ dispatch }: ThunkArgs) => {
-    dispatch({
-      type: "DELETE_EXPRESSION",
-      input: expression.input
-    });
+    dispatch(
+      ({
+        type: "DELETE_EXPRESSION",
+        input: expression.input
+      }: Action)
+    );
   };
 }
 
@@ -110,11 +118,13 @@ function evaluateExpression(expression, frameId: frameIdType) {
       return;
     }
 
-    return dispatch({
-      type: "EVALUATE_EXPRESSION",
-      input: expression.input,
-      visible: expression.visible,
-      [PROMISE]: client.evaluate(expression.input, { frameId })
-    });
+    return dispatch(
+      ({
+        type: "EVALUATE_EXPRESSION",
+        input: expression.input,
+        visible: expression.visible,
+        [PROMISE]: client.evaluate(expression.input, { frameId })
+      }: Action)
+    );
   };
 }

--- a/src/actions/navigation.js
+++ b/src/actions/navigation.js
@@ -2,6 +2,7 @@ import { clearDocuments } from "../utils/editor";
 import { getSources } from "../reducers/sources";
 import { waitForMs } from "../utils/utils";
 import { newSources } from "./sources";
+import type { ThunkArgs, Action } from "./types";
 
 /**
  * Redux actions for the navigation state
@@ -17,10 +18,12 @@ export function willNavigate(_, event) {
     await sourceMaps.clearSourceMaps();
     clearDocuments();
 
-    dispatch({
-      type: "NAVIGATE",
-      url: event.url
-    });
+    dispatch(
+      ({
+        type: "NAVIGATE",
+        url: event.url
+      }: Action)
+    );
   };
 }
 

--- a/src/actions/pause.js
+++ b/src/actions/pause.js
@@ -8,7 +8,7 @@ import { updateFrameLocations } from "../utils/pause";
 import { evaluateExpressions } from "./expressions";
 
 import type { Pause, Frame } from "../types";
-import type { ThunkArgs } from "./types";
+import type { ThunkArgs, Action } from "./types";
 
 type CommandType = { type: string };
 
@@ -27,10 +27,12 @@ export function resumed() {
   return ({ dispatch, client }: ThunkArgs) => {
     // dispatch(evaluateExpressions(null));
 
-    return dispatch({
-      type: "RESUME",
-      value: undefined
-    });
+    return dispatch(
+      ({
+        type: "RESUME",
+        value: undefined
+      }: Action)
+    );
   };
 }
 
@@ -47,13 +49,15 @@ export function paused(pauseInfo: Pause) {
     frames = await updateFrameLocations(frames, sourceMaps);
     const frame = frames[0];
 
-    dispatch({
-      type: "PAUSED",
-      pauseInfo: { why, frame, frames },
-      frames: frames,
-      selectedFrameId: frame.id,
-      loadedObjects: loadedObjects || []
-    });
+    dispatch(
+      ({
+        type: "PAUSED",
+        pauseInfo: { why, frame, frames },
+        frames: frames,
+        selectedFrameId: frame.id,
+        loadedObjects: loadedObjects || []
+      }: Action)
+    );
 
     dispatch(evaluateExpressions(frame.id));
 
@@ -73,15 +77,17 @@ export function pauseOnExceptions(
   shouldIgnoreCaughtExceptions: boolean
 ) {
   return ({ dispatch, client }: ThunkArgs) => {
-    dispatch({
-      type: "PAUSE_ON_EXCEPTIONS",
-      shouldPauseOnExceptions,
-      shouldIgnoreCaughtExceptions,
-      [PROMISE]: client.pauseOnExceptions(
+    dispatch(
+      ({
+        type: "PAUSE_ON_EXCEPTIONS",
         shouldPauseOnExceptions,
-        shouldIgnoreCaughtExceptions
-      )
-    });
+        shouldIgnoreCaughtExceptions,
+        [PROMISE]: client.pauseOnExceptions(
+          shouldPauseOnExceptions,
+          shouldIgnoreCaughtExceptions
+        )
+      }: Action)
+    );
   };
 }
 
@@ -97,10 +103,12 @@ export function command({ type }: CommandType) {
     // execute debugger thread command e.g. stepIn, stepOver
     client[type]();
 
-    return dispatch({
-      type: "COMMAND",
-      value: undefined
-    });
+    return dispatch(
+      ({
+        type: "COMMAND",
+        value: undefined
+      }: Action)
+    );
   };
 }
 
@@ -172,10 +180,12 @@ export function breakOnNext() {
   return ({ dispatch, client }: ThunkArgs) => {
     client.breakOnNext();
 
-    return dispatch({
-      type: "BREAK_ON_NEXT",
-      value: true
-    });
+    return dispatch(
+      ({
+        type: "BREAK_ON_NEXT",
+        value: true
+      }: Action)
+    );
   };
 }
 
@@ -189,10 +199,12 @@ export function selectFrame(frame: Frame) {
     dispatch(
       selectSource(frame.location.sourceId, { line: frame.location.line })
     );
-    dispatch({
-      type: "SELECT_FRAME",
-      frame
-    });
+    dispatch(
+      ({
+        type: "SELECT_FRAME",
+        frame
+      }: Action)
+    );
   };
 }
 
@@ -208,10 +220,12 @@ export function loadObjectProperties(object: any) {
       return;
     }
 
-    dispatch({
-      type: "LOAD_OBJECT_PROPERTIES",
-      objectId,
-      [PROMISE]: client.getProperties(object)
-    });
+    dispatch(
+      ({
+        type: "LOAD_OBJECT_PROPERTIES",
+        objectId,
+        [PROMISE]: client.getProperties(object)
+      }: Action)
+    );
   };
 }

--- a/src/actions/sources.js
+++ b/src/actions/sources.js
@@ -190,7 +190,7 @@ export function selectSource(id: string, options: SelectSourceOptions = {}) {
 
     if (!source) {
       // If there is no source we deselect the current selected source
-      return dispatch({ type: "CLEAR_SELECTED_SOURCE" });
+      return dispatch(({ type: "CLEAR_SELECTED_SOURCE" }: Action));
     }
 
     dispatch(({ type: "TOGGLE_PROJECT_SEARCH", value: false }: Action));

--- a/src/actions/tests/ast.js
+++ b/src/actions/tests/ast.js
@@ -92,7 +92,7 @@ describe("ast", () => {
       await dispatch(actions.setOutOfScopeLocations());
 
       const locations = getOutOfScopeLocations(getState());
-      expect(locations).toEqual(null);
+      expect(locations).toBe(undefined);
     });
   });
   describe("setSelection", () => {

--- a/src/actions/types.js
+++ b/src/actions/types.js
@@ -97,7 +97,12 @@ type SourceAction =
       line?: number,
       tabIndex?: number
     |}
-  | {| type: "SELECT_SOURCE_URL", url: string, line?: number |}
+  | {|
+      type: "SELECT_SOURCE_URL",
+      url: string,
+      line?: number,
+      tabIndex?: number
+    |}
   | {|
       type: "LOAD_SOURCE_TEXT",
       source: Source,

--- a/src/actions/types.js
+++ b/src/actions/types.js
@@ -229,7 +229,7 @@ type NavigateAction = { type: "NAVIGATE", url: string };
 type ASTAction =
   | {|
       type: "SET_SYMBOLS",
-      source: SourceText,
+      source: SourceText | Source,
       symbols: SymbolDeclaration[]
     |}
   | {|
@@ -238,7 +238,7 @@ type ASTAction =
     |}
   | {|
       type: "SET_SELECTION",
-      value: {
+      value?: {
         expression: string,
         result: any,
         location: AstLocation

--- a/src/actions/types.js
+++ b/src/actions/types.js
@@ -3,7 +3,6 @@
 import type {
   Source,
   Breakpoint,
-  Expression,
   LoadedObject,
   Location,
   SourceText,
@@ -14,6 +13,8 @@ import type {
 import type { State } from "../reducers/types";
 
 import type { SymbolDeclaration, AstLocation } from "../utils/parser";
+import type { SymbolSearchType } from "../reducers/ui";
+import type { Expression } from "../types";
 
 /**
  * Flow types
@@ -97,6 +98,7 @@ type SourceAction =
       line?: number,
       tabIndex?: number
     |}
+  | {| type: "CLEAR_SELECTED_SOURCE" |}
   | {|
       type: "SELECT_SOURCE_URL",
       url: string,
@@ -162,6 +164,10 @@ type UIAction =
       type: "TOGGLE_PANE",
       position: panelPositionType,
       paneCollapsed: boolean
+    |}
+  | {|
+      type: "SET_SYMBOL_SEARCH_TYPE",
+      symbolType: SymbolSearchType
     |};
 
 type PauseAction =
@@ -188,22 +194,22 @@ type PauseAction =
   | {|
       type: "LOAD_OBJECT_PROPERTIES",
       objectId: string,
-      status: string,
-      value: Object,
+      status?: string,
+      value?: Object,
       "@@dispatch/promise": any
     |}
   | {|
       type: "ADD_EXPRESSION",
-      id: number,
+      id?: number,
       input: string,
-      value: string,
+      value?: string,
       visible: boolean
     |}
   | {|
       type: "EVALUATE_EXPRESSION",
       input: string,
-      status: string,
-      value: Object,
+      status?: string,
+      value?: Object,
       visible: boolean,
       "@@dispatch/promise": any
     |}

--- a/src/actions/types.js
+++ b/src/actions/types.js
@@ -57,61 +57,61 @@ type BreakpointResult = {
 };
 
 type BreakpointAction =
-  | {
+  | {|
       type: "ADD_BREAKPOINT",
       breakpoint: Breakpoint,
       condition: string,
       status: AsyncStatus,
       error: string,
       value: BreakpointResult
-    }
-  | {
+    |}
+  | {|
       type: "REMOVE_BREAKPOINT",
       breakpoint: Breakpoint,
       status: AsyncStatus,
       error: string,
       disabled: boolean
-    }
-  | {
+    |}
+  | {|
       type: "SET_BREAKPOINT_CONDITION",
       breakpoint: Breakpoint,
       condition: string,
       status: AsyncStatus,
       value: BreakpointResult,
       error: string
-    }
-  | {
+    |}
+  | {|
       type: "TOGGLE_BREAKPOINTS",
       shouldDisableBreakpoints: boolean,
       status: AsyncStatus,
       error: string,
       value: any
-    };
+    |};
 
 type SourceAction =
-  | { type: "ADD_SOURCE", source: Source }
-  | { type: "ADD_SOURCES", sources: Array<Source> }
-  | {
+  | {| type: "ADD_SOURCE", source: Source |}
+  | {| type: "ADD_SOURCES", sources: Array<Source> |}
+  | {|
       type: "SELECT_SOURCE",
       source: Source,
       line?: number,
       tabIndex?: number
-    }
-  | { type: "SELECT_SOURCE_URL", url: string, line?: number }
-  | {
+    |}
+  | {| type: "SELECT_SOURCE_URL", url: string, line?: number |}
+  | {|
       type: "LOAD_SOURCE_TEXT",
       source: Source,
       status: AsyncStatus,
       error: string,
       value: SourceText
-    }
-  | {
+    |}
+  | {|
       type: "BLACKBOX",
       source: Source,
       error: string,
       value: { isBlackBoxed: boolean }
-    }
-  | {
+    |}
+  | {|
       type: "TOGGLE_PRETTY_PRINT",
       source: Source,
       originalSource: Source,
@@ -122,43 +122,43 @@ type SourceAction =
         sourceText: SourceText,
         frames: Frame[]
       }
-    }
-  | { type: "CLOSE_TAB", url: string, tabs: any }
-  | { type: "CLOSE_TABS", urls: Array<string>, tabs: any };
+    |}
+  | {| type: "CLOSE_TAB", url: string, tabs: any |}
+  | {| type: "CLOSE_TABS", urls: Array<string>, tabs: any |};
 
 export type panelPositionType = "start" | "end";
 
 type UIAction =
-  | {
+  | {|
       type: "TOGGLE_FILE_SEARCH",
       value: boolean
-    }
-  | {
+    |}
+  | {|
       type: "TOGGLE_PROJECT_SEARCH",
       value: boolean
-    }
-  | {
+    |}
+  | {|
       type: "TOGGLE_FILE_SEARCH_MODIFIER",
       modifier: "caseSensitive" | "wholeWord" | "regexMatch"
-    }
-  | {
+    |}
+  | {|
       type: "TOGGLE_FRAMEWORK_GROUPING",
       value: boolean
-    }
-  | {
+    |}
+  | {|
       type: "SHOW_SOURCE",
       sourceUrl: string
-    }
-  | {
+    |}
+  | {|
       type: "TOGGLE_PANE",
       position: panelPositionType,
       paneCollapsed: boolean
-    };
+    |};
 
 type PauseAction =
-  | { type: "BREAK_ON_NEXT", value: boolean }
-  | { type: "RESUME", value: void }
-  | {
+  | {| type: "BREAK_ON_NEXT", value: boolean |}
+  | {| type: "RESUME", value: void |}
+  | {|
       type: "PAUSED",
       pauseInfo: {
         why: Why,
@@ -168,70 +168,70 @@ type PauseAction =
       frames: Frame[],
       selectedFrameId: string,
       loadedObjects: LoadedObject[]
-    }
-  | {
+    |}
+  | {|
       type: "PAUSE_ON_EXCEPTIONS",
       shouldPauseOnExceptions: boolean,
       shouldIgnoreCaughtExceptions: boolean
-    }
-  | { type: "COMMAND", value: void }
-  | { type: "SELECT_FRAME", frame: Frame }
-  | {
+    |}
+  | {| type: "COMMAND", value: void |}
+  | {| type: "SELECT_FRAME", frame: Frame |}
+  | {|
       type: "LOAD_OBJECT_PROPERTIES",
       objectId: string,
       status: string,
       value: Object,
       "@@dispatch/promise": any
-    }
-  | {
+    |}
+  | {|
       type: "ADD_EXPRESSION",
       id: number,
       input: string,
       value: string,
       visible: boolean
-    }
-  | {
+    |}
+  | {|
       type: "EVALUATE_EXPRESSION",
       input: string,
       status: string,
       value: Object,
       visible: boolean,
       "@@dispatch/promise": any
-    }
-  | {
+    |}
+  | {|
       type: "UPDATE_EXPRESSION",
       expression: Expression,
       input: string,
       visible: boolean
-    }
-  | {
+    |}
+  | {|
       type: "DELETE_EXPRESSION",
       input: string
-    };
+    |};
 
 type NavigateAction = { type: "NAVIGATE", url: string };
 
 type ASTAction =
-  | {
+  | {|
       type: "SET_SYMBOLS",
       source: SourceText,
       symbols: SymbolDeclaration[]
-    }
-  | {
+    |}
+  | {|
       type: "OUT_OF_SCOPE_LOCATIONS",
       locations: AstLocation[]
-    }
-  | {
+    |}
+  | {|
       type: "SET_SELECTION",
       value: {
         expression: string,
         result: any,
         location: AstLocation
       }
-    }
-  | {
+    |}
+  | {|
       type: "CLEAR_SELECTION"
-    };
+    |};
 
 /**
  * Actions: Source, Breakpoint, and Navigation

--- a/src/actions/types.js
+++ b/src/actions/types.js
@@ -234,7 +234,7 @@ type ASTAction =
     |}
   | {|
       type: "OUT_OF_SCOPE_LOCATIONS",
-      locations: AstLocation[]
+      locations?: AstLocation[]
     |}
   | {|
       type: "SET_SELECTION",

--- a/src/actions/types.js
+++ b/src/actions/types.js
@@ -139,6 +139,10 @@ type UIAction =
       value: boolean
     |}
   | {|
+      type: "TOGGLE_SYMBOL_SEARCH",
+      value: boolean
+    |}
+  | {|
       type: "TOGGLE_PROJECT_SEARCH",
       value: boolean
     |}

--- a/src/actions/ui.js
+++ b/src/actions/ui.js
@@ -5,61 +5,73 @@ import {
   getProjectSearchState,
   getFileSearchState
 } from "../selectors";
-import type { ThunkArgs } from "./types";
+import type { ThunkArgs, Action } from "./types";
 import type { SymbolSearchType } from "../reducers/ui";
 
 export function toggleProjectSearch(toggleValue?: boolean) {
   return ({ dispatch, getState }: ThunkArgs) => {
     const projectSearchState = getProjectSearchState(getState());
     if (toggleValue === undefined) {
-      return dispatch({
-        type: "TOGGLE_PROJECT_SEARCH",
-        value: !projectSearchState
-      });
+      return dispatch(
+        ({
+          type: "TOGGLE_PROJECT_SEARCH",
+          value: !projectSearchState
+        }: Action)
+      );
     }
 
     if (projectSearchState == toggleValue) {
       return;
     }
 
-    dispatch({
-      type: "TOGGLE_PROJECT_SEARCH",
-      value: toggleValue
-    });
+    dispatch(
+      ({
+        type: "TOGGLE_PROJECT_SEARCH",
+        value: toggleValue
+      }: Action)
+    );
   };
 }
 
 export function toggleFileSearch(toggleValue?: boolean) {
   return ({ dispatch, getState }: ThunkArgs) => {
     if (toggleValue != null) {
-      dispatch({
-        type: "TOGGLE_FILE_SEARCH",
-        value: toggleValue
-      });
+      dispatch(
+        ({
+          type: "TOGGLE_FILE_SEARCH",
+          value: toggleValue
+        }: Action)
+      );
     } else {
-      dispatch({
-        type: "TOGGLE_FILE_SEARCH",
-        value: !getFileSearchState(getState())
-      });
+      dispatch(
+        ({
+          type: "TOGGLE_FILE_SEARCH",
+          value: !getFileSearchState(getState())
+        }: Action)
+      );
     }
   };
 }
 
 export function toggleSymbolSearch(toggleValue: boolean) {
   return ({ dispatch, getState }: ThunkArgs) => {
-    dispatch({
-      type: "TOGGLE_SYMBOL_SEARCH",
-      value: toggleValue
-    });
+    dispatch(
+      ({
+        type: "TOGGLE_SYMBOL_SEARCH",
+        value: toggleValue
+      }: Action)
+    );
   };
 }
 
 export function toggleFrameworkGrouping(toggleValue: boolean) {
   return ({ dispatch, getState }: ThunkArgs) => {
-    dispatch({
-      type: "TOGGLE_FRAMEWORK_GROUPING",
-      value: toggleValue
-    });
+    dispatch(
+      ({
+        type: "TOGGLE_FRAMEWORK_GROUPING",
+        value: toggleValue
+      }: Action)
+    );
   };
 }
 
@@ -86,10 +98,12 @@ export function toggleFileSearchModifier(modifier: string) {
 export function showSource(sourceId: string) {
   return ({ dispatch, getState }: ThunkArgs) => {
     const source = getSource(getState(), sourceId);
-    dispatch({
-      type: "SHOW_SOURCE",
-      sourceUrl: source.get("url")
-    });
+    dispatch(
+      ({
+        type: "SHOW_SOURCE",
+        sourceUrl: source.get("url")
+      }: Action)
+    );
   };
 }
 

--- a/src/actions/ui.js
+++ b/src/actions/ui.js
@@ -77,10 +77,12 @@ export function toggleFrameworkGrouping(toggleValue: boolean) {
 
 export function setSelectedSymbolType(symbolType: SymbolSearchType) {
   return ({ dispatch, getState }: ThunkArgs) => {
-    dispatch({
-      type: "SET_SYMBOL_SEARCH_TYPE",
-      symbolType
-    });
+    dispatch(
+      ({
+        type: "SET_SYMBOL_SEARCH_TYPE",
+        symbolType
+      }: Action)
+    );
   };
 }
 


### PR DESCRIPTION
Associated Issue: https://github.com/devtools-html/debugger.html/issues/3080


### Summary of Changes

* use exact object types for Actions
* added missing action types, e.g. CLEAR_SELECTED_SOURCE
* explicit casting of the actions to Action type
* made some parameters optional based on the usage patterns

### Test Plan

- `npm run test`
- `npm run flow`
- `npm run flow-redux`

flow coverage before:
![screen shot 2017-06-04 at 6 42 35 pm](https://cloud.githubusercontent.com/assets/125466/26764413/64a34fd6-495e-11e7-8c1f-5ec27d59202c.png)

flow coverage before:
![screen shot 2017-06-04 at 6 41 49 pm](https://cloud.githubusercontent.com/assets/125466/26764415/69856c50-495e-11e7-8107-7d3dd8ddb935.png)

changing ThunkArgs:

```
export type ThunkArgs = {
  dispatch: Action => Promise<any>,
  getState: () => State,
  client: any,
  sourceMaps: any
};
```
still produces 39 errors:
examples of problematic calls are:
dispatch(loadSourceText(source)).then(
                        ^^^^^^^^^^^^^^^^^^^^^^ async function. Inexact type is incompatible with exact type

dispatch(setSymbols(source));
                             ^^^^^^^^^^^^^^^^^^ async function. Inexact type is incompatible with exact type 