### PR TITLE
switch bpclient ids to location ids

### DIFF
--- a/flow-typed/debugger-html.js
+++ b/flow-typed/debugger-html.js
@@ -207,7 +207,7 @@ declare module "debugger-html" {
   declare type Source = {
     id: SourceId,
     url: string,
-    sourceMapURL: string,
+    sourceMapURL?: string,
     isBlackBoxed: boolean,
     isPrettyPrinted: boolean,
     text?: string,

--- a/src/actions/breakpoints.js
+++ b/src/actions/breakpoints.js
@@ -251,7 +251,7 @@ export function disableBreakpoint(location: Location) {
       type: "DISABLE_BREAKPOINT",
       breakpoint: bp,
       disabled: true,
-      [PROMISE]: client.removeBreakpoint(bp.id)
+      [PROMISE]: client.removeBreakpoint(bp)
     };
 
     return dispatch(action);

--- a/src/actions/breakpoints.js
+++ b/src/actions/breakpoints.js
@@ -290,7 +290,7 @@ export function removeBreakpoint(location: Location) {
 
     return dispatch(
       Object.assign({}, action, {
-        [PROMISE]: client.removeBreakpoint(bp.id)
+        [PROMISE]: client.removeBreakpoint(bp)
       })
     );
   };

--- a/src/actions/breakpoints.js
+++ b/src/actions/breakpoints.js
@@ -143,7 +143,12 @@ async function addClientBreakpoint(state, client, sourceMaps, breakpoint) {
   );
 
   const { id, hitCount } = clientBreakpoint;
-  return { id, actualLocation, hitCount, generatedLocation };
+  return {
+    id,
+    actualLocation,
+    hitCount,
+    generatedLocation: clientBreakpoint.actualLocation
+  };
 }
 
 /**

--- a/src/actions/tests/__snapshots__/pending-breakpoints.js.snap
+++ b/src/actions/tests/__snapshots__/pending-breakpoints.js.snap
@@ -62,7 +62,7 @@ Object {
   "condition": null,
   "disabled": false,
   "generatedLocation": Object {
-    "line": 5,
+    "line": 7,
     "sourceId": "foo",
     "sourceUrl": "http://localhost:8000/examples/foo",
   },

--- a/src/client/chrome/commands.js
+++ b/src/client/chrome/commands.js
@@ -6,7 +6,7 @@ import {
   createLoadedObject
 } from "./create";
 
-import type { Location } from "../types";
+import type { Location } from "debugger-html";
 import type { ServerLocation, Agents } from "./types";
 
 type setBreakpointResponseType = {

--- a/src/client/chrome/create.js
+++ b/src/client/chrome/create.js
@@ -1,6 +1,6 @@
 // @flow
 
-import type { Location, LoadedObject } from "../types";
+import type { Location, LoadedObject } from "debugger-html";
 import type { ServerLocation } from "./types";
 
 export function fromServerLocation(serverLocation?: ServerLocation): ?Location {

--- a/src/client/firefox/commands.js
+++ b/src/client/firefox/commands.js
@@ -11,7 +11,7 @@ import type {
   Script,
   Source,
   SourceId
-} from "../types";
+} from "debugger-html";
 
 import type {
   TabTarget,
@@ -80,17 +80,6 @@ function sourceContents(sourceId: SourceId): Source {
 function getBreakpointByLocation(location: Location) {
   const id = makeLocationId(location);
   const bpClient = bpClients[id];
-
-  // const values = _.values(bpClients);
-  // const bpClient = values.find(value => {
-  //   const { actor, line, column, condition } = value.location;
-  //   return (
-  //     location.line === line &&
-  //     location.sourceId === actor &&
-  //     location.column === column &&
-  //     location.condition === condition
-  //   );
-  // });
 
   if (bpClient) {
     const { actor, url, line, column, condition } = bpClient.location;

--- a/src/client/firefox/commands.js
+++ b/src/client/firefox/commands.js
@@ -1,5 +1,4 @@
 // @flow
-import _ from "lodash";
 
 import type {
   BreakpointId,

--- a/src/client/firefox/create.js
+++ b/src/client/firefox/create.js
@@ -1,14 +1,12 @@
 // @flow
 // This module converts Firefox specific types to the generic types
 
-import type { Frame, Source, Location, BreakpointResult } from "../types";
+import type { Frame, Source, Location } from "debugger-html";
 import type {
   PausedPacket,
   FramesResponse,
   FramePacket,
-  SourcePayload,
-  BPClients,
-  BreakpointResponse
+  SourcePayload
 } from "./types";
 
 export function createFrame(frame: FramePacket): Frame {
@@ -62,8 +60,8 @@ export function createPause(
 
 export function createBreakpointLocation(
   location: Location,
-  actualLocation: Object
-) {
+  actualLocation?: Object
+): Location {
   if (!actualLocation) {
     return location;
   }

--- a/src/client/firefox/create.js
+++ b/src/client/firefox/create.js
@@ -1,12 +1,14 @@
 // @flow
 // This module converts Firefox specific types to the generic types
 
-import type { Frame, Source } from "../types";
+import type { Frame, Source, Location, BreakpointResult } from "../types";
 import type {
   PausedPacket,
   FramesResponse,
   FramePacket,
-  SourcePayload
+  SourcePayload,
+  BPClients,
+  BreakpointResponse
 } from "./types";
 
 export function createFrame(frame: FramePacket): Frame {
@@ -52,4 +54,24 @@ export function createPause(
     frame: createFrame(frame),
     frames: response.frames.map(createFrame)
   });
+}
+
+// Firefox only returns `actualLocation` if it actually changed,
+// but we want it always to exist. Format `actualLocation` if it
+// exists, otherwise use `location`.
+
+export function createBreakpointLocation(
+  location: Location,
+  actualLocation: Object
+) {
+  if (!actualLocation) {
+    return location;
+  }
+
+  return {
+    sourceId: actualLocation.source.actor,
+    sourceUrl: location.sourceUrl,
+    line: actualLocation.line,
+    column: actualLocation.column
+  };
 }

--- a/src/client/firefox/types.js
+++ b/src/client/firefox/types.js
@@ -13,8 +13,7 @@ import type {
   Source,
   Pause,
   Frame,
-  SourceId,
-  Location
+  SourceId
 } from "debugger-html";
 
 type URL = string;

--- a/src/client/firefox/types.js
+++ b/src/client/firefox/types.js
@@ -362,6 +362,8 @@ export type BreakpointClient = {
   source: SourceClient
 };
 
+export type BPClients = { [id: ActorId]: BreakpointClient };
+
 export type BreakpointResponse = [
   {
     actor?: ActorId,

--- a/src/client/firefox/types.js
+++ b/src/client/firefox/types.js
@@ -1,4 +1,5 @@
 // @flow
+
 /**
  * These are Firefox specific types that allow us to type check
  * the packet information exchanged using the Firefox Remote Debug Protocol
@@ -12,8 +13,9 @@ import type {
   Source,
   Pause,
   Frame,
-  SourceId
-} from "../types";
+  SourceId,
+  Location
+} from "debugger-html";
 
 type URL = string;
 
@@ -354,7 +356,13 @@ export type ThreadClient = {
 export type BreakpointClient = {
   actor: ActorId,
   remove: () => void,
-  location: Location,
+  location: {
+    actor: string,
+    url: string,
+    line: number,
+    column: number,
+    condition: string
+  },
   setCondition: (ThreadClient, boolean, boolean) => Promise<BreakpointClient>,
   // getCondition: () => any,
   // hasCondition: () => any,

--- a/src/reducers/breakpoints.js
+++ b/src/reducers/breakpoints.js
@@ -250,11 +250,7 @@ function setCondition(state, action) {
 
   if (action.status === "done") {
     const bp = state.breakpoints.get(id);
-    const updatedBreakpoint = {
-      ...bp,
-      id: action.value.id,
-      loading: false
-    };
+    const updatedBreakpoint = { ...bp, loading: false };
     const updatedState = state.setIn(["breakpoints", id], updatedBreakpoint);
 
     return updatePendingBreakpoint(updatedState, updatedBreakpoint);

--- a/src/test/integration/runner.js
+++ b/src/test/integration/runner.js
@@ -53,23 +53,27 @@ describe("Tests", () => {
 
   it("asm", async () => await asm(ctx));
 
-  it("breakpoints - toggle", async () => await breakpoints.toggle(ctx));
+  describe("breakpoints", () => {
+    it("breakpoints - toggle", async () => await breakpoints.toggle(ctx));
 
-  it("breakpoints - toggleAll", async () => await breakpoints.toggleAll(ctx));
+    it("breakpoints - toggleAll", async () => await breakpoints.toggleAll(ctx));
 
-  it("breaking", async () => await breaking(ctx));
+    it("breaking", async () => await breaking(ctx));
 
-  it("conditional breakpoints", async () => await breakpointsCond(ctx));
+    it("conditional breakpoints", async () => await breakpointsCond(ctx));
+  });
 
   it("expressions", async () => await expressions(ctx));
 
-  it("editor select", async () => await editorSelect(ctx));
+  describe("editor", () => {
+    it("editor select", async () => await editorSelect(ctx));
 
-  it("editor gutter", async () => await editorGutter(ctx));
+    it("editor gutter", async () => await editorGutter(ctx));
 
-  xit("editor highlight", async () => await editorHighlight(ctx));
+    xit("editor highlight", async () => await editorHighlight(ctx));
 
-  xit("editor preview", async () => await editorPreview(ctx));
+    xit("editor preview", async () => await editorPreview(ctx));
+  });
 
   xit("keyboard navigation", async () => await keyboardNavigation(ctx));
 
@@ -77,9 +81,11 @@ describe("Tests", () => {
 
   xit("navigation", async () => await navigation(ctx));
 
-  it("call stack test 1", async () => await callStack.test1(ctx));
+  describe("call stack", () => {
+    it("test 1", async () => await callStack.test1(ctx));
 
-  it("call stack test 2", async () => await callStack.test2(ctx));
+    it("test 2", async () => await callStack.test2(ctx));
+  });
 
   it("debugger buttons", async () => await debuggerButtons(ctx));
 
@@ -108,18 +114,19 @@ describe("Tests", () => {
 
   it("sources", async () => await sources(ctx));
 
-  // timed out
-  // requires firefox nightly for noSliding
-  xit("source maps", async () => await sourceMaps(ctx));
+  describe("source maps", () => {
+    it("stepping", async () => await sourceMaps(ctx));
+    it("reloading", async () => await sourceMapsReloading(ctx));
+    it("source maps 2", async () => await sourceMaps2(ctx));
+    it("source maps bogus", async () => await sourceMapsBogus(ctx));
+  });
 
-  it("source maps 2", async () => await sourceMaps2(ctx));
-
-  // expected 2 to equal 1
-  xit("source maps bogus", async () => await sourceMapsBogus(ctx));
-  it("tabs - add tabs", async () => await tabs.addTabs(ctx));
-  it("tabs - reload with tabs", async () => await tabs.reloadWithTabs(ctx));
-  it("tabs - reload with no tabs", async () =>
-    await tabs.reloadWithNoTabs(ctx));
+  describe("tabs", () => {
+    // expected 2 to equal 1
+    it("add tabs", async () => await tabs.addTabs(ctx));
+    it("reload with tabs", async () => await tabs.reloadWithTabs(ctx));
+    it("reload with no tabs", async () => await tabs.reloadWithNoTabs(ctx));
+  });
 });
 
 mocha.run(failures => {

--- a/src/test/integration/tests/index.js
+++ b/src/test/integration/tests/index.js
@@ -23,6 +23,7 @@ module.exports = {
   searching: require("./searching"),
   sources: require("./sources"),
   sourceMaps: require("./sourcemaps"),
+  sourceMapsReloading: require("./sourcemaps-reloading"),
   sourceMaps2: require("./sourcemaps2"),
   sourceMapsBogus: require("./sourcemaps-bogus"),
   tabs: require("./tabs")

--- a/src/test/integration/tests/sourcemaps-reloading.js
+++ b/src/test/integration/tests/sourcemaps-reloading.js
@@ -1,0 +1,49 @@
+const {
+  initDebugger,
+  reload,
+  selectSource,
+  findElement,
+  waitForDispatch,
+  closeTab,
+  assertPausedLocation,
+  findSource,
+  waitForSources,
+  disableBreakpoint,
+  addBreakpoint,
+  waitForPaused
+} = require("../utils");
+
+function assertBP(dbg, sourceId, { line, disabled = false }) {
+  const { selectors: { getBreakpoint, getBreakpoints }, getState } = dbg;
+  const bp = getBreakpoint(getState(), { sourceId, line });
+
+  is(bp.location.line, line, "Breakpoint has correct line");
+
+  is(bp.disabled, disabled);
+}
+
+module.exports = async function sourceMapsReloading(ctx) {
+  const { ok, is, info, requestLongerTimeout } = ctx;
+
+  const dbg = await initDebugger("doc-sourcemaps.html");
+  const { selectors: { getBreakpoint, getBreakpoints }, getState } = dbg;
+
+  await waitForSources(dbg, "entry.js", "output.js", "times2.js", "opts.js");
+  const entrySrc = findSource(dbg, "entry.js");
+  await selectSource(dbg, entrySrc);
+
+  await addBreakpoint(dbg, entrySrc, 13);
+  is(getBreakpoints(getState()).size, 1, "One breakpoint exists");
+  assertBP(dbg, entrySrc.id, { line: 13 });
+
+  await addBreakpoint(dbg, entrySrc, 15);
+  await disableBreakpoint(dbg, entrySrc, 15);
+
+  // Test reloading the debugger
+  await reload(dbg, "times2.js", "opts.js");
+  await waitForDispatch(dbg, "LOAD_SOURCE_TEXT");
+
+  is(getBreakpoints(getState()).size, 2, "One breakpoint exists");
+  assertBP(dbg, entrySrc.id, { line: 13 });
+  assertBP(dbg, entrySrc.id, { line: 15, disabled: true });
+};

--- a/src/test/integration/tests/sourcemaps.js
+++ b/src/test/integration/tests/sourcemaps.js
@@ -15,7 +15,7 @@ const {
 // Tests loading sourcemapped sources, setting breakpoints, and
 // stepping in them.
 
-module.exports = async function(ctx) {
+module.exports = async function sourceMaps(ctx) {
   const { ok, is, info } = ctx;
 
   const dbg = await initDebugger("doc-sourcemaps.html");

--- a/src/test/integration/tests/tabs.js
+++ b/src/test/integration/tests/tabs.js
@@ -36,13 +36,14 @@ export async function reloadWithTabs(ctx) {
 
   let dbg = await initDebugger("doc-scripts.html", "simple1", "simple2");
 
+  // debugger
   await selectSource(dbg, "simple1");
   await selectSource(dbg, "simple2");
   expect(countTabs(dbg)).to.equal(2);
 
   // Test reloading the debugger
   await reload(dbg, "simple1", "simple2");
-  await waitForDispatch(dbg, "LOAD_SOURCE_TEXT");
+  await waitForDispatch(dbg, "SELECT_SOURCE");
   expect(countTabs(dbg)).to.equal(2);
 }
 

--- a/src/test/integration/utils/commands.js
+++ b/src/test/integration/utils/commands.js
@@ -61,10 +61,9 @@ async function selectSource(dbg, url, line) {
   info("Selecting source: " + url);
   const source = findSource(dbg, url);
   const hasText = !!dbg.selectors.getSourceText(dbg.getState(), source.id);
-  await dbg.actions.selectSource(source.id, { line });
-
+  dbg.actions.selectSource(source.id, { line });
   if (!hasText) {
-    await waitForDispatch(dbg, "LOAD_SOURCE_TEXT");
+    return waitForDispatch(dbg, "SELECT_SOURCE");
   }
 }
 
@@ -187,6 +186,14 @@ async function removeBreakpoint(dbg, sourceId, line, col) {
   return dbg.actions.removeBreakpoint({ sourceId, line, col });
 }
 
+async function disableBreakpoint(dbg, source, line) {
+  return dbg.actions.disableBreakpoint({
+    sourceId: source.id,
+    line,
+    column: undefined
+  });
+}
+
 /**
  * Toggles the Pause on exceptions feature in the debugger.
  *
@@ -260,6 +267,7 @@ module.exports = {
   navigate,
   addBreakpoint,
   removeBreakpoint,
+  disableBreakpoint,
   togglePauseOnExceptions,
   clickElement,
   mouseOverEl,

--- a/src/test/mochitest/browser.ini
+++ b/src/test/mochitest/browser.ini
@@ -70,6 +70,7 @@ skip-if = os == "linux" # bug 1351952
 [browser_dbg-searching.js]
 skip-if = true
 [browser_dbg-sourcemaps.js]
+[browser_dbg-sourcemaps-reloading.js]
 [browser_dbg-sourcemaps2.js]
 [browser_dbg-sourcemaps-bogus.js]
 [browser_dbg-sources.js]

--- a/src/test/mochitest/browser_dbg-sourcemaps-reloading.js
+++ b/src/test/mochitest/browser_dbg-sourcemaps-reloading.js
@@ -1,0 +1,52 @@
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
+
+add_task(function*() {
+  // NOTE: the CORS call makes the test run times inconsistent
+  requestLongerTimeout(2);
+
+  const dbg = yield initDebugger("doc-sourcemaps.html");
+  const { selectors: { getBreakpoint, getBreakpoints }, getState } = dbg;
+
+  yield waitForSources(dbg, "entry.js", "output.js", "times2.js", "opts.js");
+  ok(true, "Original sources exist");
+  const entrySrc = findSource(dbg, "entry.js");
+
+  yield selectSource(dbg, entrySrc);
+  ok(
+    dbg.win.cm.getValue().includes("window.keepMeAlive"),
+    "Original source text loaded correctly"
+  );
+
+  // Test that breakpoint sliding is not attempted. The breakpoint
+  // should not move anywhere.
+  yield addBreakpoint(dbg, entrySrc, 13);
+  is(getBreakpoints(getState()).size, 1, "One breakpoint exists");
+  ok(
+    getBreakpoint(getState(), { sourceId: entrySrc.id, line: 13 }),
+    "Breakpoint has correct line"
+  );
+
+  yield addBreakpoint(dbg, entrySrc, 15);
+  yield disableBreakpoint(dbg, entrySrc, 15);
+
+  // Test reloading the debugger
+  yield reload(dbg, "opts.js");
+  yield waitForDispatch(dbg, "LOAD_SOURCE_TEXT");
+
+  is(getBreakpoints(getState()).size, 2, "One breakpoint exists");
+
+  ok(
+    getBreakpoint(getState(), { sourceId: entrySrc.id, line: 13 }),
+    "Breakpoint has correct line"
+  );
+
+  ok(
+    getBreakpoint(getState(), {
+      sourceId: entrySrc.id,
+      line: 15,
+      disabled: true
+    }),
+    "Breakpoint has correct line"
+  );
+});

--- a/src/test/mochitest/head.js
+++ b/src/test/mochitest/head.js
@@ -506,6 +506,13 @@ function addBreakpoint(dbg, source, line, col) {
   return waitForDispatch(dbg, "ADD_BREAKPOINT");
 }
 
+function disableBreakpoint(dbg, source, line, col) {
+  source = findSource(dbg, source);
+  const sourceId = source.id;
+  dbg.actions.disableBreakpoint({ sourceId, line, col });
+  return waitForDispatch(dbg, "DISABLE_BREAKPOINT");
+}
+
 /**
  * Removes a breakpoint from a source at line/col.
  *


### PR DESCRIPTION
Associated Issue: #3182


### Summary of Changes

* I ran into an issue debugging [devtools-reporter](https://github.com/jasonLaster/devtools-reporter). The issue was that on reload the BP id had changed, but the source id and location were the same... Which got me thinking we should be consistent and use location ids
* I also set about adding some integration tests and cleaning them up. I'll do a mochitest for this as well before it lands