### PR TITLE
Use theme body color for conditional breaking point

### DIFF
--- a/src/components/Editor/Editor.css
+++ b/src/components/Editor/Editor.css
@@ -19,7 +19,7 @@
 }
 
 .theme-light {
-  --theme-conditional-breakpoint-color: #ccd1d5;
+  --theme-conditional-breakpoint-color: var(--theme-body-color);
 }
 
 .paused .in-scope .CodeMirror-line,


### PR DESCRIPTION
Associated Issue: #3577 
#goodnessSquad

Here's the Pull Request Doc
https://devtools-html.github.io/debugger.html/CONTRIBUTING.html#pull-requests

### Summary of Changes

* Aligned the conditional breaking point text color to use the same color as used in the source code section.

### Test Plan

Tested the color of the conditional breaking point input color is updated correctly.

Before:
![image](https://user-images.githubusercontent.com/4344533/29039013-567f0dec-7bb2-11e7-9835-32b9f93c8d31.png)

After:
![image](https://user-images.githubusercontent.com/4344533/29039024-5c991664-7bb2-11e7-980d-380417b04257.png)