### PR TITLE
Use "react-dom" instead of "../../node_modules/react-dom/dist/react-dom"

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -13,7 +13,6 @@
 
     ["module-resolver", {
       "alias": {
-        "react-dom": "react-dom/dist/react-dom",
         "devtools/client/shared/vendor/react": "react",
         "devtools/client/shared/vendor/react-dom": "react-dom"
       }

--- a/src/components/Editor/Breakpoint.js
+++ b/src/components/Editor/Breakpoint.js
@@ -1,7 +1,7 @@
 // @flow
 import { Component } from "react";
 import { isEnabled } from "devtools-config";
-import ReactDOM from "../../../node_modules/react-dom/dist/react-dom";
+import ReactDOM from "react-dom";
 
 import classnames from "classnames";
 import Svg from "../shared/Svg";

--- a/src/components/Editor/ColumnBreakpoint.js
+++ b/src/components/Editor/ColumnBreakpoint.js
@@ -1,7 +1,7 @@
 // @flow
 import { Component } from "react";
 import { isEnabled } from "devtools-config";
-const ReactDOM = require("react-dom");
+import ReactDOM from "react-dom";
 import Svg from "../shared/Svg";
 import classnames from "classnames";
 

--- a/src/components/Editor/ConditionalPanel.js
+++ b/src/components/Editor/ConditionalPanel.js
@@ -1,6 +1,6 @@
 // @flow
 import { DOM as dom } from "react";
-import ReactDOM from "../../../node_modules/react-dom/dist/react-dom";
+import ReactDOM from "react-dom";
 
 import CloseButton from "../shared/Button/Close";
 import "./ConditionalPanel.css";

--- a/src/components/Editor/SearchBar.js
+++ b/src/components/Editor/SearchBar.js
@@ -1,7 +1,7 @@
 // @flow
 
 import { DOM as dom, createFactory, Component, PropTypes } from "react";
-import { findDOMNode } from "../../../node_modules/react-dom/dist/react-dom";
+import { findDOMNode } from "react-dom";
 import { connect } from "react-redux";
 import { bindActionCreators } from "redux";
 import { filter } from "fuzzaldrin-plus";

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -1,6 +1,6 @@
 // @flow
 import { DOM as dom, PropTypes, createFactory, PureComponent } from "react";
-import ReactDOM from "../../../node_modules/react-dom/dist/react-dom";
+import ReactDOM from "react-dom";
 import ImPropTypes from "react-immutable-proptypes";
 import { bindActionCreators } from "redux";
 import { connect } from "react-redux";

--- a/src/components/SecondaryPanes/CommandBar.js
+++ b/src/components/SecondaryPanes/CommandBar.js
@@ -1,7 +1,7 @@
 // @flow
 import { DOM as dom, Component, PropTypes } from "react";
 
-import { findDOMNode } from "../../../node_modules/react-dom/dist/react-dom";
+import { findDOMNode } from "react-dom";
 import { connect } from "react-redux";
 import { bindActionCreators } from "redux";
 import {

--- a/src/components/shared/Autocomplete.js
+++ b/src/components/shared/Autocomplete.js
@@ -1,7 +1,7 @@
 // @flow
 
 import { Component, DOM as dom, createFactory } from "react";
-import ReactDOM from "../../../node_modules/react-dom/dist/react-dom";
+import ReactDOM from "react-dom";
 import { filter } from "fuzzaldrin-plus";
 import classnames from "classnames";
 import { scrollList } from "../../utils/result-list";

--- a/src/components/shared/Popover.js
+++ b/src/components/shared/Popover.js
@@ -1,5 +1,5 @@
 import { DOM as dom, PropTypes, createFactory, Component } from "react";
-import ReactDOM from "../../../node_modules/react-dom/dist/react-dom";
+import ReactDOM from "react-dom";
 import classNames from "classnames";
 import _BracketArrow from "./BracketArrow";
 const BracketArrow = createFactory(_BracketArrow);

--- a/src/utils/bootstrap.js
+++ b/src/utils/bootstrap.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { bindActionCreators, combineReducers } from "redux";
-import ReactDOM from "../../node_modules/react-dom/dist/react-dom";
+import ReactDOM from "react-dom";
 import { getValue, isFirefoxPanel } from "devtools-config";
 import { renderRoot } from "devtools-launchpad";
 import { startSourceMapWorker, stopSourceMapWorker } from "devtools-source-map";


### PR DESCRIPTION
Looks like we had a misconfiguration in the .babelrc

I did this because the weird path with `../node_modules/react-dom/dist/react-dom` was doing weird things to editor component tests. I swapped it out. things seem to be working as expected.

### Summary of Changes

* remove line which was causing a recursive `react-dom/dist/react-dom/dist` address from babel-rc
* rename all instances of `../../../[etc]/node_modules/react-dom/dist/react-dom` to `react-dom`

### Test Plan

- All Unit tests are passing. Need to double check if the build still works
