### PR TITLE
Convert editor footer and PaneToggle to jsx

### DIFF
--- a/src/components/Editor/Footer.js
+++ b/src/components/Editor/Footer.js
@@ -1,4 +1,4 @@
-import { createFactory, PureComponent, DOM as dom } from "react";
+import React, { PureComponent } from "react";
 import { connect } from "react-redux";
 import { bindActionCreators } from "redux";
 import actions from "../../actions";
@@ -13,8 +13,8 @@ import classnames from "classnames";
 import { isEnabled } from "devtools-config";
 import { isPretty } from "../../utils/source";
 import { shouldShowFooter, shouldShowPrettyPrint } from "../../utils/editor";
-import _PaneToggleButton from "../shared/Button/PaneToggle";
-const PaneToggleButton = createFactory(_PaneToggleButton);
+
+import PaneToggleButton from "../shared/Button/PaneToggle";
 
 import type { SourceRecord } from "../../reducers/sources";
 
@@ -44,18 +44,19 @@ class SourceFooter extends PureComponent {
     const tooltip = L10N.getStr("sourceTabs.prettyPrint");
     const type = "prettyPrint";
 
-    return dom.button(
-      {
-        onClick: () => togglePrettyPrint(selectedSource.get("id")),
-        className: classnames("action", type, {
+    return (
+      <button
+        onClick={() => togglePrettyPrint(selectedSource.get("id"))}
+        className={classnames("action", type, {
           active: sourceLoaded,
           pretty: isPretty(selectedSource.toJS())
-        }),
-        key: type,
-        title: tooltip,
-        "aria-label": tooltip
-      },
-      Svg(type)
+        })}
+        key={type}
+        title={tooltip}
+        aria-label={tooltip}
+      >
+        {Svg(type)}
+      </button>
     );
   }
 
@@ -72,18 +73,19 @@ class SourceFooter extends PureComponent {
     const tooltip = L10N.getStr("sourceFooter.blackbox");
     const type = "black-box";
 
-    return dom.button(
-      {
-        onClick: () => toggleBlackBox(selectedSource.toJS()),
-        className: classnames("action", type, {
+    return (
+      <button
+        onClick={() => toggleBlackBox(selectedSource.toJS())}
+        className={classnames("action", type, {
           active: sourceLoaded,
-          blackboxed
-        }),
-        key: type,
-        title: tooltip,
-        "aria-label": tooltip
-      },
-      Svg("blackBox")
+          blackboxed: blackboxed
+        })}
+        key={type}
+        title={tooltip}
+        aria-label={tooltip}
+      >
+        {Svg("blackBox")}
+      </button>
     );
   }
 
@@ -95,9 +97,10 @@ class SourceFooter extends PureComponent {
       return;
     }
 
-    return dom.span(
-      { className: "blackbox-summary" },
-      L10N.getStr("sourceFooter.blackboxed")
+    return (
+      <span className="blackbox-summary">
+        {L10N.getStr("sourceFooter.blackboxed")}
+      </span>
     );
   }
 
@@ -108,14 +111,15 @@ class SourceFooter extends PureComponent {
       return;
     }
 
-    return dom.button(
-      {
-        className: "coverage action",
-        title: "Code Coverage",
-        onClick: () => recordCoverage(),
-        "aria-label": "Code Coverage"
-      },
-      "C"
+    return (
+      <button
+        className="coverage action"
+        title="Code Coverage"
+        onClick={() => recordCoverage()}
+        aria-label="Code Coverage"
+      >
+        C
+      </button>
     );
   }
 
@@ -124,12 +128,14 @@ class SourceFooter extends PureComponent {
       return;
     }
 
-    return PaneToggleButton({
-      position: "end",
-      collapsed: !this.props.endPanelCollapsed,
-      horizontal: this.props.horizontal,
-      handleClick: this.props.togglePaneCollapse
-    });
+    return (
+      <PaneToggleButton
+        position="end"
+        collapsed={!this.props.endPanelCollapsed}
+        horizontal={this.props.horizontal}
+        handleClick={this.props.togglePaneCollapse}
+      />
+    );
   }
 
   renderCommands() {
@@ -138,12 +144,13 @@ class SourceFooter extends PureComponent {
       return null;
     }
 
-    return dom.div(
-      { className: "commands" },
-      this.prettyPrintButton(),
-      this.blackBoxButton(),
-      this.blackBoxSummary(),
-      this.coverageButton()
+    return (
+      <div className="commands">
+        {this.prettyPrintButton()}
+        {this.blackBoxButton()}
+        {this.blackBoxSummary()}
+        {this.coverageButton()}
+      </div>
     );
   }
 
@@ -154,10 +161,11 @@ class SourceFooter extends PureComponent {
       return null;
     }
 
-    return dom.div(
-      { className: "source-footer" },
-      this.renderCommands(),
-      this.renderToggleButton()
+    return (
+      <div className="source-footer">
+        {this.renderCommands()}
+        {this.renderToggleButton()}
+      </div>
     );
   }
 }

--- a/src/components/shared/Button/PaneToggle.js
+++ b/src/components/shared/Button/PaneToggle.js
@@ -1,6 +1,6 @@
 // @flow
 
-import { DOM as dom, Component } from "react";
+import React, { Component } from "react";
 import classnames from "classnames";
 import Svg from "../Svg";
 import "./PaneToggle.css";
@@ -29,16 +29,17 @@ class PaneToggleButton extends Component {
       ? L10N.getStr("expandPanes")
       : L10N.getStr("collapsePanes");
 
-    return dom.div(
-      {
-        className: classnames(`toggle-button-${position}`, {
+    return (
+      <div
+        className={classnames(`toggle-button-${position}`, {
           collapsed,
           vertical: horizontal != null ? !horizontal : false
-        }),
-        onClick: () => handleClick(position, collapsed),
-        title
-      },
-      Svg("togglePanes")
+        })}
+        onClick={() => handleClick(position, collapsed)}
+        title={title}
+      >
+        {Svg("togglePanes")}
+      </div>
     );
   }
 }


### PR DESCRIPTION
We may want to consider a size standard for the stuff like `classnames()` which can get large; maybe use a `const` defined before the JSX starts.  Let me know.