### PR TITLE
Clear the symbol search query on close.

### DIFF
--- a/src/components/PrimaryPanes/Sources.css
+++ b/src/components/PrimaryPanes/Sources.css
@@ -124,6 +124,7 @@
   border-top-color: transparent;
 }
 
-.source-footer .tab.active path, .source-footer .tab:hover path {
+.source-footer .tab.active path,
+.source-footer .tab:hover path {
   fill: var(--theme-body-color);
 }

--- a/src/components/SymbolModal.js
+++ b/src/components/SymbolModal.js
@@ -143,6 +143,7 @@ class SymbolModal extends Component {
   closeModal() {
     this.props.closeActiveSearch();
     this.props.clearHighlightLineRange();
+    this.setState({ query: "" });
   }
 
   selectResultItem(e: SyntheticEvent, item: ?FormattedSymbolDeclaration) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7211,7 +7211,7 @@ regjsparser@^0.1.4:
   dependencies:
     jsesc "~0.5.0"
 
-remark-cli@4.0.0:
+remark-cli@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/remark-cli/-/remark-cli-4.0.0.tgz#bb84c14ffeb6f5b658eff4dfbb77cdd7775bab73"
   dependencies:


### PR DESCRIPTION
Associated Issue: #3404 

### Summary of Changes

* Clear the query for SymbolModal when you close it.
* yarn.lock updated for some reason and prettier did its thing.
