### PR TITLE
Bugfix: ctrl-clicking gutter prematurely added breakpoint

### DIFF
--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -435,6 +435,7 @@ class Editor extends PureComponent {
 
     // ignore right clicks in the gutter
     if (
+      (ev.ctrlKey && ev.button === 0) ||
       ev.which === 3 ||
       (selectedSource && selectedSource.get("isBlackBoxed"))
     ) {


### PR DESCRIPTION
Associated Issue: #2668 

### Summary of Changes

Added a check in `onGutterClick` to early return if the user right clicked using <kbd>ctrl</kbd>-click.

### Test Plan

- [x] Right-clicking in the gutter **by holding down <kbd>ctrl</kbd> and left-clicking once** only shows the context menu, does not add a breakpoint

### Screenshots/Videos (OPTIONAL)

#### before

![breakpoint is added](http://g.recordit.co/qPBPpy1WVJ.gif)

#### after

![breakpoint is no longer added](http://g.recordit.co/PbqpWAFCwV.gif)