### PR TITLE
Fix #3483 - Highlight only executable lines

### DIFF
--- a/src/components/Editor/EmptyLines.css
+++ b/src/components/Editor/EmptyLines.css
@@ -1,0 +1,3 @@
+.empty-line .CodeMirror-linenumber {
+  opacity: 0.7;
+}

--- a/src/components/Editor/EmptyLines.js
+++ b/src/components/Editor/EmptyLines.js
@@ -1,0 +1,71 @@
+// @flow
+import { connect } from "react-redux";
+import { bindActionCreators } from "redux";
+import { Component } from "react";
+
+import actions from "../../actions";
+import { getSelectedSource, getEmptyLines } from "../../selectors";
+
+import "./EmptyLines.css";
+
+type props = {
+  selectedSource: SourceRecord,
+  editor: Object
+};
+
+class EmptyLines extends Component {
+  props: props;
+
+  disableEmptyLines: Function;
+
+  componentDidMount() {
+    this.disableEmptyLines();
+  }
+
+  componentDidUpdate() {
+    this.disableEmptyLines();
+  }
+
+  async componentWillUnmount() {
+    const { emptyLines, editor } = this.props;
+
+    if (!emptyLines) {
+      return;
+    }
+    editor.codeMirror.operation(() => {
+      emptyLines.forEach(line =>
+        editor.codeMirror.addLineClass(line, "line", "empty-line")
+      );
+    });
+  }
+
+  async disableEmptyLines() {
+    const { emptyLines, editor } = this.props;
+
+    if (!emptyLines) {
+      return;
+    }
+    editor.codeMirror.operation(() => {
+      emptyLines.forEach(line =>
+        editor.codeMirror.addLineClass(line, "line", "empty-line")
+      );
+    });
+  }
+
+  render() {
+    return null;
+  }
+}
+
+EmptyLines.displayName = "EmptyLines";
+
+export default connect(
+  state => {
+    const selectedSource = getSelectedSource(state);
+    return {
+      selectedSource,
+      emptyLines: getEmptyLines(state, selectedSource.toJS())
+    };
+  },
+  dispatch => bindActionCreators(actions, dispatch)
+)(EmptyLines);

--- a/src/reducers/ast.js
+++ b/src/reducers/ast.js
@@ -16,6 +16,7 @@ import type { Action } from "../actions/types";
 import type { Record } from "../utils/makeRecord";
 
 export type SymbolsMap = Map<string, SymbolDeclarations>;
+export type EmptyLinesMap = Map<string, EmptyLinesType>;
 
 export type Preview =
   | {| updating: true |}
@@ -31,6 +32,7 @@ export type Preview =
 
 export type ASTState = {
   symbols: SymbolsMap,
+  emptyLines: EmptyLinesMap,
   outOfScopeLocations: ?Array<AstLocation>,
   preview: Preview
 };
@@ -39,6 +41,7 @@ export function initialState() {
   return makeRecord(
     ({
       symbols: I.Map(),
+      emptyLines: I.Map(),
       outOfScopeLocations: null,
       preview: null
     }: ASTState)
@@ -53,6 +56,11 @@ function update(
     case "SET_SYMBOLS": {
       const { source, symbols } = action;
       return state.setIn(["symbols", source.id], symbols);
+    }
+
+    case "SET_EMPTY_LINES": {
+      const { source, emptyLines } = action;
+      return state.setIn(["emptyLines", source.id], emptyLines);
     }
 
     case "OUT_OF_SCOPE_LOCATIONS": {
@@ -122,6 +130,23 @@ export function hasSymbols(state: OuterState, source: Source): boolean {
   }
 
   return !!state.ast.getIn(["symbols", source.id]);
+}
+
+export function isEmptyLineInSource(
+  state: OuterState,
+  line: number,
+  selectedSource: Source
+) {
+  const emptyLines = getEmptyLines(state, selectedSource);
+  return emptyLines.includes(line);
+}
+
+export function getEmptyLines(state: OuterState, source: Source) {
+  if (!source) {
+    return false;
+  }
+
+  return state.ast.getIn(["emptyLines", source.id]);
 }
 
 export function getOutOfScopeLocations(state: OuterState) {


### PR DESCRIPTION
Associated Issue: #3483 

This is a *WIP*.  Resource tested was `demo/EmptyLineTest.js` from https://davidwalsh.name/demo/EmptyLineTest.php

ToDo:

- [x] Remove the App.css change; not sure how that got in here
- [x] Code the `componentWillUnmount`part
- [x] The `getEmptyLines` function could probably be prettier; seems like I've used lots of negative (`!`) logic which may be confusing for maintenance
- [ ] TESTS
- [x] Clean up `console` usage
- [x] Prevent breakpoints from being created when an empty line is clicked (do something with the context menu also?)
- [x] Ensure this functions on "source-formatted" tabs; for some reason parsing fails when I pretty-print the `EmptyLineTest.js` file; WTF.  *Update* The parse changes `let d;` to `letd;`