### PR TITLE
[Preview] Show undefineds in a tooltip

### DIFF
--- a/src/components/Editor/Preview.js
+++ b/src/components/Editor/Preview.js
@@ -156,7 +156,12 @@ class Preview extends Component {
   }
 
   getPreviewType(value) {
-    if (typeof value == "boolean" || value.class === "Function") {
+    if (
+      typeof value == "boolean" ||
+      value.type == "null" ||
+      value.type == "undefined" ||
+      value.class === "Function"
+    ) {
       return "tooltip";
     }
 

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -781,11 +781,7 @@ class Editor extends PureComponent {
 
     const { result, expression } = selection;
     const value = result;
-    if (
-      typeof value == "undefined" ||
-      value.type == "undefined" ||
-      value.optimizedOut
-    ) {
+    if (typeof value == "undefined" || value.optimizedOut) {
       return;
     }
 


### PR DESCRIPTION
Associated Issue: #3058

### Summary of Changes
* Show `undefined` and `null` in a tooltip.

### Test Plan
1. Hover over variables with value undefined and null.

### Screenshots/Videos (OPTIONAL)
![kapture 2017-06-23 at 15 17 03](https://user-images.githubusercontent.com/4562118/27470969-acb03626-5828-11e7-86bc-c1dc686f01c1.gif)