### PR TITLE
Add render mapping

### DIFF
--- a/src/utils/frame.js
+++ b/src/utils/frame.js
@@ -119,7 +119,8 @@ const displayNameMap = {
   React: {
     // eslint-disable-next-line max-len
     "ReactCompositeComponent._renderValidatedComponentWithoutOwnerOrContext/renderedElement<":
-      "Render"
+      "Render",
+    _renderValidatedComponentWithoutOwnerOrContext: "Render"
   },
   Webpack: {
     // eslint-disable-next-line camelcase


### PR DESCRIPTION
Quick mapping for the new marketing page:

### before
<img width="1392" alt="screen shot 2017-06-13 at 8 18 13 am" src="https://user-images.githubusercontent.com/254562/27082046-499fd196-5011-11e7-89c0-d9b631491e34.png">

### after

<img width="1392" alt="screen shot 2017-06-13 at 8 20 39 am" src="https://user-images.githubusercontent.com/254562/27082050-4cb48656-5011-11e7-9e0a-2ac354e9c60b.png">
