### PR TITLE
Fix empty index.html breakpoints

### DIFF
--- a/src/components/SecondaryPanes/Breakpoints.js
+++ b/src/components/SecondaryPanes/Breakpoints.js
@@ -14,7 +14,7 @@ import {
 } from "../../selectors";
 import { makeLocationId } from "../../utils/breakpoint";
 import { endTruncateStr } from "../../utils/utils";
-import { basename } from "../../utils/path";
+import { getFilename } from "../../utils/source";
 import CloseButton from "../shared/Button/Close";
 import "./Breakpoints.css";
 import get from "lodash/get";
@@ -38,13 +38,13 @@ function isCurrentlyPausedAtBreakpoint(pause, breakpoint) {
 }
 
 function renderSourceLocation(source, line, column) {
-  const url = source.get("url") ? basename(source.get("url")) : null;
+  const filename = source ? getFilename(source.toJS()) : null;
   const bpLocation = line + (column ? `:${column}` : "");
-  // const line = url !== "" ? `: ${line}` : "";
-  return url
+
+  return filename
     ? dom.div(
         { className: "location" },
-        `${endTruncateStr(url, 30)}: ${bpLocation}`
+        `${endTruncateStr(filename, 30)}: ${bpLocation}`
       )
     : null;
 }


### PR DESCRIPTION


Associated Issue: #3170

### Summary of Changes

* use the `getFilename` utility function instead of the `basename`, for consistency with Tabs and the Sourcetree

### Test Plan

- [x] Go to the increment  sourcemaps example.
- [x] Select the `(index)` in the sourcetree
- [x] Add breakpoint in the file
- [x] Should see `(index)` in the breakpoints list


### Screenshots/Videos (OPTIONAL)

#### Before

<img src='https://shipusercontent.com/abaac12a5f3d61b9c03ba5b807ed0046/Screen%20Shot%202017-06-14%20at%204.42.53%20AM.png' title='Screen Shot 2017-06-14 at 4.42.53 AM.png' width=310>

#### After

![image](https://user-images.githubusercontent.com/792924/27518848-ba9aad5c-59e0-11e7-909a-9a9c0212adb8.png)
