### PR TITLE
#3506 WhyPaused to JSX

### DIFF
--- a/src/components/SecondaryPanes/Frames/WhyPaused.js
+++ b/src/components/SecondaryPanes/Frames/WhyPaused.js
@@ -44,6 +44,7 @@ function renderMessage(pauseInfo: Pause) {
 
   return null;
 }
+renderMessage.displayName = "whyMessage";
 
 export default function renderWhyPaused({ pause }: { pause: Pause }) {
   const reason = getPauseReason(pause);
@@ -61,3 +62,4 @@ export default function renderWhyPaused({ pause }: { pause: Pause }) {
     </div>
   );
 }
+renderWhyPaused.displayName = "whyPaused";

--- a/src/components/SecondaryPanes/Frames/WhyPaused.js
+++ b/src/components/SecondaryPanes/Frames/WhyPaused.js
@@ -1,5 +1,5 @@
 // @flow
-import { DOM as dom } from "react";
+import React from "react";
 import isString from "lodash/isString";
 import get from "lodash/get";
 
@@ -26,14 +26,19 @@ function renderMessage(pauseInfo: Pause) {
 
   const message = get(pauseInfo, "why.message");
   if (message) {
-    return dom.div({ className: "message" }, message);
+    return (
+      <div className={"message"}>
+        {message}
+      </div>
+    );
   }
 
   const exception = get(pauseInfo, "why.exception");
   if (exception) {
-    return dom.div(
-      { className: "message warning" },
-      renderExceptionSummary(exception)
+    return (
+      <div className={"message warning"}>
+        {renderExceptionSummary(exception)}
+      </div>
     );
   }
 
@@ -47,9 +52,12 @@ export default function renderWhyPaused({ pause }: { pause: Pause }) {
     return null;
   }
 
-  return dom.div(
-    { className: "pane why-paused" },
-    dom.div(null, L10N.getStr(reason)),
-    renderMessage(pause)
+  return (
+    <div className={"pane why-paused"}>
+      <div>
+        {L10N.getStr(reason)}
+      </div>
+      {renderMessage(pause)}
+    </div>
   );
 }


### PR DESCRIPTION
Associated Issue: #3506 

### Summary of Changes
* Replace all React.createElement calls to JSX.

### Test Plan
Previous [snapshot test](https://github.com/devtools-html/debugger.html/blob/master/src/components/tests/WhyPaused.js) passes.