### PR TITLE
[SourceSearch] Improve not-found UI

### DIFF
--- a/assets/panel/debugger.properties
+++ b/assets/panel/debugger.properties
@@ -470,7 +470,7 @@ sourceSearch.search=Search Sources…
 
 # LOCALIZATION NOTE (sourceSearch.noResults): The center pane Source Search
 # message when the query did not match any of the sources.
-sourceSearch.noResults=No files matching %S found
+sourceSearch.noResults2=No results found
 
 # LOCALIZATION NOTE (ignoreExceptions): The pause on exceptions button tooltip
 # when the debugger will not pause on exceptions.

--- a/src/components/App.css
+++ b/src/components/App.css
@@ -37,3 +37,11 @@
   margin-top: 25px;
   margin-right: 20px;
 }
+
+/* Utils */
+.absolute-center {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+}

--- a/src/components/Editor/tests/__snapshots__/SearchBar.js.snap
+++ b/src/components/Editor/tests/__snapshots__/SearchBar.js.snap
@@ -20,6 +20,7 @@ ShallowWrapper {
         onKeyUp={[Function]}
         placeholder="Search in file…"
         query=""
+        showErrorEmoji={true}
         size=""
         summaryMsg=""
     />
@@ -81,6 +82,7 @@ ShallowWrapper {
             onKeyUp={[Function]}
             placeholder="Search in file…"
             query=""
+            showErrorEmoji={true}
             size=""
             summaryMsg=""
       />
@@ -236,6 +238,7 @@ ShallowWrapper {
                     onKeyUp={[Function]}
                     placeholder="Search in file…"
                     query=""
+                    showErrorEmoji={true}
                     size=""
                     summaryMsg=""
           />
@@ -297,6 +300,7 @@ ShallowWrapper {
                     onKeyUp={[Function]}
                     placeholder="Search in file…"
                     query=""
+                    showErrorEmoji={true}
                     size=""
                     summaryMsg=""
           />

--- a/src/components/shared/Autocomplete.css
+++ b/src/components/shared/Autocomplete.css
@@ -1,27 +1,11 @@
 .autocomplete {
-  flex: 1;
+  position: relative;
   width: 100%;
 }
 
 .autocomplete .no-result-msg {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 100%;
-  height: 100%;
-  color: var(--theme-graphs-full-red);
+  color: var(--theme-body-color-inactive);
   font-size: 24px;
   padding: 4px;
   word-break: break-all;
-}
-
-.autocomplete .no-result-msg .sad-face {
-  width: 24px;
-  margin: 0 4px;
-  line-height: 0;
-  flex-shrink: 0;
-}
-
-.autocomplete .no-result-msg .sad-face svg {
-  fill: var(--theme-graphs-full-red);
 }

--- a/src/components/shared/Autocomplete.js
+++ b/src/components/shared/Autocomplete.js
@@ -5,7 +5,6 @@ import ReactDOM from "react-dom";
 import { filter } from "fuzzaldrin-plus";
 import classnames from "classnames";
 import { scrollList } from "../../utils/result-list";
-import Svg from "./Svg";
 import "./Autocomplete.css";
 
 import _SearchInput from "./SearchInput";
@@ -124,9 +123,8 @@ export default class Autocomplete extends Component {
       });
     } else if (this.state.inputValue && !results.length) {
       return dom.div(
-        { className: "no-result-msg" },
-        Svg("sad-face"),
-        L10N.getFormatStr("sourceSearch.noResults", this.state.inputValue)
+        { className: "no-result-msg absolute-center" },
+        L10N.getStr("sourceSearch.noResults2")
       );
     }
   }
@@ -146,6 +144,7 @@ export default class Autocomplete extends Component {
         count: searchResults.length,
         placeholder: this.props.placeholder,
         size,
+        showErrorEmoji: true,
         summaryMsg,
         onChange: e =>
           this.setState({

--- a/src/components/shared/SearchInput.js
+++ b/src/components/shared/SearchInput.js
@@ -27,6 +27,7 @@ class SearchInput extends Component {
     summaryMsg: string,
     onChange: () => void,
     handleClose: () => void,
+    showErrorEmoji: boolean,
     onKeyUp: () => void,
     onKeyDown: () => void,
     onFocus: () => void,
@@ -38,10 +39,13 @@ class SearchInput extends Component {
 
   static defaultProps: Object;
 
-  renderSvg() {
-    const { count, query } = this.props;
+  shouldShowErrorEmoji() {
+    const { count, query, showErrorEmoji } = this.props;
+    return count === 0 && query.trim() !== "" && !showErrorEmoji;
+  }
 
-    if (count == 0 && query.trim() != "") {
+  renderSvg() {
+    if (this.shouldShowErrorEmoji()) {
       return Svg("sad-face");
     }
 
@@ -87,7 +91,6 @@ class SearchInput extends Component {
     const {
       query,
       placeholder,
-      count,
       summaryMsg,
       onChange,
       onKeyDown,
@@ -105,7 +108,7 @@ class SearchInput extends Component {
       this.renderSvg(),
       dom.input({
         className: classnames({
-          empty: count == 0 && query.trim() != ""
+          empty: this.shouldShowErrorEmoji()
         }),
         onChange,
         onKeyDown,
@@ -117,7 +120,7 @@ class SearchInput extends Component {
         spellCheck: false,
         ref: "input"
       }),
-      dom.div({ className: "summary" }, query != "" ? summaryMsg : ""),
+      dom.div({ className: "summary" }, summaryMsg || ""),
       this.renderNav(),
       CloseButton({
         handleClick: handleClose,
@@ -128,7 +131,8 @@ class SearchInput extends Component {
 }
 
 SearchInput.defaultProps = {
-  size: ""
+  size: "",
+  showErrorEmoji: true
 };
 
 export default SearchInput;

--- a/src/components/stories/SearchInput.js
+++ b/src/components/stories/SearchInput.js
@@ -76,4 +76,19 @@ storiesOf("SearchInput", module)
       count: 10,
       query: "yo"
     });
+  })
+  .add("error emoji default", () => {
+    setValue("features.previewWatch", false);
+    return SearchInputFactory({
+      count: 0,
+      query: ""
+    });
+  })
+  .add("error emoji override", () => {
+    setValue("features.previewWatch", false);
+    return SearchInputFactory({
+      count: 0,
+      showErrorEmoji: false,
+      query: ""
+    });
   });

--- a/src/components/tests/__snapshots__/SymbolModal.js.snap
+++ b/src/components/tests/__snapshots__/SymbolModal.js.snap
@@ -26,6 +26,7 @@ ShallowWrapper {
             onKeyUp={[Function]}
             placeholder="Search functions…"
             query=""
+            showErrorEmoji={true}
             size=""
             summaryMsg={undefined}
         />
@@ -50,6 +51,7 @@ ShallowWrapper {
                   onKeyUp={[Function]}
                   placeholder="Search functions…"
                   query=""
+                  showErrorEmoji={true}
                   size=""
                   summaryMsg={undefined}
             />
@@ -139,6 +141,7 @@ ShallowWrapper {
                               onKeyUp={[Function]}
                               placeholder="Search functions…"
                               query=""
+                              showErrorEmoji={true}
                               size=""
                               summaryMsg={undefined}
                     />
@@ -163,6 +166,7 @@ ShallowWrapper {
                               onKeyUp={[Function]}
                               placeholder="Search functions…"
                               query=""
+                              showErrorEmoji={true}
                               size=""
                               summaryMsg={undefined}
                     />


### PR DESCRIPTION
Associated Issue: #3469 

### Summary of changes

* add absolute-center util
* remove flexbox
* update message
* add noNegativity option to allow sad face opt-out

Before:
<img width="629" alt="screen shot 2017-07-27 at 12 25 14 pm" src="https://user-images.githubusercontent.com/26968615/28666198-b0d6f812-72c6-11e7-9ff0-3358713ba4a1.png">


After:
<img width="629" alt="screen shot 2017-07-27 at 12 24 05 pm" src="https://user-images.githubusercontent.com/26968615/28666202-b3746988-72c6-11e7-994a-6614b8d62e03.png">

<img width="628" alt="screen shot 2017-07-27 at 12 22 50 pm" src="https://user-images.githubusercontent.com/26968615/28666208-ba3e4d92-72c6-11e7-8cdc-1ef57845ac4c.png">

Other places where search input is used still have the same styles:
<img width="627" alt="screen shot 2017-07-27 at 12 22 42 pm" src="https://user-images.githubusercontent.com/26968615/28666220-c22e5286-72c6-11e7-919f-1aa3deab1293.png">
