### PR TITLE
Removed two unsused strings from debugger.properties

### DIFF
--- a/assets/panel/debugger.properties
+++ b/assets/panel/debugger.properties
@@ -148,14 +148,6 @@ projectTextSearch.placeholder=Find in files…
 # does not have any sources.
 sources.noSourcesAvailable=This page has no sources
 
-# LOCALIZATION NOTE (sourcesPane.showSourcesTooltip): The tooltip shown when
-# the user will navigate to the source tree view.
-sourcesPane.showSourcesTooltip=Show sources
-
-# LOCALIZATION NOTE (sourcesPane.showOutlineTooltip): The tooltip shown when
-# the user will navigate to the source outline view.
-sourcesPane.showOutlineTooltip=Show outline
-
 # LOCALIZATION NOTE (sourceSearch.search.key2): Key shortcut to open the search
 # for searching within a the currently opened files in the editor
 sourceSearch.search.key2=CmdOrCtrl+F


### PR DESCRIPTION
Associated Issue: #3355

### Summary of Changes

Removed following string from debugger.properties since it is not used any more.:
    1. `showSourcesTooltip` string
    2. `showOutlineTooltip` string

