### PR TITLE
fix storybook theme for managed tree

### DIFF
--- a/src/components/stories/ManagedTree.js
+++ b/src/components/stories/ManagedTree.js
@@ -6,7 +6,7 @@ import { L10N } from "devtools-launchpad";
 import prefs from "../../utils/prefs";
 
 import "../App.css";
-import "devtools-launchpad/src/lib/themes/dark-theme.css";
+import "devtools-modules/src/themes/dark-theme.css";
 
 // NOTE: we need this for supporting L10N in storybook
 // we can move this to a shared helper as we add additional stories


### PR DESCRIPTION
Story book managed tree was throwing an error that it couldnt find the dark theme