### PR TITLE
Do not evaluate expressions on stepping

### DIFF
--- a/src/actions/pause.js
+++ b/src/actions/pause.js
@@ -3,7 +3,7 @@
 import { selectSource } from "./sources";
 import { PROMISE } from "../utils/redux/middleware/promise";
 
-import { getPause, getLoadedObject } from "../selectors";
+import { getPause, getLoadedObject, isStepping } from "../selectors";
 import { updateFrameLocations } from "../utils/pause";
 import { evaluateExpressions } from "./expressions";
 
@@ -24,13 +24,15 @@ type CommandType = { type: string };
  * @static
  */
 export function resumed() {
-  return ({ dispatch, client }: ThunkArgs) => {
+  return ({ dispatch, client, getState }: ThunkArgs) => {
     dispatch({
       type: "RESUME",
       value: undefined
     });
 
-    dispatch(evaluateExpressions(null));
+    if (!isStepping(getState())) {
+      dispatch(evaluateExpressions(null));
+    }
   };
 }
 
@@ -103,7 +105,7 @@ export function command({ type }: CommandType) {
 
     return dispatch({
       type: "COMMAND",
-      value: undefined
+      value: { type }
     });
   };
 }

--- a/src/actions/pause.js
+++ b/src/actions/pause.js
@@ -101,7 +101,7 @@ export function pauseOnExceptions(
 export function command({ type }: CommandType) {
   return ({ dispatch, client }: ThunkArgs) => {
     // execute debugger thread command e.g. stepIn, stepOver
-    client[type]();
+    client[type]().then(() => dispatch({ type: "CLEAR_COMMAND" }));
 
     return dispatch({
       type: "COMMAND",

--- a/src/actions/types.js
+++ b/src/actions/types.js
@@ -185,7 +185,7 @@ type PauseAction =
       shouldPauseOnExceptions: boolean,
       shouldIgnoreCaughtExceptions: boolean
     }
-  | { type: "COMMAND", value: void }
+  | { type: "COMMAND", value: { type: string } }
   | { type: "SELECT_FRAME", frame: Frame, scopes: Scope[] }
   | {
       type: "LOAD_OBJECT_PROPERTIES",

--- a/src/reducers/pause.js
+++ b/src/reducers/pause.js
@@ -18,7 +18,7 @@ type PauseState = {
   shouldPauseOnExceptions: boolean,
   shouldIgnoreCaughtExceptions: boolean,
   debuggeeUrl: string,
-  command: ?string
+  command: string
 };
 
 export const State = (): PauseState => ({
@@ -31,7 +31,7 @@ export const State = (): PauseState => ({
   shouldPauseOnExceptions: prefs.pauseOnExceptions,
   shouldIgnoreCaughtExceptions: prefs.ignoreCaughtExceptions,
   debuggeeUrl: "",
-  command: undefined
+  command: ""
 });
 
 function update(state: PauseState = State(), action: Action): PauseState {
@@ -142,6 +142,9 @@ function update(state: PauseState = State(), action: Action): PauseState {
 
     case "COMMAND":
       return { ...state, command: action.value.type };
+
+    case "CLEAR_COMMAND":
+      return { ...state, command: "" };
   }
 
   return state;

--- a/src/reducers/pause.js
+++ b/src/reducers/pause.js
@@ -17,7 +17,8 @@ type PauseState = {
   loadedObjects: Object,
   shouldPauseOnExceptions: boolean,
   shouldIgnoreCaughtExceptions: boolean,
-  debuggeeUrl: string
+  debuggeeUrl: string,
+  command: ?string
 };
 
 export const State = (): PauseState => ({
@@ -29,7 +30,8 @@ export const State = (): PauseState => ({
   loadedObjects: {},
   shouldPauseOnExceptions: prefs.pauseOnExceptions,
   shouldIgnoreCaughtExceptions: prefs.ignoreCaughtExceptions,
-  debuggeeUrl: ""
+  debuggeeUrl: "",
+  command: undefined
 });
 
 function update(state: PauseState = State(), action: Action): PauseState {
@@ -137,6 +139,9 @@ function update(state: PauseState = State(), action: Action): PauseState {
         shouldPauseOnExceptions,
         shouldIgnoreCaughtExceptions
       });
+
+    case "COMMAND":
+      return { ...state, command: action.value.type };
   }
 
   return state;
@@ -164,6 +169,10 @@ export const getLoadedObjects = createSelector(
   getPauseState,
   pauseWrapper => pauseWrapper.loadedObjects
 );
+
+export function isStepping(state: OuterState) {
+  return ["stepIn", "stepOver", "stepOut"].includes(state.pause.command);
+}
 
 export function getLoadedObject(state: OuterState, objectId: string) {
   return getLoadedObjects(state)[objectId];


### PR DESCRIPTION
Associated Issue: #3493

Here's the Pull Request Doc
https://devtools-html.github.io/debugger.html/CONTRIBUTING.html#pull-requests

### Summary of Changes

* Added a new command property to the pause reducer
* Added `isStepping` to enable us know when we are stepping
* Do not evaluate expressions when we resume, if we are stepping

### Test Plan

- [x] Add breakpoint 
- [x] Pause on breakpoint 
- [x] Click step over button
- [x] See how long it takes to step

