### PR TITLE
Stop scrolling when we toggle tools

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -6,6 +6,7 @@ import { bindActionCreators } from "redux";
 import actions from "../actions";
 import { getSelectedSource, getPaneCollapse } from "../selectors";
 import type { SourceRecord } from "../reducers/sources";
+import { isVisible } from "../utils/ui";
 
 import { KeyShortcuts } from "devtools-modules";
 const shortcuts = new KeyShortcuts({ window });
@@ -85,7 +86,9 @@ class App extends Component {
   }
 
   onLayoutChange() {
-    this.setState({ horizontal: verticalLayoutBreakpoint.matches });
+    if (isVisible()) {
+      this.setState({ horizontal: verticalLayoutBreakpoint.matches });
+    }
   }
 
   renderEditorPane() {

--- a/src/components/Editor/Tabs.js
+++ b/src/components/Editor/Tabs.js
@@ -3,6 +3,7 @@
 import { DOM as dom, PureComponent, createFactory } from "react";
 import { connect } from "react-redux";
 import { bindActionCreators } from "redux";
+
 import * as I from "immutable";
 
 import {
@@ -10,6 +11,8 @@ import {
   getSourcesForTabs,
   getProjectSearchState
 } from "../../selectors";
+import { isVisible } from "../../utils/ui";
+
 import { getFilename, isPretty } from "../../utils/source";
 import classnames from "classnames";
 import actions from "../../actions";
@@ -291,7 +294,7 @@ class SourceTabs extends PureComponent {
     const sourceTabEls = this.refs.sourceTabs.children;
     const hiddenSourceTabs = getHiddenTabs(sourceTabs, sourceTabEls);
 
-    if (hiddenSourceTabs.indexOf(selectedSource) !== -1) {
+    if (isVisible() && hiddenSourceTabs.indexOf(selectedSource) !== -1) {
       return moveTab(selectedSource.get("url"), 0);
     }
 

--- a/src/components/Editor/Tabs.js
+++ b/src/components/Editor/Tabs.js
@@ -3,7 +3,6 @@
 import { DOM as dom, PureComponent, createFactory } from "react";
 import { connect } from "react-redux";
 import { bindActionCreators } from "redux";
-
 import * as I from "immutable";
 
 import {

--- a/src/test/mochitest/browser.ini
+++ b/src/test/mochitest/browser.ini
@@ -74,3 +74,4 @@ skip-if = true
 [browser_dbg-sourcemaps2.js]
 [browser_dbg-sourcemaps-bogus.js]
 [browser_dbg-sources.js]
+[browser_dbg-toggling-tools.js]

--- a/src/test/mochitest/browser_dbg-toggling-tools.js
+++ b/src/test/mochitest/browser_dbg-toggling-tools.js
@@ -1,0 +1,38 @@
+// Return a promise with a reference to jsterm, opening the split
+// console if necessary.  This cleans up the split console pref so
+// it won't pollute other tests.
+function getSplitConsole(dbg) {
+  const { toolbox, win } = dbg;
+
+  registerCleanupFunction(() => {
+    Services.prefs.clearUserPref("devtools.toolbox.splitconsoleEnabled");
+  });
+
+  if (!win) {
+    win = toolbox.win;
+  }
+
+  if (!toolbox.splitConsole) {
+    pressKey(dbg, "Escape");
+  }
+
+  return new Promise(resolve => {
+    toolbox.getPanelWhenReady("webconsole").then(() => {
+      ok(toolbox.splitConsole, "Split console is shown.");
+      let jsterm = toolbox.getPanel("webconsole").hud.jsterm;
+      resolve(jsterm);
+    });
+  });
+}
+
+add_task(function*() {
+  const dbg = yield initDebugger("doc-scripts.html");
+
+  yield selectSource(dbg, "long");
+  dbg.win.cm.scrollTo(0, 284);
+
+  pressKey(dbg, "inspector");
+  pressKey(dbg, "debugger");
+
+  is(dbg.win.cm.getScrollInfo().top, 284);
+});

--- a/src/test/mochitest/head.js
+++ b/src/test/mochitest/head.js
@@ -575,6 +575,10 @@ function invokeInTab(fnc) {
 const isLinux = Services.appinfo.OS === "Linux";
 const isMac = Services.appinfo.OS === "Darwin";
 const cmdOrCtrl = isLinux ? { ctrlKey: true } : { metaKey: true };
+const shiftOrAlt = isMac
+  ? { accelKey: true, shiftKey: true }
+  : { aaccelKey: true, ltKey: true };
+
 // On Mac, going to beginning/end only works with meta+left/right.  On
 // Windows, it only works with home/end.  On Linux, apparently, either
 // ctrl+left/right or home/end work.
@@ -584,7 +588,10 @@ const endKey = isMac
 const startKey = isMac
   ? { code: "VK_LEFT", modifiers: cmdOrCtrl }
   : { code: "VK_HOME" };
+
 const keyMappings = {
+  debugger: { code: "s", modifiers: shiftOrAlt },
+  inspector: { code: "c", modifiers: shiftOrAlt },
   sourceSearch: { code: "p", modifiers: cmdOrCtrl },
   fileSearch: { code: "f", modifiers: cmdOrCtrl },
   Enter: { code: "VK_RETURN" },

--- a/src/utils/ui.js
+++ b/src/utils/ui.js
@@ -1,0 +1,9 @@
+/* Checks to see if the root element is available and
+ * if the element is visible. We check the width of the element
+ * because it is more reliable than either checking a focus state or
+ * the visibleState or hidden property.
+ */
+export function isVisible() {
+  const el = document.querySelector("#mount");
+  return el && el.getBoundingClientRect().width;
+}


### PR DESCRIPTION
Associated Issue: #3168 #3033


### Summary of Changes

* the problem was that we were unmounting codemirror when we toggled tools. We fix that, by first checking if the app is visible when we might unmount the editor.

### Test Plan

* simple integration test for toggling tools