### PR TITLE
fix breakpoints offset issue, Remove breakpoint on click

### DIFF
--- a/src/components/Editor/CallSite.js
+++ b/src/components/Editor/CallSite.js
@@ -64,9 +64,11 @@ export default class CallSite extends Component {
 
     if (nextProps.breakpoint !== breakpoint) {
       if (this.marker) {
-        this.marker.clear();
+        this.clearCallSite();
       }
-      this.addCallSite(nextProps);
+      if (nextProps.showCallSite) {
+        this.addCallSite(nextProps);
+      }
     }
 
     if (nextProps.showCallSite !== showCallSite) {

--- a/src/components/Editor/CallSites.js
+++ b/src/components/Editor/CallSites.js
@@ -93,7 +93,7 @@ class CallSites extends Component {
 
     if (
       !isEnabled("columnBreakpoints") ||
-      !e.altKey ||
+      (!e.altKey && !target.classList.contains("call-site-bp")) ||
       (!target.classList.contains("call-site") &&
         !target.classList.contains("call-site-bp"))
     ) {
@@ -102,10 +102,8 @@ class CallSites extends Component {
 
     const { sourceId } = selectedLocation;
     const { line, column } = getTokenLocation(editor.codeMirror, target);
-    this.toggleBreakpoint(
-      toSourceLine(sourceId, line),
-      isWasm(sourceId) ? undefined : column - 2
-    );
+
+    this.toggleBreakpoint(line, isWasm(sourceId) ? undefined : column);
   }
 
   toggleBreakpoint(line, column = undefined) {

--- a/src/components/Editor/CallSites.js
+++ b/src/components/Editor/CallSites.js
@@ -18,7 +18,7 @@ import {
   getBreakpointsForSource
 } from "../../selectors";
 
-import { getTokenLocation, isWasm, toSourceLine } from "../../utils/editor";
+import { getTokenLocation, isWasm } from "../../utils/editor";
 
 import actions from "../../actions";
 


### PR DESCRIPTION


Associated Issue: #3296

Here's the Pull Request Doc
https://devtools-html.github.io/debugger.html/CONTRIBUTING.html#pull-requests

### Summary of Changes

* Remove using `toSourceLine` because for some reason editor line maps directly to the source line, (same for the columns)
* Allow clicking to remove breakpoints even though alt is not pressed

### Test Plan

Tell us a little a bit about how you tested your patch.

Example test plan:

- [x] Open the `columns` example page
- [x] Hold `alt`
- [x] Click on one of the enable callsites


#### Todo
* Add tests for callsites breakpoints


### Screenshots/Videos (OPTIONAL)
![](http://g.recordit.co/sxf6l3fIDV.gif)