### PR TITLE
Do not set source.isWasm attribute for old Firefox.

### DIFF
--- a/configs/development.json
+++ b/configs/development.json
@@ -69,7 +69,7 @@
     },
     "wasm": {
       "label": "Wasm",
-      "enabled": false
+      "enabled": true
     }
   },
   "chrome": {

--- a/src/client/firefox/commands.js
+++ b/src/client/firefox/commands.js
@@ -28,18 +28,21 @@ import { createSource, createBreakpointLocation } from "./create";
 let bpClients: BPClients;
 let threadClient: ThreadClient;
 let tabTarget: TabTarget;
-let debuggerClient: DebuggerClient | null;
+let debuggerClient: DebuggerClient;
+let supportsWasm: boolean;
 
 type Dependencies = {
   threadClient: ThreadClient,
   tabTarget: TabTarget,
-  debuggerClient: DebuggerClient | null
+  debuggerClient: DebuggerClient,
+  supportsWasm: boolean
 };
 
 function setupCommands(dependencies: Dependencies): void {
   threadClient = dependencies.threadClient;
   tabTarget = dependencies.tabTarget;
   debuggerClient = dependencies.debuggerClient;
+  supportsWasm = dependencies.supportsWasm;
   bpClients = {};
 }
 
@@ -262,7 +265,7 @@ function pauseGrip(func: Function): ObjectClient {
 
 async function fetchSources() {
   const { sources } = await threadClient.getSources();
-  return sources.map(createSource);
+  return sources.map(source => createSource(source, { supportsWasm }));
 }
 
 const clientCommands = {

--- a/src/client/firefox/create.js
+++ b/src/client/firefox/create.js
@@ -31,12 +31,15 @@ export function createFrame(frame: FramePacket): Frame {
   };
 }
 
-export function createSource(source: SourcePayload): Source {
+export function createSource(
+  source: SourcePayload,
+  { supportsWasm }: { supportsWasm: boolean }
+): Source {
   return {
     id: source.actor,
     url: source.url,
     isPrettyPrinted: false,
-    isWasm: source.introductionType === "wasm",
+    isWasm: supportsWasm && source.introductionType === "wasm",
     sourceMapURL: source.sourceMapURL,
     isBlackBoxed: false
   };

--- a/src/client/firefox/events.js
+++ b/src/client/firefox/events.js
@@ -15,15 +15,18 @@ const CALL_STACK_PAGE_SIZE = 1000;
 
 type Dependencies = {
   threadClient: ThreadClient,
-  actions: Actions
+  actions: Actions,
+  supportsWasm: boolean
 };
 
 let threadClient: ThreadClient;
 let actions: Actions;
+let supportsWasm: boolean;
 
 function setupEvents(dependencies: Dependencies) {
   threadClient = dependencies.threadClient;
   actions = dependencies.actions;
+  supportsWasm = dependencies.supportsWasm;
 
   if (threadClient) {
     Object.keys(clientEvents).forEach(eventName => {
@@ -55,7 +58,7 @@ function resumed(_: "resumed", packet: ResumedPacket) {
 }
 
 function newSource(_: "newSource", { source }: SourcePacket) {
-  actions.newSource(createSource(source));
+  actions.newSource(createSource(source, { supportsWasm }));
 
   if (isEnabled("eventListeners")) {
     actions.fetchEventListeners();

--- a/src/client/firefox/types.js
+++ b/src/client/firefox/types.js
@@ -259,6 +259,9 @@ export type DebuggerClient = {
     get: any => any,
     delete: any => void
   },
+  mainRoot: {
+    traits: any
+  },
   connect: () => Promise<*>,
   listTabs: () => Promise<*>
 };

--- a/src/utils/editor/source-documents.js
+++ b/src/utils/editor/source-documents.js
@@ -2,7 +2,6 @@
 
 import { getMode } from "../source";
 import { isWasm, getWasmLineNumberFormatter, renderWasmText } from "../wasm";
-import { isEnabled } from "devtools-config";
 
 import type { Source } from "debugger-html";
 
@@ -30,10 +29,6 @@ function resetLineNumberFormat(editor: Object) {
 }
 
 function updateLineNumberFormat(editor: Object, sourceId: string) {
-  if (!isEnabled("wasm")) {
-    return;
-  }
-
   if (!isWasm(sourceId)) {
     resetLineNumberFormat(editor);
     return;


### PR DESCRIPTION
Associated Issue: https://devtools-html.slack.com/archives/C3VTWQ4KZ/p1500478468288028

Old Firefox browsers cannot return binary source. So we need to disable source.isWasm for these.

### Summary of Changes

*  disable source.isWasm for browsers that does not support binary source

### Test Plan

- [x] Debug https://devtools-html.github.io/debugger-examples/examples/wasm/fib/fib.index.html in old firefox

Observe no console errors about `getSourceLineCount`

