### PR TITLE
Change default case sensitive search modifier to off

### DIFF
--- a/assets/panel/prefs.js
+++ b/assets/panel/prefs.js
@@ -40,6 +40,6 @@ pref("devtools.debugger.tabs", "[]");
 pref("devtools.debugger.pending-selected-location", "{}");
 pref("devtools.debugger.pending-breakpoints", "{}");
 pref("devtools.debugger.expressions", "[]");
-pref("devtools.debugger.file-search-case-sensitive", true);
+pref("devtools.debugger.file-search-case-sensitive", false);
 pref("devtools.debugger.file-search-whole-word", false );
 pref("devtools.debugger.file-search-regex-match", false);

--- a/src/utils/prefs.js
+++ b/src/utils/prefs.js
@@ -20,7 +20,7 @@ if (isDevelopment()) {
   pref("devtools.debugger.pending-selected-location", "{}");
   pref("devtools.debugger.pending-breakpoints", "{}");
   pref("devtools.debugger.expressions", "[]");
-  pref("devtools.debugger.file-search-case-sensitive", true);
+  pref("devtools.debugger.file-search-case-sensitive", false);
   pref("devtools.debugger.file-search-whole-word", false);
   pref("devtools.debugger.file-search-regex-match", false);
   pref("devtools.debugger.prefs-schema-version", "1.0.0");


### PR DESCRIPTION
Associated Issue: #3068 

### Summary of Changes

* Change the default case sensitive search modifier to be turned off, meaning the search is case-insensitive by default.

 #goodnessSquad