### PR TITLE
disable native context menu on window

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -10,6 +10,7 @@ import { isVisible } from "../utils/ui";
 
 import { KeyShortcuts } from "devtools-modules";
 const shortcuts = new KeyShortcuts({ window });
+window.oncontextmenu = e => false;
 
 const verticalLayoutBreakpoint = window.matchMedia("(min-width: 800px)");
 


### PR DESCRIPTION
Associated Issue: #3274 

### Summary of Changes

* disable native context menu.

Since we `stopPropogation` and `preventDefault` at various components down the tree, I couldn't disable the native context menu on `App` as the event doesn't bubble up there. I found this other solution online. 

### Test Plan
1. Visual Testing

### Screenshots/Videos (OPTIONAL)

