### PR TITLE
fix toggling sources

### DIFF
--- a/src/components/Editor/Breakpoint.js
+++ b/src/components/Editor/Breakpoint.js
@@ -96,7 +96,6 @@ class Breakpoint extends Component {
     }
 
     const line = breakpoint.location.line - 1;
-
     editor.codeMirror.setGutterMarker(line, "breakpoints", null);
     editor.codeMirror.removeLineClass(line, "line", "new-breakpoint");
     editor.codeMirror.removeLineClass(line, "line", "has-condition");

--- a/src/utils/editor/source-documents.js
+++ b/src/utils/editor/source-documents.js
@@ -4,14 +4,12 @@ import { getMode } from "../source";
 import type { Source } from "debugger-html";
 
 let sourceDocs = {};
-let currentDocument = null;
 
 function getDocument(key: string) {
   return sourceDocs[key];
 }
 
 function setDocument(key: string, doc: any) {
-  currentDocument = doc;
   sourceDocs[key] = doc;
 }
 
@@ -33,7 +31,7 @@ function showSourceText(editor: Object, source: Source) {
   }
 
   let doc = getDocument(source.id);
-  if (currentDocument === doc) {
+  if (editor.codeMirror.doc === doc) {
     return;
   }
 


### PR DESCRIPTION
I found this small issue when reviewing the recent refactor.

The problem was that `currentDoc` was our of sync with what codemirror believed was current. This replaces the new state by using codeMirror as the authoritative source.