### PR TITLE
fix object property styling on window property names (#2946)

### DIFF
--- a/src/components/shared/ObjectInspector.js
+++ b/src/components/shared/ObjectInspector.js
@@ -96,6 +96,11 @@ class ObjectInspector extends Component {
     self.renderItem = this.renderItem.bind(this);
   }
 
+  isDefaultProperty(item: ObjectInspectorItem) {
+    const roots = this.props.roots;
+    return isDefault(item, roots);
+  }
+
   getChildren(item: ObjectInspectorItem) {
     const { getObjectProperties } = this.props;
     const { actors } = this;
@@ -136,7 +141,7 @@ class ObjectInspector extends Component {
       {
         className: classnames("node object-node", {
           focused,
-          "default-property": isDefault(item)
+          "default-property": this.isDefaultProperty(item)
         }),
         style: { marginLeft: depth * 15 },
         onClick: e => {

--- a/src/utils/object-inspector.js
+++ b/src/utils/object-inspector.js
@@ -3,7 +3,7 @@ import { maybeEscapePropertyName } from "devtools-reps";
 
 let WINDOW_PROPERTIES = {};
 
-if (typeof window == "object") {
+if (typeof window === "object") {
   WINDOW_PROPERTIES = Object.getOwnPropertyNames(window);
 }
 
@@ -63,7 +63,11 @@ function getPromiseProperties(item) {
   });
 }
 
-function isDefault(item) {
+function isDefault(item, roots) {
+  if (roots && roots.length === 1) {
+    const value = getValue(roots[0]);
+    return value.class === "Window";
+  }
   return WINDOW_PROPERTIES.includes(item.name);
 }
 

--- a/src/utils/tests/object-inspector.js
+++ b/src/utils/tests/object-inspector.js
@@ -1,7 +1,8 @@
 const {
   makeNodesForProperties,
   isPromise,
-  getPromiseProperties
+  getPromiseProperties,
+  isDefault
 } = require("../object-inspector");
 
 const root = {
@@ -129,6 +130,25 @@ describe("object-inspector", () => {
 
       expect(names).toEqual(["bar", "[default properties]"]);
       expect(paths).toEqual(["root/bar", "root/##-default"]);
+    });
+
+    it("window prop on normal object", () => {
+      const windowRoots = [
+        {
+          contents: { value: { class: "Window" } }
+        }
+      ];
+
+      const objectRoots = [
+        {
+          contents: { value: { class: "Object" } }
+        }
+      ];
+
+      const item = { name: "location" };
+
+      expect(isDefault(item, windowRoots)).toEqual(true);
+      expect(isDefault(item, objectRoots)).toEqual(false);
     });
 
     // For large arrays


### PR DESCRIPTION
Associated Issue: #2946

### Summary of Changes

* Adds additional logic so that window property names render properly on objects

### Test Plan

Visual Testing

1. Run debugger
2. Enter expression in watch expression: `a = { aLocation: 1, location: 2};`
3. Both properties should display in the same design. 

### Screenshots/Videos (OPTIONAL)
![screen shot 2017-06-05 at 10 33 39 pm](https://cloud.githubusercontent.com/assets/2481105/26811328/17d267dc-4a3f-11e7-895c-fa84b1f9c7d4.png)
