### PR TITLE
Continue conversion from commonjs to es modules

### DIFF
--- a/src/client/chrome.js
+++ b/src/client/chrome.js
@@ -1,7 +1,7 @@
 // @flow
 
-const { setupCommands, clientCommands } = require("./chrome/commands");
-const { setupEvents, clientEvents, pageEvents } = require("./chrome/events");
+import { setupCommands, clientCommands } from "./chrome/commands";
+import { setupEvents, clientEvents, pageEvents } from "./chrome/events";
 
 export async function onConnect(connection: any, actions: Object) {
   const { tabConnection, connTarget: { type } } = connection;

--- a/src/client/chrome/commands.js
+++ b/src/client/chrome/commands.js
@@ -1,10 +1,10 @@
 // @flow
 
-const {
+import {
   toServerLocation,
   fromServerLocation,
   createLoadedObject
-} = require("./create");
+} from "./create";
 
 import type { Location } from "../types";
 import type { ServerLocation, Agents } from "./types";
@@ -124,7 +124,4 @@ const clientCommands = {
   getProperties
 };
 
-module.exports = {
-  setupCommands,
-  clientCommands
-};
+export { setupCommands, clientCommands };

--- a/src/client/chrome/create.js
+++ b/src/client/chrome/create.js
@@ -3,7 +3,7 @@
 import type { Location, LoadedObject } from "../types";
 import type { ServerLocation } from "./types";
 
-function fromServerLocation(serverLocation?: ServerLocation): ?Location {
+export function fromServerLocation(serverLocation?: ServerLocation): ?Location {
   if (serverLocation) {
     return {
       sourceId: serverLocation.scriptId,
@@ -13,14 +13,14 @@ function fromServerLocation(serverLocation?: ServerLocation): ?Location {
   }
 }
 
-function toServerLocation(location: Location): ServerLocation {
+export function toServerLocation(location: Location): ServerLocation {
   return {
     scriptId: location.sourceId,
     lineNumber: location.line - 1
   };
 }
 
-function createFrame(frame: any) {
+export function createFrame(frame: any) {
   return {
     id: frame.callFrameId,
     displayName: frame.functionName,
@@ -29,7 +29,10 @@ function createFrame(frame: any) {
   };
 }
 
-function createLoadedObject(serverObject: any, parentId: string): LoadedObject {
+export function createLoadedObject(
+  serverObject: any,
+  parentId: string
+): LoadedObject {
   const { value, name } = serverObject;
 
   return {
@@ -39,10 +42,3 @@ function createLoadedObject(serverObject: any, parentId: string): LoadedObject {
     value
   };
 }
-
-export {
-  fromServerLocation,
-  toServerLocation,
-  createFrame,
-  createLoadedObject
-};

--- a/src/client/chrome/create.js
+++ b/src/client/chrome/create.js
@@ -40,7 +40,7 @@ function createLoadedObject(serverObject: any, parentId: string): LoadedObject {
   };
 }
 
-module.exports = {
+export {
   fromServerLocation,
   toServerLocation,
   createFrame,

--- a/src/client/chrome/events.js
+++ b/src/client/chrome/events.js
@@ -1,6 +1,6 @@
 // @flow
 
-const { createFrame, createLoadedObject } = require("./create");
+import { createFrame, createLoadedObject } from "./create";
 
 let actions;
 let pageAgent;
@@ -121,8 +121,4 @@ const pageEvents = {
   frameStoppedLoading
 };
 
-module.exports = {
-  setupEvents,
-  pageEvents,
-  clientEvents
-};
+export { setupEvents, pageEvents, clientEvents };

--- a/src/client/firefox/commands.js
+++ b/src/client/firefox/commands.js
@@ -23,7 +23,7 @@ import type {
   BreakpointResponse
 } from "./types";
 
-const { createSource } = require("./create");
+import { createSource } from "./create";
 
 let bpClients: { [id: ActorId]: BreakpointClient };
 let threadClient: ThreadClient;
@@ -306,7 +306,4 @@ const clientCommands = {
   fetchSources
 };
 
-module.exports = {
-  setupCommands,
-  clientCommands
-};
+export { setupCommands, clientCommands };

--- a/src/client/firefox/create.js
+++ b/src/client/firefox/create.js
@@ -9,7 +9,7 @@ import type {
   SourcePayload
 } from "./types";
 
-function createFrame(frame: FramePacket): Frame {
+export function createFrame(frame: FramePacket): Frame {
   let title;
   if (frame.type == "call") {
     let c = frame.callee;

--- a/src/client/firefox/events.js
+++ b/src/client/firefox/events.js
@@ -8,8 +8,8 @@ import type {
   Actions
 } from "./types";
 
-const { createPause, createSource } = require("./create");
-const { isEnabled } = require("devtools-config");
+import { createPause, createSource } from "./create";
+import { isEnabled } from "devtools-config";
 
 const CALL_STACK_PAGE_SIZE = 1000;
 
@@ -68,7 +68,4 @@ const clientEvents = {
   newSource
 };
 
-module.exports = {
-  setupEvents,
-  clientEvents
-};
+export { setupEvents, clientEvents };

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -1,14 +1,15 @@
 // @flow
 
-const firefox = require("./firefox");
-const chrome = require("./chrome");
-const { prefs } = require("../utils/prefs");
-const { isFirefoxPanel } = require("devtools-config");
-const {
+import * as firefox from "./firefox";
+import * as chrome from "./chrome";
+
+import { prefs } from "../utils/prefs";
+import { isFirefoxPanel } from "devtools-config";
+import {
   bootstrapApp,
   bootstrapStore,
   bootstrapWorkers
-} = require("../utils/bootstrap");
+} from "../utils/bootstrap";
 
 function loadFromPrefs(actions: Object) {
   const { pauseOnExceptions, ignoreCaughtExceptions } = prefs;
@@ -60,4 +61,4 @@ async function onConnect(connection: Object, services: Object) {
   return { store, actions, selectors, client: commands };
 }
 
-module.exports = { onConnect };
+export { onConnect };

--- a/src/components/Editor/Tabs.js
+++ b/src/components/Editor/Tabs.js
@@ -432,7 +432,7 @@ class SourceTabs extends PureComponent {
 
 SourceTabs.displayName = "SourceTabs";
 
-module.exports = connect(
+export default connect(
   state => {
     return {
       selectedSource: getSelectedSource(state),

--- a/src/components/SecondaryPanes/Breakpoints.js
+++ b/src/components/SecondaryPanes/Breakpoints.js
@@ -17,7 +17,7 @@ import { endTruncateStr } from "../../utils/utils";
 import { basename } from "../../utils/path";
 import CloseButton from "../shared/Button/Close";
 import "./Breakpoints.css";
-const get = require("lodash/get");
+import get from "lodash/get";
 
 import type { Breakpoint } from "../../types";
 

--- a/src/components/SecondaryPanes/WhyPaused.js
+++ b/src/components/SecondaryPanes/WhyPaused.js
@@ -10,7 +10,7 @@ import { getPauseReason } from "../../utils/pause";
 import type { Pause } from "debugger-html";
 
 import "./WhyPaused.css";
-const get = require("lodash/get");
+import get from "lodash/get";
 
 function renderExceptionSummary(exception) {
   if (isString(exception)) {

--- a/src/utils/log.js
+++ b/src/utils/log.js
@@ -8,7 +8,7 @@
  * @module utils/log
  */
 
-const { isDevelopment } = require("devtools-config");
+import { isDevelopment } from "devtools-config";
 
 /**
  * Produces a formatted console log line by imploding args, prefixed by [log]
@@ -19,12 +19,10 @@ const { isDevelopment } = require("devtools-config");
  * @memberof utils/log
  * @static
  */
-function log(...args: any[]) {
+export function log(...args: any[]) {
   if (!isDevelopment()) {
     return;
   }
 
   console.log.apply(console, ["[log]", ...args]);
 }
-
-module.exports = log;

--- a/src/utils/pause.js
+++ b/src/utils/pause.js
@@ -1,6 +1,6 @@
 // @flow
 import type { Pause, Frame } from "../types";
-const get = require("lodash/get");
+import get from "lodash/get";
 
 export function updateFrameLocations(
   frames: Frame[],

--- a/src/utils/redux/middleware/thunk.js
+++ b/src/utils/redux/middleware/thunk.js
@@ -9,7 +9,7 @@ import type { ThunkArgs, ActionType } from "../../../actions/types";
  * middleware constructure. This allows the action to create multiple
  * actions (most likely asynchronously).
  */
-function thunk(makeArgs: any) {
+export function thunk(makeArgs: any) {
   return ({ dispatch, getState }: ThunkArgs) => {
     const args = { dispatch, getState };
 
@@ -20,4 +20,3 @@ function thunk(makeArgs: any) {
     };
   };
 }
-exports.thunk = thunk;

--- a/src/utils/redux/middleware/wait-service.js
+++ b/src/utils/redux/middleware/wait-service.js
@@ -24,7 +24,7 @@ const NAME = (exports.NAME = "@@service/waitUntil");
 
 import type { ThunkArgs } from "../../../actions/types";
 
-function waitUntilService({ dispatch, getState }: ThunkArgs) {
+export function waitUntilService({ dispatch, getState }: ThunkArgs) {
   let pending = [];
 
   function checkPending(action) {
@@ -60,4 +60,3 @@ function waitUntilService({ dispatch, getState }: ThunkArgs) {
     return result;
   };
 }
-exports.waitUntilService = waitUntilService;


### PR DESCRIPTION
# Continue conversion from commonjs to es modules
Associated Issue: #1884

## Summary of Changes

Refactor the following files to use ES module syntax:
- [x] src/client/chrome.js
- [x] src/client/chrome/commands.js
- [x] src/client/chrome/create.js
- [x] src/client/chrome/events.js
- [x] src/client/firefox/commands.js
- [x] src/client/firefox/create.js
- [x] src/client/firefox/events.js
- [x] src/client/index.js
- [x] src/components/Editor/Tabs.js
- [x] src/components/SecondaryPanes/Breakpoints.js
- [x] src/components/SecondaryPanes/WhyPaused.js
- [x] src/utils/log.js
- [x] src/utils/pause.js
- [x] src/utils/redux/middleware/thunk.js
- [x] src/utils/redux/middleware/wait-service.js

### Test Plan

- [x] `yarn test-all`
