### PR TITLE
bugfix: [Breakpoints] width is set to 1px

### DIFF
--- a/src/components/Editor/Editor.css
+++ b/src/components/Editor/Editor.css
@@ -87,7 +87,7 @@ html[dir="rtl"] .editor-mount {
 }
 
 .editor.new-breakpoint {
-  width: 29px;
+  min-width: 29px;
   position: absolute;
 }
 

--- a/src/components/Editor/Editor.css
+++ b/src/components/Editor/Editor.css
@@ -86,6 +86,11 @@ html[dir="rtl"] .editor-mount {
   right: -4px;
 }
 
+.editor.new-breakpoint {
+  width: 29px;
+  position: absolute;
+}
+
 .inline-bp {
   background-color: #9ddfff;
   width: 20px;


### PR DESCRIPTION
Associated Issue: #3383

### Summary of Changes

* force new-breakpoint to have width 29px

### Screenshots/Videos (OPTIONAL)
![babybps](https://user-images.githubusercontent.com/26968615/28517490-d1aa0660-7064-11e7-8aa8-0db2079d34c7.gif)
