### PR TITLE
Polish conditional breakpoint

### DIFF
--- a/src/components/Editor/ConditionalPanel.css
+++ b/src/components/Editor/ConditionalPanel.css
@@ -11,8 +11,11 @@
 
 .conditional-breakpoint-panel .prompt {
   font-size: 1.8em;
-  color: var(--theme-comment-alt);
+  color: var(--theme-conditional-breakpoint-color);
   padding-left: 3px;
+  padding-right: 3px;
+  text-align: right;
+  width: 30px;
 }
 
 .conditional-breakpoint-panel input {
@@ -21,7 +24,7 @@
   border: none;
   background: var(--theme-toolbar-background);
   font-size: 14px;
-  color: var(--theme-comment);
+  color: var(--theme-conditional-breakpoint-color);
   line-height: 30px;
 }
 

--- a/src/components/Editor/ConditionalPanel.css
+++ b/src/components/Editor/ConditionalPanel.css
@@ -14,6 +14,7 @@
   color: var(--theme-conditional-breakpoint-color);
   padding-left: 3px;
   padding-right: 3px;
+  padding-bottom: 3px;
   text-align: right;
   width: 30px;
 }

--- a/src/components/Editor/Editor.css
+++ b/src/components/Editor/Editor.css
@@ -8,6 +8,10 @@
   --debug-line-border: rgb(119, 134, 162);
 }
 
+.editor-wrapper .CodeMirror-linewidget {
+  margin-right: -7px;
+}
+
 .theme-dark {
   --theme-conditional-breakpoint-color: #9fa4a9;
 }

--- a/src/components/Editor/Editor.css
+++ b/src/components/Editor/Editor.css
@@ -8,6 +8,18 @@
   --debug-line-border: rgb(119, 134, 162);
 }
 
+.theme-dark {
+  --theme-conditional-breakpoint-color: #9fa4a9;
+}
+
+.theme-light {
+  --theme-conditional-breakpoint-color: #ccd1d5;
+}
+
+.theme-firebug {
+  --theme-conditional-breakpoint-color: #ccd1d5;
+}
+
 .out-of-scope .CodeMirror-line,
 .out-of-scope .CodeMirror-linenumber {
   opacity: 0.8;

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -505,7 +505,7 @@ class Editor extends PureComponent {
 
     this.cbPanel = this.editor.codeMirror.addLineWidget(line, panel, {
       coverGutter: true,
-      noHScroll: true
+      noHScroll: false
     });
     this.cbPanel.node.querySelector("input").focus();
   }


### PR DESCRIPTION
Associated Issue: #2918 

### Summary of Changes

* added new color for conditional breakpoint text in dark theme
* center the guillemet >> in the gutter
* made conditional breakpoint more resposive

One drawback is that conditional breakpoint is very tightly coupled with Codemirror's linewidget, where re-drawing logic resides. I turned off `noHScroll` flag, but in turn it made the close button to hide when editor windows becomes to narrow (check video)

### Test Plan

Tell us a little a bit about how you tested your patch.

Visual test is required:
- Open an editor
- Right-click on line numbers and select "Add Conditional Breakpoint"
- Check the visuals of the conditional breakpoint (text color, alighment, responsiveness)

### Screenshots/Videos (OPTIONAL)
![cond_bp](https://cloud.githubusercontent.com/assets/69977/26828501/7053c044-4b0d-11e7-81bf-6618da0bbbf0.gif)
