### PR TITLE
CodeMirror operations

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "babel-traverse": "^6.22.1",
     "babel-types": "^6.22.0",
     "babylon": "^6.15.0",
-    "codemirror": "^5.1.0",
+    "codemirror": "^5.28.0",
     "devtools-components": "^0.0.1",
     "devtools-launchpad": "0.0.88",
     "devtools-reps": "^0.9.0",

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -110,6 +110,7 @@ class Editor extends PureComponent {
   }
 
   componentWillReceiveProps(nextProps) {
+    this.state.editor.codeMirror.startOperation();
     // This lifecycle method is responsible for updating the editor
     // text.
     const { selectedSource, selectedLocation } = nextProps;
@@ -263,6 +264,8 @@ class Editor extends PureComponent {
     if (selectedSource && selectedSource.has("text")) {
       this.highlightLine();
     }
+
+    this.state.editor.codeMirror.endOperation();
   }
 
   onToggleBreakpoint(key, e) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1896,9 +1896,9 @@ code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
 
-codemirror@^5.1.0, codemirror@^5.25.0:
-  version "5.26.0"
-  resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.26.0.tgz#bcbee86816ed123870c260461c2b5c40b68746e5"
+codemirror@^5.25.0, codemirror@^5.28.0:
+  version "5.28.0"
+  resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.28.0.tgz#2978d9280d671351a4f5737d06bbd681a0fd6f83"
 
 collapse-white-space@^1.0.0, collapse-white-space@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
- Upgrade CodeMirror
- Use `startOperation`/`endOperation` to wrap editor component changes into only one CodeMirror update. Improves performance especially for complex changes like showing and highlighting the debug line.