### PR TITLE
Revert breakpoint clearing

### DIFF
--- a/src/actions/sources.js
+++ b/src/actions/sources.js
@@ -23,6 +23,7 @@ import { prefs } from "../utils/prefs";
 import { removeDocument } from "../utils/editor";
 
 import {
+  getBreakpoint,
   getSource,
   getSourceByURL,
   getSourceText,
@@ -55,10 +56,12 @@ async function checkPendingBreakpoint(
   pendingBreakpoint,
   source
 ) {
-  const { sourceUrl } = pendingBreakpoint.location;
+  const { line, sourceUrl, column } = pendingBreakpoint.location;
   const sameSource = sourceUrl && sourceUrl === source.url;
+  const location = { sourceId: source.id, sourceUrl, line, column };
+  const bp = getBreakpoint(state, location);
 
-  if (sameSource) {
+  if (sameSource && !bp) {
     await dispatch(syncBreakpoint(source.id, pendingBreakpoint));
   }
 }

--- a/src/actions/sources.js
+++ b/src/actions/sources.js
@@ -23,7 +23,6 @@ import { prefs } from "../utils/prefs";
 import { removeDocument } from "../utils/editor";
 
 import {
-  getBreakpoint,
   getSource,
   getSourceByURL,
   getSourceText,
@@ -56,12 +55,10 @@ async function checkPendingBreakpoint(
   pendingBreakpoint,
   source
 ) {
-  const { line, sourceUrl, column } = pendingBreakpoint.location;
+  const { sourceUrl } = pendingBreakpoint.location;
   const sameSource = sourceUrl && sourceUrl === source.url;
-  const location = { sourceId: source.id, sourceUrl, line, column };
-  const bp = getBreakpoint(state, location);
 
-  if (sameSource && !bp) {
+  if (sameSource) {
     await dispatch(syncBreakpoint(source.id, pendingBreakpoint));
   }
 }

--- a/src/actions/tests/__snapshots__/pending-breakpoints.js.snap
+++ b/src/actions/tests/__snapshots__/pending-breakpoints.js.snap
@@ -13,6 +13,7 @@ Object {
   "id": "bar.js:7:",
   "loading": false,
   "location": Object {
+    "column": undefined,
     "line": 7,
     "sourceId": "bar.js",
     "sourceUrl": "http://localhost:8000/examples/bar.js",

--- a/src/actions/tests/helpers/breakpoints.js
+++ b/src/actions/tests/helpers/breakpoints.js
@@ -21,6 +21,7 @@ export function mockPendingBreakpoint(overrides = {}) {
 
 function generateCorrectingThreadClient(offset = 0) {
   return {
+    getBreakpointByLocation: jest.fn(),
     setBreakpoint: (location, condition) => {
       const actualLocation = Object.assign({}, location, {
         line: location.line + offset
@@ -60,6 +61,7 @@ export function generateBreakpoint(filename) {
 }
 
 export const simpleMockThreadClient = {
+  getBreakpointByLocation: jest.fn(),
   setBreakpoint: (location, _condition) =>
     Promise.resolve({ id: "hi", actualLocation: location }),
 

--- a/src/client/firefox/commands.js
+++ b/src/client/firefox/commands.js
@@ -1,4 +1,5 @@
 // @flow
+import _ from "lodash";
 
 import type {
   BreakpointId,
@@ -72,6 +73,34 @@ function breakOnNext(): Promise<*> {
 function sourceContents(sourceId: SourceId): Source {
   const sourceClient = threadClient.source({ actor: sourceId });
   return sourceClient.source();
+}
+
+function getBreakpointByLocation(location: Location) {
+  const values = _.values(bpClients);
+  const bpClient = values.find(value => {
+    const { actor, line, column, condition } = value.location;
+    return (
+      location.line === line &&
+      location.sourceId === actor &&
+      location.column === column &&
+      location.condition === condition
+    );
+  });
+
+  if (bpClient) {
+    const { actor, url, line, column, condition } = bpClient.location;
+    return {
+      id: bpClient.actor,
+      actualLocation: {
+        line,
+        column,
+        condition,
+        sourceId: actor,
+        sourceUrl: url
+      }
+    };
+  }
+  return null;
 }
 
 function setBreakpoint(
@@ -252,6 +281,7 @@ const clientCommands = {
   stepOver,
   breakOnNext,
   sourceContents,
+  getBreakpointByLocation,
   setBreakpoint,
   removeBreakpoint,
   setBreakpointCondition,

--- a/src/reducers/breakpoints.js
+++ b/src/reducers/breakpoints.js
@@ -90,10 +90,6 @@ function update(
       setPendingBreakpoints(newState);
       return newState;
     }
-
-    case "NAVIGATE": {
-      return initialState();
-    }
   }
 
   return state;

--- a/src/utils/breakpoint/index.js
+++ b/src/utils/breakpoint/index.js
@@ -34,8 +34,8 @@ export function allBreakpointsDisabled(state) {
 }
 
 // syncing
-export function equalizeLocationColumn(location, hasColumn) {
-  if (hasColumn) {
+export function equalizeLocationColumn(location, referenceLocation) {
+  if (referenceLocation.column) {
     return location;
   }
   return { ...location, column: undefined };


### PR DESCRIPTION
This fixes an issue we were seeing with breakpoints being added when they already existed on the server.

This fix is basically reverting the behavior we had before.