### PR TITLE
Move getClosestExpression into worker

### DIFF
--- a/src/utils/parser/index.js
+++ b/src/utils/parser/index.js
@@ -1,11 +1,11 @@
 // @flow
 
 import { workerUtils } from "devtools-utils";
-import { getClosestExpression } from "./utils/closest";
 const { WorkerDispatcher } = workerUtils;
 
 const dispatcher = new WorkerDispatcher();
 
+const getClosestExpression = dispatcher.task("getClosestExpression");
 const getSymbols = dispatcher.task("getSymbols");
 const getVariablesInScope = dispatcher.task("getVariablesInScope");
 const getOutOfScopeLocations = dispatcher.task("getOutOfScopeLocations");

--- a/src/utils/parser/worker.js
+++ b/src/utils/parser/worker.js
@@ -1,3 +1,4 @@
+import { getClosestExpression } from "./utils/closest";
 import { getVariablesInScope } from "./scopes";
 import getSymbols from "./getSymbols";
 import getOutOfScopeLocations from "./getOutOfScopeLocations";
@@ -6,6 +7,7 @@ import { workerUtils } from "devtools-utils";
 const { workerHandler } = workerUtils;
 
 self.onmessage = workerHandler({
+  getClosestExpression,
   getOutOfScopeLocations,
   getSymbols,
   getVariablesInScope


### PR DESCRIPTION
### Summary of Changes

* Moves getClosestExpression usage into the worker to decouple parser-related dependencies (babylon, parse-script-tags) from debugger.js

### Test Plan

* Run `node bin/copy-assets.js` to verify babylon et al aren't included in debugger.js
* Launch debugger and verify that:
  * expressions are resolved in preview
  * getClosestExpression is called within the worker
