### PR TITLE
[Expressions] should have a unique key

### DIFF
--- a/src/components/PrimaryPanes/SourcesTree.js
+++ b/src/components/PrimaryPanes/SourcesTree.js
@@ -247,8 +247,6 @@ class SourcesTree extends Component {
 
     const isEmpty = sourceTree.contents.length === 0;
 
-    console.log(listItems);
-
     const tree = ManagedTree({
       key: isEmpty ? "empty" : "full",
       getParent: item => {

--- a/src/components/PrimaryPanes/SourcesTree.js
+++ b/src/components/PrimaryPanes/SourcesTree.js
@@ -247,6 +247,8 @@ class SourcesTree extends Component {
 
     const isEmpty = sourceTree.contents.length === 0;
 
+    console.log(listItems);
+
     const tree = ManagedTree({
       key: isEmpty ? "empty" : "full",
       getParent: item => {
@@ -259,7 +261,7 @@ class SourcesTree extends Component {
         return [];
       },
       getRoots: () => sourceTree.contents,
-      getKey: (item, i) => item.path,
+      getPath: item => item.path,
       itemHeight: 21,
       autoExpandDepth: 1,
       autoExpandAll: false,

--- a/src/components/ProjectSearch/TextSearch.js
+++ b/src/components/ProjectSearch/TextSearch.js
@@ -166,6 +166,12 @@ export default class TextSearch extends Component {
   renderResults() {
     const { results } = this.props;
     results = results.filter(result => result.matches.length > 0);
+    function getFilePath(item) {
+      return item.filepath
+        ? `${item.sourceId}`
+        : `${item.sourceId}-${item.line}-${item.column}`;
+    }
+
     return ManagedTree({
       getRoots: () => results,
       getChildren: file => {
@@ -176,10 +182,7 @@ export default class TextSearch extends Component {
       autoExpandDepth: 1,
       focused: results[0],
       getParent: item => null,
-      getKey: item =>
-        item.filepath
-          ? `${item.sourceId}`
-          : `${item.sourceId}-${item.line}-${item.column}`,
+      getPath: getFilePath,
       renderItem: (item, depth, focused, _, expanded, { setExpanded }) =>
         item.filepath
           ? this.renderFile(item, focused, expanded, setExpanded)

--- a/src/components/SecondaryPanes/ChromeScopes.js
+++ b/src/components/SecondaryPanes/ChromeScopes.js
@@ -186,7 +186,7 @@ class Scopes extends Component {
         getParent: item => null,
         getChildren: this.getChildren,
         getRoots: () => roots,
-        getKey: item => item.path,
+        getPath: item => item.path,
         autoExpand: 0,
         autoExpandDepth: 1,
         autoExpandAll: false,

--- a/src/components/SecondaryPanes/tests/Expressions.js
+++ b/src/components/SecondaryPanes/tests/Expressions.js
@@ -1,0 +1,73 @@
+import React from "react";
+import { shallow } from "enzyme";
+import Expressions from "../Expressions";
+
+const ExpressionsComponent = React.createFactory(Expressions.WrappedComponent);
+
+function generateDefaults(overrides) {
+  return {
+    loadObjectProperties: jest.fn(),
+    expressions: [
+      {
+        input: "expression1",
+        value: {
+          result: {
+            value: "foo",
+            class: ""
+          }
+        }
+      },
+      {
+        input: "expression2",
+        value: {
+          result: {
+            value: "bar",
+            class: ""
+          }
+        }
+      }
+    ],
+    ...overrides
+  };
+}
+
+function render(overrides = {}) {
+  const props = generateDefaults(overrides);
+  const component = shallow(new ExpressionsComponent(props));
+  return { component, props };
+}
+
+describe("Expressions", () => {
+  it("should render", async () => {
+    const { component } = render();
+    expect(component).toMatchSnapshot();
+  });
+
+  it("should always have unique keys", async () => {
+    const overrides = {
+      expressions: [
+        {
+          input: "expression1",
+          value: {
+            result: {
+              value: undefined,
+              class: ""
+            }
+          }
+        },
+        {
+          input: "expression2",
+          value: {
+            result: {
+              value: undefined,
+              class: ""
+            }
+          }
+        }
+      ]
+    };
+
+    const { component } = render(overrides);
+    expect(component).toMatchSnapshot();
+  });
+});

--- a/src/components/SecondaryPanes/tests/__snapshots__/Expressions.js.snap
+++ b/src/components/SecondaryPanes/tests/__snapshots__/Expressions.js.snap
@@ -1,0 +1,947 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Expressions should always have unique keys 1`] = `
+ShallowWrapper {
+  "complexSelector": ComplexSelector {
+    "buildPredicate": [Function],
+    "childrenOfNode": [Function],
+    "findWhereUnwrapped": [Function],
+  },
+  "length": 1,
+  "node": <ul
+    className="pane expressions-list"
+>
+    <li
+        className="expression-container"
+    >
+        <div
+            className="expression-content"
+        >
+            <ObjectInspector
+                autoExpandDepth={0}
+                getObjectProperties={[Function]}
+                loadObjectProperties={[Function]}
+                onDoubleClick={[Function]}
+                roots={
+                    Array [
+                        Object {
+                          "contents": Object {
+                            "value": Object {
+                              "class": "",
+                              "value": undefined,
+                            },
+                          },
+                          "name": "expression1",
+                          "path": undefined,
+                        },
+                      ]
+                }
+            />
+            <div
+                className="expression-container__close-btn"
+            >
+                <CloseButton
+                    handleClick={[Function]}
+                />
+            </div>
+        </div>
+    </li>
+    <li
+        className="expression-container"
+    >
+        <div
+            className="expression-content"
+        >
+            <ObjectInspector
+                autoExpandDepth={0}
+                getObjectProperties={[Function]}
+                loadObjectProperties={[Function]}
+                onDoubleClick={[Function]}
+                roots={
+                    Array [
+                        Object {
+                          "contents": Object {
+                            "value": Object {
+                              "class": "",
+                              "value": undefined,
+                            },
+                          },
+                          "name": "expression2",
+                          "path": undefined,
+                        },
+                      ]
+                }
+            />
+            <div
+                className="expression-container__close-btn"
+            >
+                <CloseButton
+                    handleClick={[Function]}
+                />
+            </div>
+        </div>
+    </li>
+    <li
+        className="expression-input-container"
+    >
+        <input
+            className="input-expression"
+            onBlur={[Function]}
+            onKeyPress={[Function]}
+            placeholder="Add Watch Expression"
+            type="text"
+        />
+    </li>
+</ul>,
+  "nodes": Array [
+    <ul
+      className="pane expressions-list"
+>
+      <li
+            className="expression-container"
+      >
+            <div
+                  className="expression-content"
+            >
+                  <ObjectInspector
+                        autoExpandDepth={0}
+                        getObjectProperties={[Function]}
+                        loadObjectProperties={[Function]}
+                        onDoubleClick={[Function]}
+                        roots={
+                              Array [
+                                    Object {
+                                      "contents": Object {
+                                        "value": Object {
+                                          "class": "",
+                                          "value": undefined,
+                                        },
+                                      },
+                                      "name": "expression1",
+                                      "path": undefined,
+                                    },
+                                  ]
+                        }
+                  />
+                  <div
+                        className="expression-container__close-btn"
+                  >
+                        <CloseButton
+                              handleClick={[Function]}
+                        />
+                  </div>
+            </div>
+      </li>
+      <li
+            className="expression-container"
+      >
+            <div
+                  className="expression-content"
+            >
+                  <ObjectInspector
+                        autoExpandDepth={0}
+                        getObjectProperties={[Function]}
+                        loadObjectProperties={[Function]}
+                        onDoubleClick={[Function]}
+                        roots={
+                              Array [
+                                    Object {
+                                      "contents": Object {
+                                        "value": Object {
+                                          "class": "",
+                                          "value": undefined,
+                                        },
+                                      },
+                                      "name": "expression2",
+                                      "path": undefined,
+                                    },
+                                  ]
+                        }
+                  />
+                  <div
+                        className="expression-container__close-btn"
+                  >
+                        <CloseButton
+                              handleClick={[Function]}
+                        />
+                  </div>
+            </div>
+      </li>
+      <li
+            className="expression-input-container"
+      >
+            <input
+                  className="input-expression"
+                  onBlur={[Function]}
+                  onKeyPress={[Function]}
+                  placeholder="Add Watch Expression"
+                  type="text"
+            />
+      </li>
+</ul>,
+  ],
+  "options": Object {},
+  "renderer": ReactShallowRenderer {
+    "_instance": ShallowComponentWrapper {
+      "_calledComponentWillUnmount": false,
+      "_compositeType": 1,
+      "_context": Object {},
+      "_currentElement": <Expressions
+        expressions={
+                Array [
+                        Object {
+                          "input": "expression1",
+                          "value": Object {
+                            "result": Object {
+                              "class": "",
+                              "value": undefined,
+                            },
+                          },
+                        },
+                        Object {
+                          "input": "expression2",
+                          "value": Object {
+                            "result": Object {
+                              "class": "",
+                              "value": undefined,
+                            },
+                          },
+                        },
+                      ]
+        }
+        loadObjectProperties={[Function]}
+/>,
+      "_debugID": 3,
+      "_hostContainerInfo": null,
+      "_hostParent": null,
+      "_instance": Expressions {
+        "_reactInternalInstance": [Circular],
+        "context": Object {},
+        "props": Object {
+          "expressions": Array [
+            Object {
+              "input": "expression1",
+              "value": Object {
+                "result": Object {
+                  "class": "",
+                  "value": undefined,
+                },
+              },
+            },
+            Object {
+              "input": "expression2",
+              "value": Object {
+                "result": Object {
+                  "class": "",
+                  "value": undefined,
+                },
+              },
+            },
+          ],
+          "loadObjectProperties": [Function],
+        },
+        "refs": Object {},
+        "renderExpression": [Function],
+        "state": Object {
+          "editing": null,
+        },
+        "updater": Object {
+          "enqueueCallback": [Function],
+          "enqueueCallbackInternal": [Function],
+          "enqueueElementInternal": [Function],
+          "enqueueForceUpdate": [Function],
+          "enqueueReplaceState": [Function],
+          "enqueueSetState": [Function],
+          "isMounted": [Function],
+          "validateCallback": [Function],
+        },
+      },
+      "_mountOrder": 2,
+      "_pendingCallbacks": null,
+      "_pendingElement": null,
+      "_pendingForceUpdate": false,
+      "_pendingReplaceState": false,
+      "_pendingStateQueue": null,
+      "_renderedComponent": Object {
+        "_currentElement": <ul
+          className="pane expressions-list"
+>
+          <li
+                    className="expression-container"
+          >
+                    <div
+                              className="expression-content"
+                    >
+                              <ObjectInspector
+                                        autoExpandDepth={0}
+                                        getObjectProperties={[Function]}
+                                        loadObjectProperties={[Function]}
+                                        onDoubleClick={[Function]}
+                                        roots={
+                                                  Array [
+                                                            Object {
+                                                              "contents": Object {
+                                                                "value": Object {
+                                                                  "class": "",
+                                                                  "value": undefined,
+                                                                },
+                                                              },
+                                                              "name": "expression1",
+                                                              "path": undefined,
+                                                            },
+                                                          ]
+                                        }
+                              />
+                              <div
+                                        className="expression-container__close-btn"
+                              >
+                                        <CloseButton
+                                                  handleClick={[Function]}
+                                        />
+                              </div>
+                    </div>
+          </li>
+          <li
+                    className="expression-container"
+          >
+                    <div
+                              className="expression-content"
+                    >
+                              <ObjectInspector
+                                        autoExpandDepth={0}
+                                        getObjectProperties={[Function]}
+                                        loadObjectProperties={[Function]}
+                                        onDoubleClick={[Function]}
+                                        roots={
+                                                  Array [
+                                                            Object {
+                                                              "contents": Object {
+                                                                "value": Object {
+                                                                  "class": "",
+                                                                  "value": undefined,
+                                                                },
+                                                              },
+                                                              "name": "expression2",
+                                                              "path": undefined,
+                                                            },
+                                                          ]
+                                        }
+                              />
+                              <div
+                                        className="expression-container__close-btn"
+                              >
+                                        <CloseButton
+                                                  handleClick={[Function]}
+                                        />
+                              </div>
+                    </div>
+          </li>
+          <li
+                    className="expression-input-container"
+          >
+                    <input
+                              className="input-expression"
+                              onBlur={[Function]}
+                              onKeyPress={[Function]}
+                              placeholder="Add Watch Expression"
+                              type="text"
+                    />
+          </li>
+</ul>,
+        "_debugID": 4,
+        "_renderedOutput": <ul
+          className="pane expressions-list"
+>
+          <li
+                    className="expression-container"
+          >
+                    <div
+                              className="expression-content"
+                    >
+                              <ObjectInspector
+                                        autoExpandDepth={0}
+                                        getObjectProperties={[Function]}
+                                        loadObjectProperties={[Function]}
+                                        onDoubleClick={[Function]}
+                                        roots={
+                                                  Array [
+                                                            Object {
+                                                              "contents": Object {
+                                                                "value": Object {
+                                                                  "class": "",
+                                                                  "value": undefined,
+                                                                },
+                                                              },
+                                                              "name": "expression1",
+                                                              "path": undefined,
+                                                            },
+                                                          ]
+                                        }
+                              />
+                              <div
+                                        className="expression-container__close-btn"
+                              >
+                                        <CloseButton
+                                                  handleClick={[Function]}
+                                        />
+                              </div>
+                    </div>
+          </li>
+          <li
+                    className="expression-container"
+          >
+                    <div
+                              className="expression-content"
+                    >
+                              <ObjectInspector
+                                        autoExpandDepth={0}
+                                        getObjectProperties={[Function]}
+                                        loadObjectProperties={[Function]}
+                                        onDoubleClick={[Function]}
+                                        roots={
+                                                  Array [
+                                                            Object {
+                                                              "contents": Object {
+                                                                "value": Object {
+                                                                  "class": "",
+                                                                  "value": undefined,
+                                                                },
+                                                              },
+                                                              "name": "expression2",
+                                                              "path": undefined,
+                                                            },
+                                                          ]
+                                        }
+                              />
+                              <div
+                                        className="expression-container__close-btn"
+                              >
+                                        <CloseButton
+                                                  handleClick={[Function]}
+                                        />
+                              </div>
+                    </div>
+          </li>
+          <li
+                    className="expression-input-container"
+          >
+                    <input
+                              className="input-expression"
+                              onBlur={[Function]}
+                              onKeyPress={[Function]}
+                              placeholder="Add Watch Expression"
+                              type="text"
+                    />
+          </li>
+</ul>,
+      },
+      "_renderedNodeType": 0,
+      "_rootNodeID": 0,
+      "_topLevelWrapper": null,
+      "_updateBatchNumber": null,
+      "_warnedAboutRefsInRender": false,
+    },
+    "getRenderOutput": [Function],
+    "render": [Function],
+  },
+  "root": [Circular],
+  "unrendered": <Expressions
+    expressions={
+        Array [
+            Object {
+              "input": "expression1",
+              "value": Object {
+                "result": Object {
+                  "class": "",
+                  "value": undefined,
+                },
+              },
+            },
+            Object {
+              "input": "expression2",
+              "value": Object {
+                "result": Object {
+                  "class": "",
+                  "value": undefined,
+                },
+              },
+            },
+          ]
+    }
+    loadObjectProperties={[Function]}
+/>,
+}
+`;
+
+exports[`Expressions should render 1`] = `
+ShallowWrapper {
+  "complexSelector": ComplexSelector {
+    "buildPredicate": [Function],
+    "childrenOfNode": [Function],
+    "findWhereUnwrapped": [Function],
+  },
+  "length": 1,
+  "node": <ul
+    className="pane expressions-list"
+>
+    <li
+        className="expression-container"
+    >
+        <div
+            className="expression-content"
+        >
+            <ObjectInspector
+                autoExpandDepth={0}
+                getObjectProperties={[Function]}
+                loadObjectProperties={[Function]}
+                onDoubleClick={[Function]}
+                roots={
+                    Array [
+                        Object {
+                          "contents": Object {
+                            "value": Object {
+                              "class": "",
+                              "value": "foo",
+                            },
+                          },
+                          "name": "expression1",
+                          "path": undefined,
+                        },
+                      ]
+                }
+            />
+            <div
+                className="expression-container__close-btn"
+            >
+                <CloseButton
+                    handleClick={[Function]}
+                />
+            </div>
+        </div>
+    </li>
+    <li
+        className="expression-container"
+    >
+        <div
+            className="expression-content"
+        >
+            <ObjectInspector
+                autoExpandDepth={0}
+                getObjectProperties={[Function]}
+                loadObjectProperties={[Function]}
+                onDoubleClick={[Function]}
+                roots={
+                    Array [
+                        Object {
+                          "contents": Object {
+                            "value": Object {
+                              "class": "",
+                              "value": "bar",
+                            },
+                          },
+                          "name": "expression2",
+                          "path": undefined,
+                        },
+                      ]
+                }
+            />
+            <div
+                className="expression-container__close-btn"
+            >
+                <CloseButton
+                    handleClick={[Function]}
+                />
+            </div>
+        </div>
+    </li>
+    <li
+        className="expression-input-container"
+    >
+        <input
+            className="input-expression"
+            onBlur={[Function]}
+            onKeyPress={[Function]}
+            placeholder="Add Watch Expression"
+            type="text"
+        />
+    </li>
+</ul>,
+  "nodes": Array [
+    <ul
+      className="pane expressions-list"
+>
+      <li
+            className="expression-container"
+      >
+            <div
+                  className="expression-content"
+            >
+                  <ObjectInspector
+                        autoExpandDepth={0}
+                        getObjectProperties={[Function]}
+                        loadObjectProperties={[Function]}
+                        onDoubleClick={[Function]}
+                        roots={
+                              Array [
+                                    Object {
+                                      "contents": Object {
+                                        "value": Object {
+                                          "class": "",
+                                          "value": "foo",
+                                        },
+                                      },
+                                      "name": "expression1",
+                                      "path": undefined,
+                                    },
+                                  ]
+                        }
+                  />
+                  <div
+                        className="expression-container__close-btn"
+                  >
+                        <CloseButton
+                              handleClick={[Function]}
+                        />
+                  </div>
+            </div>
+      </li>
+      <li
+            className="expression-container"
+      >
+            <div
+                  className="expression-content"
+            >
+                  <ObjectInspector
+                        autoExpandDepth={0}
+                        getObjectProperties={[Function]}
+                        loadObjectProperties={[Function]}
+                        onDoubleClick={[Function]}
+                        roots={
+                              Array [
+                                    Object {
+                                      "contents": Object {
+                                        "value": Object {
+                                          "class": "",
+                                          "value": "bar",
+                                        },
+                                      },
+                                      "name": "expression2",
+                                      "path": undefined,
+                                    },
+                                  ]
+                        }
+                  />
+                  <div
+                        className="expression-container__close-btn"
+                  >
+                        <CloseButton
+                              handleClick={[Function]}
+                        />
+                  </div>
+            </div>
+      </li>
+      <li
+            className="expression-input-container"
+      >
+            <input
+                  className="input-expression"
+                  onBlur={[Function]}
+                  onKeyPress={[Function]}
+                  placeholder="Add Watch Expression"
+                  type="text"
+            />
+      </li>
+</ul>,
+  ],
+  "options": Object {},
+  "renderer": ReactShallowRenderer {
+    "_instance": ShallowComponentWrapper {
+      "_calledComponentWillUnmount": false,
+      "_compositeType": 1,
+      "_context": Object {},
+      "_currentElement": <Expressions
+        expressions={
+                Array [
+                        Object {
+                          "input": "expression1",
+                          "value": Object {
+                            "result": Object {
+                              "class": "",
+                              "value": "foo",
+                            },
+                          },
+                        },
+                        Object {
+                          "input": "expression2",
+                          "value": Object {
+                            "result": Object {
+                              "class": "",
+                              "value": "bar",
+                            },
+                          },
+                        },
+                      ]
+        }
+        loadObjectProperties={[Function]}
+/>,
+      "_debugID": 1,
+      "_hostContainerInfo": null,
+      "_hostParent": null,
+      "_instance": Expressions {
+        "_reactInternalInstance": [Circular],
+        "context": Object {},
+        "props": Object {
+          "expressions": Array [
+            Object {
+              "input": "expression1",
+              "value": Object {
+                "result": Object {
+                  "class": "",
+                  "value": "foo",
+                },
+              },
+            },
+            Object {
+              "input": "expression2",
+              "value": Object {
+                "result": Object {
+                  "class": "",
+                  "value": "bar",
+                },
+              },
+            },
+          ],
+          "loadObjectProperties": [Function],
+        },
+        "refs": Object {},
+        "renderExpression": [Function],
+        "state": Object {
+          "editing": null,
+        },
+        "updater": Object {
+          "enqueueCallback": [Function],
+          "enqueueCallbackInternal": [Function],
+          "enqueueElementInternal": [Function],
+          "enqueueForceUpdate": [Function],
+          "enqueueReplaceState": [Function],
+          "enqueueSetState": [Function],
+          "isMounted": [Function],
+          "validateCallback": [Function],
+        },
+      },
+      "_mountOrder": 1,
+      "_pendingCallbacks": null,
+      "_pendingElement": null,
+      "_pendingForceUpdate": false,
+      "_pendingReplaceState": false,
+      "_pendingStateQueue": null,
+      "_renderedComponent": Object {
+        "_currentElement": <ul
+          className="pane expressions-list"
+>
+          <li
+                    className="expression-container"
+          >
+                    <div
+                              className="expression-content"
+                    >
+                              <ObjectInspector
+                                        autoExpandDepth={0}
+                                        getObjectProperties={[Function]}
+                                        loadObjectProperties={[Function]}
+                                        onDoubleClick={[Function]}
+                                        roots={
+                                                  Array [
+                                                            Object {
+                                                              "contents": Object {
+                                                                "value": Object {
+                                                                  "class": "",
+                                                                  "value": "foo",
+                                                                },
+                                                              },
+                                                              "name": "expression1",
+                                                              "path": undefined,
+                                                            },
+                                                          ]
+                                        }
+                              />
+                              <div
+                                        className="expression-container__close-btn"
+                              >
+                                        <CloseButton
+                                                  handleClick={[Function]}
+                                        />
+                              </div>
+                    </div>
+          </li>
+          <li
+                    className="expression-container"
+          >
+                    <div
+                              className="expression-content"
+                    >
+                              <ObjectInspector
+                                        autoExpandDepth={0}
+                                        getObjectProperties={[Function]}
+                                        loadObjectProperties={[Function]}
+                                        onDoubleClick={[Function]}
+                                        roots={
+                                                  Array [
+                                                            Object {
+                                                              "contents": Object {
+                                                                "value": Object {
+                                                                  "class": "",
+                                                                  "value": "bar",
+                                                                },
+                                                              },
+                                                              "name": "expression2",
+                                                              "path": undefined,
+                                                            },
+                                                          ]
+                                        }
+                              />
+                              <div
+                                        className="expression-container__close-btn"
+                              >
+                                        <CloseButton
+                                                  handleClick={[Function]}
+                                        />
+                              </div>
+                    </div>
+          </li>
+          <li
+                    className="expression-input-container"
+          >
+                    <input
+                              className="input-expression"
+                              onBlur={[Function]}
+                              onKeyPress={[Function]}
+                              placeholder="Add Watch Expression"
+                              type="text"
+                    />
+          </li>
+</ul>,
+        "_debugID": 2,
+        "_renderedOutput": <ul
+          className="pane expressions-list"
+>
+          <li
+                    className="expression-container"
+          >
+                    <div
+                              className="expression-content"
+                    >
+                              <ObjectInspector
+                                        autoExpandDepth={0}
+                                        getObjectProperties={[Function]}
+                                        loadObjectProperties={[Function]}
+                                        onDoubleClick={[Function]}
+                                        roots={
+                                                  Array [
+                                                            Object {
+                                                              "contents": Object {
+                                                                "value": Object {
+                                                                  "class": "",
+                                                                  "value": "foo",
+                                                                },
+                                                              },
+                                                              "name": "expression1",
+                                                              "path": undefined,
+                                                            },
+                                                          ]
+                                        }
+                              />
+                              <div
+                                        className="expression-container__close-btn"
+                              >
+                                        <CloseButton
+                                                  handleClick={[Function]}
+                                        />
+                              </div>
+                    </div>
+          </li>
+          <li
+                    className="expression-container"
+          >
+                    <div
+                              className="expression-content"
+                    >
+                              <ObjectInspector
+                                        autoExpandDepth={0}
+                                        getObjectProperties={[Function]}
+                                        loadObjectProperties={[Function]}
+                                        onDoubleClick={[Function]}
+                                        roots={
+                                                  Array [
+                                                            Object {
+                                                              "contents": Object {
+                                                                "value": Object {
+                                                                  "class": "",
+                                                                  "value": "bar",
+                                                                },
+                                                              },
+                                                              "name": "expression2",
+                                                              "path": undefined,
+                                                            },
+                                                          ]
+                                        }
+                              />
+                              <div
+                                        className="expression-container__close-btn"
+                              >
+                                        <CloseButton
+                                                  handleClick={[Function]}
+                                        />
+                              </div>
+                    </div>
+          </li>
+          <li
+                    className="expression-input-container"
+          >
+                    <input
+                              className="input-expression"
+                              onBlur={[Function]}
+                              onKeyPress={[Function]}
+                              placeholder="Add Watch Expression"
+                              type="text"
+                    />
+          </li>
+</ul>,
+      },
+      "_renderedNodeType": 0,
+      "_rootNodeID": 0,
+      "_topLevelWrapper": null,
+      "_updateBatchNumber": null,
+      "_warnedAboutRefsInRender": false,
+    },
+    "getRenderOutput": [Function],
+    "render": [Function],
+  },
+  "root": [Circular],
+  "unrendered": <Expressions
+    expressions={
+        Array [
+            Object {
+              "input": "expression1",
+              "value": Object {
+                "result": Object {
+                  "class": "",
+                  "value": "foo",
+                },
+              },
+            },
+            Object {
+              "input": "expression2",
+              "value": Object {
+                "result": Object {
+                  "class": "",
+                  "value": "bar",
+                },
+              },
+            },
+          ]
+    }
+    loadObjectProperties={[Function]}
+/>,
+}
+`;

--- a/src/components/shared/ManagedTree.js
+++ b/src/components/shared/ManagedTree.js
@@ -15,7 +15,7 @@ type Props = {
   autoExpandAll: boolean,
   autoExpandDepth: number,
   getChildren: Item => Item[],
-  getKey: Item => string,
+  getPath: Item => string,
   getParent: () => any,
   getRoots: () => any,
   highlightItems?: Array<Item>,
@@ -67,11 +67,11 @@ class ManagedTree extends Component {
 
   setExpanded(item: Item, isExpanded: boolean) {
     const expanded = this.state.expanded;
-    const key = this.props.getKey(item);
+    const itemPath = this.props.getPath(item);
     if (isExpanded) {
-      expanded.add(key);
+      expanded.add(itemPath);
     } else {
-      expanded.delete(key);
+      expanded.delete(itemPath);
     }
     this.setState({ expanded });
 
@@ -84,7 +84,7 @@ class ManagedTree extends Component {
 
   expandListItems(listItems: Array<Item>) {
     const expanded = this.state.expanded;
-    listItems.forEach(item => expanded.add(this.props.getKey(item)));
+    listItems.forEach(item => expanded.add(this.props.getPath(item)));
     this.focusItem(listItems[0]);
     this.setState({ expanded: expanded });
   }
@@ -93,14 +93,14 @@ class ManagedTree extends Component {
     const expanded = this.state.expanded;
 
     // This file is visible, so we highlight it.
-    if (expanded.has(this.props.getKey(highlightItems[0]))) {
+    if (expanded.has(this.props.getPath(highlightItems[0]))) {
       this.focusItem(highlightItems[0]);
     } else {
       // Look at folders starting from the top-level until finds a
       // closed folder and highlights this folder
       const index = highlightItems
         .reverse()
-        .findIndex(item => !expanded.has(this.props.getKey(item)));
+        .findIndex(item => !expanded.has(this.props.getPath(item)));
       this.focusItem(highlightItems[index]);
     }
   }
@@ -118,20 +118,21 @@ class ManagedTree extends Component {
   render() {
     const { expanded, focusedItem } = this.state;
 
-    const props = Object.assign({}, this.props, {
-      isExpanded: item => expanded.has(this.props.getKey(item)),
+    const overrides = {
+      isExpanded: item => expanded.has(this.props.getPath(item)),
       focused: focusedItem,
-
+      getKey: this.props.getPath,
       onExpand: item => this.setExpanded(item, true),
       onCollapse: item => this.setExpanded(item, false),
       onFocus: this.focusItem,
-
       renderItem: (...args) => {
         return this.props.renderItem(...args, {
           setExpanded: this.setExpanded
         });
       }
-    });
+    };
+
+    const props = { ...this.props, ...overrides };
     return dom.div({ className: "managed-tree" }, Tree(props));
   }
 }

--- a/src/components/shared/ObjectInspector.js
+++ b/src/components/shared/ObjectInspector.js
@@ -192,7 +192,7 @@ class ObjectInspector extends Component {
       getParent: item => null,
       getChildren: this.getChildren,
       getRoots: () => roots,
-      getKey: (item: Item) => item.path,
+      getPath: (item: Item) => `${item.path}/${item.name}`,
       autoExpand: 0,
       autoExpandDepth,
       autoExpandAll: false,

--- a/src/components/stories/ManagedTree.js
+++ b/src/components/stories/ManagedTree.js
@@ -48,7 +48,7 @@ function ManagedTreeFactory(options, { dir = "ltr", theme = "light" } = {}) {
           getParent: item => null,
           getChildren: () => {},
           getRoots: () => {},
-          getKey: () => {},
+          getPath: () => {},
           autoExpand: 0,
           autoExpandDepth: 0,
           autoExpandAll: false,
@@ -89,7 +89,7 @@ storiesOf("ManagedTree", module)
       autoExpandDepth: 1,
       getRoots: () => [root],
       getChildren: item => item.children || [],
-      getKey: item => item.path
+      getPath: item => item.path
     });
   })
   .add("2 deep tree", () => {
@@ -118,6 +118,6 @@ storiesOf("ManagedTree", module)
       autoExpandDepth: 1,
       getRoots: () => [root],
       getChildren: item => item.children || [],
-      getKey: item => item.path
+      getPath: item => item.path
     });
   });


### PR DESCRIPTION
Associated Issue: #3496 

### Summary of Changes
* change getKey to getPath to maybe make it clearer that it has more
tasks than setting the key

* make objectInspector getPath method create a unique path, even if the
element is undefined


### Test Plan

Unit tests