### PR TITLE
Add WTR Runner

### DIFF
--- a/bin/wtr-runner.js
+++ b/bin/wtr-runner.js
@@ -1,0 +1,33 @@
+const CDP = require("chrome-remote-interface");
+
+const results = [];
+
+function runTests() {
+  return new Promise(resolve => {
+    CDP(client => {
+      // Extract used DevTools domains.
+      const { Page, Runtime } = client;
+
+      // Enable events on domains we are interested in.
+      Promise.all([Page.enable()]).then(() => {
+        return Page.navigate({ url: "http://localhost:8000/integration" });
+      });
+
+      Runtime.enable();
+      Runtime.consoleAPICalled(({ type, args }) => {
+        const argVals = args.map(arg => arg.value).join(", ");
+        console.log(argVals);
+
+        if (argVals.match(/WERE DON/)) {
+          results.push(argVals);
+          client.close();
+          resolve();
+        }
+      });
+    });
+  });
+}
+
+runTests().then(() => {
+  console.log(results.join("\n"));
+});

--- a/src/test/integration/runner.js
+++ b/src/test/integration/runner.js
@@ -24,7 +24,8 @@ const ctx = { ok, is, info, requestLongerTimeout };
 mocha.setup({ timeout: 10000, ui: "bdd" });
 
 describe("Tests", () => {
-  beforeEach(() => {
+  beforeEach(function() {
+    console.log("TEST START", this.currentTest.title);
     prefs.pauseOnExceptions = false;
     prefs.ignoreCaughtExceptions = false;
     prefs.pendingSelectedLocation = {};
@@ -33,13 +34,21 @@ describe("Tests", () => {
     prefs.tabs = [];
   });
 
-  afterEach(() => {
+  afterEach(function() {
     prefs.pauseOnExceptions = false;
     prefs.ignoreCaughtExceptions = false;
     prefs.pendingSelectedLocation = {};
     prefs.expressions = [];
     prefs.pendingBreakpoints = [];
     prefs.tabs = [];
+
+    const err = this.currentTest.err;
+    const msg = err ? "FAILURE" : "SUCCESS";
+    console.log(`TEST ${msg}`, this.currentTest.title);
+    if (err) {
+      console.log(err.message);
+      console.log(err.stack);
+    }
   });
 
   it("asm", async () => await asm(ctx));
@@ -113,4 +122,6 @@ describe("Tests", () => {
     await tabs.reloadWithNoTabs(ctx));
 });
 
-mocha.run();
+mocha.run(failures => {
+  console.log("WERE DON", failures);
+});


### PR DESCRIPTION
Associated Issue: #2634


### Summary of Changes

This re-introduces the work done here: https://github.com/devtools-html/debugger.html/pull/2852 to have a wtr headless runner. The test runs fail, but it's still good to have in the codebase so that we can get the tests passing and then run it in CI.

NOTE: you need to start chrome headlessly to run the tests
canary --headless --remote-debugging-port=9222 https://chromium.org