### PR TITLE
Fix commandbar stopping 

### DIFF
--- a/src/components/SecondaryPanes/SecondaryPanes.css
+++ b/src/components/SecondaryPanes/SecondaryPanes.css
@@ -5,6 +5,17 @@
   white-space: nowrap;
 }
 
+/*
+  We apply overflow to the container with the commandbar.
+  This allows the commandbar to remain fixed when scrolling
+  until the content completely ends. Not just the height of
+  the wrapper.
+  Ref: https://github.com/devtools-html/debugger.html/issues/3426
+*/
+.secondary-panes--sticky-commandbar {
+  overflow-y: scroll;
+}
+
 .secondary-panes .accordion {
   flex: 1 0 auto;
 }

--- a/src/components/SecondaryPanes/index.js
+++ b/src/components/SecondaryPanes/index.js
@@ -217,7 +217,7 @@ class SecondaryPanes extends Component {
   render() {
     return dom.div(
       {
-        className: "secondary-panes"
+        className: "secondary-panes secondary-panes--sticky-commandbar"
       },
       CommandBar(),
       this.props.horizontal


### PR DESCRIPTION
Associated Issue: #3426 

### Summary of Changes

* Overflow the secondary panel that contains the commandbar

### Test Plan

Pause on a breakpoint. Open up window/this vars until you have plenty of place to scroll. Scroll beyond the height of your viewport.

Notice the commandbar will now keep stuck all the way to the bottom.
