### PR TITLE
highlight pause expressions

### DIFF
--- a/src/components/Editor/Editor.css
+++ b/src/components/Editor/Editor.css
@@ -1,12 +1,12 @@
 .editor-wrapper {
-  --debug-line-background: rgba(226, 236, 247, 0.5);
   --debug-line-border: rgb(145, 188, 219);
+  --debug-expression-background: rgba(202, 227, 255, 0.5);
   --editor-searchbar-height: 27px;
   --editor-second-searchbar-height: 27px;
 }
 
 .theme-dark .editor-wrapper {
-  --debug-line-background: rgb(73, 82, 103);
+  --debug-expression-background: rgb(73, 82, 103);
   --debug-line-border: rgb(119, 134, 162);
 }
 
@@ -160,8 +160,12 @@ html[dir="rtl"] .editor-mount {
   color: var(--theme-content-color3);
 }
 
+.debug-expression {
+  background-color: var(--debug-expression-background);
+}
+
 .new-debug-line .CodeMirror-line {
-  background-color: var(--debug-line-background) !important;
+  background-color: transparent !important;
   outline: var(--debug-line-border) solid 1px;
 }
 

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -93,6 +93,7 @@ class Editor extends PureComponent {
   editor: SourceEditor;
   pendingJumpLine: any;
   lastJumpLine: any;
+  debugExpression: any;
   state: EditorState;
 
   constructor() {
@@ -584,6 +585,10 @@ class Editor extends PureComponent {
   clearDebugLine(selectedFrame) {
     if (selectedFrame) {
       const line = selectedFrame.location.line;
+      if (this.debugExpression) {
+        this.debugExpression.clear();
+      }
+
       this.editor.codeMirror.removeLineClass(
         line - 1,
         "line",
@@ -598,8 +603,14 @@ class Editor extends PureComponent {
       selectedLocation &&
       selectedFrame.location.sourceId === selectedLocation.sourceId
     ) {
-      const line = selectedFrame.location.line;
+      const { line, column } = selectedFrame.location;
       this.editor.codeMirror.addLineClass(line - 1, "line", "new-debug-line");
+
+      this.debugExpression = this.editor.codeMirror.markText(
+        { line: line - 1, ch: column },
+        { line: line - 1, ch: null },
+        { className: "debug-expression" }
+      );
     }
   }
 

--- a/src/test/mochitest/head.js
+++ b/src/test/mochitest/head.js
@@ -215,10 +215,20 @@ function assertPausedLocation(dbg, source, line) {
   is(location.line, line);
 
   // Check the debug line
+  const lineInfo = getCM(dbg).lineInfo(line - 1);
   ok(
-    getCM(dbg).lineInfo(line - 1).wrapClass.includes("debug-line"),
+    lineInfo.wrapClass.includes("debug-line"),
     "Line is highlighted as paused"
   );
+
+  const markedSpans = lineInfo.handle.markedSpans;
+  if (markedSpans && markedSpans.length > 0) {
+    const marker = markedSpans[0].marker;
+    ok(
+      marker.className.includes("debug-expression"),
+      "expression is highlighted as paused"
+    );
+  }
 }
 
 /**


### PR DESCRIPTION

### Summary of Changes

This updates our debug line highlighter so that it starts at the column we're paused at. This is more informative because we're often not paused at the beginning of a line.

### Test Plan

I'd like to update `editor-highlight`

### Screenshots/Videos (OPTIONAL)

#### after
![](http://g.recordit.co/CUkjkNvKGe.gif)

#### before

![](http://g.recordit.co/u3nipVl3Oa.gif)