### PR TITLE
prevent Ctrl+Shift+O from opening bookmarks organizer under Linux

### DIFF
--- a/src/components/SymbolModal.js
+++ b/src/components/SymbolModal.js
@@ -121,7 +121,8 @@ class SymbolModal extends Component {
     }
   }
 
-  openSymbolModal() {
+  openSymbolModal(_, e) {
+    e.preventDefault();
     this.props.setActiveSearch("symbol");
   }
 


### PR DESCRIPTION
Associated Issue: #3327

This is a workaround to prevent the bookmarks organizer from opening under Linux.