### PR TITLE
fix popup shortcut

### DIFF
--- a/src/components/SymbolModal.js
+++ b/src/components/SymbolModal.js
@@ -123,6 +123,7 @@ class SymbolModal extends Component {
 
   openSymbolModal(_, e) {
     e.preventDefault();
+    e.stopPropagation();
     this.props.setActiveSearch("symbol");
   }
 


### PR DESCRIPTION
this keeps cmd+shift+o from opening the devtools settings pane

### testing
tested in the panel