### PR TITLE
[ProjectSearch] toggle between project text search and file name search

### DIFF
--- a/assets/panel/debugger.properties
+++ b/assets/panel/debugger.properties
@@ -466,7 +466,7 @@ welcome.search=%S to search for sources
 
 # LOCALIZATION NOTE (sourceSearch.search): The center pane Source Search
 # prompt for searching for files.
-sourceSearch.search=Search Sources…
+sourceSearch.search=Find files
 
 # LOCALIZATION NOTE (sourceSearch.noResults): The center pane Source Search
 # message when the query did not match any of the sources.

--- a/assets/panel/debugger.properties
+++ b/assets/panel/debugger.properties
@@ -140,6 +140,10 @@ sources.search.alt.key=CmdOrCtrl+O
 # full project text search for searching all the files the debugger has seen.
 projectTextSearch.key=CmdOrCtrl+Shift+F
 
+# LOCALIZATION NOTE (projectTextSearch.placeholder): A placeholder shown
+# when searching across all of the files in a project.
+projectTextSearch.placeholder=Find in files…
+
 # LOCALIZATION NOTE (sources.noSourcesAvailable): Text shown when the debugger
 # does not have any sources.
 sources.noSourcesAvailable=This page has no sources
@@ -466,7 +470,7 @@ welcome.search=%S to search for sources
 
 # LOCALIZATION NOTE (sourceSearch.search): The center pane Source Search
 # prompt for searching for files.
-sourceSearch.search=Find files
+sourceSearch.search=Search Sources…
 
 # LOCALIZATION NOTE (sourceSearch.noResults): The center pane Source Search
 # message when the query did not match any of the sources.

--- a/src/components/ProjectSearch/ProjectSearch.css
+++ b/src/components/ProjectSearch/ProjectSearch.css
@@ -5,6 +5,7 @@
   width: calc(100% - 1px);
   height: calc(100% - 31px);
   display: flex;
+  flex-direction: column;
   z-index: 200;
   background-color: var(--theme-body-background);
   overflow-y: auto;
@@ -17,4 +18,31 @@
 
 .theme-dark .result-list li .subtitle {
   color: var(--theme-comment-alt);
+}
+
+.toggle-search {
+  background-color: var(--theme-toolbar-background);
+  border-bottom: 1px solid var(--theme-splitter-color);
+  color: var(--theme-comment-alt);
+  display: flex;
+  flex-shrink: 0;
+  justify-content: flex-start;
+  line-height: 40px;
+  padding: 0 13px;
+  width: calc(100% - 1px);
+}
+
+.toggle-search .title {
+  font-weight: 500;
+  font-size: 120%;
+}
+
+.toggle-search .text {
+  margin-left: 1em;
+  cursor: pointer;
+}
+
+.toggle-search .active {
+  color: var(--theme-selection-background);
+  cursor: default;
 }

--- a/src/components/ProjectSearch/SourceSearch.js
+++ b/src/components/ProjectSearch/SourceSearch.js
@@ -59,7 +59,7 @@ export default class SourceSearch extends Component {
   }
 
   render() {
-    const { sources } = this.props;
+    const { sources, searchBottomBar } = this.props;
     return Autocomplete({
       selectItem: (e, result) => {
         this.props.selectSource(result.id);
@@ -69,7 +69,8 @@ export default class SourceSearch extends Component {
       items: this.searchResults(sources),
       inputValue: this.state.inputValue,
       placeholder: L10N.getStr("sourceSearch.search"),
-      size: "big"
+      size: "big",
+      children: searchBottomBar
     });
   }
 }

--- a/src/components/ProjectSearch/TextSearch.css
+++ b/src/components/ProjectSearch/TextSearch.css
@@ -1,6 +1,5 @@
 .project-text-search {
   flex-grow: 1;
-  font-family: Menlo, monospace;
 }
 
 .project-text-search .result {
@@ -13,6 +12,10 @@
 
 .project-text-search .matches-summary {
   margin-left: 5px;
+}
+
+.project-text-search .result {
+  font-family: Menlo, monospace;
 }
 
 .project-text-search .result.focused {

--- a/src/components/ProjectSearch/TextSearch.js
+++ b/src/components/ProjectSearch/TextSearch.js
@@ -205,7 +205,7 @@ export default class TextSearch extends Component {
     return SearchInput({
       query: this.state.inputValue,
       count: resultCount,
-      placeholder: "Search Project",
+      placeholder: "Find in Project",
       size: "big",
       summaryMsg,
       onChange: e => this.inputOnChange(e),
@@ -218,24 +218,26 @@ export default class TextSearch extends Component {
   }
 
   render() {
+    const { searchBottomBar } = this.props;
     return dom.div(
       {
         className: "project-text-search"
       },
       this.renderInput(),
+      searchBottomBar,
       this.renderResults()
     );
   }
 }
 
 TextSearch.propTypes = {
-  addTab: PropTypes.func,
   sources: PropTypes.object,
   results: PropTypes.array,
   query: PropTypes.string,
   closeActiveSearch: PropTypes.func,
   searchSources: PropTypes.func,
-  selectSource: PropTypes.func
+  selectSource: PropTypes.func,
+  searchBottomBar: PropTypes.object
 };
 
 TextSearch.contextTypes = {

--- a/src/components/ProjectSearch/TextSearch.js
+++ b/src/components/ProjectSearch/TextSearch.js
@@ -205,7 +205,7 @@ export default class TextSearch extends Component {
     return SearchInput({
       query: this.state.inputValue,
       count: resultCount,
-      placeholder: "Find in Project",
+      placeholder: L10N.getStr("projectTextSearch.placeholder"),
       size: "big",
       summaryMsg,
       onChange: e => this.inputOnChange(e),

--- a/src/components/ProjectSearch/ToggleSearch.js
+++ b/src/components/ProjectSearch/ToggleSearch.js
@@ -1,22 +1,26 @@
 import { Component, DOM as dom, PropTypes } from "react";
+import classnames from "classnames";
 
 export default class ToggleSearch extends Component {
   render() {
     const { kind, toggle } = this.props;
+    const isSourcesActive = kind === "sources";
     return dom.div(
       { className: "toggle-search" },
-      dom.span({ className: "title" }, "Search:"),
-      kind === "sources"
-        ? dom.span(
-            {},
-            dom.span({ className: "text active" }, "sources"),
-            dom.span({ className: "text", onClick: toggle }, "text")
-          )
-        : dom.span(
-            {},
-            dom.span({ className: "text", onClick: toggle }, "sources"),
-            dom.span({ className: "text active" }, "text")
-          )
+      dom.span(
+        {
+          className: classnames("text", { active: isSourcesActive }),
+          onClick: toggle
+        },
+        L10N.getStr("sourceSearch.search")
+      ),
+      dom.span(
+        {
+          className: classnames("text", { active: !isSourcesActive }),
+          onClick: toggle
+        },
+        L10N.getStr("projectTextSearch.placeholder")
+      )
     );
   }
 }

--- a/src/components/ProjectSearch/ToggleSearch.js
+++ b/src/components/ProjectSearch/ToggleSearch.js
@@ -1,0 +1,29 @@
+import { Component, DOM as dom, PropTypes } from "react";
+
+export default class ToggleSearch extends Component {
+  render() {
+    const { kind, toggle } = this.props;
+    return dom.div(
+      { className: "toggle-search" },
+      dom.span({ className: "title" }, "Search:"),
+      kind === "sources"
+        ? dom.span(
+            {},
+            dom.span({ className: "text active" }, "sources"),
+            dom.span({ className: "text", onClick: toggle }, "text")
+          )
+        : dom.span(
+            {},
+            dom.span({ className: "text", onClick: toggle }, "sources"),
+            dom.span({ className: "text active" }, "text")
+          )
+    );
+  }
+}
+
+ToggleSearch.propTypes = {
+  kind: PropTypes.string.isRequired,
+  toggle: PropTypes.func.isRequired
+};
+
+ToggleSearch.displayName = "ToggleSearch";

--- a/src/components/ProjectSearch/index.js
+++ b/src/components/ProjectSearch/index.js
@@ -20,6 +20,9 @@ const TextSearch = createFactory(_TextSearch);
 import _SourceSearch from "./SourceSearch";
 const SourceSearch = createFactory(_SourceSearch);
 
+import _ToggleSearch from "./ToggleSearch";
+const ToggleSearch = createFactory(_ToggleSearch);
+
 class ProjectSearch extends Component {
   state: Object;
   onEscape: Function;
@@ -65,51 +68,30 @@ class ProjectSearch extends Component {
   }
 
   toggleProjectTextSearch(key, e) {
-    const { closeActiveSearch, addTab, closeTab, setActiveSearch } = this.props;
-    e.preventDefault();
+    const { closeActiveSearch, setActiveSearch } = this.props;
+    if (e) {
+      e.preventDefault();
+    }
 
     if (!isEnabled("projectTextSearch")) {
       return;
     }
 
     if (this.isProjectSearchEnabled()) {
-      closeTab();
       return closeActiveSearch();
     }
-
-    addTab(
-      {
-        id: "project",
-        isBlackBoxed: false,
-        isPrettyPrinted: false,
-        sourceMapURL: null,
-        url: "project"
-      },
-      0
-    );
-
     return setActiveSearch("project");
   }
 
   toggleSourceSearch(key, e) {
-    const { closeActiveSearch, addTab, closeTab, setActiveSearch } = this.props;
-    e.preventDefault();
-
-    if (this.isSourceSearchEnabled()) {
-      closeTab();
-      return closeActiveSearch();
+    const { closeActiveSearch, setActiveSearch } = this.props;
+    if (e) {
+      e.preventDefault();
     }
 
-    addTab(
-      {
-        id: "source",
-        isBlackBoxed: false,
-        isPrettyPrinted: false,
-        sourceMapURL: null,
-        url: "source"
-      },
-      0
-    );
+    if (this.isSourceSearchEnabled()) {
+      return closeActiveSearch();
+    }
     return setActiveSearch("source");
   }
 
@@ -123,7 +105,15 @@ class ProjectSearch extends Component {
 
   renderSourceSearch() {
     const { sources, selectSource, closeActiveSearch } = this.props;
-    return SourceSearch({ sources, selectSource, closeActiveSearch });
+    return SourceSearch({
+      sources,
+      selectSource,
+      closeActiveSearch,
+      searchBottomBar: ToggleSearch({
+        kind: "sources",
+        toggle: this.toggleProjectTextSearch
+      })
+    });
   }
 
   renderTextSearch() {
@@ -142,7 +132,11 @@ class ProjectSearch extends Component {
       searchSources,
       closeActiveSearch,
       selectSource,
-      query
+      query,
+      searchBottomBar: ToggleSearch({
+        kind: "project",
+        toggle: this.toggleSourceSearch
+      })
     });
   }
 
@@ -168,9 +162,7 @@ ProjectSearch.propTypes = {
   closeActiveSearch: PropTypes.func.isRequired,
   searchSources: PropTypes.func,
   activeSearch: PropTypes.string,
-  selectSource: PropTypes.func.isRequired,
-  addTab: PropTypes.func,
-  closeTab: PropTypes.func
+  selectSource: PropTypes.func.isRequired
 };
 
 ProjectSearch.contextTypes = {

--- a/src/components/shared/Autocomplete.js
+++ b/src/components/shared/Autocomplete.js
@@ -26,7 +26,8 @@ type Props = {
   close: (value: any) => void,
   inputValue: string,
   placeholder: string,
-  size: string
+  size: string,
+  children: any
 };
 
 export default class Autocomplete extends Component {
@@ -131,7 +132,7 @@ export default class Autocomplete extends Component {
 
   render() {
     const { focused } = this.state;
-    const { size } = this.props;
+    const { size, children } = this.props;
     const searchResults = this.getSearchResults();
     const summaryMsg = L10N.getFormatStr(
       "sourceSearch.resultsSummary1",
@@ -156,6 +157,7 @@ export default class Autocomplete extends Component {
         onKeyDown: this.onKeyDown,
         handleClose: this.props.close
       }),
+      children,
       this.renderResults(searchResults)
     );
   }


### PR DESCRIPTION
The code is not too pretty, but it does what is required and since this
is a temporary ui I think it is ok.

Autocomplete was modified to render children before results

Associated Issue: #3091 
### Summary of Changes

* This adds UI for the project text search and files search (CMD or CTRL + o and CMD or CTRL + Shift + f) as shown in the image in issue 3091 
* This is temporary UI

### Test Plan

* Enable "projectTextSearch" in `configs/local.json`
* Press the above key combos to bring up the search bar
* Click on the active "files" or "text" link to change the UI

### Screenshots

![toggle-search-1](https://user-images.githubusercontent.com/142361/28726843-16c14928-73c3-11e7-8a2e-be2eca7454f2.gif)
