### PR TITLE
Test symbol extraction for async/exported functions

### DIFF
--- a/src/utils/parser/tests/__snapshots__/closest.js.snap
+++ b/src/utils/parser/tests/__snapshots__/closest.js.snap
@@ -88,34 +88,39 @@ FunctionDeclaration (1:0,3:1)
 `;
 
 exports[`parser getClosestScope finds a scope given at the end 1`] = `
-FunctionExpression (7:1,9:1)
-  async: false
-  body: BlockStatement (7:12,9:1)
+FunctionDeclaration (9:0,11:1)
+  async: true
+  body: BlockStatement (9:25,11:1)
     body:
-      - ExpressionStatement (8:2,8:4)
-          expression: NumericLiteral (8:2,8:3)
+      - ReturnStatement (10:2,10:15)
+          argument: StringLiteral (10:9,10:14)
             extra:
-              raw: '2'
-              rawValue: 2
-            value: 2
+              raw: '"meh"'
+              rawValue: 'meh'
+            value: 'meh'
     directives: []
   expression: false
-  extra:
-    parenStart: 64
-    parenthesized: true
   generator: false
-  id: null
+  id: Identifier (9:15,9:22)
+    name: 'slowFoo'
   params: []
 `;
 
 exports[`parser getClosestScope finds the scope at the beginning 1`] = `
-FunctionExpression (5:8,5:21)
+FunctionDeclaration (5:7,7:1)
   async: false
-  body: BlockStatement (5:19,5:21)
-    body: []
+  body: BlockStatement (5:24,7:1)
+    body:
+      - ReturnStatement (6:2,6:15)
+          argument: StringLiteral (6:9,6:14)
+            extra:
+              raw: '"yay"'
+              rawValue: 'yay'
+            value: 'yay'
     directives: []
   expression: false
   generator: false
-  id: null
+  id: Identifier (5:16,5:21)
+    name: 'exFoo'
   params: []
 `;

--- a/src/utils/parser/tests/__snapshots__/getSymbols.js.snap
+++ b/src/utils/parser/tests/__snapshots__/getSymbols.js.snap
@@ -363,13 +363,16 @@ exports[`Parser.getSymbols func 1`] = `
 member expressions
 
 call expressions
-[(7, 1), (9, 1)]   undefined 
+[(19, 1), (21, 1)]   undefined 
 identifiers
 [(1, 9), (1, 15)]  square square 
 [(1, 16), (1, 17)]  n n 
 [(2, 9), (2, 10)]  n n 
 [(2, 13), (2, 14)]  n n 
-[(5, 0), (5, 5)]  child child 
+[(5, 16), (5, 21)]  exFoo exFoo 
+[(9, 15), (9, 22)]  slowFoo slowFoo 
+[(13, 22), (13, 31)]  exSlowFoo exSlowFoo 
+[(17, 0), (17, 5)]  child child 
 variables
 [(1, 16), (1, 17)]   n "
 `;

--- a/src/utils/parser/tests/fixtures/func.js
+++ b/src/utils/parser/tests/fixtures/func.js
@@ -2,6 +2,18 @@ function square(n) {
   return n * n;
 }
 
+export function exFoo() {
+  return "yay";
+}
+
+async function slowFoo() {
+  return "meh";
+}
+
+export async function exSlowFoo() {
+  return "yay in a bit";
+}
+
 child = function() {};
 
 (function() {


### PR DESCRIPTION
Associated Issue: #3158

### Summary of Changes

* Add examples of export, async and export async functions to the func.js parser tests.
* Update the corresponding snapshot files.