### PR TITLE
Fix #3369 - Remove button hover color if button is disabled

### DIFF
--- a/src/components/SecondaryPanes/CommandBar.css
+++ b/src/components/SecondaryPanes/CommandBar.css
@@ -32,7 +32,7 @@ html[dir="rtl"] .command-bar {
   fill: currentColor;
 }
 
-.command-bar > button:hover {
+.command-bar > button:not(.disabled):hover {
   background: var(--theme-toolbar-background-hover);
 }
 


### PR DESCRIPTION
Associated Issue: #3369 

### Summary of Changes

* Added simple selector modification to not highlight disabled buttons

### Test Plan

Hover over disabled buttons -- no more background color change.