### PR TITLE
[Photon] Remove border-bottom from the last child of accordions (#3720)

### DIFF
--- a/src/components/shared/Accordion.css
+++ b/src/components/shared/Accordion.css
@@ -38,6 +38,10 @@
   font-size: 12px;
 }
 
+.accordion div:last-child ._content {
+  border-bottom: none;
+}
+
 .accordion ._header .header-buttons {
   display: flex;
   margin-left: auto;


### PR DESCRIPTION
Associated Issue: #3720 

### Summary of Changes

* Remove border-bottom from the last child of accordions

### Test Plan

Check both the different responsive views of the debugger (horizontal and vertical) and observe that the accordions don't have a trailing border-bottom for the last accordion's content.
