### PR TITLE
Add more cases to warn for yarn lock changes, and run prepush script in parallel

### DIFF
--- a/bin/check-warn-yarn-changed.js
+++ b/bin/check-warn-yarn-changed.js
@@ -1,0 +1,26 @@
+// MIT © Sindre Sorhus - sindresorhus.com
+// via https://gist.github.com/sindresorhus/7996717
+
+const { execFile } = require('child_process');
+
+module.exports = function checkWarnIfYarnChanged(origHead, head) {
+  return new Promise((resolve, reject) => {
+    execFile(
+      'git',
+      ['diff-tree', '-r', '--name-only', '--no-commit-id', origHead, head],
+      (error, stdout, stderr) => {
+        if (error) {
+          console.error('stderr', stderr);
+          reject(error);
+          return;
+        }
+        if (stdout.includes('yarn.lock')) {
+          console.log('🎅 yarn.lock changed; RUN: yarn install');
+          resolve(true);
+        } else {
+          resolve(false);
+        }
+      }
+    );
+  });
+};

--- a/bin/post-checkout.js
+++ b/bin/post-checkout.js
@@ -1,0 +1,8 @@
+const [origHead, head, flag] = process.env.GIT_PARAMS.split(' ');
+
+// Flag is 1 if we moved between branches. Flag is 0 if we merely checked out a file from another branch.
+if (flag !== '1') {
+  process.exit();
+}
+
+require('./check-warn-yarn-changed.js')(origHead, head);

--- a/bin/post-merge.js
+++ b/bin/post-merge.js
@@ -1,16 +1,1 @@
-// MIT © Sindre Sorhus - sindresorhus.com
-// via https://gist.github.com/sindresorhus/7996717
-
-const execFile = require("child_process").execFile;
-
-execFile("git",
-  ["diff-tree", "-r", "--name-only", "--no-commit-id", "ORIG_HEAD", "HEAD"],
-  (error, stdout, stderr) => {
-  if (error) {
-    console.error("stderr", stderr);
-    throw error;
-  }
-  if (stdout.includes("yarn.lock")) {
-    console.log("🎅 yarn.lock changed; RUN: yarn install");
-  }
-});
+require('./check-warn-yarn-changed.js')('ORIG_HEAD', 'HEAD');

--- a/bin/post-rewrite.js
+++ b/bin/post-rewrite.js
@@ -1,0 +1,19 @@
+// This is either 'rebase' or 'amend'.
+if (process.env.GIT_PARAMS !== 'rebase') {
+  process.exit();
+}
+
+const checkWarnYarnChanged = require('./check-warn-yarn-changed.js');
+
+const { createInterface } = require('readline');
+
+const rl = createInterface({
+  input: process.stdin,
+});
+
+rl.on('line', line => {
+  const [origHead, head] = line.split(' ');
+  checkWarnYarnChanged(origHead, head).then(
+    changed => changed && process.exit()
+  );
+});

--- a/package.json
+++ b/package.json
@@ -42,9 +42,11 @@
     "flow-react": "flow-coverage-report -i 'src/components/**/*.js' -t text",
     "storybook": "start-storybook -p 9001 -c .storybook",
     "snapshot": "NODE_ENV='development' build-storybook && percy-storybook",
-    "prepush": "yarn lint && yarn test && yarn flow",
+    "postcheckout": "node bin/post-checkout.js",
     "postmerge": "node bin/post-merge.js",
+    "postrewrite": "node bin/post-rewrite.js",
     "precommit": "lint-staged",
+    "prepush": "yarn lint && yarn test && yarn flow",
     "nom": "rm -rf node_modules yarn.lock; yarn install"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "prettier": "node bin/prettier.js",
     "license-check": "devtools-license-check",
     "links": "ls -l node_modules/ | grep ^l || echo 'no linked packages'",
-    "lint": "yarn lint-css -s && yarn lint-js -s && yarn lint-md",
+    "lint": "run-p lint-css lint-js lint-md",
     "lint-css": "stylelint \"src/components/**/*.css\"",
     "lint-js": "eslint *.js \"src/**/*.js\"",
     "lint-md": "remark -qf *.md src configs docs",
@@ -46,7 +46,7 @@
     "postmerge": "node bin/post-merge.js",
     "postrewrite": "node bin/post-rewrite.js",
     "precommit": "lint-staged",
-    "prepush": "yarn lint && yarn test && yarn flow",
+    "prepush": "run-p lint test flow",
     "nom": "rm -rf node_modules yarn.lock; yarn install"
   },
   "dependencies": {
@@ -115,6 +115,7 @@
     "jest": "^20.0.1",
     "jest-localstorage-mock": "^1.1.1",
     "lint-staged": "^4.0.1",
+    "npm-run-all": "^4.0.2",
     "react-addons-perf": "15.3.2",
     "react-addons-test-utils": "=15.3.2",
     "remark-cli": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -306,6 +306,10 @@ array-equal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/array-equal/-/array-equal-1.0.0.tgz#8c2a5ef2472fd9ea742b04c77a75093ba2757c93"
 
+array-filter@~0.0.0:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/array-filter/-/array-filter-0.0.1.tgz#7da8cf2e26628ed732803581fd21f67cacd2eeec"
+
 array-find-index@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/array-find-index/-/array-find-index-1.0.2.tgz#df010aa1287e164bbda6f9723b0a96a1ec4187a1"
@@ -326,6 +330,14 @@ array-iterate@^1.0.0:
   resolved "https://registry.yarnpkg.com/array-iterate/-/array-iterate-1.1.0.tgz#4f13148ffffa5f2756b50460e5eac8eed31a14e6"
   dependencies:
     has "^1.0.1"
+
+array-map@~0.0.0:
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/array-map/-/array-map-0.0.0.tgz#88a2bab73d1cf7bcd5c1b118a003f66f665fa662"
+
+array-reduce@~0.0.0:
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/array-reduce/-/array-reduce-0.0.0.tgz#173899d3ffd1c7d9383e4479525dbe278cab5f2b"
 
 array-union@^1.0.1:
   version "1.0.2"
@@ -3001,6 +3013,18 @@ event-emitter@~0.3.5:
     d "1"
     es5-ext "~0.10.14"
 
+event-stream@~3.3.0:
+  version "3.3.4"
+  resolved "https://registry.yarnpkg.com/event-stream/-/event-stream-3.3.4.tgz#4ab4c9a0f5a54db9338b4c34d86bfce8f4b35571"
+  dependencies:
+    duplexer "~0.1.1"
+    from "~0"
+    map-stream "~0.1.0"
+    pause-stream "0.0.11"
+    split "0.3"
+    stream-combiner "~0.0.4"
+    through "~2.3.1"
+
 events@^1.0.0, events@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
@@ -3313,6 +3337,10 @@ forwarded@~0.1.0:
 fresh@0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.0.tgz#f474ca5e6a9246d6fd8e0953cfa9b9c805afa78e"
+
+from@~0:
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/from/-/from-0.1.7.tgz#83c60afc58b9c56997007ed1a768b3ab303a44fe"
 
 fs-extra@^2.0.0:
   version "2.1.2"
@@ -5253,6 +5281,10 @@ map-obj@^1.0.0, map-obj@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-1.0.1.tgz#d933ceb9205d82bdcf4886f6742bdc2b4dea146d"
 
+map-stream@~0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/map-stream/-/map-stream-0.1.0.tgz#e56aa94c4c8055a16404a0674b78f215f7c8e194"
+
 markdown-escapes@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/markdown-escapes/-/markdown-escapes-1.0.0.tgz#c8ca19f1d94d682459e0a93c86db27a7ef716b23"
@@ -5690,6 +5722,18 @@ npm-prefix@^1.2.0:
     shellsubstitute "^1.1.0"
     untildify "^2.1.0"
 
+npm-run-all@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/npm-run-all/-/npm-run-all-4.0.2.tgz#a84669348e6db6ccbe052200b4cdb6bfe034a4fe"
+  dependencies:
+    chalk "^1.1.3"
+    cross-spawn "^5.0.1"
+    minimatch "^3.0.2"
+    ps-tree "^1.0.1"
+    read-pkg "^2.0.0"
+    shell-quote "^1.6.1"
+    string.prototype.padend "^3.0.0"
+
 npm-run-path@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f"
@@ -6040,6 +6084,12 @@ path-type@^2.0.0:
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-2.0.0.tgz#f012ccb8415b7096fc2daa1054c3d72389594c73"
   dependencies:
     pify "^2.0.0"
+
+pause-stream@0.0.11:
+  version "0.0.11"
+  resolved "https://registry.yarnpkg.com/pause-stream/-/pause-stream-0.0.11.tgz#fe5a34b0cbce12b5aa6a2b403ee2e73b602f1445"
+  dependencies:
+    through "~2.3"
 
 pbkdf2-compat@2.0.1:
   version "2.0.1"
@@ -6535,6 +6585,12 @@ ps-node@^0.1.4:
   resolved "https://registry.yarnpkg.com/ps-node/-/ps-node-0.1.6.tgz#9af67a99d7b1d0132e51a503099d38a8d2ace2c3"
   dependencies:
     table-parser "^0.1.3"
+
+ps-tree@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/ps-tree/-/ps-tree-1.1.0.tgz#b421b24140d6203f1ed3c76996b4427b08e8c014"
+  dependencies:
+    event-stream "~3.3.0"
 
 pseudomap@^1.0.1:
   version "1.0.2"
@@ -7553,6 +7609,15 @@ shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
 
+shell-quote@^1.6.1:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.6.1.tgz#f4781949cce402697127430ea3b3c5476f481767"
+  dependencies:
+    array-filter "~0.0.0"
+    array-map "~0.0.0"
+    array-reduce "~0.0.0"
+    jsonify "~0.0.0"
+
 shelljs@^0.7.4, shelljs@^0.7.5:
   version "0.7.8"
   resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.7.8.tgz#decbcf874b0d1e5fb72e14b164a9683048e9acb3"
@@ -7671,6 +7736,12 @@ split2@^0.2.1:
   dependencies:
     through2 "~0.6.1"
 
+split@0.3:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/split/-/split-0.3.3.tgz#cd0eea5e63a211dfff7eb0f091c4133e2d0dd28f"
+  dependencies:
+    through "2"
+
 sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
@@ -7735,6 +7806,12 @@ stream-combiner@^0.2.1:
   dependencies:
     duplexer "~0.1.1"
     through "~2.3.4"
+
+stream-combiner@~0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/stream-combiner/-/stream-combiner-0.0.4.tgz#4d5e433c185261dde623ca3f44c586bcf5c4ad14"
+  dependencies:
+    duplexer "~0.1.1"
 
 stream-http@^2.3.1:
   version "2.7.1"
@@ -8126,7 +8203,7 @@ through2@^2.0.0, through2@^2.0.1, through2@~2.0.0:
     readable-stream "^2.1.5"
     xtend "~4.0.1"
 
-"through@>=2.2.7 <3", through@^2.3.6, through@~2.3.4:
+through@2, "through@>=2.2.7 <3", through@^2.3.6, through@~2.3, through@~2.3.1, through@~2.3.4:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
 


### PR DESCRIPTION
Associated Issue: no issue

### Summary of Changes

* Add yarn.lock checks for `git checkout` and `git rebase` too, in addition to the existing `git pull`
* Use npm-run-all to run push scripts in parallel

### Test Plan

I tried to move back and forth between branches, tried to rebase, tried to merge another branch, and tried to push, all with `yarn.lock` changes.
