### PR TITLE
Exclude integration tests in webpack build

### DIFF
--- a/bin/run-mochitests-docker
+++ b/bin/run-mochitests-docker
@@ -7,7 +7,6 @@ docker run -it \
   -v `pwd`/assets/build/pretty-print-worker.js:/gecko/devtools/client/debugger/new/pretty-print-worker.js \
   -v `pwd`/assets/build/parser-worker.js:/gecko/devtools/client/debugger/new/parser-worker.js \
   -v `pwd`/assets/build/search-worker.js:/gecko/devtools/client/debugger/new/search-worker.js \
-  -v `pwd`/assets/build/integration-tests.js:/gecko/devtools/client/debugger/new/integration-tests.js \
   -v `pwd`/assets/build/debugger.css:/gecko/devtools/client/debugger/new/debugger.css \
   -v `pwd`/assets/build/panel/debugger.properties:/gecko/devtools/client/locales/en-US/debugger.properties \
   -v `pwd`/assets/build/panel/prefs.js:/gecko/devtools/client/preferences/debugger.js \

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -19,8 +19,7 @@ let webpackConfig = {
     debugger: getEntry("main.js"),
     "parser-worker": getEntry("utils/parser/worker.js"),
     "pretty-print-worker": getEntry("utils/pretty-print/worker.js"),
-    "search-worker": getEntry("utils/search/worker.js"),
-    "integration-tests": getEntry("test/integration/tests.js")
+    "search-worker": getEntry("utils/search/worker.js")
   },
 
   output: {


### PR DESCRIPTION
Associated Issue: #3514

### Summary of Changes

We're seeing a webpack warning now that there's nothing to build any more.
