### PR TITLE
style exceptions in WhyPaused as red

### DIFF
--- a/src/components/SecondaryPanes/Frames/WhyPaused.css
+++ b/src/components/SecondaryPanes/Frames/WhyPaused.css
@@ -19,3 +19,9 @@
 .why-paused .message {
   font-size: 10px;
 }
+
+.why-paused .message.warning {
+  font-size: 10px;
+  color: var(--theme-graphs-full-red);
+  font-weight: bold;
+}

--- a/src/components/SecondaryPanes/Frames/WhyPaused.js
+++ b/src/components/SecondaryPanes/Frames/WhyPaused.js
@@ -31,7 +31,10 @@ function renderMessage(pauseInfo: Pause) {
 
   const exception = get(pauseInfo, "why.exception");
   if (exception) {
-    return dom.div({ className: "message" }, renderExceptionSummary(exception));
+    return dom.div(
+      { className: "message warning" },
+      renderExceptionSummary(exception)
+    );
   }
 
   return null;

--- a/src/components/tests/__snapshots__/WhyPaused.js.snap
+++ b/src/components/tests/__snapshots__/WhyPaused.js.snap
@@ -71,7 +71,7 @@ ShallowWrapper {
         Paused on exception
     </div>
     <div
-        className="message"
+        className="message warning"
     >
         ReferenceError: o is not defined
     </div>
@@ -84,7 +84,7 @@ ShallowWrapper {
             Paused on exception
       </div>
       <div
-            className="message"
+            className="message warning"
       >
             ReferenceError: o is not defined
       </div>
@@ -104,7 +104,7 @@ ShallowWrapper {
         Paused on exception
     </div>
     <div
-        className="message"
+        className="message warning"
     >
         ReferenceError: o is not defined
     </div>
@@ -127,7 +127,7 @@ ShallowWrapper {
         Paused on exception
     </div>
     <div
-        className="message"
+        className="message warning"
     >
         Not Available
     </div>
@@ -140,7 +140,7 @@ ShallowWrapper {
             Paused on exception
       </div>
       <div
-            className="message"
+            className="message warning"
       >
             Not Available
       </div>
@@ -160,7 +160,7 @@ ShallowWrapper {
         Paused on exception
     </div>
     <div
-        className="message"
+        className="message warning"
     >
         Not Available
     </div>

--- a/src/utils/parser/tests/__snapshots__/closest.js.snap
+++ b/src/utils/parser/tests/__snapshots__/closest.js.snap
@@ -101,7 +101,7 @@ FunctionExpression (7:1,9:1)
     directives: []
   expression: false
   extra:
-    parenStart: 64
+    parenStart: 70
     parenthesized: true
   generator: false
   id: null

--- a/src/utils/parser/tests/__snapshots__/closest.js.snap
+++ b/src/utils/parser/tests/__snapshots__/closest.js.snap
@@ -101,7 +101,7 @@ FunctionExpression (7:1,9:1)
     directives: []
   expression: false
   extra:
-    parenStart: 70
+    parenStart: 64
     parenthesized: true
   generator: false
   id: null

--- a/yarn.lock
+++ b/yarn.lock
@@ -3856,11 +3856,11 @@ husky@^0.13.2:
     is-ci "^1.0.9"
     normalize-path "^1.0.0"
 
-iconv-lite@0.4.13, iconv-lite@~0.4.13:
+iconv-lite@0.4.13:
   version "0.4.13"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.13.tgz#1f88aba4ab0b1508e8312acc39345f36e992e2f2"
 
-iconv-lite@0.4.15:
+iconv-lite@0.4.15, iconv-lite@~0.4.13:
   version "0.4.15"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.15.tgz#fe265a218ac6a57cfe854927e9d04c19825eddeb"
 


### PR DESCRIPTION
Associated Issue: #3130 
### Summary of Changes

* Changed the color of error message to var(--theme-graphs-full-red) and made it bold

### Test Plan

- open the debugger
- turn on "Pause on uncaught exceptions"
- open this [example page](https://devtools-html.github.io/debugger-examples/examples/exceptions.html)
- when debugger pauses on exception you should see the error details in red

Here's the Debugger's Testing doc
https://docs.google.com/document/d/1oBMRxV8A2ag2t22YsQOxTdEv0mXKzIg0tggJjRkU1S0/edit#.
Feel free to improve it!

### Screenshots/Videos (OPTIONAL)
![image](https://user-images.githubusercontent.com/69977/26950700-3691f7a2-4cea-11e7-8802-ed07f4e21704.png)

