### PR TITLE
Update assertPausedLocation

### DIFF
--- a/src/test/mochitest/browser_dbg-breaking-from-console.js
+++ b/src/test/mochitest/browser_dbg-breaking-from-console.js
@@ -29,5 +29,5 @@ add_task(function*() {
   yield waitForDispatch(dbg, "LOAD_SOURCE_TEXT");
   is(dbg.win.cm.getValue(), "debugger");
   const source = getSelectedSource(getState()).toJS();
-  assertPausedLocation(dbg, source, 1);
+  assertPausedLocation(dbg);
 });

--- a/src/test/mochitest/browser_dbg-breaking.js
+++ b/src/test/mochitest/browser_dbg-breaking.js
@@ -3,7 +3,7 @@
 
 // Tests the breakpoints are hit in various situations.
 
-add_task(function* () {
+add_task(function*() {
   const dbg = yield initDebugger("doc-scripts.html");
   const { selectors: { getSelectedSource }, getState } = dbg;
 
@@ -12,7 +12,7 @@ add_task(function* () {
   yield addBreakpoint(dbg, "scripts.html", 18);
   reload(dbg);
   yield waitForPaused(dbg);
-  assertPausedLocation(dbg, "scripts.html", 18);
+  assertPausedLocation(dbg);
   yield resume(dbg);
 
   const paused = waitForPaused(dbg);
@@ -28,5 +28,5 @@ add_task(function* () {
   yield addBreakpoint(dbg, source, 5);
   invokeInTab("evaledFunc");
   yield waitForPaused(dbg);
-  assertPausedLocation(dbg, source, 5);
+  assertPausedLocation(dbg);
 });

--- a/src/test/mochitest/browser_dbg-debugger-buttons.js
+++ b/src/test/mochitest/browser_dbg-debugger-buttons.js
@@ -24,31 +24,31 @@ function clickStepOut(dbg) {
  *  4. stepOver to the end of a function
  *  5. stepUp at the end of a function
  */
-add_task(function* () {
+add_task(function*() {
   const dbg = yield initDebugger("doc-debugger-statements.html");
 
   yield reload(dbg);
   yield waitForPaused(dbg);
-  assertPausedLocation(dbg, "debugger-statements.html", 8);
+  assertPausedLocation(dbg);
 
   // resume
   clickElement(dbg, "resume");
   yield waitForPaused(dbg);
-  assertPausedLocation(dbg, "debugger-statements.html", 12);
+  assertPausedLocation(dbg);
 
   // step over
   yield clickStepOver(dbg);
-  assertPausedLocation(dbg, "debugger-statements.html", 13);
+  assertPausedLocation(dbg);
 
   // step into
   yield clickStepIn(dbg);
-  assertPausedLocation(dbg, "debugger-statements.html", 18);
+  assertPausedLocation(dbg);
 
   // step over
   yield clickStepOver(dbg);
-  assertPausedLocation(dbg, "debugger-statements.html", 20);
+  assertPausedLocation(dbg);
 
   // step out
   yield clickStepOut(dbg);
-  assertPausedLocation(dbg, "debugger-statements.html", 20);
+  assertPausedLocation(dbg);
 });

--- a/src/test/mochitest/browser_dbg-editor-select.js
+++ b/src/test/mochitest/browser_dbg-editor-select.js
@@ -29,17 +29,17 @@ add_task(function*() {
   // Call the function that we set a breakpoint in.
   invokeInTab("main");
   yield waitForPaused(dbg);
-  assertPausedLocation(dbg, simple1, 4);
+  assertPausedLocation(dbg);
 
   // Step through to another file and make sure it's paused in the
   // right place.
   yield stepIn(dbg);
-  assertPausedLocation(dbg, simple2, 2);
+  assertPausedLocation(dbg);
 
   // Step back out to the initial file.
   yield stepOut(dbg);
   yield stepOut(dbg);
-  assertPausedLocation(dbg, simple1, 5);
+  assertPausedLocation(dbg);
   yield resume(dbg);
 
   // Make sure that we can set a breakpoint on a line out of the
@@ -49,6 +49,6 @@ add_task(function*() {
 
   invokeInTab("testModel");
   yield waitForPaused(dbg);
-  assertPausedLocation(dbg, longSrc, 66);
+  assertPausedLocation(dbg);
   ok(isElementVisible(dbg, "breakpoint"), "Breakpoint is visible");
 });

--- a/src/test/mochitest/browser_dbg-iframes.js
+++ b/src/test/mochitest/browser_dbg-iframes.js
@@ -6,21 +6,21 @@
  *  1. pause in the main thread
  *  2. pause in the iframe
  */
-add_task(function* () {
+add_task(function*() {
   const dbg = yield initDebugger("doc-iframes.html");
 
   // test pausing in the main thread
   yield reload(dbg);
   yield waitForPaused(dbg);
-  assertPausedLocation(dbg, "iframes.html", 8);
+  assertPausedLocation(dbg);
 
   // test pausing in the iframe
   yield resume(dbg);
   yield waitForPaused(dbg);
-  assertPausedLocation(dbg, "debugger-statements.html", 8);
+  assertPausedLocation(dbg);
 
   // test pausing in the iframe
   yield resume(dbg);
   yield waitForPaused(dbg);
-  assertPausedLocation(dbg, "debugger-statements.html", 12);
+  assertPausedLocation(dbg);
 });

--- a/src/test/mochitest/browser_dbg-navigation.js
+++ b/src/test/mochitest/browser_dbg-navigation.js
@@ -10,7 +10,7 @@ function countSources(dbg) {
  * Test navigating
  * navigating while paused will reset the pause state and sources
  */
-add_task(function* () {
+add_task(function*() {
   const dbg = yield initDebugger("doc-script-switching.html");
   const { selectors: { getSelectedSource, getPause }, getState } = dbg;
 
@@ -21,7 +21,7 @@ add_task(function* () {
   yield addBreakpoint(dbg, "simple1.js", 4);
   invokeInTab("main");
   yield waitForPaused(dbg);
-  assertPausedLocation(dbg, "simple1.js", 4);
+  assertPausedLocation(dbg);
   is(countSources(dbg), 4, "4 sources are loaded.");
 
   yield navigate(dbg, "about:blank");
@@ -29,7 +29,8 @@ add_task(function* () {
   is(countSources(dbg), 0, "0 sources are loaded.");
   ok(!getPause(getState()), "No pause state exists");
 
-  yield navigate(dbg,
+  yield navigate(
+    dbg,
     "doc-scripts.html",
     "simple1.js",
     "simple2.js",
@@ -42,6 +43,8 @@ add_task(function* () {
   // Test that the current select source persists across reloads
   yield selectSource(dbg, "long.js");
   yield reload(dbg, "long.js");
-  ok(getSelectedSource(getState()).get("url").includes("long.js"),
-     "Selected source is long.js");
+  ok(
+    getSelectedSource(getState()).get("url").includes("long.js"),
+    "Selected source is long.js"
+  );
 });

--- a/src/test/mochitest/browser_dbg-pause-exceptions.js
+++ b/src/test/mochitest/browser_dbg-pause-exceptions.js
@@ -16,7 +16,7 @@ function caughtException() {
   3. pause on a caught error
   4. skip a caught error
 */
-add_task(function* () {
+add_task(function*() {
   const dbg = yield initDebugger("doc-exceptions.html");
 
   // test skipping an uncaught exception
@@ -27,19 +27,19 @@ add_task(function* () {
   yield togglePauseOnExceptions(dbg, true, false);
   uncaughtException();
   yield waitForPaused(dbg);
-  assertPausedLocation(dbg, "exceptions.js", 2);
+  assertPausedLocation(dbg);
   yield resume(dbg);
 
   // Test pausing on a caught Error
   caughtException();
   yield waitForPaused(dbg);
-  assertPausedLocation(dbg, "exceptions.js", 15);
+  assertPausedLocation(dbg);
   yield resume(dbg);
 
   // Test skipping a caught error
   yield togglePauseOnExceptions(dbg, true, true);
   caughtException();
   yield waitForPaused(dbg);
-  assertPausedLocation(dbg, "exceptions.js", 17);
+  assertPausedLocation(dbg);
   yield resume(dbg);
 });

--- a/src/test/mochitest/browser_dbg-pretty-print-paused.js
+++ b/src/test/mochitest/browser_dbg-pretty-print-paused.js
@@ -11,13 +11,13 @@ add_task(function*() {
 
   invokeInTab("arithmetic");
   yield waitForPaused(dbg);
-  assertPausedLocation(dbg, "math.min.js", 2);
+  assertPausedLocation(dbg);
 
   clickElement(dbg, "prettyPrintButton");
   yield waitForDispatch(dbg, "SELECT_SOURCE");
 
   // this doesnt work yet
-  // assertPausedLocation(dbg, "math.min.js:formatted", 18);
+  // assertPausedLocation(dbg);
 
   yield resume(dbg);
 });

--- a/src/test/mochitest/browser_dbg-pretty-print.js
+++ b/src/test/mochitest/browser_dbg-pretty-print.js
@@ -21,9 +21,9 @@ add_task(function*() {
 
   invokeInTab("arithmetic");
   yield waitForPaused(dbg);
-  assertPausedLocation(dbg, ppSrc, 18);
+  assertPausedLocation(dbg);
   yield stepOver(dbg);
-  assertPausedLocation(dbg, ppSrc, 27);
+  assertPausedLocation(dbg);
   yield resume(dbg);
 
   // The pretty-print button should go away in the pretty-printed

--- a/src/test/mochitest/browser_dbg-sourcemaps-bogus.js
+++ b/src/test/mochitest/browser_dbg-sourcemaps-bogus.js
@@ -18,7 +18,7 @@ add_task(function*() {
   yield addBreakpoint(dbg, "bogus-map.js", 4);
   invokeInTab("runCode");
   yield waitForPaused(dbg);
-  assertPausedLocation(dbg, "bogus-map.js", 4);
+  assertPausedLocation(dbg);
 
   // Make sure that only the single generated source exists. The
   // sourcemap failed to download.

--- a/src/test/mochitest/browser_dbg-sourcemaps.js
+++ b/src/test/mochitest/browser_dbg-sourcemaps.js
@@ -75,14 +75,14 @@ add_task(function*() {
 
   invokeInTab("keepMeAlive");
   yield waitForPaused(dbg);
-  assertPausedLocation(dbg, entrySrc, 15);
+  assertPausedLocation(dbg);
 
   yield stepIn(dbg);
-  assertPausedLocation(dbg, "times2.js", 2);
+  assertPausedLocation(dbg);
   yield stepOver(dbg);
-  assertPausedLocation(dbg, "times2.js", 3);
+  assertPausedLocation(dbg);
 
   yield stepOut(dbg);
   yield stepOut(dbg);
-  assertPausedLocation(dbg, "entry.js", 16);
+  assertPausedLocation(dbg);
 });

--- a/src/test/mochitest/browser_dbg-sourcemaps2.js
+++ b/src/test/mochitest/browser_dbg-sourcemaps2.js
@@ -31,5 +31,5 @@ add_task(function*() {
   invokeInTab("logMessage");
 
   yield waitForPaused(dbg);
-  assertPausedLocation(dbg, "main.js", 4);
+  assertPausedLocation(dbg);
 });

--- a/src/test/mochitest/browser_dbg_keyboard-shortcuts.js
+++ b/src/test/mochitest/browser_dbg_keyboard-shortcuts.js
@@ -30,17 +30,17 @@ add_task(function*() {
 
   yield reload(dbg);
   yield waitForPaused(dbg);
-  assertPausedLocation(dbg, "debugger-statements.html", 8);
+  assertPausedLocation(dbg);
 
   yield pressResume(dbg);
-  assertPausedLocation(dbg, "debugger-statements.html", 12);
+  assertPausedLocation(dbg);
 
   yield pressStepIn(dbg);
-  assertPausedLocation(dbg, "debugger-statements.html", 13);
+  assertPausedLocation(dbg);
 
   yield pressStepOut(dbg);
-  assertPausedLocation(dbg, "debugger-statements.html", 14);
+  assertPausedLocation(dbg);
 
   yield pressStepOver(dbg);
-  assertPausedLocation(dbg, "debugger-statements.html", 9);
+  assertPausedLocation(dbg);
 });


### PR DESCRIPTION
### Summary of Changes

Update assertPausedLocation, this lets us run `./mach mochitest --repat 20 browser_browser_toolbox_debugger.js` successfully. previously it would fail hard.

We're updating `assertPausedLocation` because the browser toolbox occasionally steps into a weird source `GCTelemettry`

<img width="1062" alt="screen shot 2017-08-10 at 12 08 45 pm" src="https://user-images.githubusercontent.com/254562/29183645-7483ab38-7dd1-11e7-8a8d-95445ac63fc1.png">
