### PR TITLE
fix 'this page has no sources' misalignment (issue 3253)

### DIFF
--- a/src/components/PrimaryPanes/Sources.css
+++ b/src/components/PrimaryPanes/Sources.css
@@ -61,7 +61,10 @@
   color: var(--theme-comment-alt);
   font-weight: lighter;
   padding-top: 5px;
-  text-align: center;
+  flex-grow: 1;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 
 .sources-panel .source-footer {


### PR DESCRIPTION
Associated Issue: #3253 

### Summary of Changes

* Changed the CSS of the class `.no-sources-messages` so message appears centered vertically and not at the top.

### Test Plan

- Launch the debugger and open a website with no sources. I used https://devtools-html.github.io/debugger-examples/
- See in the sources panel how the message looks like. It should appear aligned at the center, both horizontally and vertically.
- Open a new website that has sources. I used https://www.github.com
- See that the sources panel appears as usual

### Screenshots/Videos

How the "This page has no sources" messages looks like now:

<img width="397" alt="screen shot 2017-07-13 at 11 55 56" src="https://user-images.githubusercontent.com/63681/28161046-52ae1e28-67c2-11e7-970c-c952436027f5.png">

When the page does have sources, it looks OK:

<img width="411" alt="screen shot 2017-07-13 at 11 56 15" src="https://user-images.githubusercontent.com/63681/28161073-6b4cdb4a-67c2-11e7-8b97-d394a3811c58.png">

---

### Notes

I'm running into trouble setting up the project locally on my machine with yarn. I had to bypass the pre-push hook, but since this is only a CSS change…

