### PR TITLE
Include comments in "out of scope" locations

### DIFF
--- a/configs/development.json
+++ b/configs/development.json
@@ -65,7 +65,7 @@
     },
     "highlightScopeLines": {
       "label": "Highlight the lines in scope",
-      "enabled": true
+      "enabled": false
     }
   },
   "chrome": {

--- a/configs/development.json
+++ b/configs/development.json
@@ -65,7 +65,7 @@
     },
     "highlightScopeLines": {
       "label": "Highlight the lines in scope",
-      "enabled": false
+      "enabled": true
     }
   },
   "chrome": {

--- a/src/actions/tests/__snapshots__/ast.js.snap
+++ b/src/actions/tests/__snapshots__/ast.js.snap
@@ -65,6 +65,7 @@ Object {
 
 exports[`ast setSymbols when the source is loaded should be able to set symbols 1`] = `
 Object {
+  "comments": Array [],
   "functions": Array [
     Object {
       "identifier": Object {

--- a/src/actions/tests/__snapshots__/ast.js.snap
+++ b/src/actions/tests/__snapshots__/ast.js.snap
@@ -4,6 +4,16 @@ exports[`ast getOutOfScopeLocations with selected line 1`] = `
 Array [
   Object {
     "end": Object {
+      "column": 16,
+      "line": 1,
+    },
+    "start": Object {
+      "column": 0,
+      "line": 1,
+    },
+  },
+  Object {
+    "end": Object {
       "column": 3,
       "line": 10,
     },

--- a/src/utils/parser/getOutOfScopeLocations.js
+++ b/src/utils/parser/getOutOfScopeLocations.js
@@ -9,9 +9,9 @@ import { containsLocation, containsPosition } from "./utils/helpers";
 
 import getSymbols from "./getSymbols";
 
-function findFunctions(source) {
-  const symbols = getSymbols(source);
-  return symbols.functions;
+function findSymbols(source) {
+  const { functions } = getSymbols(source);
+  return { functions };
 }
 
 /**
@@ -77,8 +77,12 @@ function getOutOfScopeLocations(
   source: Source,
   position: AstPosition
 ): AstLocation[] {
-  return findFunctions(source)
+  const { functions, comments } = findSymbols(source);
+  const commentLocations = comments.map(c => c.loc);
+
+  return functions
     .map(getLocation)
+    .concat(commentLocations)
     .filter(loc => !containsPosition(loc, position))
     .reduce(removeOverlaps, [])
     .sort(sortByStart);

--- a/src/utils/parser/getOutOfScopeLocations.js
+++ b/src/utils/parser/getOutOfScopeLocations.js
@@ -10,8 +10,8 @@ import { containsLocation, containsPosition } from "./utils/helpers";
 import getSymbols from "./getSymbols";
 
 function findSymbols(source) {
-  const { functions } = getSymbols(source);
-  return { functions };
+  const { functions, comments } = getSymbols(source);
+  return { functions, comments };
 }
 
 /**
@@ -78,7 +78,7 @@ function getOutOfScopeLocations(
   position: AstPosition
 ): AstLocation[] {
   const { functions, comments } = findSymbols(source);
-  const commentLocations = comments.map(c => c.loc);
+  const commentLocations = comments.map(c => c.location);
 
   return functions
     .map(getLocation)

--- a/src/utils/parser/getSymbols.js
+++ b/src/utils/parser/getSymbols.js
@@ -69,7 +69,7 @@ function getComments(ast) {
   }));
 }
 
-function extractSymbols(source: SourceText) {
+function extractSymbols(source: Source) {
   const functions = [];
   const variables = [];
   const memberExpressions = [];
@@ -153,7 +153,7 @@ function extractSymbols(source: SourceText) {
   };
 }
 
-export default function getSymbols(source: SourceText): SymbolDeclarations {
+export default function getSymbols(source: Source): SymbolDeclarations {
   if (symbolDeclarations.has(source.id)) {
     const symbols = symbolDeclarations.get(source.id);
     if (symbols) {

--- a/src/utils/parser/tests/__snapshots__/getOutOfScopeLocations.js.snap
+++ b/src/utils/parser/tests/__snapshots__/getOutOfScopeLocations.js.snap
@@ -1,7 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Parser.getOutOfScopeLocations should exclude function for locations on declaration 1`] = `
-"(3, 14) -> (23, 1)
+"(1, 0) -> (1, 16)
+(3, 14) -> (23, 1)
 (25, 16) -> (29, 1)
 (31, 20) -> (33, 1)
 (35, 26) -> (37, 1)
@@ -10,7 +11,8 @@ exports[`Parser.getOutOfScopeLocations should exclude function for locations on 
 `;
 
 exports[`Parser.getOutOfScopeLocations should exclude non-enclosing function blocks 1`] = `
-"(8, 16) -> (10, 3)
+"(1, 0) -> (1, 16)
+(8, 16) -> (10, 3)
 (12, 22) -> (14, 3)
 (16, 16) -> (18, 3)
 (20, 27) -> (22, 3)
@@ -22,7 +24,8 @@ exports[`Parser.getOutOfScopeLocations should exclude non-enclosing function blo
 `;
 
 exports[`Parser.getOutOfScopeLocations should roll up function blocks 1`] = `
-"(3, 14) -> (23, 1)
+"(1, 0) -> (1, 16)
+(3, 14) -> (23, 1)
 (25, 16) -> (29, 1)
 (31, 20) -> (33, 1)
 (35, 26) -> (37, 1)

--- a/src/utils/parser/tests/fixtures/outOfScopeComment.js
+++ b/src/utils/parser/tests/fixtures/outOfScopeComment.js
@@ -1,0 +1,4 @@
+// Some comment
+(function() {
+  const x = 1;
+})();

--- a/src/utils/parser/tests/getOutOfScopeLocations.js
+++ b/src/utils/parser/tests/getOutOfScopeLocations.js
@@ -42,7 +42,7 @@ describe("Parser.getOutOfScopeLocations", () => {
   });
 
   it("should treat comments as out of scope", () => {
-    const actual = getOutOfScopeLocations(getSourceText("outOfScopeComment"), {
+    const actual = getOutOfScopeLocations(getSource("outOfScopeComment"), {
       line: 3,
       column: 2
     });

--- a/src/utils/parser/tests/getOutOfScopeLocations.js
+++ b/src/utils/parser/tests/getOutOfScopeLocations.js
@@ -40,4 +40,15 @@ describe("Parser.getOutOfScopeLocations", () => {
 
     expect(formatLines(actual)).toMatchSnapshot();
   });
+
+  it("should treat comments as out of scope", () => {
+    const actual = getOutOfScopeLocations(getSourceText("outOfScopeComment"), {
+      line: 3,
+      column: 2
+    });
+
+    expect(actual).toEqual([
+      { end: { column: 15, line: 1 }, start: { column: 0, line: 1 } }
+    ]);
+  });
 });

--- a/src/utils/parser/utils/ast.js
+++ b/src/utils/parser/utils/ast.js
@@ -75,4 +75,5 @@ export function traverseAst(source: Source, visitor: Visitor) {
   }
 
   traverse(ast, visitor);
+  return ast;
 }


### PR DESCRIPTION
Associated Issue: #3055

### Summary of Changes

* in getOutOfScopeLocations.js changed function findFunctions to findSymbols and concat functions to comments

### Test Plan

- [x] should treat comments as out of scope

the only reason this PR is under my account is that @giladartzi's machine didn't compile the code properly. Beautiful work in #goodnessSquad