### PR TITLE
fixes text showing between panels in dark theme

### DIFF
--- a/src/components/Editor/Editor.css
+++ b/src/components/Editor/Editor.css
@@ -39,7 +39,7 @@
 .editor-wrapper {
   position: absolute;
   height: calc(100% - 31px);
-  width: 100%;
+  width: calc(100% - 1.5px);
   top: 30px;
   left: 0px;
   --editor-footer-height: 27px;


### PR DESCRIPTION
Associated Issue: #3524

### Summary of Changes

* changes the width of `.editor-wrapper`

### Test Plan
- Be sure to enable the dark theme in debugger app setttings
- Use `cmd + shift + f` to toggle the text search capabiity

Here, the `splitter` div between the `search-container` and the `secondary panes` were most susceptible to show text between the gap. The best way to examine this is simply to drag the splitter from left to right and check for any text that shows through.

Because of the nature of this issue, any written test(s) have been skipped. Please see before and after shots below:

Before: 
<img width="1440" alt="screen shot 2017-08-14 at 9 32 18 pm" src="https://user-images.githubusercontent.com/10334352/29302376-6149b5b6-8138-11e7-8eb6-8c52063704c5.png">

After: 
<img width="1440" alt="screen shot 2017-08-14 at 9 32 01 pm" src="https://user-images.githubusercontent.com/10334352/29302380-687efa1c-8138-11e7-9936-85405743a02f.png">




