### PR TITLE
Project text search styling

### DIFF
--- a/src/components/Editor/Tabs.js
+++ b/src/components/Editor/Tabs.js
@@ -358,7 +358,7 @@ class SourceTabs extends PureComponent {
     const { closeTab, closeActiveSearch, setActiveSearch } = this.props;
 
     function tabName(tab) {
-      return `${tab} ${tab == "project" ? "text" : ""} search`;
+      return `${tab} search results`;
     }
 
     function onClickClose(ev) {

--- a/src/components/ProjectSearch/TextSearch.css
+++ b/src/components/ProjectSearch/TextSearch.css
@@ -5,8 +5,12 @@
 .project-text-search .result {
   display: flex;
   cursor: default;
-  margin: 2px 0 2px 0;
-  padding: 5px 0 5px 30px;
+  margin-bottom: 1px;
+  padding: 4px 0 4px 30px;
+}
+
+.project-text-search .matches-summary {
+  margin-left: 2px;
 }
 
 .project-text-search .result.focused {
@@ -15,13 +19,19 @@
 
 .project-text-search .result .query-match {
   background-color: var(--theme-selection-background);
-  color: #ffffff;
-  padding: 2px 5px;
+  color: white;
+  padding: 1px 4px;
+  margin: 0 2px 0 2px;
   border-radius: 2px;
 }
 
 .project-text-search .result.focused .line-number {
   font-weight: bolder;
+}
+
+.project-text-search .result .line-number {
+  margin-right: 1em;
+  width: 2em;
 }
 
 .project-text-search .file-result {
@@ -43,10 +53,6 @@
 .project-text-search .line-match {
   display: "flex";
   grow: 1;
-}
-
-.project-text-search .result .line-number {
-  padding-right: 5px;
 }
 
 .project-text-search .search-field {

--- a/src/components/ProjectSearch/TextSearch.js
+++ b/src/components/ProjectSearch/TextSearch.js
@@ -54,6 +54,9 @@ export default class TextSearch extends Component {
   }
 
   renderFile(file, focused, expanded, setExpanded) {
+    if (file.matches.length === 0) {
+      return null;
+    }
     return dom.div(
       {
         className: classnames("file-result", { focused }),


### PR DESCRIPTION

Associated Issue: #3326

### Summary of Changes

- stop showing files that have no matches
-  add "results" to the tab title to indicate its showing results
- fixed jumpy text when line is focused on

### Test Plan
- [x] Check "Project text search" in launchpad settings
- [x] Select a couple of sources from the source tree
- [x] do CMD+SHIFT+F to open Project search panel
- [x] Search across opened source texts files

### Screenshots
![image](https://user-images.githubusercontent.com/792924/28146159-98ace470-676f-11e7-923d-b9b858becfc5.png)

![image](https://user-images.githubusercontent.com/792924/28146161-a3a6663a-676f-11e7-8421-2ad4173067ec.png)


