### PR TITLE
Add a wallaby config to the project.

### DIFF
--- a/wallaby.conf.js
+++ b/wallaby.conf.js
@@ -1,0 +1,41 @@
+module.exports = function(wallaby) {
+  return {
+    files: [
+      { pattern: "node_modules/workerjs/**", instrument: false },
+      { pattern: "src/test/fixtures/*.js" },
+      { pattern: "src/**/fixtures/*.+(js|html|json)", instrument: false },
+      { pattern: "src/test/__mocks__/**", instrument: false },
+      { pattern: "src/**/*.js" },
+      { pattern: "!src/test/integration/**" },
+      { pattern: "!src/test/mochitest/**" },
+      { pattern: "!src/**/tests/*.js" },
+      { pattern: "src/**/*.snap", instrument: false },
+      { pattern: "bin/*.js" },
+      { pattern: "configs/*.json", instrument: false },
+      { pattern: "assets/images/Svg.js" },
+      { pattern: "assets/**", instrument: false }
+    ],
+    tests: [{ pattern: "!src/test/**" }, { pattern: "src/**/tests/*.js" }],
+    env: {
+      type: "node",
+      runner: "node"
+    },
+    testFramework: "jest",
+    reportUnhandledPromises: false,
+    compilers: {
+      "+(src|assets)/**/*.js": wallaby.compilers.babel()
+    },
+    preprocessors: {
+      "node_modules/workerjs/requireworker.js": f =>
+        `${f.content.replace(
+          "(modulePath) {",
+          `(modulePath) {modulePath=modulePath.replace(${JSON.stringify(
+            wallaby.projectCacheDir
+          )}, ${JSON.stringify(wallaby.localProjectDir)});`
+        )}\nglobal.$_$wpe = global.$_$wp = ` +
+        "global.$_$wf = global.$_$w = global.$_$wv = () => {};" +
+        " global.$_$tracer = { log: () => {} };"
+    },
+    debug: true
+  };
+};


### PR DESCRIPTION
Associated Issue: N/A

### Summary of Changes

* add a wallaby.conf.js file to the project (credit for the config goes to @ArtemGovorov over at https://github.com/wallabyjs/public/issues/1255)

I've been using Wallaby as a testing tool lately. I had put this in my local ignore (`.git/info/exclude`) but after showing @jasonLaster he suggested adding it so others can use Wallaby if they choose to and won't need to figure out how to configure it themselves.