### PR TITLE
Add footer tabs to sources pane for outline view

### DIFF
--- a/src/components/Sources.css
+++ b/src/components/Sources.css
@@ -67,3 +67,42 @@
 .hidden {
   display: none;
 }
+
+.commands {
+  width: 100%;
+}
+
+.tab {
+  flex: 1;
+  justify-content: center;
+  border: 1px solid transparent;
+  border-bottom-left-radius: 2px;
+  border-bottom-right-radius: 2px;
+  display: inline-flex;
+  align-items: flex-end;
+  position: relative;
+  transition: all 0.25s ease;
+  min-width: 40px;
+  overflow: hidden;
+  padding: 5px;
+  margin-bottom: 4px;
+  margin-top: -1px;
+}
+
+.tab:hover {
+  background-color: var(--theme-toolbar-background-alt);
+  border-color: var(--theme-splitter-color);
+  cursor: pointer;
+}
+
+.tab.active {
+  color: var(--theme-body-color);
+  background-color: var(--theme-body-background);
+  border-color: var(--theme-splitter-color);
+  border-top-color: transparent;
+}
+
+.tab.active path,
+.tab:hover path {
+  fill: var(--theme-body-color);
+}

--- a/src/components/Sources.css
+++ b/src/components/Sources.css
@@ -68,7 +68,7 @@
   display: none;
 }
 
-.commands {
+.sources-footer {
   width: 100%;
 }
 
@@ -79,10 +79,8 @@
   border-bottom-left-radius: 2px;
   border-bottom-right-radius: 2px;
   display: inline-flex;
-  align-items: flex-end;
   position: relative;
   transition: all 0.25s ease;
-  min-width: 40px;
   overflow: hidden;
   padding: 5px;
   margin-bottom: 4px;

--- a/src/components/Sources.css
+++ b/src/components/Sources.css
@@ -68,11 +68,11 @@
   display: none;
 }
 
-.sources-footer {
+.source-footer {
   width: 100%;
 }
 
-.tab {
+.source-footer .tab {
   flex: 1;
   justify-content: center;
   border: 1px solid transparent;
@@ -87,20 +87,20 @@
   margin-top: -1px;
 }
 
-.tab:hover {
+.source-footer .tab:hover {
   background-color: var(--theme-toolbar-background-alt);
   border-color: var(--theme-splitter-color);
   cursor: pointer;
 }
 
-.tab.active {
+.source-footer .tab.active {
   color: var(--theme-body-color);
   background-color: var(--theme-body-background);
   border-color: var(--theme-splitter-color);
   border-top-color: transparent;
 }
 
-.tab.active path,
-.tab:hover path {
+.source-footer .tab.active path,
+.source-footer .tab:hover path {
   fill: var(--theme-body-color);
 }

--- a/src/components/Sources.js
+++ b/src/components/Sources.js
@@ -73,10 +73,30 @@ class Sources extends Component {
     );
   }
 
+  showPane(selectedPane: string) {
+    this.setState({ selectedPane });
+  }
+
   renderOutlineTabs() {
     return [
-      dom.div({ className: classnames("tab", "active") }, "outline"),
-      dom.div({ className: "tab" }, "sources")
+      dom.div(
+        {
+          className: classnames("tab", {
+            active: this.state.selectedPane === "sources"
+          }),
+          onClick: () => this.showPane("sources")
+        },
+        "sources"
+      ),
+      dom.div(
+        {
+          className: classnames("tab", {
+            active: this.state.selectedPane === "outline"
+          }),
+          onClick: () => this.showPane("outline")
+        },
+        "outline"
+      )
     ];
   }
 

--- a/src/components/Sources.js
+++ b/src/components/Sources.js
@@ -10,6 +10,7 @@ import Svg from "./shared/Svg";
 import { getSources } from "../selectors";
 import { isEnabled } from "devtools-config";
 import "./Sources.css";
+import classnames from "classnames";
 
 import _Outline from "./Outline";
 const Outline = createFactory(_Outline);
@@ -72,12 +73,28 @@ class Sources extends Component {
     );
   }
 
+  renderOutlineTabs() {
+    return [
+      dom.div({ className: classnames("tab", "active") }, "outline"),
+      dom.div({ className: "tab" }, "sources")
+    ];
+  }
+
   renderFooter() {
     return dom.div(
       {
         className: "source-footer"
       },
       dom.div({ className: "commands" }, this.renderOutlineToggleButton())
+    );
+  }
+
+  renderNewFooter() {
+    return dom.div(
+      {
+        className: "source-footer"
+      },
+      dom.div({ className: "commands" }, this.renderOutlineTabs())
     );
   }
 
@@ -114,7 +131,7 @@ class Sources extends Component {
         isHidden: selectedPane === "outline"
       }),
       Outline({ selectSource, isHidden: selectedPane === "sources" }),
-      this.renderFooter()
+      this.renderNewFooter()
     );
   }
 }

--- a/src/components/Sources.js
+++ b/src/components/Sources.js
@@ -6,7 +6,6 @@ import { bindActionCreators } from "redux";
 import { connect } from "react-redux";
 import { formatKeyShortcut } from "../utils/text";
 import actions from "../actions";
-import Svg from "./shared/Svg";
 import { getSources } from "../selectors";
 import { isEnabled } from "devtools-config";
 import "./Sources.css";
@@ -25,7 +24,7 @@ type SourcesState = {
 class Sources extends Component {
   renderShortcut: Function;
   selectedPane: String;
-  togglePane: Function;
+  showPane: Function;
   renderFooter: Function;
   renderChildren: Function;
   state: SourcesState;
@@ -35,42 +34,8 @@ class Sources extends Component {
     this.state = { selectedPane: "sources" };
 
     this.renderShortcut = this.renderShortcut.bind(this);
-    this.togglePane = this.togglePane.bind(this);
+    this.showPane = this.showPane.bind(this);
     this.renderFooter = this.renderFooter.bind(this);
-  }
-
-  togglePane() {
-    const selectedPane = this.state.selectedPane === "sources"
-      ? "outline"
-      : "sources";
-
-    this.setState({ selectedPane });
-  }
-
-  renderOutlineToggleButton() {
-    if (!isEnabled("outline")) {
-      return;
-    }
-
-    const { selectedPane } = this.state;
-    const showSourcesTooltip = L10N.getStr("sourcesPane.showSourcesTooltip");
-    const showOutlineTooltip = L10N.getStr("sourcesPane.showOutlineTooltip");
-
-    const isSourcesPaneSelected = selectedPane === "sources";
-    const tooltip = isSourcesPaneSelected
-      ? showOutlineTooltip
-      : showSourcesTooltip;
-    const type = isSourcesPaneSelected ? "showSources" : "showOutline";
-
-    return dom.button(
-      {
-        className: "action",
-        onClick: this.togglePane,
-        key: type,
-        title: tooltip
-      },
-      Svg(type)
-    );
   }
 
   showPane(selectedPane: string) {
@@ -78,24 +43,30 @@ class Sources extends Component {
   }
 
   renderOutlineTabs() {
+    if (!isEnabled("outline")) {
+      return;
+    }
+
     return [
       dom.div(
         {
           className: classnames("tab", {
             active: this.state.selectedPane === "sources"
           }),
-          onClick: () => this.showPane("sources")
+          onClick: () => this.showPane("sources"),
+          key: "sources-tab"
         },
-        "sources"
+        "Sources View"
       ),
       dom.div(
         {
           className: classnames("tab", {
             active: this.state.selectedPane === "outline"
           }),
-          onClick: () => this.showPane("outline")
+          onClick: () => this.showPane("outline"),
+          key: "outline-tab"
         },
-        "outline"
+        "Outline View"
       )
     ];
   }
@@ -105,16 +76,7 @@ class Sources extends Component {
       {
         className: "source-footer"
       },
-      dom.div({ className: "commands" }, this.renderOutlineToggleButton())
-    );
-  }
-
-  renderNewFooter() {
-    return dom.div(
-      {
-        className: "source-footer"
-      },
-      dom.div({ className: "commands" }, this.renderOutlineTabs())
+      this.renderOutlineTabs()
     );
   }
 
@@ -151,7 +113,7 @@ class Sources extends Component {
         isHidden: selectedPane === "outline"
       }),
       Outline({ selectSource, isHidden: selectedPane === "sources" }),
-      this.renderNewFooter()
+      this.renderFooter()
     );
   }
 }


### PR DESCRIPTION
Associated Issue: #2901

As part of the outline view, the SVG button toggling the outline view of the sources pane has been replaced with tabs

### Summary of Changes

* Replaced the toggle SVG with footer tabs for sources and outline view

### Test Plan

- [x] Activating "Outline" in Settings shows the footer 
- [x] Deactivating "Outline" in settings hides the footer
- [x] Clicking the "Outline View" tab navigates to the outline view
- [x] Clicking the "Sources View" tab navigates to the outline view

### Screenshots/Videos (OPTIONAL)
![debugger](https://cloud.githubusercontent.com/assets/1628866/26779038/217584e6-49e4-11e7-9545-0b225594af56.gif)
