### PR TITLE
[FunctionSearch] clear query after selecting an item #2526

### DIFF
--- a/docs/updates/README.md
+++ b/docs/updates/README.md
@@ -107,13 +107,14 @@ This was a really great week for QA improvements as the debugger is getting more
 
 * We now disable out of scope lines when the debugger pauses.
 * We have huge updates to preview - it's faster, more consistent, and works for HTML elements
-* Breakpoints are kept in sync as code changes. Big thanks to @codehag
+* Breakpoints are kept in sync as code changes. Big thanks to [@codehag]
 * We're chipping away at two new features: Outline View and Project Search
 
 
 [@asolove]:http://github.com/asolove
 [@ryanjduffy]:http://github.com/ryanjduffy
 [@diessica]:http://github.com/diessica
+[@codehag]:http://github.com/codehag
 [@andreicristianpetcu]:http://github.com/andreicristianpetcu
 [@Andarist]:http://github.com/Andarist
 [pr-6]:https://github.com/devtools-html/debugger.html/pull/2784

--- a/docs/updates/README.md
+++ b/docs/updates/README.md
@@ -107,7 +107,7 @@ This was a really great week for QA improvements as the debugger is getting more
 
 * We now disable out of scope lines when the debugger pauses.
 * We have huge updates to preview - it's faster, more consistent, and works for HTML elements
-* Breakpoints are kept in sync as code changes. Big thanks to [@codehag]
+* Breakpoints are kept in sync as code changes. Big thanks to @codehag
 * We're chipping away at two new features: Outline View and Project Search
 
 

--- a/src/components/Editor/SearchBar.js
+++ b/src/components/Editor/SearchBar.js
@@ -255,9 +255,10 @@ class SearchBar extends Component {
   }
 
   closeSearch(e: SyntheticEvent) {
-    const { editor } = this.props;
+    const { editor, setFileSearchQuery } = this.props;
 
     if (this.props.searchOn && editor) {
+      setFileSearchQuery("");
       this.clearSearch();
       this.props.toggleFileSearch(false);
       this.props.toggleSymbolSearch(false);


### PR DESCRIPTION
Associated Issue: #2526 

### Summary of Changes

* search query is cleared when search is closed

![yuhquwtauh](https://user-images.githubusercontent.com/4222159/26871164-eda8750e-4b7a-11e7-8a7f-4c15c050f931.gif)
