### PR TITLE
Search bar doesn't get focus if already open

### DIFF
--- a/src/components/Editor/SearchBar.js
+++ b/src/components/Editor/SearchBar.js
@@ -345,6 +345,7 @@ class SearchBar extends Component {
     const searchInput = this.searchInput();
     if (searchInput) {
       searchInput.setSelectionRange(0, searchInput.value.length);
+      searchInput.focus();
     }
   }
 


### PR DESCRIPTION
Associated Issue: #3152

### Summary of Changes

* the method `toggleSearch` was called, which in turn calls `selectSearchInput` which selects the entire range in the input. But it doesn't focus.
I just added focus() inside `selectSearchInput`.

