### PR TITLE
#3083: change 'Copy Link Address' id

### DIFF
--- a/src/components/Editor/Tabs.js
+++ b/src/components/Editor/Tabs.js
@@ -243,7 +243,7 @@ class SourceTabs extends PureComponent {
     };
 
     const copySourceUrl = {
-      id: "node-menu-close-tabs-to-right",
+      id: "node-menu-copy-source-url",
       label: copyLinkLabel,
       accesskey: copyLinkKey,
       disabled: false,


### PR DESCRIPTION
Associated Issue: #3083 

### Summary of Changes

* change 'Copy Link Address' id from 'node-menu-close-tabs-to-right' to 'node-menu-copy-source-url'

### Test Plan

- [x] Clicking “Copy Link Address” save url
- [x] Paste url
