### PR TITLE
Update getting-setup.md

### DIFF
--- a/docs/getting-setup.md
+++ b/docs/getting-setup.md
@@ -168,7 +168,7 @@ If you find any issues on these two platforms comment on these issues:
 **Firefox windows command**
 
 ```bash
-"C:\Program Files (x86)\Mozilla Firefox\firefox.exe" -start-debugger-server 6080 -P development
+"C:\Program Files (x86)\Mozilla Firefox\firefox.exe" --start-debugging-server 6080 -P development
 ```
 
 ### Debugger examples


### PR DESCRIPTION
Proposing a small change to the Firefox Windows command, based on #1248, where using `--start-debugging-server` works while `-start-debugger-server` fails.
