### PR TITLE
Remove column breakpoint

### DIFF
--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -528,7 +528,7 @@ class Editor extends PureComponent {
       removeBreakpoint({
         sourceId: sourceId,
         line: line + 1,
-        column: column
+        column: column || bp.location.column
       });
     } else {
       addBreakpoint(

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -525,10 +525,12 @@ class Editor extends PureComponent {
     const { sourceId } = selectedLocation;
 
     if (bp) {
+      // NOTE: it's possible the breakpoint has slid to a column
+      column = column || bp.location.column;
       removeBreakpoint({
         sourceId: sourceId,
         line: line + 1,
-        column: column || bp.location.column
+        column
       });
     } else {
       addBreakpoint(

--- a/src/utils/editor/index.js
+++ b/src/utils/editor/index.js
@@ -44,7 +44,11 @@ function isTextForSource(sourceText) {
 
 function breakpointAtLocation(breakpoints, { line, column = undefined }) {
   return breakpoints.find(bp => {
-    return bp.location.line === line + 1 && bp.location.column === column;
+    const sameColumn = isEnabled("columnBreakpoints") && column
+      ? bp.location.column === column
+      : true;
+    const sameLine = bp.location.line === line + 1;
+    return sameLine && sameColumn;
   });
 }
 

--- a/src/utils/editor/index.js
+++ b/src/utils/editor/index.js
@@ -44,11 +44,18 @@ function isTextForSource(sourceText) {
 
 function breakpointAtLocation(breakpoints, { line, column = undefined }) {
   return breakpoints.find(bp => {
-    const sameColumn = isEnabled("columnBreakpoints") && column
-      ? bp.location.column === column
-      : true;
     const sameLine = bp.location.line === line + 1;
-    return sameLine && sameColumn;
+    if (!sameLine) {
+      return false;
+    }
+
+    // NOTE: when column breakpoints are disabled we want to find
+    // the first breakpoint
+    if (!isEnabled("columnBreakpoints")) {
+      return true;
+    }
+
+    return bp.location.column === column;
   });
 }
 


### PR DESCRIPTION
Associated Issue: #3042 

### Summary of Changes

* Removing the column breakpoints

### Test Plan

- Set a bp on an empty line/comment that slides to the next line.
- Clicking on the bp on the gutter removes it