### PR TITLE
fix duplicate search bars

### DIFF
--- a/src/utils/editor/index.js
+++ b/src/utils/editor/index.js
@@ -94,6 +94,7 @@ function createEditor() {
       // Override code mirror keymap to avoid conflicts with split console.
       Esc: false,
       "Cmd-F": false,
+      "Ctrl-F": false,
       "Cmd-G": false
     }
   });


### PR DESCRIPTION
Associated Issue: #3006

### Summary of Changes

We disable codemirrors default search bar so that we can use our own in the panel. This previously worked for the mac, but not for windows. This should now be fixed, but it would be nice if a windows user could verify.

STR:

1. open a file in the debugger
2. ctrl+f should see the search bar
3. ctrl+f should see another search bar
