### PR TITLE
Add hover color to new-tab button

### DIFF
--- a/src/components/Editor/Tabs.css
+++ b/src/components/Editor/Tabs.css
@@ -13,7 +13,8 @@
 
 .source-header .new-tab-btn {
   padding: 4px;
-  margin: 4px 2px 2px 2px;
+  margin-top: 4px;
+  margin-left: 3px;
   fill: var(--theme-content-color3);
   transition: 0.1s ease;
   align-self: center;
@@ -25,6 +26,7 @@
 
 .source-header .new-tab-btn svg {
   width: 12px;
+  display: block;
 }
 
 .source-tabs {

--- a/src/components/Editor/Tabs.css
+++ b/src/components/Editor/Tabs.css
@@ -14,7 +14,7 @@
 .source-header .new-tab-btn {
   padding: 4px;
   margin-top: 4px;
-  margin-left: 3px;
+  margin-left: 2px;
   fill: var(--theme-content-color3);
   transition: 0.1s ease;
   align-self: center;

--- a/src/components/Editor/Tabs.css
+++ b/src/components/Editor/Tabs.css
@@ -12,11 +12,15 @@
 }
 
 .source-header .new-tab-btn {
-  padding: 0px 4px;
-  margin-top: 4px;
+  padding: 4px;
+  margin: 4px 2px 2px 2px;
   fill: var(--theme-content-color3);
   transition: 0.1s ease;
   align-self: center;
+}
+
+.source-header .new-tab-btn:hover {
+  background-color: var(--theme-toolbar-background-hover);
 }
 
 .source-header .new-tab-btn svg {


### PR DESCRIPTION
Associated Issue: https://github.com/devtools-html/debugger.html/issues/3732

### Summary of Changes

* Added background-color on hover for new-tab button. 
* Changed padding and margin for cleaner look on hover.

### Screenshot
![add-btn-hover](https://user-images.githubusercontent.com/6098743/29563924-51f751d8-875d-11e7-8d5f-a1b9be828842.gif)

