### PR TITLE
[WatchExpressions] The debugger is wrongfully showing a watch expression as a source

### DIFF
--- a/src/actions/sources.js
+++ b/src/actions/sources.js
@@ -44,7 +44,7 @@ import type { State } from "../reducers/types";
 function checkSelectedSource(state: State, dispatch, source) {
   const pendingLocation = getPendingSelectedLocation(state);
 
-  if (pendingLocation && pendingLocation.url === source.url) {
+  if (pendingLocation && !!source.url && pendingLocation.url === source.url) {
     dispatch(selectSource(source.id, { line: pendingLocation.line }));
   }
 }

--- a/src/actions/tests/sources.js
+++ b/src/actions/tests/sources.js
@@ -9,7 +9,8 @@ const {
   getSources,
   getSelectedSource,
   getSourceTabs,
-  getOutOfScopeLocations
+  getOutOfScopeLocations,
+  getSelectedLocation
 } = selectors;
 
 const threadClient = {
@@ -184,105 +185,13 @@ describe("sources", () => {
     const badSource = getSource(getState(), "bad-id");
     expect(badSource.get("error").indexOf("unknown source")).not.toBe(-1);
   });
-});
 
-describe("closing tabs", () => {
-  it("closing a tab", async () => {
+  it("should not select new sources that lack a URL", async () => {
     const { dispatch, getState } = createStore(threadClient);
-    await dispatch(actions.newSource(makeSource("foo.js")));
-    dispatch(actions.selectSource("foo.js"));
-    dispatch(actions.closeTab("http://localhost:8000/examples/foo.js"));
+    await dispatch(actions.newSource({ id: "foo" }));
 
-    expect(getSelectedSource(getState())).toBe(undefined);
-    expect(getSourceTabs(getState()).size).toBe(0);
-  });
-
-  it("closing the inactive tab", async () => {
-    const { dispatch, getState } = createStore(threadClient);
-    await dispatch(actions.newSource(makeSource("foo.js")));
-    await dispatch(actions.newSource(makeSource("bar.js")));
-    dispatch(actions.selectSource("foo.js"));
-    dispatch(actions.selectSource("bar.js"));
-    dispatch(actions.closeTab("http://localhost:8000/examples/foo.js"));
-
-    expect(getSelectedSource(getState()).get("id")).toBe("bar.js");
-    expect(getSourceTabs(getState()).size).toBe(1);
-  });
-
-  it("closing the only tab", async () => {
-    const { dispatch, getState } = createStore(threadClient);
-    await dispatch(actions.newSource(makeSource("foo.js")));
-    dispatch(actions.selectSource("foo.js"));
-    dispatch(actions.closeTab("http://localhost:8000/examples/foo.js"));
-
-    expect(getSelectedSource(getState())).toBe(undefined);
-    expect(getSourceTabs(getState()).size).toBe(0);
-  });
-
-  it("closing the active tab", async () => {
-    const { dispatch, getState } = createStore(threadClient);
-    await dispatch(actions.newSource(makeSource("foo.js")));
-    await dispatch(actions.newSource(makeSource("bar.js")));
-    dispatch(actions.selectSource("foo.js"));
-    dispatch(actions.selectSource("bar.js"));
-    dispatch(actions.closeTab("http://localhost:8000/examples/bar.js"));
-
-    expect(getSelectedSource(getState()).get("id")).toBe("foo.js");
-    expect(getSourceTabs(getState()).size).toBe(1);
-  });
-
-  it("closing many inactive tabs", async () => {
-    const { dispatch, getState } = createStore({});
-    await dispatch(actions.newSource(makeSource("foo.js")));
-    await dispatch(actions.newSource(makeSource("bar.js")));
-    await dispatch(actions.newSource(makeSource("bazz.js")));
-    dispatch(actions.selectSource("foo.js"));
-    dispatch(actions.selectSource("bar.js"));
-    dispatch(actions.selectSource("bazz.js"));
-    dispatch(
-      actions.closeTabs([
-        "http://localhost:8000/examples/foo.js",
-        "http://localhost:8000/examples/bar.js"
-      ])
-    );
-
-    expect(getSelectedSource(getState()).get("id")).toBe("bazz.js");
-    expect(getSourceTabs(getState()).size).toBe(1);
-  });
-
-  it("closing many tabs including the active tab", async () => {
-    const { dispatch, getState } = createStore({});
-    await dispatch(actions.newSource(makeSource("foo.js")));
-    await dispatch(actions.newSource(makeSource("bar.js")));
-    await dispatch(actions.newSource(makeSource("bazz.js")));
-    dispatch(actions.selectSource("foo.js"));
-    dispatch(actions.selectSource("bar.js"));
-    dispatch(actions.selectSource("bazz.js"));
-    dispatch(
-      actions.closeTabs([
-        "http://localhost:8000/examples/bar.js",
-        "http://localhost:8000/examples/bazz.js"
-      ])
-    );
-
-    expect(getSelectedSource(getState()).get("id")).toBe("foo.js");
-    expect(getSourceTabs(getState()).size).toBe(1);
-  });
-
-  it("closing all the tabs", async () => {
-    const { dispatch, getState } = createStore({});
-    await dispatch(actions.newSource(makeSource("foo.js")));
-    await dispatch(actions.newSource(makeSource("bar.js")));
-    dispatch(actions.selectSource("foo.js"));
-    dispatch(actions.selectSource("bar.js"));
-    dispatch(
-      actions.closeTabs([
-        "http://localhost:8000/examples/foo.js",
-        "http://localhost:8000/examples/bar.js"
-      ])
-    );
-
-    expect(getSelectedSource(getState())).toBe(undefined);
-    expect(getSourceTabs(getState()).size).toBe(0);
+    expect(getSources(getState()).size).toEqual(1);
+    const selectedLocation = getSelectedLocation(getState());
+    expect(selectedLocation).toEqual(undefined);
   });
 });

--- a/src/actions/tests/tabs.js
+++ b/src/actions/tests/tabs.js
@@ -1,0 +1,110 @@
+import {
+  actions,
+  selectors,
+  createStore,
+  makeSource
+} from "../../utils/test-head";
+const { getSelectedSource, getSourceTabs } = selectors;
+
+const threadClient = {};
+
+describe("closing tabs", () => {
+  it("closing a tab", async () => {
+    const { dispatch, getState } = createStore(threadClient);
+    await dispatch(actions.newSource(makeSource("foo.js")));
+    dispatch(actions.selectSource("foo.js"));
+    dispatch(actions.closeTab("http://localhost:8000/examples/foo.js"));
+
+    expect(getSelectedSource(getState())).toBe(undefined);
+    expect(getSourceTabs(getState()).size).toBe(0);
+  });
+
+  it("closing the inactive tab", async () => {
+    const { dispatch, getState } = createStore(threadClient);
+    await dispatch(actions.newSource(makeSource("foo.js")));
+    await dispatch(actions.newSource(makeSource("bar.js")));
+    dispatch(actions.selectSource("foo.js"));
+    dispatch(actions.selectSource("bar.js"));
+    dispatch(actions.closeTab("http://localhost:8000/examples/foo.js"));
+
+    expect(getSelectedSource(getState()).get("id")).toBe("bar.js");
+    expect(getSourceTabs(getState()).size).toBe(1);
+  });
+
+  it("closing the only tab", async () => {
+    const { dispatch, getState } = createStore(threadClient);
+    await dispatch(actions.newSource(makeSource("foo.js")));
+    dispatch(actions.selectSource("foo.js"));
+    dispatch(actions.closeTab("http://localhost:8000/examples/foo.js"));
+
+    expect(getSelectedSource(getState())).toBe(undefined);
+    expect(getSourceTabs(getState()).size).toBe(0);
+  });
+
+  it("closing the active tab", async () => {
+    const { dispatch, getState } = createStore(threadClient);
+    await dispatch(actions.newSource(makeSource("foo.js")));
+    await dispatch(actions.newSource(makeSource("bar.js")));
+    dispatch(actions.selectSource("foo.js"));
+    dispatch(actions.selectSource("bar.js"));
+    dispatch(actions.closeTab("http://localhost:8000/examples/bar.js"));
+
+    expect(getSelectedSource(getState()).get("id")).toBe("foo.js");
+    expect(getSourceTabs(getState()).size).toBe(1);
+  });
+
+  it("closing many inactive tabs", async () => {
+    const { dispatch, getState } = createStore({});
+    await dispatch(actions.newSource(makeSource("foo.js")));
+    await dispatch(actions.newSource(makeSource("bar.js")));
+    await dispatch(actions.newSource(makeSource("bazz.js")));
+    dispatch(actions.selectSource("foo.js"));
+    dispatch(actions.selectSource("bar.js"));
+    dispatch(actions.selectSource("bazz.js"));
+    dispatch(
+      actions.closeTabs([
+        "http://localhost:8000/examples/foo.js",
+        "http://localhost:8000/examples/bar.js"
+      ])
+    );
+
+    expect(getSelectedSource(getState()).get("id")).toBe("bazz.js");
+    expect(getSourceTabs(getState()).size).toBe(1);
+  });
+
+  it("closing many tabs including the active tab", async () => {
+    const { dispatch, getState } = createStore({});
+    await dispatch(actions.newSource(makeSource("foo.js")));
+    await dispatch(actions.newSource(makeSource("bar.js")));
+    await dispatch(actions.newSource(makeSource("bazz.js")));
+    dispatch(actions.selectSource("foo.js"));
+    dispatch(actions.selectSource("bar.js"));
+    dispatch(actions.selectSource("bazz.js"));
+    dispatch(
+      actions.closeTabs([
+        "http://localhost:8000/examples/bar.js",
+        "http://localhost:8000/examples/bazz.js"
+      ])
+    );
+
+    expect(getSelectedSource(getState()).get("id")).toBe("foo.js");
+    expect(getSourceTabs(getState()).size).toBe(1);
+  });
+
+  it("closing all the tabs", async () => {
+    const { dispatch, getState } = createStore({});
+    await dispatch(actions.newSource(makeSource("foo.js")));
+    await dispatch(actions.newSource(makeSource("bar.js")));
+    dispatch(actions.selectSource("foo.js"));
+    dispatch(actions.selectSource("bar.js"));
+    dispatch(
+      actions.closeTabs([
+        "http://localhost:8000/examples/foo.js",
+        "http://localhost:8000/examples/bar.js"
+      ])
+    );
+
+    expect(getSelectedSource(getState())).toBe(undefined);
+    expect(getSourceTabs(getState()).size).toBe(0);
+  });
+});

--- a/src/reducers/sources.js
+++ b/src/reducers/sources.js
@@ -319,6 +319,10 @@ export function getPrettySource(state: OuterState, id: string) {
 }
 
 function getSourceByUrlInSources(sources: SourcesMap, url: string) {
+  if (!url) {
+    return null;
+  }
+
   return sources.find(source => source.get("url") === url);
 }
 


### PR DESCRIPTION
Fixes: #3318

### Summary of Changes

* stop showing tabs that don't have a URL (was causing issues and showing the wrong source)
* stop selecting sources that don't have a URL


### Test Plan

Unit test

### screenshot

<img width="766" alt="screen shot 2017-07-21 at 4 47 28 pm" src="https://user-images.githubusercontent.com/254562/28481978-51637a36-6e34-11e7-913a-cb07de86cf68.png">
