### PR TITLE
Fix reloading issue with selected tabs + breakpoints

### DIFF
--- a/src/actions/navigation.js
+++ b/src/actions/navigation.js
@@ -28,6 +28,13 @@ export function navigate(url) {
   };
 }
 
+export function connect(url) {
+  return {
+    type: "CONNECT",
+    url
+  };
+}
+
 /**
  * @memberof actions/navigation
  * @static

--- a/src/actions/tests/navigation.js
+++ b/src/actions/tests/navigation.js
@@ -1,9 +1,9 @@
 import { createStore, selectors, actions } from "../../utils/test-head";
 import expect from "expect.js";
 describe("navigation", () => {
-  it("navigate sets the debuggeeUrl", () => {
+  it("connect sets the debuggeeUrl", () => {
     const { dispatch, getState } = createStore();
-    dispatch(actions.navigate("http://test.com/foo"));
+    dispatch(actions.connect("http://test.com/foo"));
     expect(selectors.getDebuggeeUrl(getState())).to.be("http://test.com/foo");
   });
 });

--- a/src/client/firefox.js
+++ b/src/client/firefox.js
@@ -30,7 +30,7 @@ export async function onConnect(connection: any, actions: Object) {
   // bfcache) so explicity fire `newSource` events for all returned
   // sources.
   const sources = await clientCommands.fetchSources();
-  actions.navigate(tabTarget._form.url);
+  actions.connect(tabTarget._form.url);
   await actions.newSources(sources);
 
   // If the threadClient is already paused, make sure to show a

--- a/src/client/firefox/tests/onconnect.js
+++ b/src/client/firefox/tests/onconnect.js
@@ -27,7 +27,7 @@ const debuggerClient = {};
 
 const actions = {
   _sources: [],
-  navigate: () => {},
+  connect: () => {},
 
   newSources: function(sources) {
     return new Promise(resolve => {

--- a/src/reducers/pause.js
+++ b/src/reducers/pause.js
@@ -124,7 +124,7 @@ function update(state: PauseState = State(), action: Action): PauseState {
       }
       break;
 
-    case "NAVIGATE":
+    case "CONNECT":
       return Object.assign({}, State(), { debuggeeUrl: action.url });
 
     case "PAUSE_ON_EXCEPTIONS":

--- a/src/reducers/sources.js
+++ b/src/reducers/sources.js
@@ -40,18 +40,20 @@ export type SourcesState = {
   tabs: TabList
 };
 
-export const State = makeRecord(
-  ({
-    sources: I.Map(),
-    selectedLocation: undefined,
-    pendingSelectedLocation: prefs.pendingSelectedLocation,
-    sourcesText: I.Map(),
-    tabs: I.List(restoreTabs())
-  }: SourcesState)
-);
+export function initialState(): Record<SourcesState> {
+  return makeRecord(
+    ({
+      sources: I.Map(),
+      selectedLocation: undefined,
+      pendingSelectedLocation: prefs.pendingSelectedLocation,
+      sourcesText: I.Map(),
+      tabs: I.List(restoreTabs())
+    }: SourcesState)
+  )();
+}
 
 function update(
-  state: Record<SourcesState> = State(),
+  state: Record<SourcesState> = initialState(),
   action: Action
 ): Record<SourcesState> {
   let location = null;
@@ -139,8 +141,12 @@ function update(
     case "NAVIGATE":
       const source = getSelectedSource({ sources: state });
       const url = source && source.get("url");
-      prefs.pendingSelectedLocation = { url };
-      return State().set("pendingSelectedLocation", { url });
+
+      if (!url) {
+        return initialState();
+      }
+
+      return initialState().set("pendingSelectedLocation", { url });
   }
 
   return state;
@@ -172,7 +178,7 @@ function setSourceTextProps(state, action: any): Record<SourcesState> {
   return updateSource(state, text);
 }
 
-function updateSource(state: State, source: Object | Source) {
+function updateSource(state: Record<SourcesState>, source: Object | Source) {
   if (!source.id) {
     return state;
   }

--- a/src/reducers/tests/sources.js
+++ b/src/reducers/tests/sources.js
@@ -3,13 +3,13 @@ declare var describe: (name: string, func: () => void) => void;
 declare var it: (desc: string, func: () => void) => void;
 declare var expect: (value: any) => any;
 
-import update, { State } from "../sources";
+import update, { initialState } from "../sources";
 import { foobar } from "../../test/fixtures";
 const fakeSources = foobar.sources.sources;
 
 describe("sources reducer", () => {
   it("should work", () => {
-    let state = State();
+    let state = initialState();
     state = update(state, {
       type: "ADD_SOURCE",
       source: fakeSources.fooSourceActor

--- a/src/test/mochitest/browser.ini
+++ b/src/test/mochitest/browser.ini
@@ -45,6 +45,7 @@ support-files =
 [browser_dbg-breaking.js]
 [browser_dbg-breaking-from-console.js]
 [browser_dbg-breakpoints.js]
+[browser_dbg-breakpoints-reloading.js]
 [browser_dbg-breakpoints-cond.js]
 [browser_dbg-call-stack.js]
 [browser_dbg-expressions.js]
@@ -74,4 +75,5 @@ skip-if = true
 [browser_dbg-sourcemaps2.js]
 [browser_dbg-sourcemaps-bogus.js]
 [browser_dbg-sources.js]
+[browser_dbg-tabs.js]
 [browser_dbg-toggling-tools.js]

--- a/src/test/mochitest/browser_dbg-breakpoints-reloading.js
+++ b/src/test/mochitest/browser_dbg-breakpoints-reloading.js
@@ -1,0 +1,39 @@
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
+
+// Tests pending breakpoints when reloading
+
+// Utilities for interacting with the editor
+function clickGutter(dbg, line) {
+  clickElement(dbg, "gutter", line);
+}
+
+function getLineEl(dbg, line) {
+  const lines = dbg.win.document.querySelectorAll(".CodeMirror-code > div");
+  return lines[line - 1];
+}
+
+function addBreakpoint(dbg, line) {
+  clickGutter(dbg, line);
+  return waitForDispatch(dbg, "ADD_BREAKPOINT");
+}
+
+function assertEditorBreakpoint(dbg, line) {
+  const exists = !!getLineEl(dbg, line).querySelector(".new-breakpoint");
+  ok(exists, `Breakpoint exists on line ${line}`);
+}
+
+add_task(function*() {
+  const dbg = yield initDebugger("doc-scripts.html");
+  const { selectors: { getBreakpoints, getBreakpoint }, getState } = dbg;
+  const source = findSource(dbg, "simple1.js");
+
+  yield selectSource(dbg, source.url);
+  yield addBreakpoint(dbg, 5);
+  yield addBreakpoint(dbg, 2);
+
+  yield reload(dbg, "simple1");
+  yield waitForSelectedSource(dbg);
+  assertEditorBreakpoint(dbg, 4);
+  assertEditorBreakpoint(dbg, 5);
+});

--- a/src/test/mochitest/browser_dbg-tabs.js
+++ b/src/test/mochitest/browser_dbg-tabs.js
@@ -1,0 +1,39 @@
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
+
+// Tests adding and removing tabs
+
+function countTabs(dbg) {
+  return findElement(dbg, "sourceTabs").children.length;
+}
+
+add_task(function*() {
+  let dbg = yield initDebugger("doc-scripts.html");
+
+  yield selectSource(dbg, "simple1");
+  yield selectSource(dbg, "simple2");
+  is(countTabs(dbg), 2);
+
+  // Test reloading the debugger
+  yield reload(dbg, "simple1", "simple2");
+  is(countTabs(dbg), 2);
+  yield waitForSelectedSource(dbg);
+
+  // Test reloading the debuggee a second time
+  yield reload(dbg, "simple1", "simple2");
+  is(countTabs(dbg), 2);
+  yield waitForSelectedSource(dbg);
+});
+
+add_task(function*() {
+  let dbg = yield initDebugger("doc-scripts.html", "simple1", "simple2");
+
+  yield selectSource(dbg, "simple1");
+  yield selectSource(dbg, "simple2");
+  closeTab(dbg, "simple1");
+  closeTab(dbg, "simple2");
+
+  // Test reloading the debugger
+  yield reload(dbg, "simple1", "simple2");
+  is(countTabs(dbg), 0);
+});


### PR DESCRIPTION
Fixes: #3221

We were seeing two issues:

1. tabs were not selected on reload
2. breakpoints were jumping (we saw this same kinda thing earlier) the root cause is when we try to add the same bp again

how is everything fixed? I changed the action from navigate to connect which now just sets the debuggee url and does not clear any state. I also added lots of tests! 