### PR TITLE
WebAssembly text generation on debugger side

### DIFF
--- a/assets/images/Svg.js
+++ b/assets/images/Svg.js
@@ -18,6 +18,7 @@ const svg = {
   underscore: require("./underscore.svg"),
   lodash: require("./lodash.svg"),
   ember: require("./ember.svg"),
+  vuejs: require("./vuejs.svg"),
   "magnifying-glass": require("./magnifying-glass.svg"),
   "arrow-up": require("./arrow-up.svg"),
   "arrow-down": require("./arrow-down.svg"),

--- a/assets/images/vuejs.svg
+++ b/assets/images/vuejs.svg
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   viewBox="0 0 400 400"
+   height="400"
+   width="400"
+   xml:space="preserve"
+   id="svg2"
+   version="1.1"><metadata
+     id="metadata8"><rdf:RDF><cc:Work
+         rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" /></cc:Work></rdf:RDF></metadata><defs
+     id="defs6" /><g
+     transform="matrix(1.3333333,0,0,-1.3333333,0,400)"
+     id="g10"><g
+       transform="translate(178.0626,235.0086)"
+       id="g12"><path
+         id="path14"
+         style="fill:#41b883;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         d="M 0,0 -22.669,-39.264 -45.338,0 h -75.491 L -22.669,-170.017 75.491,0 Z" /></g><g
+       transform="translate(178.0626,235.0086)"
+       id="g16"><path
+         id="path18"
+         style="fill:#34495e;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         d="M 0,0 -22.669,-39.264 -45.338,0 H -81.565 L -22.669,-102.01 36.227,0 Z" /></g></g></svg>

--- a/flow-typed/debugger-html.js
+++ b/flow-typed/debugger-html.js
@@ -205,6 +205,7 @@ declare module "debugger-html" {
     sourceMapURL?: string,
     isBlackBoxed: boolean,
     isPrettyPrinted: boolean,
+    isWasm: boolean,
     text?: string,
     contentType?: string,
     error?: string,

--- a/package.json
+++ b/package.json
@@ -70,7 +70,8 @@
     "react": "=15.3.2",
     "redux-saga": "^0.15.4",
     "reselect": "^3.0.0",
-    "svg-inline-react": "^1.0.2"
+    "svg-inline-react": "^1.0.2",
+    "wasmparser": "^0.4.10"
   },
   "files": [
     "src",

--- a/src/actions/navigation.js
+++ b/src/actions/navigation.js
@@ -3,6 +3,7 @@ import { getSources } from "../reducers/sources";
 import { waitForMs } from "../utils/utils";
 import { newSources } from "./sources";
 import { clearSymbols } from "../utils/parser";
+import { clearWasmStates } from "../utils/wasm";
 
 /**
  * Redux actions for the navigation state
@@ -16,6 +17,7 @@ import { clearSymbols } from "../utils/parser";
 export function willNavigate(_, event) {
   return async function({ dispatch, getState, client, sourceMaps }: ThunkArgs) {
     await sourceMaps.clearSourceMaps();
+    clearWasmStates();
     clearDocuments();
     clearSymbols();
 

--- a/src/client/firefox.js
+++ b/src/client/firefox.js
@@ -21,7 +21,11 @@ export async function onConnect(connection: any, actions: Object) {
   tabTarget.on("will-navigate", actions.willNavigate);
   tabTarget.on("navigate", actions.navigated);
 
-  await threadClient.reconfigure({ observeAsmJS: true });
+  let wasmBinarySource = !!debuggerClient.mainRoot.traits.wasmBinarySource;
+  await threadClient.reconfigure({
+    observeAsmJS: true,
+    wasmBinarySource: wasmBinarySource
+  });
 
   // In Firefox, we need to initially request all of the sources. This
   // usually fires off individual `newSource` notifications as the

--- a/src/client/firefox/create.js
+++ b/src/client/firefox/create.js
@@ -36,6 +36,7 @@ export function createSource(source: SourcePayload): Source {
     id: source.actor,
     url: source.url,
     isPrettyPrinted: false,
+    isWasm: source.introductionType === "wasm",
     sourceMapURL: source.sourceMapURL,
     isBlackBoxed: false
   };

--- a/src/client/firefox/tests/onconnect.js
+++ b/src/client/firefox/tests/onconnect.js
@@ -23,7 +23,11 @@ const threadClient = {
   getLastPausePacket: () => null
 };
 
-const debuggerClient = {};
+const debuggerClient = {
+  mainRoot: {
+    traits: {}
+  }
+};
 
 const actions = {
   _sources: [],

--- a/src/components/Editor/Breakpoint.js
+++ b/src/components/Editor/Breakpoint.js
@@ -6,7 +6,7 @@ import ReactDOM from "react-dom";
 import classnames from "classnames";
 import Svg from "../shared/Svg";
 
-import { getDocument, showSourceText } from "../../utils/editor";
+import { getDocument, showSourceText, toEditorLine } from "../../utils/editor";
 
 const breakpointSvg = document.createElement("div");
 ReactDOM.render(Svg("breakpoint"), breakpointSvg);
@@ -25,6 +25,7 @@ class Breakpoint extends Component {
   props: {
     breakpoint: Object,
     selectedSource: Object,
+    line: number,
     editor: Object
   };
 
@@ -44,7 +45,9 @@ class Breakpoint extends Component {
       return;
     }
 
-    const line = breakpoint.location.line - 1;
+    const sourceId = selectedSource.get("id");
+    const line = toEditorLine(sourceId, breakpoint.location.line);
+
     showSourceText(editor, selectedSource.toJS());
 
     editor.codeMirror.setGutterMarker(
@@ -95,11 +98,13 @@ class Breakpoint extends Component {
       return;
     }
 
-    const line = breakpoint.location.line - 1;
-    const doc = getDocument(selectedSource.get("id"));
+    const sourceId = selectedSource.get("id");
+    const doc = getDocument(sourceId);
     if (!doc) {
       return;
     }
+
+    const line = toEditorLine(sourceId, breakpoint.location.line);
 
     // NOTE: when we upgrade codemirror we can use `doc.setGutterMarker`
     if (doc.setGutterMarker) {

--- a/src/components/Editor/CallSite.js
+++ b/src/components/Editor/CallSite.js
@@ -1,7 +1,7 @@
 // @flow
 import { Component } from "react";
 
-import { markText } from "../../utils/editor";
+import { markText, toEditorLocation } from "../../utils/editor";
 require("./CallSite.css");
 
 type MarkerType = {
@@ -11,6 +11,7 @@ type MarkerType = {
 type props = {
   callSite: Object,
   editor: Object,
+  source: Object,
   breakpoint: Object,
   showCallSite: Boolean
 };
@@ -30,9 +31,11 @@ export default class CallSite extends Component {
   }
 
   addCallSite(nextProps: props) {
-    const { editor, callSite, breakpoint } = nextProps || this.props;
+    const { editor, callSite, breakpoint, source } = nextProps || this.props;
     const className = !breakpoint ? "call-site" : "call-site-bp";
-    this.marker = markText(editor, className, callSite.location);
+    const sourceId = source.get("id");
+    const editorLocation = toEditorLocation(sourceId, callSite.location);
+    this.marker = markText(editor, className, editorLocation);
   }
 
   clearCallSite() {

--- a/src/components/Editor/CallSites.js
+++ b/src/components/Editor/CallSites.js
@@ -18,7 +18,7 @@ import {
   getBreakpointsForSource
 } from "../../selectors";
 
-import { getTokenLocation } from "../../utils/editor";
+import { getTokenLocation, isWasm, toSourceLine } from "../../utils/editor";
 
 import actions from "../../actions";
 
@@ -89,7 +89,7 @@ class CallSites extends Component {
 
   onTokenClick(e) {
     const { target } = e;
-    const { editor } = this.props;
+    const { editor, selectedLocation } = this.props;
 
     if (
       !isEnabled("columnBreakpoints") ||
@@ -100,9 +100,12 @@ class CallSites extends Component {
       return;
     }
 
+    const { sourceId } = selectedLocation;
     const { line, column } = getTokenLocation(editor.codeMirror, target);
-
-    this.toggleBreakpoint(line + 1, column - 2);
+    this.toggleBreakpoint(
+      toSourceLine(sourceId, line),
+      isWasm(sourceId) ? undefined : column - 2
+    );
   }
 
   toggleBreakpoint(line, column = undefined) {
@@ -147,7 +150,7 @@ class CallSites extends Component {
   }
 
   render() {
-    const { editor, callSites } = this.props;
+    const { editor, callSites, selectedSource } = this.props;
     const { showCallSites } = this.state;
     let sites;
     if (!callSites) {
@@ -162,6 +165,7 @@ class CallSites extends Component {
             key: index,
             callSite,
             editor,
+            source: selectedSource,
             breakpoint: callSite.breakpoint,
             showCallSite: showCallSites
           });

--- a/src/components/Editor/Editor.css
+++ b/src/components/Editor/Editor.css
@@ -22,11 +22,13 @@
   --theme-conditional-breakpoint-color: #ccd1d5;
 }
 
-.paused .in-scope .CodeMirror-line, .paused .in-scope .CodeMirror-linenumber {
+.paused .in-scope .CodeMirror-line,
+.paused .in-scope .CodeMirror-linenumber {
   opacity: 1;
 }
 
-.paused .CodeMirror-line, .paused .CodeMirror-linenumber {
+.paused .CodeMirror-line,
+.paused .CodeMirror-linenumber {
   opacity: 0.7;
 }
 

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -77,28 +77,24 @@ const cssVars = {
   footerHeight: "var(--editor-footer-height)"
 };
 
-type EditorState = {
-  highlightedLineRange: ?Object
-};
-
 class Editor extends PureComponent {
   cbPanel: any;
   editor: SourceEditor;
   pendingJumpLine: any;
   lastJumpLine: any;
   debugExpression: any;
-  state: EditorState;
+  state: Object;
 
   constructor() {
     super();
 
     this.cbPanel = null;
-    this.editor = null;
     this.pendingJumpLine = null;
     this.lastJumpLine = null;
 
     this.state = {
-      highlightedLineRange: null
+      highlightedLineRange: null,
+      editor: null
     };
 
     const self: any = this;
@@ -123,7 +119,7 @@ class Editor extends PureComponent {
       nextProps.startPanelSize !== this.props.startPanelSize ||
       nextProps.endPanelSize !== this.props.endPanelSize
     ) {
-      this.editor.codeMirror.setSize();
+      this.state.editor.codeMirror.setSize();
     }
 
     if (!selectedSource) {
@@ -135,17 +131,17 @@ class Editor extends PureComponent {
     } else if (selectedSource.get("error")) {
       this.showMessage(selectedSource.get("error"));
     } else if (this.props.selectedSource !== selectedSource) {
-      showSourceText(this.editor, selectedSource.toJS());
+      showSourceText(this.state.editor, selectedSource.toJS());
     }
 
     if (this.props.linesInScope !== nextProps.linesInScope) {
-      this.editor.codeMirror.operation(() => {
-        clearLineClass(this.editor.codeMirror, "in-scope");
+      this.state.editor.codeMirror.operation(() => {
+        clearLineClass(this.state.editor.codeMirror, "in-scope");
       });
     }
 
     this.setDebugLine(nextProps.selectedFrame, selectedLocation);
-    resizeBreakpointGutter(this.editor.codeMirror);
+    resizeBreakpointGutter(this.state.editor.codeMirror);
   }
 
   setupEditor() {
@@ -200,12 +196,13 @@ class Editor extends PureComponent {
 
     codeMirror.on("scroll", this.onScroll);
 
+    this.setState({ editor });
     return editor;
   }
 
   componentDidMount() {
     this.cbPanel = null;
-    this.editor = this.setupEditor();
+    const editor = this.setupEditor();
 
     const { selectedSource } = this.props;
     const { shortcuts } = this.context;
@@ -221,12 +218,12 @@ class Editor extends PureComponent {
     shortcuts.on(searchAgainPrevKey, this.onSearchAgain);
     shortcuts.on(searchAgainKey, this.onSearchAgain);
 
-    updateDocument(this.editor, selectedSource);
+    updateDocument(editor, selectedSource);
   }
 
   componentWillUnmount() {
-    this.editor.destroy();
-    this.editor = null;
+    this.state.editor.destroy();
+    this.setState({ editor: null });
 
     const searchAgainKey = L10N.getStr("sourceSearch.search.again.key2");
     const searchAgainPrevKey = L10N.getStr(
@@ -267,7 +264,7 @@ class Editor extends PureComponent {
 
   onToggleBreakpoint(key, e) {
     e.preventDefault();
-    const { codeMirror } = this.editor;
+    const { codeMirror } = this.state.editor;
     const line = getCursorLine(codeMirror);
 
     if (e.shiftKey) {
@@ -278,7 +275,7 @@ class Editor extends PureComponent {
   }
 
   onKeyDown(e) {
-    const { codeMirror } = this.editor;
+    const { codeMirror } = this.state.editor;
     let { key, target } = e;
     let codeWrapper = codeMirror.getWrapperElement();
     let textArea = codeWrapper.querySelector("textArea");
@@ -301,11 +298,11 @@ class Editor extends PureComponent {
    * is a multiselection.
    */
   onEscape(key, e) {
-    if (!this.editor) {
+    if (!this.state.editor) {
       return;
     }
 
-    const { codeMirror } = this.editor;
+    const { codeMirror } = this.state.editor;
     if (codeMirror.listSelections().length > 1) {
       codeMirror.execCommand("singleSelection");
       e.preventDefault();
@@ -318,8 +315,8 @@ class Editor extends PureComponent {
 
   onSearchAgain(_, e) {
     const { query, searchModifiers } = this.props;
-    const { editor: { codeMirror } } = this.editor;
-    const ctx = { ed: this.editor, cm: codeMirror };
+    const { editor: { codeMirror } } = this.state.editor;
+    const ctx = { ed: this.state.editor, cm: codeMirror };
 
     const direction = e.shiftKey ? "prev" : "next";
     traverseResults(e, ctx, query, direction, searchModifiers.toJS());
@@ -386,7 +383,7 @@ class Editor extends PureComponent {
       return;
     }
 
-    const line = lineAtHeight(this.editor, event);
+    const line = lineAtHeight(this.state.editor, event);
     const breakpoint = breakpoints.find(bp => bp.location.line === line);
 
     GutterMenu({
@@ -405,7 +402,7 @@ class Editor extends PureComponent {
   onMouseOver(e) {
     const { target } = e;
     if (this.inSelectedFrameSource()) {
-      updateSelection(target, this.editor, this.props);
+      updateSelection(target, this.state.editor, this.props);
     }
   }
 
@@ -432,7 +429,7 @@ class Editor extends PureComponent {
       closePanel: this.closeConditionalPanel
     });
 
-    this.cbPanel = this.editor.codeMirror.addLineWidget(line, panel, {
+    this.cbPanel = this.state.editor.codeMirror.addLineWidget(line, panel, {
       coverGutter: true,
       noHScroll: false
     });
@@ -455,7 +452,7 @@ class Editor extends PureComponent {
         this.debugExpression.clear();
       }
 
-      this.editor.codeMirror.removeLineClass(
+      this.state.editor.codeMirror.removeLineClass(
         line - 1,
         "line",
         "new-debug-line"
@@ -470,9 +467,13 @@ class Editor extends PureComponent {
       selectedFrame.location.sourceId === selectedLocation.sourceId
     ) {
       const { line, column } = selectedFrame.location;
-      this.editor.codeMirror.addLineClass(line - 1, "line", "new-debug-line");
+      this.state.editor.codeMirror.addLineClass(
+        line - 1,
+        "line",
+        "new-debug-line"
+      );
 
-      this.debugExpression = markText(this.editor, "debug-expression", {
+      this.debugExpression = markText(this.state.editor, "debug-expression", {
         start: { line, column },
         end: { line, column: null }
       });
@@ -491,11 +492,11 @@ class Editor extends PureComponent {
     // happening ever again (in case CodeMirror re-applies the
     // class, etc).
     if (this.lastJumpLine) {
-      clearLineClass(this.editor.codeMirror, "highlight-line");
+      clearLineClass(this.state.editor.codeMirror, "highlight-line");
     }
 
     const line = this.pendingJumpLine;
-    this.editor.alignLine(line);
+    this.state.editor.alignLine(line);
 
     // We only want to do the flashing animation if it's not a debug
     // line, which has it's own styling.
@@ -506,7 +507,11 @@ class Editor extends PureComponent {
       (!this.props.selectedFrame ||
         this.props.selectedFrame.location.line !== line)
     ) {
-      this.editor.codeMirror.addLineClass(line - 1, "line", "highlight-line");
+      this.state.editor.codeMirror.addLineClass(
+        line - 1,
+        "line",
+        "highlight-line"
+      );
     }
 
     this.lastJumpLine = line;
@@ -514,9 +519,9 @@ class Editor extends PureComponent {
   }
 
   showMessage(msg) {
-    this.editor.replaceDocument(this.editor.createDocument());
-    this.editor.setText(msg);
-    this.editor.setMode({ name: "text" });
+    this.state.editor.replaceDocument(this.state.editor.createDocument());
+    this.state.editor.setText(msg);
+    this.state.editor.setMode({ name: "text" });
   }
 
   renderHighlightLines() {
@@ -527,7 +532,7 @@ class Editor extends PureComponent {
     }
 
     return HighlightLines({
-      editor: this.editor,
+      editor: this.state.editor,
       highlightedLineRange
     });
   }
@@ -539,7 +544,7 @@ class Editor extends PureComponent {
       !selectedSource ||
       selectedSource.get("loading") ||
       !hitCount ||
-      !this.editor
+      !this.state.editor
     ) {
       return;
     }
@@ -548,7 +553,7 @@ class Editor extends PureComponent {
       HitMarker({
         key: marker.get("line"),
         hitData: marker.toJS(),
-        editor: this.editor.codeMirror
+        editor: this.state.editor.codeMirror
       })
     );
   }
@@ -577,7 +582,7 @@ class Editor extends PureComponent {
 
   renderPreview() {
     const { selectedSource, selection } = this.props;
-    if (!this.editor || !selectedSource) {
+    if (!this.state.editor || !selectedSource) {
       return null;
     }
 
@@ -593,7 +598,7 @@ class Editor extends PureComponent {
 
     return Preview({
       value,
-      editor: this.editor,
+      editor: this.state.editor,
       location: location,
       expression: expression,
       popoverPos: cursorPos,
@@ -611,9 +616,9 @@ class Editor extends PureComponent {
       return;
     }
 
-    this.editor.codeMirror.operation(() => {
+    this.state.editor.codeMirror.operation(() => {
       linesInScope.forEach(line => {
-        this.editor.codeMirror.addLineClass(line - 1, "line", "in-scope");
+        this.state.editor.codeMirror.addLineClass(line - 1, "line", "in-scope");
       });
     });
   }
@@ -628,7 +633,7 @@ class Editor extends PureComponent {
   }
 
   renderCallSites() {
-    const editor = this.editor;
+    const editor = this.state.editor;
 
     if (!editor || !isEnabled("columnBreakpoints")) {
       return null;
@@ -655,7 +660,7 @@ class Editor extends PureComponent {
         })
       },
       SearchBar({
-        editor: this.editor,
+        editor: this.state.editor,
         selectSource,
         selectedSource,
         highlightLineRange,
@@ -668,10 +673,10 @@ class Editor extends PureComponent {
       this.renderHighlightLines(),
       this.renderInScopeLines(),
       this.renderHitCounts(),
-      Footer({ editor: this.editor, horizontal }),
+      Footer({ editor: this.state.editor, horizontal }),
       this.renderPreview(),
       this.renderCallSites(),
-      Breakpoints({ editor: this.editor })
+      Breakpoints({ editor: this.state.editor })
     );
   }
 }

--- a/src/components/Editor/tests/__snapshots__/Editor.js.snap
+++ b/src/components/Editor/tests/__snapshots__/Editor.js.snap
@@ -102,7 +102,6 @@ ShallowWrapper {
         "context": Object {
           "shortcuts": undefined,
         },
-        "editor": null,
         "lastJumpLine": null,
         "onEscape": [Function],
         "onGutterClick": [Function],
@@ -134,6 +133,7 @@ ShallowWrapper {
         },
         "refs": Object {},
         "state": Object {
+          "editor": null,
           "highlightedLineRange": null,
         },
         "toggleConditionalPanel": [Function],

--- a/src/components/Editor/tests/__snapshots__/Editor.js.snap
+++ b/src/components/Editor/tests/__snapshots__/Editor.js.snap
@@ -110,7 +110,7 @@ ShallowWrapper {
         "onScroll": [Function],
         "onSearchAgain": [Function],
         "onToggleBreakpoint": [Function],
-        "pendingJumpLine": null,
+        "pendingJumpLocation": null,
         "props": Object {
           "addBreakpoint": [Function],
           "addExpression": [Function],

--- a/src/components/PrimaryPanes/index.js
+++ b/src/components/PrimaryPanes/index.js
@@ -1,7 +1,6 @@
 // @flow
 
-import { DOM as dom, PropTypes, Component, createFactory } from "react";
-import ImPropTypes from "react-immutable-proptypes";
+import { DOM as dom, Component, createFactory } from "react";
 import { bindActionCreators } from "redux";
 import { connect } from "react-redux";
 import { formatKeyShortcut } from "../../utils/text";
@@ -17,8 +16,18 @@ const Outline = createFactory(_Outline);
 import _SourcesTree from "./SourcesTree";
 const SourcesTree = createFactory(_SourcesTree);
 
+import type { SourcesMap } from "../../reducers/types";
 type SourcesState = {
   selectedPane: string
+};
+
+type Props = {
+  sources: SourcesMap,
+  selectSource: (string, Object) => void,
+  horizontal: boolean,
+  setActiveSearch: string => void,
+  closeActiveSearch: () => void,
+  sourceSearchOn: boolean
 };
 
 class PrimaryPanes extends Component {
@@ -28,8 +37,9 @@ class PrimaryPanes extends Component {
   renderFooter: Function;
   renderChildren: Function;
   state: SourcesState;
+  props: Props;
 
-  constructor(props) {
+  constructor(props: Props) {
     super(props);
     this.state = { selectedPane: "sources" };
 
@@ -87,10 +97,10 @@ class PrimaryPanes extends Component {
           className: "sources-header-info",
           dir: "ltr",
           onClick: () => {
-            if (this.props.projectSearchOn) {
-              this.props.setActiveSearch();
+            if (this.props.sourceSearchOn) {
+              return this.props.closeActiveSearch();
             }
-            this.props.setActiveSearch("project");
+            this.props.setActiveSearch("source");
           }
         },
         L10N.getFormatStr(
@@ -123,20 +133,12 @@ class PrimaryPanes extends Component {
   }
 }
 
-PrimaryPanes.propTypes = {
-  sources: ImPropTypes.map.isRequired,
-  selectSource: PropTypes.func.isRequired,
-  horizontal: PropTypes.bool.isRequired,
-  setActiveSearch: PropTypes.func.isRequired,
-  projectSearchOn: PropTypes.bool.isRequired
-};
-
 PrimaryPanes.displayName = "PrimaryPanes";
 
 export default connect(
   state => ({
     sources: getSources(state),
-    projectSearchOn: getActiveSearchState(state) === "project"
+    sourceSearchOn: getActiveSearchState(state) === "source"
   }),
   dispatch => bindActionCreators(actions, dispatch)
 )(PrimaryPanes);

--- a/src/components/SecondaryPanes/Breakpoints.js
+++ b/src/components/SecondaryPanes/Breakpoints.js
@@ -40,9 +40,12 @@ function isCurrentlyPausedAtBreakpoint(pause, breakpoint) {
 
 function renderSourceLocation(source, line, column) {
   const filename = source ? getFilename(source.toJS()) : null;
+  const isWasm = source && typeof source.get("text") !== "string";
   const columnVal =
     isEnabled("columnBreakpoints") && column ? `:${column}` : "";
-  const bpLocation = `${line}${columnVal}`;
+  const bpLocation = isWasm
+    ? `0x${line.toString(16).toUpperCase()}`
+    : `${line}${columnVal}`;
 
   return filename
     ? dom.div(

--- a/src/reducers/types.js
+++ b/src/reducers/types.js
@@ -1,5 +1,5 @@
 import type { PauseState } from "./pause";
-import type { SourcesState } from "./source";
+import type { SourcesState } from "./sources";
 import type { BreakpointsState } from "./breakpoints";
 
 export type State = {
@@ -8,6 +8,6 @@ export type State = {
   breakpoints: BreakpointsState
 };
 
-export type { SourceRecord } from "./source";
+export type { SourceRecord, SourcesMap } from "./sources";
 
 export type { BreakpointMap } from "./breakpoints";

--- a/src/selectors/linesInScope.js
+++ b/src/selectors/linesInScope.js
@@ -1,5 +1,6 @@
 import { getOutOfScopeLocations } from "../reducers/ast";
 import { getSelectedSource } from "../reducers/sources";
+import { getSourceLineCount } from "../utils/source";
 
 import range from "lodash/range";
 import flatMap from "lodash/flatMap";
@@ -31,7 +32,7 @@ export default function getInScopeLines(state: OuterState) {
     source.toJS()
   );
 
-  const sourceNumLines = source.get("text").split("\n").length;
+  const sourceNumLines = getSourceLineCount(source.toJS());
   const sourceLines = range(1, sourceNumLines + 1);
 
   if (!linesOutOfScope) {

--- a/src/utils/breakpoint/index.js
+++ b/src/utils/breakpoint/index.js
@@ -81,7 +81,7 @@ export function breakpointAtLocation(
   { line, column }: Location
 ) {
   return breakpoints.find(breakpoint => {
-    const sameLine = breakpoint.location.line === line + 1;
+    const sameLine = breakpoint.location.line === line;
     if (!sameLine) {
       return false;
     }

--- a/src/utils/editor/source-documents.js
+++ b/src/utils/editor/source-documents.js
@@ -2,6 +2,7 @@
 
 import { getMode } from "../source";
 import type { Source } from "debugger-html";
+import { isWasm, getWasmLineNumberFormatter, renderWasmText } from "../wasm";
 
 let sourceDocs = {};
 
@@ -21,6 +22,43 @@ function clearDocuments() {
   sourceDocs = {};
 }
 
+function resetLineNumberFormat(editor: Object) {
+  let cm = editor.codeMirror;
+  cm.setOption("lineNumberFormatter", number => number);
+}
+
+function updateLineNumberFormat(editor: Object, sourceId: string) {
+  if (!isWasm(sourceId)) {
+    resetLineNumberFormat(editor);
+    return;
+  }
+  let cm = editor.codeMirror;
+  let lineNumberFormatter = getWasmLineNumberFormatter(sourceId);
+  cm.setOption("lineNumberFormatter", lineNumberFormatter);
+}
+
+function updateDocument(editor: Object, sourceId: string) {
+  if (!sourceId) {
+    return;
+  }
+  const doc = getDocument(sourceId) || editor.createDocument();
+  editor.replaceDocument(doc);
+
+  updateLineNumberFormat(editor, sourceId);
+}
+
+function setEditorText(editor: Object, source: Source) {
+  const { text, id: sourceId } = source;
+  if (source.isWasm) {
+    const wasmLines = renderWasmText(sourceId, (text: any));
+    // cm will try to split into lines anyway, saving memory
+    const wasmText = { split: () => wasmLines, match: () => false };
+    editor.setText(wasmText);
+  } else {
+    editor.setText(text);
+  }
+}
+
 /**
  * Handle getting the source document or creating a new
  * document with the correct mode and text.
@@ -37,6 +75,7 @@ function showSourceText(editor: Object, source: Source) {
 
   if (doc) {
     editor.replaceDocument(doc);
+    updateLineNumberFormat(editor, source.id);
     return doc;
   }
 
@@ -44,8 +83,9 @@ function showSourceText(editor: Object, source: Source) {
   setDocument(source.id, doc);
   editor.replaceDocument(doc);
 
-  editor.setText(source.text);
+  setEditorText(editor, source);
   editor.setMode(getMode(source));
+  updateLineNumberFormat(editor, source.id);
 }
 
 export {
@@ -53,5 +93,8 @@ export {
   setDocument,
   removeDocument,
   clearDocuments,
+  resetLineNumberFormat,
+  updateLineNumberFormat,
+  updateDocument,
   showSourceText
 };

--- a/src/utils/frame.js
+++ b/src/utils/frame.js
@@ -59,6 +59,10 @@ function isEmber(frame) {
   return getFrameUrl(frame).match(/ember/i);
 }
 
+function isVueJS(frame) {
+  return getFrameUrl(frame).match(/vue\.js/i);
+}
+
 function isRxJs(frame) {
   return getFrameUrl(frame).match(/rxjs/i);
 }
@@ -115,6 +119,10 @@ export function getLibraryFromUrl(frame: Frame) {
     return "Ember";
   }
 
+  if (isVueJS(frame)) {
+    return "VueJS";
+  }
+
   if (isRxJs(frame)) {
     return "RxJS";
   }
@@ -137,6 +145,9 @@ const displayNameMap = {
     "ReactCompositeComponent._renderValidatedComponentWithoutOwnerOrContext/renderedElement<":
       "Render",
     _renderValidatedComponentWithoutOwnerOrContext: "Render"
+  },
+  VueJS: {
+    "renderMixin/Vue.prototype._render": "Render"
   },
   Webpack: {
     // eslint-disable-next-line camelcase

--- a/src/utils/source.js
+++ b/src/utils/source.js
@@ -124,6 +124,18 @@ function getSourcePath(source: Source) {
 }
 
 /**
+ * Returns amount of lines in the source. If source is a WebAssembly binary,
+ * the function returns amount of bytes.
+ */
+function getSourceLineCount(source: Source) {
+  if (source.isWasm) {
+    const { binary } = (source.text: any);
+    return binary.length;
+  }
+  return source.text != undefined ? source.text.split("\n").length : 0;
+}
+
+/**
  *
  * Returns Code Mirror mode for source content type
  * @param contentType
@@ -133,9 +145,9 @@ function getSourcePath(source: Source) {
  */
 
 function getMode(source: Source) {
-  const { contentType, text } = source;
+  const { contentType, text, isWasm } = source;
 
-  if (!text) {
+  if (!text || isWasm) {
     return { name: "text" };
   }
 
@@ -177,5 +189,6 @@ export {
   getFilename,
   getFilenameFromURL,
   getSourcePath,
+  getSourceLineCount,
   getMode
 };

--- a/src/utils/tests/source.js
+++ b/src/utils/tests/source.js
@@ -1,4 +1,4 @@
-import { getFilename, getMode } from "../source.js";
+import { getFilename, getMode, getSourceLineCount } from "../source.js";
 
 describe("sources", () => {
   describe("getFilename", () => {
@@ -88,6 +88,38 @@ describe("sources", () => {
         text: "x = (a) -> 3"
       };
       expect(getMode(source)).toBe("coffeescript");
+    });
+
+    it("wasm", () => {
+      const source = {
+        contentType: "",
+        isWasm: true,
+        text: {
+          binary: "\x00asm\x01\x00\x00\x00"
+        }
+      };
+      expect(getMode(source)).toEqual({ name: "text" });
+    });
+  });
+
+  describe("getSourceLineCount", () => {
+    it("should give us the amount bytes for wasm source", () => {
+      const source = {
+        contentType: "",
+        isWasm: true,
+        text: {
+          binary: "\x00asm\x01\x00\x00\x00"
+        }
+      };
+      expect(getSourceLineCount(source)).toEqual(8);
+    });
+
+    it("should give us the amout of lines for js source", () => {
+      const source = {
+        contentType: "text/javascript",
+        text: "function foo(){\n}"
+      };
+      expect(getSourceLineCount(source)).toEqual(2);
     });
   });
 });

--- a/src/utils/tests/wasm.js
+++ b/src/utils/tests/wasm.js
@@ -1,0 +1,72 @@
+import {
+  isWasm,
+  lineToWasmOffset,
+  wasmOffsetToLine,
+  clearWasmStates,
+  renderWasmText
+} from "../wasm.js";
+
+describe("wasm", () => {
+  // Compiled version of `(module (func (nop)))`
+  const SIMPLE_WASM = {
+    binary:
+      "\x00asm\x01\x00\x00\x00\x01\x84\x80\x80\x80\x00\x01`\x00\x00" +
+      "\x03\x82\x80\x80\x80\x00\x01\x00\x06\x81\x80\x80\x80\x00\x00" +
+      "\n\x89\x80\x80\x80\x00\x01\x83\x80\x80\x80\x00\x00\x01\v"
+  };
+  const SIMPLE_WASM_TEXT = `(module
+  (type $type0 (func))
+  (func $func0
+    nop
+  )
+)`;
+  const SIMPLE_WASM_NOP_TEXT_LINE = 3;
+  const SIMPLE_WASM_NOP_OFFSET = 46;
+
+  describe("isWasm", () => {
+    it("should give us the false when wasm text was not registered", () => {
+      const sourceId = "source.0";
+      expect(isWasm(sourceId)).toEqual(false);
+    });
+    it("should give us the true when wasm text was registered", () => {
+      const sourceId = "source.1";
+      renderWasmText(sourceId, SIMPLE_WASM);
+      expect(isWasm(sourceId)).toEqual(true);
+      // clear shall remove
+      clearWasmStates();
+      expect(isWasm(sourceId)).toEqual(false);
+    });
+  });
+
+  describe("renderWasmText", () => {
+    it("render simple wasm", () => {
+      const sourceId = "source.2";
+      const lines = renderWasmText(sourceId, SIMPLE_WASM);
+      expect(lines.join("\n")).toEqual(SIMPLE_WASM_TEXT);
+      clearWasmStates();
+    });
+  });
+
+  describe("lineToWasmOffset", () => {
+    // Test data sanity check: checking if 'nop' is found in the SIMPLE_WASM.
+    expect(SIMPLE_WASM.binary[SIMPLE_WASM_NOP_OFFSET]).toEqual("\x01");
+
+    it("get simple wasm nop offset", () => {
+      const sourceId = "source.3";
+      renderWasmText(sourceId, SIMPLE_WASM);
+      const offset = lineToWasmOffset(sourceId, SIMPLE_WASM_NOP_TEXT_LINE);
+      expect(offset).toEqual(SIMPLE_WASM_NOP_OFFSET);
+      clearWasmStates();
+    });
+  });
+
+  describe("wasmOffsetToLine", () => {
+    it("get simple wasm nop line", () => {
+      const sourceId = "source.4";
+      renderWasmText(sourceId, SIMPLE_WASM);
+      const line = wasmOffsetToLine(sourceId, SIMPLE_WASM_NOP_OFFSET);
+      expect(line).toEqual(SIMPLE_WASM_NOP_TEXT_LINE);
+      clearWasmStates();
+    });
+  });
+});

--- a/src/utils/wasm.js
+++ b/src/utils/wasm.js
@@ -1,0 +1,142 @@
+/* @flow */
+
+import { BinaryReader } from "wasmparser/dist/WasmParser";
+import { WasmDisassembler } from "wasmparser/dist/WasmDis";
+
+type WasmState = {
+  lines: Array<number>,
+  offsets: Array<number>
+};
+
+var wasmStates: { [string]: WasmState } = Object.create(null);
+
+/**
+ * @memberof utils/wasm
+ * @static
+ */
+function getWasmText(sourceId: string, data: Uint8Array) {
+  let parser = new BinaryReader();
+  parser.setData(data.buffer, 0, data.length);
+  let dis = new WasmDisassembler();
+  dis.addOffsets = true;
+  let done = dis.disassembleChunk(parser);
+  let result = dis.getResult();
+  if (result.lines.length === 0) {
+    result = { lines: ["No luck with wast conversion"], offsets: [0], done };
+  }
+
+  let offsets = result.offsets,
+    lines = [];
+  for (let i = 0; i < offsets.length; i++) {
+    lines[offsets[i]] = i;
+  }
+
+  wasmStates[sourceId] = { offsets, lines };
+
+  return { lines: result.lines, done: result.done };
+}
+
+/**
+ * @memberof utils/wasm
+ * @static
+ */
+function getWasmLineNumberFormatter(sourceId: string) {
+  const codeOf0 = 48,
+    codeOfA = 65;
+  let buffer = [
+    codeOf0,
+    codeOf0,
+    codeOf0,
+    codeOf0,
+    codeOf0,
+    codeOf0,
+    codeOf0,
+    codeOf0
+  ];
+  let last0 = 7;
+  return function(number: number) {
+    let offset = lineToWasmOffset(sourceId, number - 1);
+    if (offset === undefined) {
+      return "";
+    }
+    let i = 7;
+    for (let n = offset | 0; n !== 0 && i >= 0; n >>= 4, i--) {
+      let nibble = n & 15;
+      buffer[i] = nibble < 10 ? codeOf0 + nibble : codeOfA - 10 + nibble;
+    }
+    for (let j = i; j > last0; j--) {
+      buffer[j] = codeOf0;
+    }
+    last0 = i;
+    return String.fromCharCode.apply(null, buffer);
+  };
+}
+
+/**
+ * @memberof utils/wasm
+ * @static
+ */
+function isWasm(sourceId: string) {
+  return sourceId in wasmStates;
+}
+
+/**
+ * @memberof utils/wasm
+ * @static
+ */
+function lineToWasmOffset(sourceId: string, number: number) {
+  let wasmState = wasmStates[sourceId];
+  if (!wasmState) {
+    return undefined;
+  }
+  let offset = wasmState.offsets[number];
+  while (offset === undefined && number > 0) {
+    offset = wasmState.offsets[--number];
+  }
+  return offset;
+}
+
+/**
+ * @memberof utils/wasm
+ * @static
+ */
+function wasmOffsetToLine(sourceId: string, offset: number) {
+  let wasmState = wasmStates[sourceId];
+  if (!wasmState) {
+    return undefined;
+  }
+  return wasmState.lines[offset];
+}
+
+/**
+ * @memberof utils/wasm
+ * @static
+ */
+function clearWasmStates() {
+  wasmStates = Object.create(null);
+}
+
+function renderWasmText(sourceId: string, { binary }: Object) {
+  // binary does not survive as Uint8Array, converting from string
+  let data = new Uint8Array(binary.length);
+  for (let i = 0; i < data.length; i++) {
+    data[i] = binary.charCodeAt(i);
+  }
+  let { lines } = getWasmText(sourceId, data);
+  const MAX_LINES = 100000;
+  if (lines.length > MAX_LINES) {
+    lines.splice(MAX_LINES, lines.length - MAX_LINES);
+    lines.push(";; .... text is truncated due to the size");
+  }
+  return lines;
+}
+
+export {
+  getWasmText,
+  getWasmLineNumberFormatter,
+  isWasm,
+  lineToWasmOffset,
+  wasmOffsetToLine,
+  clearWasmStates,
+  renderWasmText
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -119,6 +119,10 @@
     walk "^2.3.9"
     yargs "^7.0.2"
 
+"@types/node@^7.0.12":
+  version "7.0.31"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-7.0.31.tgz#80ea4d175599b2a00149c29a10a4eb2dff592e86"
+
 JSONStream@^0.8.4:
   version "0.8.4"
   resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-0.8.4.tgz#91657dfe6ff857483066132b4618b62e8f4887bd"
@@ -8904,6 +8908,12 @@ walker@~1.0.5:
   resolved "https://registry.yarnpkg.com/walker/-/walker-1.0.7.tgz#2f7f9b8fd10d677262b18a884e28d19618e028fb"
   dependencies:
     makeerror "1.0.x"
+
+wasmparser@^0.4.10:
+  version "0.4.10"
+  resolved "https://registry.yarnpkg.com/wasmparser/-/wasmparser-0.4.10.tgz#5bbc692a0d46a971a5b0c6717bb0b6f025dc1be8"
+  dependencies:
+    "@types/node" "^7.0.12"
 
 watch@~0.10.0:
   version "0.10.0"


### PR DESCRIPTION
Associated Issue: n/a

### Summary of Changes

* adds code generation for editor
* better source-to-editor text line mapping

### Test Plan

Example test plan (for original source):

1. Open https://devtools-html.github.io/debugger-examples/examples/wasm/fib/fib.index.html
2. Open debugger and refresh fib.index.html page (the latter is to enable wasm debugging)
3. Find/open "fib.c"
4. Set breakpoint at line 4
5. Refresh refresh fib.index.html page

Alternative test plan (for wasm):

3a. Find/open "wasm:https://devtools-html.github.io/debugger-examples/examples/wasm/fib/fib.index.html:d65901927dbe8357"
4a. Set breakpoint at the beginnig of $func5 @0000027D
5a. Refresh refresh fib.index.html page

Expected results: stop at set breakpoint(s).

Some other defects found:
- [ ] unable to set breakpoints in step 4a
- [ ] when trying to step through in original source (after step 5), it take multiple step commands to pass to the next line.