### PR TITLE
Add overflow:scroll to dropdown element

### DIFF
--- a/src/components/shared/Dropdown.css
+++ b/src/components/shared/Dropdown.css
@@ -9,6 +9,7 @@
   top: 23px;
   width: var(--width);
   z-index: 1000;
+  overflow: scroll;
 }
 
 html[dir="rtl"] .dropdown {


### PR DESCRIPTION
Associated Issue: #3625

### Summary of Changes

* Adds overflow:scroll to dropdown element

Before:
<img width="254" alt="screen shot 2017-08-11 at 17 39 51" src="https://user-images.githubusercontent.com/1628866/29220669-1e5911d0-7ebc-11e7-89ef-2ae54ae64f6b.png">

After: 
![overflow](https://user-images.githubusercontent.com/1628866/29220726-5176d98a-7ebc-11e7-9af4-55f010cdaaff.gif)

