### PR TITLE
breakpoints disappear on sourcemapped sources

### DIFF
--- a/src/components/Editor/Breakpoints.js
+++ b/src/components/Editor/Breakpoints.js
@@ -1,7 +1,6 @@
 import { connect } from "react-redux";
 import { bindActionCreators } from "redux";
 import { Component, createFactory, DOM as dom } from "react";
-import { isEnabled } from "devtools-config";
 
 import _Breakpoint from "./Breakpoint";
 const Breakpoint = createFactory(_Breakpoint);
@@ -39,19 +38,14 @@ class Breakpoints extends Component {
 
     return dom.div(
       {},
-      breakpoints
-        .valueSeq()
-        .filter(
-          b => (isEnabled("columnBreakpoints") ? !b.location.column : true)
-        )
-        .map(bp =>
-          Breakpoint({
-            key: makeLocationId(bp.location),
-            breakpoint: bp,
-            selectedSource,
-            editor: editor
-          })
-        )
+      breakpoints.valueSeq().map(bp =>
+        Breakpoint({
+          key: makeLocationId(bp.location),
+          breakpoint: bp,
+          selectedSource,
+          editor: editor
+        })
+      )
     );
   }
 }

--- a/src/components/Editor/tests/Breakpoints.js
+++ b/src/components/Editor/tests/Breakpoints.js
@@ -1,0 +1,46 @@
+import React from "react";
+import { shallow } from "enzyme";
+import Breakpoints from "../Breakpoints";
+import * as I from "immutable";
+
+const BreakpointsComponent = React.createFactory(Breakpoints.WrappedComponent);
+
+function generateDefaults(overrides) {
+  const sourceId = "server1.conn1.child1/source1";
+  const matchingBreakpoints = { id1: { location: { sourceId } } };
+
+  return {
+    selectedSource: { sourceId, get: () => false },
+    editor: {
+      codeMirror: {
+        setGutterMarker: jest.fn()
+      }
+    },
+    breakpoints: I.Map(matchingBreakpoints),
+    ...overrides
+  };
+}
+
+function render(overrides = {}) {
+  const props = generateDefaults(overrides);
+  const component = shallow(new BreakpointsComponent(props));
+  return { component, props };
+}
+
+describe("Breakpoints Component", () => {
+  it("should render breakpoints without columns", async () => {
+    const sourceId = "server1.conn1.child1/source1";
+    const breakpoints = I.Map({ id1: { location: { sourceId } } });
+
+    const { component, props } = render({ breakpoints });
+    expect(component.find("Breakpoint").length).toBe(props.breakpoints.size);
+  });
+
+  it("should render breakpoints with columns", async () => {
+    const sourceId = "server1.conn1.child1/source1";
+    const breakpoints = I.Map({ id1: { location: { column: 2, sourceId } } });
+
+    const { component, props } = render({ breakpoints });
+    expect(component.find("Breakpoint").length).toBe(props.breakpoints.size);
+  });
+});

--- a/src/components/Editor/tests/Breakpoints.js
+++ b/src/components/Editor/tests/Breakpoints.js
@@ -42,5 +42,6 @@ describe("Breakpoints Component", () => {
 
     const { component, props } = render({ breakpoints });
     expect(component.find("Breakpoint").length).toBe(props.breakpoints.size);
+    expect(component).toMatchSnapshot();
   });
 });

--- a/src/components/Editor/tests/__snapshots__/Breakpoints.js.snap
+++ b/src/components/Editor/tests/__snapshots__/Breakpoints.js.snap
@@ -1,0 +1,235 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Breakpoints Component should render breakpoints with columns 1`] = `
+ShallowWrapper {
+  "complexSelector": ComplexSelector {
+    "buildPredicate": [Function],
+    "childrenOfNode": [Function],
+    "findWhereUnwrapped": [Function],
+  },
+  "length": 1,
+  "node": <div>
+    Array [
+        <Breakpoint
+          breakpoint={
+                Object {
+                      "location": Object {
+                        "column": 2,
+                        "sourceId": "server1.conn1.child1/source1",
+                      },
+                    }
+          }
+          editor={
+                Object {
+                      "codeMirror": Object {
+                        "setGutterMarker": [Function],
+                      },
+                    }
+          }
+          selectedSource={
+                Object {
+                      "get": [Function],
+                      "sourceId": "server1.conn1.child1/source1",
+                    }
+          }
+    />,
+      ]
+</div>,
+  "nodes": Array [
+    <div>
+      Array [
+            <Breakpoint
+              breakpoint={
+                      Object {
+                              "location": Object {
+                                "column": 2,
+                                "sourceId": "server1.conn1.child1/source1",
+                              },
+                            }
+              }
+              editor={
+                      Object {
+                              "codeMirror": Object {
+                                "setGutterMarker": [Function],
+                              },
+                            }
+              }
+              selectedSource={
+                      Object {
+                              "get": [Function],
+                              "sourceId": "server1.conn1.child1/source1",
+                            }
+              }
+      />,
+          ]
+</div>,
+  ],
+  "options": Object {},
+  "renderer": ReactShallowRenderer {
+    "_instance": ShallowComponentWrapper {
+      "_calledComponentWillUnmount": false,
+      "_compositeType": 0,
+      "_context": Object {},
+      "_currentElement": <Breakpoints
+        breakpoints={
+                Immutable.Map {
+                        id1: Object {
+                                "location": Object {
+                                  "column": 2,
+                                  "sourceId": "server1.conn1.child1/source1",
+                                },
+                              },
+                }
+        }
+        editor={
+                Object {
+                        "codeMirror": Object {
+                          "setGutterMarker": [Function],
+                        },
+                      }
+        }
+        selectedSource={
+                Object {
+                        "get": [Function],
+                        "sourceId": "server1.conn1.child1/source1",
+                      }
+        }
+/>,
+      "_debugID": 3,
+      "_hostContainerInfo": null,
+      "_hostParent": null,
+      "_instance": Breakpoints {
+        "_reactInternalInstance": [Circular],
+        "context": Object {},
+        "props": Object {
+          "breakpoints": Immutable.Map {
+            id1: Object {
+                        "location": Object {
+                          "column": 2,
+                          "sourceId": "server1.conn1.child1/source1",
+                        },
+                      },
+},
+          "editor": Object {
+            "codeMirror": Object {
+              "setGutterMarker": [Function],
+            },
+          },
+          "selectedSource": Object {
+            "get": [Function],
+            "sourceId": "server1.conn1.child1/source1",
+          },
+        },
+        "refs": Object {},
+        "state": null,
+        "updater": Object {
+          "enqueueCallback": [Function],
+          "enqueueCallbackInternal": [Function],
+          "enqueueElementInternal": [Function],
+          "enqueueForceUpdate": [Function],
+          "enqueueReplaceState": [Function],
+          "enqueueSetState": [Function],
+          "isMounted": [Function],
+          "validateCallback": [Function],
+        },
+      },
+      "_mountOrder": 4,
+      "_pendingCallbacks": null,
+      "_pendingElement": null,
+      "_pendingForceUpdate": false,
+      "_pendingReplaceState": false,
+      "_pendingStateQueue": null,
+      "_renderedComponent": Object {
+        "_currentElement": <div>
+          Array [
+                    <Breakpoint
+                      breakpoint={
+                                  Object {
+                                              "location": Object {
+                                                "column": 2,
+                                                "sourceId": "server1.conn1.child1/source1",
+                                              },
+                                            }
+                      }
+                      editor={
+                                  Object {
+                                              "codeMirror": Object {
+                                                "setGutterMarker": [Function],
+                                              },
+                                            }
+                      }
+                      selectedSource={
+                                  Object {
+                                              "get": [Function],
+                                              "sourceId": "server1.conn1.child1/source1",
+                                            }
+                      }
+          />,
+                  ]
+</div>,
+        "_debugID": 4,
+        "_renderedOutput": <div>
+          Array [
+                    <Breakpoint
+                      breakpoint={
+                                  Object {
+                                              "location": Object {
+                                                "column": 2,
+                                                "sourceId": "server1.conn1.child1/source1",
+                                              },
+                                            }
+                      }
+                      editor={
+                                  Object {
+                                              "codeMirror": Object {
+                                                "setGutterMarker": [Function],
+                                              },
+                                            }
+                      }
+                      selectedSource={
+                                  Object {
+                                              "get": [Function],
+                                              "sourceId": "server1.conn1.child1/source1",
+                                            }
+                      }
+          />,
+                  ]
+</div>,
+      },
+      "_renderedNodeType": 0,
+      "_rootNodeID": 0,
+      "_topLevelWrapper": null,
+      "_updateBatchNumber": null,
+      "_warnedAboutRefsInRender": false,
+    },
+    "getRenderOutput": [Function],
+    "render": [Function],
+  },
+  "root": [Circular],
+  "unrendered": <Breakpoints
+    breakpoints={
+        Immutable.Map {
+            id1: Object {
+                "location": Object {
+                  "column": 2,
+                  "sourceId": "server1.conn1.child1/source1",
+                },
+              },
+        }
+    }
+    editor={
+        Object {
+            "codeMirror": Object {
+              "setGutterMarker": [Function],
+            },
+          }
+    }
+    selectedSource={
+        Object {
+            "get": [Function],
+            "sourceId": "server1.conn1.child1/source1",
+          }
+    }
+/>,
+}
+`;


### PR DESCRIPTION
Associated Issue: #3439 

When I started working on this issue, I wasn't sure what was wrong and it looked quite concerning, so i went ahead and started on it.

It looks like the error was coming from column breakpoints being ignored when column bps are enabled, and since all breakpoints which come from original sources have columns, these were being ignored. I removed the filter, as the breakpoints render correctly without it.

Caveat: Not sure if this is how it should work, or if column breakpoints are enabled by default.

I tested in a couple of spots:

TODO mvc: https://devtools-html.github.io/debugger-examples/examples/todomvc/
Sourcemapped files: http://wbamberg.github.io/example-websites/source-mapping/index.html
messy sourcemapped files: https://devtools-html.github.io/debugger-examples/examples/sequence-print/sequence_print.html

These three were also tested in the panel

I added a test to illustrate the case.

### Summary of Changes

* remove filtering of column bps from Breakpoints Component

### Test Plan

Add tests for both column and non column breakpoints. These were the bulk of the work, and are probably useful even if the fix isn't