### PR TITLE
bail early on closestExpression

### DIFF
--- a/src/actions/tests/__snapshots__/ast.js.snap
+++ b/src/actions/tests/__snapshots__/ast.js.snap
@@ -52,6 +52,23 @@ exports[`ast setSymbols when the source is loaded should be able to set symbols 
 Object {
   "functions": Array [
     Object {
+      "identifier": Object {
+        "end": 13,
+        "loc": Object {
+          "end": Object {
+            "column": 13,
+            "line": 1,
+          },
+          "identifierName": "base",
+          "start": Object {
+            "column": 9,
+            "line": 1,
+          },
+        },
+        "name": "base",
+        "start": 9,
+        "type": "Identifier",
+      },
       "location": Object {
         "end": Object {
           "column": 21,

--- a/src/utils/parser/getOutOfScopeLocations.js
+++ b/src/utils/parser/getOutOfScopeLocations.js
@@ -21,7 +21,7 @@ function findFunctions(source) {
  */
 
 function getLocation(func) {
-  let location = Object.assign({}, func.location);
+  const location = { ...func.location };
 
   // if the function has an identifier, start the block after it so the
   // identifier is included in the "scope" of its parent

--- a/src/utils/parser/getOutOfScopeLocations.js
+++ b/src/utils/parser/getOutOfScopeLocations.js
@@ -5,28 +5,13 @@ import type { AstLocation, AstPosition } from "./types";
 
 import get from "lodash/fp/get";
 
-import {
-  containsLocation,
-  containsPosition,
-  isFunction
-} from "./utils/helpers";
-import { traverseAst } from "./utils/ast";
+import { containsLocation, containsPosition } from "./utils/helpers";
 
-/**
- * Returns all functions (declarations, expressions, arrows) for the given
- * source
- */
-function findFunctions(source: SourceText) {
-  const fns = [];
-  traverseAst(source, {
-    enter(path) {
-      if (isFunction(path)) {
-        fns.push(path);
-      }
-    }
-  });
+import getSymbols from "./getSymbols";
 
-  return fns;
+function findFunctions(source) {
+  const symbols = getSymbols(source);
+  return symbols.functions;
 }
 
 /**
@@ -34,18 +19,19 @@ function findFunctions(source: SourceText) {
  * function declaration, the location will begin after the function identifier
  * but before the function parameters.
  */
-const getLocation = path => {
-  let location = Object.assign({}, get("node.loc", path));
+
+function getLocation(func) {
+  let location = Object.assign({}, func.location);
 
   // if the function has an identifier, start the block after it so the
   // identifier is included in the "scope" of its parent
-  const identifierEnd = get("node.id.loc.end", path);
+  const identifierEnd = get("identifier.loc.end", func);
   if (identifierEnd) {
     location.start = identifierEnd;
   }
 
   return location;
-};
+}
 
 /**
  * Reduces an array of locations to remove items that are completely enclosed

--- a/src/utils/parser/getSymbols.js
+++ b/src/utils/parser/getSymbols.js
@@ -13,7 +13,8 @@ const symbolDeclarations = new Map();
 export type SymbolDeclaration = {|
   name: string,
   location: BabelLocation,
-  parameterNames?: string[]
+  parameterNames?: string[],
+  identifier?: Object
 |};
 
 export type FunctionDeclaration = SymbolDeclaration & {|
@@ -72,7 +73,8 @@ export default function getSymbols(source: SourceText): SymbolDeclarations {
         symbols.functions.push({
           name: getFunctionName(path),
           location: path.node.loc,
-          parameterNames: getFunctionParameterNames(path)
+          parameterNames: getFunctionParameterNames(path),
+          identifier: path.node.id
         });
       }
 

--- a/src/utils/parser/utils/closest.js
+++ b/src/utils/parser/utils/closest.js
@@ -25,11 +25,11 @@ function getClosestMemberExpression(source, token, location: Location) {
   traverseAst(source, {
     enter(path: NodePath) {
       const { node } = path;
-      if (
-        t.isMemberExpression(node) &&
-        node.property.name === token &&
-        nodeContainsPosition(node, location)
-      ) {
+      if (!nodeContainsPosition(node, location)) {
+        return path.skip();
+      }
+
+      if (t.isMemberExpression(node) && node.property.name === token) {
         const memberExpression = getMemberExpression(node);
         expression = {
           expression: memberExpression,
@@ -66,7 +66,11 @@ export function getClosestScope(source: SourceText, location: Location) {
 
   traverseAst(source, {
     enter(path) {
-      if (isLexicalScope(path) && nodeContainsPosition(path.node, location)) {
+      if (!nodeContainsPosition(path.node, location)) {
+        return path.skip();
+      }
+
+      if (isLexicalScope(path)) {
         closestPath = path;
       }
     }
@@ -84,9 +88,10 @@ export function getClosestPath(source: SourceText, location: Location) {
 
   traverseAst(source, {
     enter(path) {
-      if (nodeContainsPosition(path.node, location)) {
-        closestPath = path;
+      if (!nodeContainsPosition(path.node, location)) {
+        return path.skip();
       }
+      closestPath = path;
     }
   });
 


### PR DESCRIPTION
Associated Issue: #3209 

This offers much needed perf wins when debugging large 10K+ files (a.k.a. the debugger.js file). Previously the perf times were a couple seconds for finding the closest expression and out of scope lines and now they're a couple hundred milliseconds or less...

It's amazing how much it pays to be lazy.


I got these rough stats from adding logging to our worker utils
```js
 37         var t0 = performance.now();
 38         this.worker.postMessage({ id, method, args });
 39
 40         const listener = ({ data: result }) => {
 41           if (result.id !== id) {
 42             return;
 43           }
 44
 45           this.worker.removeEventListener("message", listener);
 46           var t1 = performance.now();
 47           console.log(`${method} took:` + (t1 - t0) + " milliseconds.");
 48
```