### PR TITLE
[WIP] Improve editor perf by using CodeMirror operations

### DIFF
--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -116,6 +116,8 @@ class Editor extends PureComponent {
   componentWillReceiveProps(nextProps) {
     // This lifecycle method is responsible for updating the editor
     // text.
+    this.editor.codeMirror.startOperation();
+
     const { selectedSource, selectedLocation } = nextProps;
     this.clearDebugLine(this.props.selectedFrame);
 
@@ -263,6 +265,8 @@ class Editor extends PureComponent {
     if (selectedSource && selectedSource.has("text")) {
       this.highlightLine();
     }
+
+    this.editor.codeMirror.endOperation();
   }
 
   onToggleBreakpoint(key, e) {


### PR DESCRIPTION
(⚠️  this PR is waiting for a new release of CodeMirror that includes the methods it requires. For now, you'll have to manually update node modules to the CodeMirror master for it to work.)

By starting an operation before the editor receives props, and ending it only after it's final `didUpdate`, we allow the editor and its children components to call as many CodeMirror methods as they like while still only paying for the cost of one CodeMirror update cycle.