### PR TITLE
Speed up Out Of Scope lines

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,6 +2,6 @@ assets/*
 src/test/examples/**
 src/test/integration/**
 src/test/unit-sources/**
-src/utils/parser/tests/fixtures/**
+src/**/fixtures/**
 src/test/mochitest/**
 bin/

--- a/configs/development.json
+++ b/configs/development.json
@@ -62,6 +62,10 @@
     "projectTextSearch": {
       "label": "Project Text Search",
       "enabled": false
+    },
+    "highlightScopeLines": {
+      "label": "Highlight the lines in scope",
+      "enabled": false
     }
   },
   "chrome": {

--- a/src/actions/ast.js
+++ b/src/actions/ast.js
@@ -2,6 +2,7 @@
 
 import {
   getSourceText,
+  getSource,
   hasSymbols,
   getSelectedLocation,
   getSelectedSourceText,
@@ -40,9 +41,13 @@ export function setSymbols(source: Source) {
 export function setOutOfScopeLocations() {
   return async ({ dispatch, getState }: ThunkArgs) => {
     const location = getSelectedLocation(getState());
-    const sourceText = getSourceText(getState(), location.sourceId);
+    if (!location) {
+      return;
+    }
 
-    if (!location.line || !sourceText) {
+    const source = getSource(getState(), location.sourceId);
+
+    if (!location.line || !source) {
       return dispatch({
         type: "OUT_OF_SCOPE_LOCATIONS",
         locations: null
@@ -50,7 +55,7 @@ export function setOutOfScopeLocations() {
     }
 
     const locations = await parser.getOutOfScopeLocations(
-      sourceText.toJS(),
+      source.toJS(),
       location
     );
 

--- a/src/actions/tests/__snapshots__/ast.js.snap
+++ b/src/actions/tests/__snapshots__/ast.js.snap
@@ -1,17 +1,32 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ast getOutOfScopeLocations simple 1`] = `
+exports[`ast getOutOfScopeLocations with selected line 1`] = `
 Array [
   Object {
     "end": Object {
-      "column": 21,
-      "line": 1,
+      "column": 3,
+      "line": 10,
     },
     "start": Object {
-      "column": 13,
-      "line": 1,
+      "column": 22,
+      "line": 8,
     },
   },
+]
+`;
+
+exports[`ast getOutOfScopeLocations with selected line 2`] = `
+Array [
+  1,
+  2,
+  3,
+  4,
+  5,
+  6,
+  7,
+  10,
+  11,
+  12,
 ]
 `;
 

--- a/src/actions/tests/ast.js
+++ b/src/actions/tests/ast.js
@@ -7,7 +7,7 @@ import {
 
 import readFixture from "./helpers/readFixture";
 const { getSymbols, getOutOfScopeLocations } = selectors;
-import getLinesInScope from "../../selectors/linesInScope";
+import getInScopeLines from "../../selectors/linesInScope";
 
 const threadClient = {
   sourceContents: function(sourceId) {
@@ -82,7 +82,7 @@ describe("ast", () => {
       await dispatch(actions.selectSource("scopes.js", { line: 5 }));
 
       const locations = getOutOfScopeLocations(getState());
-      const lines = getLinesInScope(getState());
+      const lines = getInScopeLines(getState());
 
       expect(locations).toMatchSnapshot();
       expect(lines).toMatchSnapshot();
@@ -95,7 +95,7 @@ describe("ast", () => {
       await dispatch(actions.selectSource("base.js"));
 
       const locations = getOutOfScopeLocations(getState());
-      const lines = getLinesInScope(getState());
+      const lines = getInScopeLines(getState());
 
       expect(locations).toEqual(null);
       expect(lines).toEqual([1]);

--- a/src/actions/tests/ast.js
+++ b/src/actions/tests/ast.js
@@ -5,7 +5,9 @@ import {
   makeSource
 } from "../../utils/test-head";
 
+import readFixture from "./helpers/readFixture";
 const { getSymbols, getOutOfScopeLocations } = selectors;
+import getLinesInScope from "../../selectors/linesInScope";
 
 const threadClient = {
   sourceContents: function(sourceId) {
@@ -30,7 +32,8 @@ const threadClient = {
 
 const sourceTexts = {
   "base.js": "function base(boo) {}",
-  "foo.js": "function base(boo) { return this.bazz; } outOfScope"
+  "foo.js": "function base(boo) { return this.bazz; } outOfScope",
+  "scopes.js": readFixture("scopes.js")
 };
 
 const evaluationResult = {
@@ -72,32 +75,33 @@ describe("ast", () => {
   });
 
   describe("getOutOfScopeLocations", () => {
-    it("simple", async () => {
+    it("with selected line", async () => {
       const { dispatch, getState } = createStore(threadClient);
-      const base = makeSource("base.js");
-      await dispatch(actions.newSource(base));
-      await dispatch(actions.loadSourceText({ id: "base.js" }));
-      await dispatch(actions.selectSource("base.js", { line: 1 }));
-
-      await dispatch(actions.setOutOfScopeLocations());
+      const source = makeSource("scopes.js");
+      await dispatch(actions.newSource(source));
+      await dispatch(actions.selectSource("scopes.js", { line: 5 }));
 
       const locations = getOutOfScopeLocations(getState());
+      const lines = getLinesInScope(getState());
+
       expect(locations).toMatchSnapshot();
+      expect(lines).toMatchSnapshot();
     });
 
     it("without a selected line", async () => {
       const { dispatch, getState } = createStore(threadClient);
       const base = makeSource("base.js");
       await dispatch(actions.newSource(base));
-      await dispatch(actions.loadSourceText({ id: "base.js" }));
       await dispatch(actions.selectSource("base.js"));
 
-      await dispatch(actions.setOutOfScopeLocations());
-
       const locations = getOutOfScopeLocations(getState());
+      const lines = getLinesInScope(getState());
+
       expect(locations).toEqual(null);
+      expect(lines).toEqual([1]);
     });
   });
+
   describe("setSelection", () => {
     it("simple", async () => {
       const { dispatch, getState } = createStore(threadClient);

--- a/src/actions/tests/fixtures/scopes.js
+++ b/src/actions/tests/fixtures/scopes.js
@@ -1,0 +1,11 @@
+// Program Scope
+
+function outer() {
+  function inner() {
+    const x = 1;
+  }
+
+  const declaration = function() {
+    const x = 1;
+  };
+}

--- a/src/actions/tests/helpers/readFixture.js
+++ b/src/actions/tests/helpers/readFixture.js
@@ -1,0 +1,10 @@
+import fs from "fs";
+import path from "path";
+
+export default function readFixture(name) {
+  const text = fs.readFileSync(
+    path.join(__dirname, `../fixtures/${name}`),
+    "utf8"
+  );
+  return text;
+}

--- a/src/components/Editor/Editor.css
+++ b/src/components/Editor/Editor.css
@@ -22,8 +22,12 @@
   --theme-conditional-breakpoint-color: #ccd1d5;
 }
 
-.out-of-scope .CodeMirror-line, .out-of-scope .CodeMirror-linenumber {
-  opacity: 0.8;
+.paused .in-scope .CodeMirror-line, .paused .in-scope .CodeMirror-linenumber {
+  opacity: 1;
+}
+
+.paused .CodeMirror-line, .paused .CodeMirror-linenumber {
+  opacity: 0.7;
 }
 
 /**

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -31,7 +31,7 @@ import {
   getFileSearchModifierState
 } from "../../selectors";
 
-import getLinesInScope from "../../selectors/linesInScope";
+import getInScopeLines from "../../selectors/linesInScope";
 
 import { makeLocationId } from "../../utils/breakpoint";
 import actions from "../../actions";
@@ -932,7 +932,7 @@ export default connect(
       coverageOn: getCoverageEnabled(state),
       query: getFileSearchQueryState(state),
       searchModifiers: getFileSearchModifierState(state),
-      linesInScope: getLinesInScope(state),
+      linesInScope: getInScopeLines(state),
       selection: getSelection(state)
     };
   },

--- a/src/reducers/ast.js
+++ b/src/reducers/ast.js
@@ -79,6 +79,10 @@ function update(
       });
     }
 
+    case "RESUMED": {
+      return state.set("outOfScopeLocations", null);
+    }
+
     default: {
       return state;
     }

--- a/src/selectors/linesInScope.js
+++ b/src/selectors/linesInScope.js
@@ -1,0 +1,41 @@
+import { getOutOfScopeLocations, getSelectedSource } from "../selectors";
+
+import range from "lodash/range";
+import flatMap from "lodash/flatMap";
+import uniq from "lodash/uniq";
+import without from "lodash/without";
+
+function getLinesOutOfScope(outOfScopeLocations: AstLocation[]) {
+  if (!outOfScopeLocations) {
+    return null;
+  }
+
+  return uniq(
+    flatMap(outOfScopeLocations, location =>
+      range(location.start.line, location.end.line)
+    )
+  );
+}
+
+export default function getLinesInScope(state: OuterState) {
+  const source = getSelectedSource(state);
+  const outOfScopeLocations = getOutOfScopeLocations(state);
+
+  if (!source || !source.get("text")) {
+    return;
+  }
+
+  const linesOutOfScope = getLinesOutOfScope(
+    outOfScopeLocations,
+    source.toJS()
+  );
+
+  const sourceNumLines = source.get("text").split("\n").length;
+  const sourceLines = range(1, sourceNumLines + 1);
+
+  if (!linesOutOfScope) {
+    return sourceLines;
+  }
+
+  return without(sourceLines, ...linesOutOfScope);
+}

--- a/src/selectors/linesInScope.js
+++ b/src/selectors/linesInScope.js
@@ -5,7 +5,7 @@ import flatMap from "lodash/flatMap";
 import uniq from "lodash/uniq";
 import without from "lodash/without";
 
-function getLinesOutOfScope(outOfScopeLocations: AstLocation[]) {
+function getOutOfScopeLines(outOfScopeLocations: AstLocation[]) {
   if (!outOfScopeLocations) {
     return null;
   }
@@ -17,7 +17,7 @@ function getLinesOutOfScope(outOfScopeLocations: AstLocation[]) {
   );
 }
 
-export default function getLinesInScope(state: OuterState) {
+export default function getInScopeLines(state: OuterState) {
   const source = getSelectedSource(state);
   const outOfScopeLocations = getOutOfScopeLocations(state);
 
@@ -25,7 +25,7 @@ export default function getLinesInScope(state: OuterState) {
     return;
   }
 
-  const linesOutOfScope = getLinesOutOfScope(
+  const linesOutOfScope = getOutOfScopeLines(
     outOfScopeLocations,
     source.toJS()
   );

--- a/src/utils/scopes.js
+++ b/src/utils/scopes.js
@@ -2,7 +2,6 @@
 
 import toPairs from "lodash/toPairs";
 import get from "lodash/get";
-
 import type { Frame, Pause, Scope } from "debugger-html";
 
 type ScopeData = {


### PR DESCRIPTION
Associated Issue: #3180

### Summary of Changes

This refactors out of scope lines a bit to support getting a list of in scope lines that can be used by the editor to check if a token is in scope on hover.



### Test Plan

Jest tests