### PR TITLE
Move highlighting debug line to child component

### DIFF
--- a/src/components/Editor/DebugLine.js
+++ b/src/components/Editor/DebugLine.js
@@ -1,0 +1,56 @@
+// @flow
+import { Component } from "react";
+import type { SourceEditor } from "devtools-source-editor";
+import type { Frame } from "../../types";
+
+type DebugLineProps = {
+  editor: SourceEditor,
+  frame: Frame,
+  visibleSourceId: string
+};
+
+class DebugLine extends Component {
+  props: DebugLineProps;
+
+  componentDidUpdate(prevProps: DebugLineProps) {
+    const lastFrame = prevProps.frame;
+    const lastLine = lastFrame && lastFrame.location.line;
+    const nextFrame = this.props.frame;
+    const nextLine = nextFrame && nextFrame.location.line;
+
+    if (lastLine && lastLine != nextLine) {
+      this.clearDebugLine(lastLine);
+    }
+
+    const nextSourceId = nextFrame && nextFrame.location.sourceId;
+    const { visibleSourceId } = this.props;
+
+    if (nextLine && nextSourceId === visibleSourceId) {
+      this.setDebugLine(nextLine);
+    }
+  }
+
+  clearDebugLine(line: number) {
+    this.props.editor.codeMirror.removeLineClass(
+      line - 1,
+      "line",
+      "new-debug-line"
+    );
+  }
+
+  setDebugLine(line: number) {
+    this.props.editor.codeMirror.addLineClass(
+      line - 1,
+      "line",
+      "new-debug-line"
+    );
+  }
+
+  render() {
+    return null;
+  }
+}
+
+DebugLine.displayName = "DebugLine";
+
+export default DebugLine;

--- a/src/components/Editor/DebugLine.js
+++ b/src/components/Editor/DebugLine.js
@@ -23,12 +23,10 @@ class DebugLine extends PureComponent {
   }
 
   clearDebugLine(line: number) {
-    console.log("Cleared debug line");
     this.props.codeMirror.removeLineClass(line - 1, "line", "new-debug-line");
   }
 
   setDebugLine(line: number) {
-    console.log("Added debug line");
     this.props.codeMirror.addLineClass(line - 1, "line", "new-debug-line");
   }
 

--- a/src/components/Editor/DebugLine.js
+++ b/src/components/Editor/DebugLine.js
@@ -1,49 +1,35 @@
 // @flow
-import { Component } from "react";
-import type { SourceEditor } from "devtools-source-editor";
-import type { Frame } from "../../types";
+import { PureComponent } from "react";
 
 type DebugLineProps = {
-  editor: SourceEditor,
-  frame: Frame,
-  visibleSourceId: string
+  codeMirror: any,
+  line: number
 };
 
-class DebugLine extends Component {
+class DebugLine extends PureComponent {
   props: DebugLineProps;
 
   componentDidUpdate(prevProps: DebugLineProps) {
-    const lastFrame = prevProps.frame;
-    const lastLine = lastFrame && lastFrame.location.line;
-    const nextFrame = this.props.frame;
-    const nextLine = nextFrame && nextFrame.location.line;
+    this.clearDebugLine(prevProps.line);
+    this.setDebugLine(this.props.line);
+  }
 
-    if (lastLine && lastLine != nextLine) {
-      this.clearDebugLine(lastLine);
-    }
+  componentDidMount() {
+    this.setDebugLine(this.props.line);
+  }
 
-    const nextSourceId = nextFrame && nextFrame.location.sourceId;
-    const { visibleSourceId } = this.props;
-
-    if (nextLine && nextSourceId === visibleSourceId) {
-      this.setDebugLine(nextLine);
-    }
+  componentWillUnmount() {
+    this.clearDebugLine(this.props.line);
   }
 
   clearDebugLine(line: number) {
-    this.props.editor.codeMirror.removeLineClass(
-      line - 1,
-      "line",
-      "new-debug-line"
-    );
+    console.log("Cleared debug line");
+    this.props.codeMirror.removeLineClass(line - 1, "line", "new-debug-line");
   }
 
   setDebugLine(line: number) {
-    this.props.editor.codeMirror.addLineClass(
-      line - 1,
-      "line",
-      "new-debug-line"
-    );
+    console.log("Added debug line");
+    this.props.codeMirror.addLineClass(line - 1, "line", "new-debug-line");
   }
 
   render() {

--- a/src/components/Editor/DebugLine.js
+++ b/src/components/Editor/DebugLine.js
@@ -1,8 +1,9 @@
 // @flow
 import { PureComponent } from "react";
+import { getDocument } from "../../utils/editor";
 
 type DebugLineProps = {
-  codeMirror: any,
+  sourceId: string,
   line: number
 };
 
@@ -23,11 +24,19 @@ class DebugLine extends PureComponent {
   }
 
   clearDebugLine(line: number) {
-    this.props.codeMirror.removeLineClass(line - 1, "line", "new-debug-line");
+    getDocument(this.props.sourceId).removeLineClass(
+      line - 1,
+      "line",
+      "new-debug-line"
+    );
   }
 
   setDebugLine(line: number) {
-    this.props.codeMirror.addLineClass(line - 1, "line", "new-debug-line");
+    getDocument(this.props.sourceId).addLineClass(
+      line - 1,
+      "line",
+      "new-debug-line"
+    );
   }
 
   render() {

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -762,11 +762,11 @@ class Editor extends PureComponent {
   }
 
   renderDebugLine() {
-    const { sourceText, selectedFrame } = this.props;
+    const { selectedFrame, selectedSource, sourceText } = this.props;
 
     if (sourceText && !sourceText.get("loading") && selectedFrame) {
       return DebugLine({
-        codeMirror: this.editor.codeMirror,
+        sourceId: selectedSource.get("id"),
         line: this.props.selectedFrame.location.line
       });
     }

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -762,14 +762,9 @@ class Editor extends PureComponent {
   }
 
   renderDebugLine() {
-    const { selectedSource, sourceText, selectedFrame } = this.props;
+    const { sourceText, selectedFrame } = this.props;
 
-    if (
-      selectedSource &&
-      sourceText &&
-      !sourceText.get("loading") &&
-      selectedFrame
-    ) {
+    if (sourceText && !sourceText.get("loading") && selectedFrame) {
       return DebugLine({
         codeMirror: this.editor.codeMirror,
         line: this.props.selectedFrame.location.line

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -167,7 +167,6 @@ class Editor extends PureComponent {
       this.showSourceText(sourceText, selectedLocation);
     }
 
-    console.log("would have set debug line");
     resizeBreakpointGutter(this.editor.codeMirror);
   }
 
@@ -763,13 +762,19 @@ class Editor extends PureComponent {
   }
 
   renderDebugLine() {
-    return DebugLine({
-      editor: this.editor,
-      frame: this.props.selectedFrame,
-      visibleSourceId: this.props.selectedSource
-        ? this.props.selectedSource.get("id")
-        : ""
-    });
+    const { selectedSource, sourceText, selectedFrame } = this.props;
+
+    if (
+      selectedSource &&
+      sourceText &&
+      !sourceText.get("loading") &&
+      selectedFrame
+    ) {
+      return DebugLine({
+        codeMirror: this.editor.codeMirror,
+        line: this.props.selectedFrame.location.line
+      });
+    }
   }
 
   renderPreview() {

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -53,6 +53,9 @@ const ColumnBreakpoint = createFactory(_ColumnBreakpoint);
 import _HitMarker from "./HitMarker";
 const HitMarker = createFactory(_HitMarker);
 
+import _DebugLine from "./DebugLine";
+const DebugLine = createFactory(_DebugLine);
+
 import {
   getDocument,
   setDocument,
@@ -146,7 +149,6 @@ class Editor extends PureComponent {
     // This lifecycle method is responsible for updating the editor
     // text.
     const { sourceText, selectedLocation } = nextProps;
-    this.clearDebugLine(this.props.selectedFrame);
 
     if (
       nextProps.startPanelSize !== this.props.startPanelSize ||
@@ -165,7 +167,7 @@ class Editor extends PureComponent {
       this.showSourceText(sourceText, selectedLocation);
     }
 
-    this.setDebugLine(nextProps.selectedFrame, selectedLocation);
+    console.log("would have set debug line");
     resizeBreakpointGutter(this.editor.codeMirror);
   }
 
@@ -600,28 +602,6 @@ class Editor extends PureComponent {
     }
   }
 
-  clearDebugLine(selectedFrame) {
-    if (selectedFrame) {
-      const line = selectedFrame.location.line;
-      this.editor.codeMirror.removeLineClass(
-        line - 1,
-        "line",
-        "new-debug-line"
-      );
-    }
-  }
-
-  setDebugLine(selectedFrame, selectedLocation) {
-    if (
-      selectedFrame &&
-      selectedLocation &&
-      selectedFrame.location.sourceId === selectedLocation.sourceId
-    ) {
-      const line = selectedFrame.location.line;
-      this.editor.codeMirror.addLineClass(line - 1, "line", "new-debug-line");
-    }
-  }
-
   // If the location has changed and a specific line is requested,
   // move to that line and flash it.
   highlightLine() {
@@ -782,6 +762,16 @@ class Editor extends PureComponent {
     };
   }
 
+  renderDebugLine() {
+    return DebugLine({
+      editor: this.editor,
+      frame: this.props.selectedFrame,
+      visibleSourceId: this.props.selectedSource
+        ? this.props.selectedSource.get("id")
+        : ""
+    });
+  }
+
   renderPreview() {
     const { selectedToken, selectedExpression } = this.state;
     const { selectedFrame, sourceText } = this.props;
@@ -851,6 +841,7 @@ class Editor extends PureComponent {
       this.renderHighlightLines(),
       this.renderBreakpoints(),
       this.renderHitCounts(),
+      this.renderDebugLine(),
       Footer({ editor: this.editor, horizontal }),
       this.renderPreview()
     );


### PR DESCRIPTION
A research project done somewhat in parallel with the debugger team's hack week activities.

### Motivation

The Editor component has extremely complex stateful behavior, including responsibility for maintaining lots of seemingly-separable concerns about the underlying CodeMirror editor's state. Carrying out these responsibilities is also the source of some slowness, as CodeMirror updates itself multiple times for each action, even though they could all be done as a single batch.

### What's here

- [X] Extracting management of the debugger line into a separate component

### Latter issues should address

- Lots more child components can get pulled out.
- Strategy for batching editor updates across multiple child components 