### PR TITLE
Prevent width value warning error in outline stories

### DIFF
--- a/src/components/stories/Outline.js
+++ b/src/components/stories/Outline.js
@@ -39,7 +39,7 @@ function OutlineFactory(options, { dir = "ltr", theme = "light" } = {}) {
       className: `outline ${themeClass}`,
       dir,
       style: {
-        width: "300",
+        width: "300px",
         margin: "40px 40px",
         border: "1px solid var(--theme-splitter-color)"
       }


### PR DESCRIPTION
### Summary of Changes

* Changing `300` to `300px` with this story to prevent an invalid value warning within the console.

### Test Plan

Visit the Storybook "Outline" examples, see no warning.
