### PR TITLE
click "functions" to open symbol search modal

### DIFF
--- a/assets/panel/debugger.properties
+++ b/assets/panel/debugger.properties
@@ -592,6 +592,10 @@ symbolSearch.search.variablesPlaceholder=Search variables…
 # searching for a function or variable
 symbolSearch.search.key2=CmdOrCtrl+Shift+O
 
+# LOCALIZATION NOTE(symbolSearch.searchModifier.modifiersLabel): A label
+# preceding the group of modifiers
+symbolSearch.searchModifier.modifiersLabel=Modifiers:
+
 # LOCALIZATION NOTE(symbolSearch.searchModifier.regex): A search option
 # when searching text in a file
 symbolSearch.searchModifier.regex=Regex

--- a/src/components/Editor/SearchBar.css
+++ b/src/components/Editor/SearchBar.css
@@ -87,21 +87,16 @@
   max-width: 68%;
 }
 
-.search-bottom-bar .search-type-toggles .search-toggle-title {
-  color: var(--theme-body-color-inactive);
-  font-size: 11px;
-  font-weight: normal;
-  margin: 0;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  overflow: hidden;
-}
-
-.search-bottom-bar .search-type-toggles .search-type-btn {
+.search-bottom-bar .search-type-name {
+  padding: 1px 0 0 0;
   margin: 0 0 0 6px;
   border: none;
   background: transparent;
   color: var(--theme-comment-alt);
+}
+
+.search-bottom-bar .search-type-toggles .search-type-name:hover {
+  cursor: pointer;
 }
 
 .search-bottom-bar .search-type-toggles .search-type-btn:hover {

--- a/src/components/Editor/SearchBar.css
+++ b/src/components/Editor/SearchBar.css
@@ -61,11 +61,8 @@
   width: 16px;
 }
 
-.search-bottom-bar .search-modifiers button svg:hover {
-  cursor: pointer;
-}
-
 .search-bottom-bar .search-modifiers button:hover {
+  cursor: pointer;
   background: var(--theme-toolbar-background-hover);
 }
 

--- a/src/components/Editor/SearchBar.js
+++ b/src/components/Editor/SearchBar.js
@@ -358,6 +358,9 @@ class SearchBar extends Component {
 
     return (
       <div className="search-modifiers">
+        <span className="search-type-name">
+          {L10N.getStr("symbolSearch.searchModifier.modifiersLabel")}
+        </span>
         <SearchModBtn
           modVal="regexMatch"
           className="regex-match-btn"
@@ -376,6 +379,21 @@ class SearchBar extends Component {
           svgName="whole-word-match"
           tooltip={L10N.getStr("symbolSearch.searchModifier.wholeWord")}
         />
+      </div>
+    );
+  }
+
+  renderSearchType() {
+    return (
+      <div className="search-type-toggles">
+        <span
+          className="search-type-name"
+          onClick={() => {
+            this.props.setActiveSearch("symbol");
+          }}
+        >
+          {L10N.getStr("symbolSearch.search.functionsPlaceholder")}
+        </span>
       </div>
     );
   }
@@ -401,6 +419,7 @@ class SearchBar extends Component {
           handleClose={this.closeSearch}
         />
         <div className="search-bottom-bar">
+          {this.renderSearchType()}
           {this.renderSearchModifiers()}
         </div>
       </div>

--- a/src/components/Editor/SearchBar.js
+++ b/src/components/Editor/SearchBar.js
@@ -388,9 +388,7 @@ class SearchBar extends Component {
       <div className="search-type-toggles">
         <span
           className="search-type-name"
-          onClick={() => {
-            this.props.setActiveSearch("symbol");
-          }}
+          onClick={() => this.props.setActiveSearch("symbol")}
         >
           {L10N.getStr("symbolSearch.search.functionsPlaceholder")}
         </span>

--- a/src/components/Editor/tests/__snapshots__/SearchBar.js.snap
+++ b/src/components/Editor/tests/__snapshots__/SearchBar.js.snap
@@ -28,8 +28,23 @@ ShallowWrapper {
         className="search-bottom-bar"
     >
         <div
+            className="search-type-toggles"
+        >
+            <span
+                className="search-type-name"
+                onClick={[Function]}
+            >
+                Search functions…
+            </span>
+        </div>
+        <div
             className="search-modifiers"
         >
+            <span
+                className="search-type-name"
+            >
+                Modifiers:
+            </span>
             <SearchModBtn
                 className="regex-match-btn"
                 modVal="regexMatch"
@@ -72,8 +87,23 @@ ShallowWrapper {
             className="search-bottom-bar"
       >
             <div
+                  className="search-type-toggles"
+            >
+                  <span
+                        className="search-type-name"
+                        onClick={[Function]}
+                  >
+                        Search functions…
+                  </span>
+            </div>
+            <div
                   className="search-modifiers"
             >
+                  <span
+                        className="search-type-name"
+                  >
+                        Modifiers:
+                  </span>
                   <SearchModBtn
                         className="regex-match-btn"
                         modVal="regexMatch"
@@ -210,8 +240,23 @@ ShallowWrapper {
                     className="search-bottom-bar"
           >
                     <div
+                              className="search-type-toggles"
+                    >
+                              <span
+                                        className="search-type-name"
+                                        onClick={[Function]}
+                              >
+                                        Search functions…
+                              </span>
+                    </div>
+                    <div
                               className="search-modifiers"
                     >
+                              <span
+                                        className="search-type-name"
+                              >
+                                        Modifiers:
+                              </span>
                               <SearchModBtn
                                         className="regex-match-btn"
                                         modVal="regexMatch"
@@ -254,8 +299,23 @@ ShallowWrapper {
                     className="search-bottom-bar"
           >
                     <div
+                              className="search-type-toggles"
+                    >
+                              <span
+                                        className="search-type-name"
+                                        onClick={[Function]}
+                              >
+                                        Search functions…
+                              </span>
+                    </div>
+                    <div
                               className="search-modifiers"
                     >
+                              <span
+                                        className="search-type-name"
+                              >
+                                        Modifiers:
+                              </span>
                               <SearchModBtn
                                         className="regex-match-btn"
                                         modVal="regexMatch"


### PR DESCRIPTION

Associated Issue: #3233

### Summary of Changes

* Add a link that pops up the functions search modal when clicked to the find text UI.

### Test Plan

* Press CmdOrCtrl + F to bring up the text search dialog
* Click the "Search functions..." text to bring up the functions search modal

### Screenshots/Videos (OPTIONAL)

![ffdebug](https://user-images.githubusercontent.com/142361/29194449-f2a2d158-7e29-11e7-9357-44207929fa5b.gif)

