### PR TITLE
Disable updating line number formats

### DIFF
--- a/configs/development.json
+++ b/configs/development.json
@@ -66,6 +66,10 @@
     "highlightScopeLines": {
       "label": "Highlight the lines in scope",
       "enabled": false
+    },
+    "wasm": {
+      "label": "Wasm",
+      "enabled": false
     }
   },
   "chrome": {

--- a/src/utils/editor/source-documents.js
+++ b/src/utils/editor/source-documents.js
@@ -1,8 +1,10 @@
 // @flow
 
 import { getMode } from "../source";
-import type { Source } from "debugger-html";
 import { isWasm, getWasmLineNumberFormatter, renderWasmText } from "../wasm";
+import { isEnabled } from "devtools-config";
+
+import type { Source } from "debugger-html";
 
 let sourceDocs = {};
 
@@ -28,10 +30,15 @@ function resetLineNumberFormat(editor: Object) {
 }
 
 function updateLineNumberFormat(editor: Object, sourceId: string) {
+  if (!isEnabled("wasm")) {
+    return;
+  }
+
   if (!isWasm(sourceId)) {
     resetLineNumberFormat(editor);
     return;
   }
+
   let cm = editor.codeMirror;
   let lineNumberFormatter = getWasmLineNumberFormatter(sourceId);
   cm.setOption("lineNumberFormatter", lineNumberFormatter);
@@ -85,6 +92,7 @@ function showSourceText(editor: Object, source: Source) {
 
   setEditorText(editor, source);
   editor.setMode(getMode(source));
+
   updateLineNumberFormat(editor, source.id);
 }
 


### PR DESCRIPTION
Associated Issue: #3383


### Summary of Changes

* Fixes a situation where toggling sources causes 1px BPs

[STR] 
1. navigate to https://devtools-html.github.io/debugger-examples/examples/todomvc/
2. add a bp in todo-view.js and todo.js
3. reload (view a bp in todo.js)
4. click on the todo-view.js in the bp panel

AR: see the BP in todo-view
ER: see a 1px bp

![](http://g.recordit.co/wxd1pW9pE4.gif)