### PR TITLE
Refactor Breakpoints to be location symmetric

### DIFF
--- a/src/actions/tests/__snapshots__/pending-breakpoints.js.snap
+++ b/src/actions/tests/__snapshots__/pending-breakpoints.js.snap
@@ -13,7 +13,6 @@ Object {
   "id": "bar.js:7:",
   "loading": false,
   "location": Object {
-    "column": undefined,
     "line": 7,
     "sourceId": "bar.js",
     "sourceUrl": "http://localhost:8000/examples/bar.js",

--- a/src/actions/tests/breakpoints.js
+++ b/src/actions/tests/breakpoints.js
@@ -1,4 +1,9 @@
-import { createStore, selectors, actions } from "../../utils/test-head";
+import {
+  createStore,
+  selectors,
+  actions,
+  makeSource
+} from "../../utils/test-head";
 import {
   simulateCorrectThreadClient,
   simpleMockThreadClient
@@ -109,6 +114,81 @@ describe("breakpoints", () => {
 
     expect(selectors.getBreakpoint(getState(), loc1).disabled).toBe(false);
     expect(selectors.getBreakpoint(getState(), loc2).disabled).toBe(false);
+  });
+
+  it("should toggle a breakpoint at a location", async () => {
+    const { dispatch, getState } = createStore(simpleMockThreadClient);
+
+    await dispatch(actions.newSource(makeSource("foo1")));
+    await dispatch(actions.selectSource("foo1", { line: 1 }));
+
+    await dispatch(actions.toggleBreakpoint(5));
+    await dispatch(actions.toggleBreakpoint(6, 1));
+    expect(
+      selectors.getBreakpoint(getState(), { sourceId: "foo1", line: 5 })
+        .disabled
+    ).toBe(false);
+
+    expect(
+      selectors.getBreakpoint(getState(), {
+        sourceId: "foo1",
+        line: 6,
+        column: 1
+      }).disabled
+    ).toBe(false);
+
+    await dispatch(actions.toggleBreakpoint(5));
+    await dispatch(actions.toggleBreakpoint(6, 1));
+
+    expect(
+      selectors.getBreakpoint(getState(), { sourceId: "foo1", line: 5 })
+    ).toBe(undefined);
+
+    expect(
+      selectors.getBreakpoint(getState(), {
+        sourceId: "foo1",
+        line: 6,
+        column: 1
+      })
+    ).toBe(undefined);
+  });
+
+  it("should disable/enable a breakpoint at a location", async () => {
+    const { dispatch, getState } = createStore(simpleMockThreadClient);
+
+    await dispatch(actions.newSource(makeSource("foo1")));
+    await dispatch(actions.selectSource("foo1", { line: 1 }));
+
+    await dispatch(actions.toggleBreakpoint(5));
+    await dispatch(actions.toggleBreakpoint(6, 1));
+    expect(
+      selectors.getBreakpoint(getState(), { sourceId: "foo1", line: 5 })
+        .disabled
+    ).toBe(false);
+
+    expect(
+      selectors.getBreakpoint(getState(), {
+        sourceId: "foo1",
+        line: 6,
+        column: 1
+      }).disabled
+    ).toBe(false);
+
+    await dispatch(actions.toggleDisabledBreakpoint(5));
+    await dispatch(actions.toggleDisabledBreakpoint(6, 1));
+
+    expect(
+      selectors.getBreakpoint(getState(), { sourceId: "foo1", line: 5 })
+        .disabled
+    ).toBe(true);
+
+    expect(
+      selectors.getBreakpoint(getState(), {
+        sourceId: "foo1",
+        line: 6,
+        column: 1
+      }).disabled
+    ).toBe(true);
   });
 
   it("should set the breakpoint condition", async () => {

--- a/src/actions/tests/helpers/breakpoints.js
+++ b/src/actions/tests/helpers/breakpoints.js
@@ -1,5 +1,16 @@
 import { makeLocationId } from "../../../utils/breakpoint";
 
+const sourceFixtures = {
+  foo1: {
+    source: "function foo1() {\n  return 5;\n}",
+    contentType: "text/javascript"
+  },
+  foo2: {
+    source: "function foo2(x, y) {\n  return x + y;\n}",
+    contentType: "text/javascript"
+  }
+};
+
 export function mockPendingBreakpoint(overrides = {}) {
   const { sourceUrl, line, column, condition, disabled } = overrides;
   return {
@@ -65,8 +76,17 @@ export const simpleMockThreadClient = {
   setBreakpoint: (location, _condition) =>
     Promise.resolve({ id: "hi", actualLocation: location }),
 
-  removeBreakpoint: _id => Promise.resolve({ status: "done" }),
+  removeBreakpoint: _id => Promise.resolve(),
 
   setBreakpointCondition: (_id, _location, _condition, _noSliding) =>
-    Promise.resolve({ sourceId: "a", line: 5 })
+    Promise.resolve({ sourceId: "a", line: 5 }),
+
+  sourceContents: sourceId =>
+    new Promise((resolve, reject) => {
+      if (sourceFixtures[sourceId]) {
+        resolve(sourceFixtures[sourceId]);
+      }
+
+      reject(`unknown source: ${sourceId}`);
+    })
 };

--- a/src/actions/utils/breakpoints.js
+++ b/src/actions/utils/breakpoints.js
@@ -11,10 +11,7 @@ export async function formatClientBreakpoint(
 
   // make sure that we are re-adding the same type of breakpoint. Column
   // or line
-  const actualLocation = equalizeLocationColumn(
-    clientOriginalLocation,
-    location
-  );
+  const actualLocation = clientOriginalLocation;
 
   // the generatedLocation might have slid, so now we can adjust it
   const generatedLocation = clientBreakpoint.actualLocation;

--- a/src/components/Editor/Breakpoints.js
+++ b/src/components/Editor/Breakpoints.js
@@ -1,0 +1,67 @@
+import { connect } from "react-redux";
+import { bindActionCreators } from "redux";
+import { Component, createFactory, DOM as dom } from "react";
+import { isEnabled } from "devtools-config";
+
+import _Breakpoint from "./Breakpoint";
+const Breakpoint = createFactory(_Breakpoint);
+
+import actions from "../../actions";
+import { getSelectedSource } from "../../selectors";
+import getVisibleBreakpoints from "../../selectors/visibleBreakpoints";
+import { makeLocationId } from "../../utils/breakpoint";
+
+import type { SourceRecord, BreakpointMap } from "../../reducers/types";
+
+type props = {
+  selectedSource: SourceRecord,
+  breakpoints: BreakpointMap,
+  editor: Object
+};
+
+class Breakpoints extends Component {
+  props: props;
+
+  shouldComponentUpdate(nextProps: any) {
+    if (nextProps.selectedSource && nextProps.selectedSource.get("loading")) {
+      return false;
+    }
+
+    return true;
+  }
+
+  render() {
+    const { breakpoints, selectedSource, editor } = this.props;
+
+    if (!selectedSource || !breakpoints || selectedSource.get("isBlackBoxed")) {
+      return null;
+    }
+
+    return dom.div(
+      {},
+      breakpoints
+        .valueSeq()
+        .filter(
+          b => (isEnabled("columnBreakpoints") ? !b.location.column : true)
+        )
+        .map(bp =>
+          Breakpoint({
+            key: makeLocationId(bp.location),
+            breakpoint: bp,
+            selectedSource,
+            editor: editor
+          })
+        )
+    );
+  }
+}
+
+Breakpoints.displayName = "Breakpoints";
+
+export default connect(
+  state => ({
+    breakpoints: getVisibleBreakpoints(state),
+    selectedSource: getSelectedSource(state)
+  }),
+  dispatch => bindActionCreators(actions, dispatch)
+)(Breakpoints);

--- a/src/components/Editor/CallSites.js
+++ b/src/components/Editor/CallSites.js
@@ -38,6 +38,7 @@ class CallSites extends Component {
     symbols: Array<Symbol>,
     callSites: Array<Symbol>,
     editor: Object,
+    breakpoints: Map,
     addBreakpoint: Function,
     removeBreakpoint: Function,
     selectedSource: Object,

--- a/src/components/Editor/GutterMenu.js
+++ b/src/components/Editor/GutterMenu.js
@@ -1,47 +1,44 @@
 import { showMenu } from "devtools-launchpad";
 
 export default function GutterMenu({
-  bp,
+  breakpoint,
   line,
   event,
   toggleBreakpoint,
   showConditionalPanel,
-  toggleBreakpointDisabledStatus,
+  toggleDisabledBreakpoint,
   isCbPanelOpen,
   closeConditionalPanel
 }) {
   event.stopPropagation();
   event.preventDefault();
-  let breakpoint = {
-    id: "node-menu-add-breakpoint",
-    label: L10N.getStr("editor.addBreakpoint")
-  },
-    conditional = {
+
+  const gutterItems = {
+    addBreakpoint: {
+      id: "node-menu-add-breakpoint",
+      label: L10N.getStr("editor.addBreakpoint")
+    },
+    addConditional: {
       id: "node-menu-add-conditional-breakpoint",
       label: L10N.getStr("editor.addConditionalBreakpoint")
     },
-    disabled;
-  if (bp) {
-    breakpoint = {
+    removeBreakpoint: {
       id: "node-menu-remove-breakpoint",
       label: L10N.getStr("editor.removeBreakpoint")
-    };
-    conditional = {
+    },
+    editConditional: {
       id: "node-menu-edit-conditional-breakpoint",
       label: L10N.getStr("editor.editBreakpoint")
-    };
-    if (bp.disabled) {
-      disabled = {
-        id: "node-menu-enable-breakpoint",
-        label: L10N.getStr("editor.enableBreakpoint")
-      };
-    } else {
-      disabled = {
-        id: "node-menu-disable-breakpoint",
-        label: L10N.getStr("editor.disableBreakpoint")
-      };
+    },
+    enableBreakpoint: {
+      id: "node-menu-enable-breakpoint",
+      label: L10N.getStr("editor.enableBreakpoint")
+    },
+    disableBreakpoint: {
+      id: "node-menu-disable-breakpoint",
+      label: L10N.getStr("editor.disableBreakpoint")
     }
-  }
+  };
 
   const toggleBreakpointItem = Object.assign(
     {
@@ -54,7 +51,7 @@ export default function GutterMenu({
         }
       }
     },
-    breakpoint
+    breakpoint ? gutterItems.removeBreakpoint : gutterItems.addBreakpoint
   );
 
   const conditionalBreakpoint = Object.assign(
@@ -63,19 +60,23 @@ export default function GutterMenu({
       disabled: false,
       click: () => showConditionalPanel(line)
     },
-    conditional
+    breakpoint && breakpoint.condition
+      ? gutterItems.editConditional
+      : gutterItems.addConditional
   );
 
   let items = [toggleBreakpointItem, conditionalBreakpoint];
 
-  if (bp) {
+  if (breakpoint) {
     const disableBreakpoint = Object.assign(
       {
         accesskey: "D",
         disabled: false,
-        click: () => toggleBreakpointDisabledStatus(line)
+        click: () => toggleDisabledBreakpoint(line)
       },
-      disabled
+      breakpoint.disabled
+        ? gutterItems.enableBreakpoint
+        : gutterItems.disableBreakpoint
     );
     items.push(disableBreakpoint);
   }

--- a/src/components/Editor/tests/Editor.js
+++ b/src/components/Editor/tests/Editor.js
@@ -13,6 +13,8 @@ function generateDefaults(overrides) {
     enableBreakpoint: jest.fn(),
     removeBreakpoint: jest.fn(),
     setBreakpointCondition: jest.fn(),
+    toggleBreakpoint: jest.fn(),
+    toggleDisabledBreakpoint: jest.fn(),
     getExpression: jest.fn(),
     addExpression: jest.fn(),
     query: "",

--- a/src/components/Editor/tests/__snapshots__/Editor.js.snap
+++ b/src/components/Editor/tests/__snapshots__/Editor.js.snap
@@ -34,6 +34,9 @@ ShallowWrapper {
         editor={null}
         horizontal={undefined}
     />
+    <Connect(Breakpoints)
+        editor={null}
+    />
 </div>,
   "nodes": Array [
     <div
@@ -61,6 +64,9 @@ ShallowWrapper {
       <Connect(SourceFooter)
             editor={null}
             horizontal={undefined}
+      />
+      <Connect(Breakpoints)
+            editor={null}
       />
 </div>,
   ],
@@ -91,6 +97,8 @@ ShallowWrapper {
                       }
         }
         setBreakpointCondition={[Function]}
+        toggleBreakpoint={[Function]}
+        toggleDisabledBreakpoint={[Function]}
 />,
       "_debugID": 1,
       "_hostContainerInfo": null,
@@ -129,13 +137,13 @@ ShallowWrapper {
             "wholeWord": false,
           },
           "setBreakpointCondition": [Function],
+          "toggleBreakpoint": [Function],
+          "toggleDisabledBreakpoint": [Function],
         },
         "refs": Object {},
         "state": Object {
           "highlightedLineRange": null,
         },
-        "toggleBreakpoint": [Function],
-        "toggleBreakpointDisabledStatus": [Function],
         "toggleConditionalPanel": [Function],
         "updater": Object {
           "enqueueCallback": [Function],
@@ -181,6 +189,9 @@ ShallowWrapper {
                     editor={null}
                     horizontal={undefined}
           />
+          <Connect(Breakpoints)
+                    editor={null}
+          />
 </div>,
         "_debugID": 2,
         "_renderedOutput": <div
@@ -208,6 +219,9 @@ ShallowWrapper {
           <Connect(SourceFooter)
                     editor={null}
                     horizontal={undefined}
+          />
+          <Connect(Breakpoints)
+                    editor={null}
           />
 </div>,
       },
@@ -242,6 +256,8 @@ ShallowWrapper {
           }
     }
     setBreakpointCondition={[Function]}
+    toggleBreakpoint={[Function]}
+    toggleDisabledBreakpoint={[Function]}
 />,
 }
 `;

--- a/src/reducers/breakpoints.js
+++ b/src/reducers/breakpoints.js
@@ -25,9 +25,12 @@ import type { Breakpoint, PendingBreakpoint, Location } from "../types";
 import type { Action } from "../actions/types";
 import type { Record } from "../utils/makeRecord";
 
+export type BreakpointMap = I.Map<string, Breakpoint>;
+export type PendingBreakpointMap = I.Map<string, PendingBreakpoint>;
+
 export type BreakpointsState = {
-  breakpoints: I.Map<string, Breakpoint>,
-  pendingBreakpoints: I.Map<string, PendingBreakpoint>,
+  breakpoints: BreakpointMap,
+  pendingBreakpoints: PendingBreakpointMap,
   breakpointsDisabled: false
 };
 
@@ -211,6 +214,7 @@ function disableBreakpoint(state, action) {
     loading: false,
     disabled: true
   };
+
   const updatedState = state.setIn(["breakpoints", id], breakpoint);
   return updatePendingBreakpoint(updatedState, breakpoint);
 }
@@ -349,6 +353,21 @@ export function getBreakpoints(state: OuterState) {
   return state.breakpoints.get("breakpoints");
 }
 
+export function getBreakpointsDisabled(state: OuterState): boolean {
+  return state.breakpoints.get("breakpointsDisabled");
+}
+
+export function getBreakpointsLoading(state: OuterState) {
+  const breakpoints = getBreakpoints(state);
+  const isLoading = !!breakpoints.valueSeq().filter(bp => bp.loading).first();
+
+  return breakpoints.size > 0 && isLoading;
+}
+
+export function getPendingBreakpoints(state: OuterState) {
+  return state.breakpoints.pendingBreakpoints;
+}
+
 export function getBreakpointsForSource(state: OuterState, sourceId: string) {
   if (!sourceId) {
     return I.Map();
@@ -363,21 +382,6 @@ export function getBreakpointsForSource(state: OuterState, sourceId: string) {
       : bp.location;
     return location.sourceId === sourceId;
   });
-}
-
-export function getBreakpointsDisabled(state: OuterState): boolean {
-  return state.breakpoints.get("breakpointsDisabled");
-}
-
-export function getBreakpointsLoading(state: OuterState) {
-  const breakpoints = getBreakpoints(state);
-  const isLoading = !!breakpoints.valueSeq().filter(bp => bp.loading).first();
-
-  return breakpoints.size > 0 && isLoading;
-}
-
-export function getPendingBreakpoints(state: OuterState) {
-  return state.breakpoints.pendingBreakpoints;
 }
 
 export default update;

--- a/src/reducers/types.js
+++ b/src/reducers/types.js
@@ -1,9 +1,13 @@
-import type { PauseState } from "pause";
-import type { SourcesState } from "source";
-import type { BreakpointsState } from "breakpoints";
+import type { PauseState } from "./pause";
+import type { SourcesState } from "./source";
+import type { BreakpointsState } from "./breakpoints";
 
 export type State = {
   pause: PauseState,
   sources: SourcesState,
   breakpoints: BreakpointsState
 };
+
+export type { SourceRecord } from "./source";
+
+export type { BreakpointMap } from "./breakpoints";

--- a/src/selectors.js
+++ b/src/selectors.js
@@ -8,6 +8,10 @@ import * as ui from "./reducers/ui";
 import * as ast from "./reducers/ast";
 import * as coverage from "./reducers/coverage";
 
+import getBreakpointAtLocation from "./selectors/breakpointAtLocation";
+import getInScopeLines from "./selectors/linesInScope";
+import getVisibleBreakpoints from "./selectors/visibleBreakpoints";
+
 /**
  * @param object - location
  */
@@ -21,5 +25,6 @@ module.exports = Object.assign(
   eventListeners,
   ui,
   ast,
-  coverage
+  coverage,
+  { getBreakpointAtLocation, getInScopeLines, getVisibleBreakpoints }
 );

--- a/src/selectors/linesInScope.js
+++ b/src/selectors/linesInScope.js
@@ -1,4 +1,5 @@
-import { getOutOfScopeLocations, getSelectedSource } from "../selectors";
+import { getOutOfScopeLocations } from "../reducers/ast";
+import { getSelectedSource } from "../reducers/sources";
 
 import range from "lodash/range";
 import flatMap from "lodash/flatMap";

--- a/src/selectors/visibleBreakpoints.js
+++ b/src/selectors/visibleBreakpoints.js
@@ -1,0 +1,45 @@
+import { getBreakpoints } from "../reducers/breakpoints";
+import { getSelectedSource } from "../reducers/sources";
+import { isGeneratedId } from "devtools-source-map";
+
+function getLocation(breakpoint, isGeneratedSource) {
+  return isGeneratedSource
+    ? breakpoint.generatedLocation || breakpoint.location
+    : breakpoint.location;
+}
+
+function formatBreakpoint(breakpoint, selectedSource) {
+  const { condition, loading, disabled } = breakpoint;
+  const sourceId = selectedSource.get("id");
+  const isGeneratedSource = isGeneratedId(sourceId);
+
+  return {
+    location: getLocation(breakpoint, isGeneratedSource),
+    condition,
+    loading,
+    disabled
+  };
+}
+
+function isVisible(breakpoint, selectedSource) {
+  const sourceId = selectedSource.get("id");
+  const isGeneratedSource = isGeneratedId(sourceId);
+
+  const location = getLocation(breakpoint, isGeneratedSource);
+  return location.sourceId === sourceId;
+}
+/*
+ * Finds the breakpoints, which appear in the selected source.
+ *
+ * This
+ */
+export default function getVisibleBreakpoints(state: OuterState) {
+  const selectedSource = getSelectedSource(state);
+  if (!selectedSource) {
+    return null;
+  }
+
+  return getBreakpoints(state)
+    .filter(bp => isVisible(bp, selectedSource))
+    .map(bp => formatBreakpoint(bp, selectedSource));
+}

--- a/src/test/mochitest/browser_dbg-editor-select.js
+++ b/src/test/mochitest/browser_dbg-editor-select.js
@@ -11,7 +11,7 @@ function isElementVisible(dbg, elementName) {
   return bpLine && isVisibleWithin(cm, bpLine);
 }
 
-add_task(function* () {
+add_task(function*() {
   // This test runs too slowly on linux debug. I'd like to figure out
   // which is the slowest part of this and make it run faster, but to
   // fix a frequent failure allow a longer timeout.

--- a/src/test/mochitest/browser_dbg-sourcemaps2.js
+++ b/src/test/mochitest/browser_dbg-sourcemaps2.js
@@ -24,7 +24,7 @@ add_task(function*() {
   yield addBreakpoint(dbg, mainSrc, 4);
   is(getBreakpoints(getState()).size, 1, "One breakpoint exists");
   ok(
-    getBreakpoint(getState(), { sourceId: mainSrc.id, line: 4 }),
+    getBreakpoint(getState(), { sourceId: mainSrc.id, line: 4, column: 2 }),
     "Breakpoint has correct line"
   );
 

--- a/src/utils/breakpoint/index.js
+++ b/src/utils/breakpoint/index.js
@@ -1,4 +1,3 @@
-import { isGeneratedId } from "devtools-source-map";
 import { isEnabled } from "devtools-config";
 
 // Return the first argument that is a string, or null if nothing is a
@@ -14,8 +13,7 @@ export function firstString(...args) {
 
 export function locationMoved(location, newLocation) {
   return (
-    location.line !== newLocation.line ||
-    (location.column != null && location.column !== newLocation.column)
+    location.line !== newLocation.line || location.column !== newLocation.column
   );
 }
 
@@ -46,17 +44,10 @@ export function equalizeLocationColumn(location, referenceLocation) {
 
 export function breakpointAtLocation(
   breakpoints,
-  selectedLocation,
   { line, column = undefined }
 ) {
-  const isGeneratedSource = isGeneratedId(selectedLocation.sourceId);
-
   return breakpoints.find(breakpoint => {
-    const location = isGeneratedSource
-      ? breakpoint.generatedLocation
-      : breakpoint.location;
-
-    const sameLine = location.line === line + 1;
+    const sameLine = breakpoint.location.line === line + 1;
     if (!sameLine) {
       return false;
     }
@@ -67,6 +58,6 @@ export function breakpointAtLocation(
       return true;
     }
 
-    return location.column === column;
+    return breakpoint.location.column === column;
   });
 }

--- a/src/utils/editor/expression.js
+++ b/src/utils/editor/expression.js
@@ -42,7 +42,7 @@ export function updateSelection(
       !target.parentElement.closest(".CodeMirror-line")) ||
     cursorPos.top == 0;
   const isUpdating = selection && selection.updating;
-  const inScope = linesInScope.includes(location.line);
+  const inScope = linesInScope && linesInScope.includes(location.line);
 
   if (invalidTarget || !inScope || isUpdating || invalidToken) {
     return;

--- a/src/utils/editor/index.js
+++ b/src/utils/editor/index.js
@@ -96,6 +96,10 @@ function markText(editor: any, className, location: any) {
   );
 }
 
+function lineAtHeight(editor, event) {
+  return editor.codeMirror.lineAtHeight(event.clientY) + 1;
+}
+
 module.exports = Object.assign(
   {},
   expressionUtils,
@@ -108,6 +112,7 @@ module.exports = Object.assign(
     shouldShowFooter,
     traverseResults,
     updateDocument,
-    markText
+    markText,
+    lineAtHeight
   }
 );

--- a/src/utils/editor/source-documents.js
+++ b/src/utils/editor/source-documents.js
@@ -1,12 +1,17 @@
 // @flow
 
+import { getMode } from "../source";
+import type { Source } from "debugger-html";
+
 let sourceDocs = {};
+let currentDocument = null;
 
 function getDocument(key: string) {
   return sourceDocs[key];
 }
 
 function setDocument(key: string, doc: any) {
+  currentDocument = doc;
   sourceDocs[key] = doc;
 }
 
@@ -18,4 +23,37 @@ function clearDocuments() {
   sourceDocs = {};
 }
 
-export { getDocument, setDocument, removeDocument, clearDocuments };
+/**
+ * Handle getting the source document or creating a new
+ * document with the correct mode and text.
+ */
+function showSourceText(editor: Object, source: Source) {
+  if (!source) {
+    return;
+  }
+
+  let doc = getDocument(source.id);
+  if (currentDocument === doc) {
+    return;
+  }
+
+  if (doc) {
+    editor.replaceDocument(doc);
+    return doc;
+  }
+
+  doc = editor.createDocument();
+  setDocument(source.id, doc);
+  editor.replaceDocument(doc);
+
+  editor.setText(source.text);
+  editor.setMode(getMode(source));
+}
+
+export {
+  getDocument,
+  setDocument,
+  removeDocument,
+  clearDocuments,
+  showSourceText
+};


### PR DESCRIPTION
### Summary of Changes

This is a follow up refactor. The goal is to provide some abstractions so that BPs are better represented in the components:

1. Components don't know/nor care if they're original or generated
2. Components only care about showing BPs
3. Toggle BP takes a line and column and does the rest
4. The reducer formats a generic BP with the "right" location