### PR TITLE
Support complex file trees

### DIFF
--- a/src/components/App.css
+++ b/src/components/App.css
@@ -37,4 +37,3 @@
   margin-top: 25px;
   margin-right: 20px;
 }
-

--- a/src/utils/tests/__snapshots__/sources-tree.js.snap
+++ b/src/utils/tests/__snapshots__/sources-tree.js.snap
@@ -1,0 +1,8 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`sources-tree doesnt throw when adding a deeper file 1`] = `
+" - root path= 
+  - unpkg.com path=/unpkg.com 
+    - codemirror@5.1 path=/unpkg.com/codemirror@5.1 source_id=server1.conn13.child1/37 
+"
+`;

--- a/src/utils/tests/sources-tree.js
+++ b/src/utils/tests/sources-tree.js
@@ -9,7 +9,8 @@ import {
   getURL,
   isExactUrlMatch,
   createTree,
-  isDirectory
+  isDirectory,
+  formatTree
 } from "../sources-tree.js";
 
 describe("sources-tree", () => {
@@ -558,5 +559,24 @@ describe("sources-tree", () => {
     expect(getRelativePath("https://example.com/path/to/file.html")).toBe(
       relPath
     );
+  });
+
+  it("doesnt throw when adding a deeper file", () => {
+    const codeMirror = Map({
+      id: "server1.conn13.child1/37",
+      url: "https://unpkg.com/codemirror@5.1"
+    });
+
+    const xml = Map({
+      id: "server1.conn13.child1/39",
+      url: "https://unpkg.com/codemirror@5.1/mode/xml/xml.js"
+    });
+
+    const tree = createNode("root", "", []);
+
+    addToTree(tree, codeMirror);
+    addToTree(tree, xml);
+
+    expect(formatTree(tree)).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
Associated Issue: #3430

### Summary of Changes

* bail early when we get to a case we can't handle in the source tree
* screenshot shows the files in source search, but not in the source tree

### Test Plan

* add a unit test to verify the behavior

### Screenshot

<img width="647" alt="screen shot 2017-07-27 at 11 38 32 am" src="https://user-images.githubusercontent.com/254562/28681118-698770b8-72c6-11e7-8a42-b39f7d63c823.png">
