### PR TITLE
Fix flakiness

### DIFF
--- a/src/test/tests-framework.js
+++ b/src/test/tests-framework.js
@@ -5,9 +5,15 @@ import {
   stopPrettyPrintWorker
 } from "../utils/pretty-print";
 
-import { startParserWorker, stopParserWorker } from "../utils/parser";
+import {
+  startParserWorker,
+  stopParserWorker,
+  clearSymbols
+} from "../utils/parser";
 import { startSearchWorker, stopSearchWorker } from "../utils/search";
 import { getValue } from "devtools-config";
+
+global.jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000;
 
 beforeAll(() => {
   startSourceMapWorker(getValue("workers.sourceMapURL"));
@@ -21,4 +27,8 @@ afterAll(() => {
   stopPrettyPrintWorker();
   stopParserWorker();
   stopSearchWorker();
+});
+
+beforeEach(() => {
+  clearSymbols();
 });


### PR DESCRIPTION
Associated Issue: #3544


### Summary of Changes

* bump timeout cause parsing can be slow
* clear the caches after each test
* i tried starting and stopping processes and tests went from ~10 seconds to ~40. we might need to do that someday, but i want to avoid it if we can.
