### PR TITLE
Fix positioning of source search no results message

### DIFF
--- a/src/components/shared/Autocomplete.css
+++ b/src/components/shared/Autocomplete.css
@@ -1,6 +1,7 @@
 .autocomplete {
   position: relative;
   width: 100%;
+  height: 100%;
 }
 
 .autocomplete .no-result-msg {


### PR DESCRIPTION
Associated Issue: #3547 

### Summary of Changes

* set autocomplete height to 100% so the message centers properly.

### Screenshots/Videos

<img width="1920" alt="screen shot 2017-08-09 at 9 11 56 pm" src="https://user-images.githubusercontent.com/580982/29152928-7014e178-7d47-11e7-8f13-81bfcdfd035a.png">


