### PR TITLE
Add stub 'closeActiveSearch' so Tabs stories don't error out

### DIFF
--- a/src/components/stories/tabs.js
+++ b/src/components/stories/tabs.js
@@ -53,6 +53,7 @@ function TabsFactory(options, { dir = "ltr", theme = "light" } = {}) {
             searchOn: false,
             selectedSource: null,
             selectSource: action("selectSource"),
+            closeActiveSearch: () => {},
             moveTab: action("moveTab"),
             closeTab: action("closeTab"),
             closeTabs: action("closeTabs"),


### PR DESCRIPTION
Clicking any tab in the "Editor Tabs" stories triggers an error because `closeActiveSearch` is not provided as a prop

### Summary of Changes

* Add a stub `closeActiveSearch` function to prevent the error

### Test Plan

Click any tab and you no longer see the `closeActiveSearch` error.