### PR TITLE
[Expressions] Items should be of same height

### DIFF
--- a/src/components/shared/previewFunction.css
+++ b/src/components/shared/previewFunction.css
@@ -1,5 +1,4 @@
 .function-signature {
-  line-height: 20px;
   align-self: center;
 }
 


### PR DESCRIPTION
Associated Issue: #3447

### Summary of Changes

* Remove `line-height` of `.function-signature` 

### Screenshots/Videos (OPTIONAL)
|After |Before |
|---|---|
|![scr1](https://user-images.githubusercontent.com/1755089/28746149-108662b4-74a4-11e7-86bc-b25d3f64422c.png)|![scr2](https://user-images.githubusercontent.com/1755089/28746150-1426ce40-74a4-11e7-8ba9-2d2a3647cd11.png)|
