### PR TITLE
Fix framework grouping collapsing

### DIFF
--- a/src/components/SecondaryPanes/Frames/index.js
+++ b/src/components/SecondaryPanes/Frames/index.js
@@ -45,15 +45,6 @@ class Frames extends Component {
     showAllFrames: boolean
   };
 
-  collapseFrames(frames) {
-    const { frameworkGroupingOn } = this.props;
-    if (!frameworkGroupingOn) {
-      return frames;
-    }
-
-    return collapseFrames(frames);
-  }
-
   renderFrames: Function;
   toggleFramesDisplay: Function;
   truncateFrames: Function;
@@ -88,6 +79,15 @@ class Frames extends Component {
     this.setState({
       showAllFrames: !this.state.showAllFrames
     });
+  }
+
+  collapseFrames(frames) {
+    const { frameworkGroupingOn } = this.props;
+    if (!frameworkGroupingOn) {
+      return frames;
+    }
+
+    return collapseFrames(frames);
   }
 
   truncateFrames(frames) {
@@ -154,7 +154,7 @@ class Frames extends Component {
       ? L10N.getStr("callStack.collapse")
       : L10N.getStr("callStack.expand");
 
-    frames = collapseFrames(frames);
+    frames = this.collapseFrames(frames);
     if (frames.length <= NUM_FRAMES_SHOWN) {
       return null;
     }


### PR DESCRIPTION
Associated Issue: #<issue number>


### Summary of Changes

* fixes collapsing for both frames that are not grouped

![](http://g.recordit.co/574wzU0R6V.gif)