### PR TITLE
Fix height of text search result items

### DIFF
--- a/src/components/ProjectSearch/TextSearch.css
+++ b/src/components/ProjectSearch/TextSearch.css
@@ -3,13 +3,14 @@
   display: flex;
   flex-direction: column;
   overflow-y: hidden;
+  height: 100%;
 }
 
 .project-text-search .result {
   display: flex;
   cursor: default;
-  margin-bottom: 1px;
   padding: 4px 0 4px 30px;
+  line-height: 16px;
   font-size: 10px;
 }
 
@@ -46,8 +47,7 @@
   font-weight: bold;
   line-height: 20px;
   cursor: default;
-  margin: 2px 0;
-  padding: 3px 0 3px 5px;
+  padding: 2px 0 2px 5px;
   font-size: 12px;
 }
 
@@ -72,4 +72,9 @@
 
 .project-text-search .managed-tree {
   overflow-y: auto;
+  height: calc(100% - 81px);
+}
+
+.project-text-search .managed-tree .tree {
+  height: 100%;
 }

--- a/src/components/ProjectSearch/TextSearch.js
+++ b/src/components/ProjectSearch/TextSearch.js
@@ -189,7 +189,7 @@ export default class TextSearch extends Component {
       <ManagedTree
         getRoots={() => results}
         getChildren={file => file.matches || []}
-        itemHeight={20}
+        itemHeight={24}
         autoExpand={1}
         autoExpandDepth={1}
         focused={results[0]}


### PR DESCRIPTION
Associated Issue: #3665 
 
### Summary of Changes

* Updated CSS in TextSearch.css to set the height of elements to 24px.
* Set the height of parent and grandparent of tree node for scroll on focus 

### Screenshots
![scroll-fix](https://user-images.githubusercontent.com/6098743/29485766-18043de8-84f5-11e7-9622-77095a92c826.gif)


