### PR TITLE
switch to janitor

### DIFF
--- a/bin/run-mochitests-docker
+++ b/bin/run-mochitests-docker
@@ -17,5 +17,11 @@ docker run -it \
   -v "/tmp/.X11-unix:/tmp/.X11-unix:rw" \
   -e "DISPLAY=unix$DISPLAY" \
   --ipc host \
-  jryans/debugger-gecko \
-  /bin/bash -c "export SHELL=/bin/bash; touch devtools/client/debugger/new/test/mochitest/browser.ini && ./mach build && ./mach mochitest --subsuite devtools devtools/client/debugger/new/test/mochitest/"
+  janx/firefox-hg \
+  /bin/bash -c "export SHELL=/bin/bash; \
+    echo \" \
+      ac_add_options --enable-artifact-builds\n \
+      mk_add_options MOZ_OBJDIR=./objdir-frontend\n \" > mozconfig \
+    touch devtools/client/debugger/new/test/mochitest/browser.ini \
+    && ./mach build \
+    && ./mach mochitest --subsuite devtools devtools/client/debugger/new/test/mochitest/"

--- a/bin/run-mochitests-docker
+++ b/bin/run-mochitests-docker
@@ -23,5 +23,6 @@ docker run -it \
       ac_add_options --enable-artifact-builds\n \
       mk_add_options MOZ_OBJDIR=./objdir-frontend\n \" > mozconfig \
     touch devtools/client/debugger/new/test/mochitest/browser.ini \
+    && ./mach clobber \
     && ./mach build \
     && ./mach mochitest --subsuite devtools devtools/client/debugger/new/test/mochitest/"

--- a/bin/update-docker
+++ b/bin/update-docker
@@ -4,13 +4,9 @@ DOWNLOADS_PATH=${DOWNLOADS_PATH:-"$HOME/downloads"}
 
 mkdir -p $DOWNLOADS_PATH
 
-# Using the first 8 chars of the Docker image hash for brevity
 if [[ -e $DOWNLOADS_PATH/mc.tar ]]; then
   time docker load -i $DOWNLOADS_PATH/mc.tar;
 else
-  # It appears the old Docker in CircleCI 1.0 doesn't support pulling a specific
-  # hash such as jryans/debugger-gecko@sha256:b60ff65ecf613774330979f108b70506508aad54dde815564c743da287f10b4b
-  # We should finish the upgrade to CircleCI 2.0 so that this can be less strange.
   time docker pull janx/firefox-hg
   docker images
   time docker save janx/firefox-hg > $DOWNLOADS_PATH/mc.tar

--- a/bin/update-docker
+++ b/bin/update-docker
@@ -5,13 +5,13 @@ DOWNLOADS_PATH=${DOWNLOADS_PATH:-"$HOME/downloads"}
 mkdir -p $DOWNLOADS_PATH
 
 # Using the first 8 chars of the Docker image hash for brevity
-if [[ -e $DOWNLOADS_PATH/gecko-b60ff65e.tar ]]; then
-  time docker load -i $DOWNLOADS_PATH/gecko-b60ff65e.tar;
+if [[ -e $DOWNLOADS_PATH/mc.tar ]]; then
+  time docker load -i $DOWNLOADS_PATH/mc.tar;
 else
   # It appears the old Docker in CircleCI 1.0 doesn't support pulling a specific
   # hash such as jryans/debugger-gecko@sha256:b60ff65ecf613774330979f108b70506508aad54dde815564c743da287f10b4b
   # We should finish the upgrade to CircleCI 2.0 so that this can be less strange.
-  time docker pull jryans/debugger-gecko
+  time docker pull janx/firefox-hg
   docker images
-  time docker save jryans/debugger-gecko > $DOWNLOADS_PATH/gecko-b60ff65e.tar
+  time docker save janx/firefox-hg > $DOWNLOADS_PATH/mc.tar
 fi

--- a/circle.yml
+++ b/circle.yml
@@ -20,19 +20,19 @@ test:
     - greenkeeper-lockfile-update
   override:
     - mkdir -p $CIRCLE_TEST_REPORTS/mocha
-    # - mkdir -p $CIRCLE_TEST_REPORTS/flow-coverage
-    # - mkdir -p $CIRCLE_TEST_REPORTS/jest-coverage
-    # - jest -i --testResultsProcessor jest-junit-reporter --coverage --coverageDirectory=$CIRCLE_TEST_REPORTS/jest-coverage
-    # - yarn license-check
-    # - yarn lint-css
-    # - yarn lint-js
-    # - yarn lint-md
-    # - yarn flow
-    # - ./bin/run-mochitests-docker
+    - mkdir -p $CIRCLE_TEST_REPORTS/flow-coverage
+    - mkdir -p $CIRCLE_TEST_REPORTS/jest-coverage
+    - jest -i --testResultsProcessor jest-junit-reporter --coverage --coverageDirectory=$CIRCLE_TEST_REPORTS/jest-coverage
+    - yarn license-check
+    - yarn lint-css
+    - yarn lint-js
+    - yarn lint-md
+    - yarn flow
+    - ./bin/run-mochitests-docker
   post:
-    # - yarn flow-coverage -- -t json -o $CIRCLE_TEST_REPORTS/flow-coverage
-    # - yarn check --integrity
-    # - bash <(curl -s https://codecov.io/bash) -f $CIRCLE_TEST_REPORTS/jest-coverage/coverage-final.json
+    - yarn flow-coverage -- -t json -o $CIRCLE_TEST_REPORTS/flow-coverage
+    - yarn check --integrity
+    - bash <(curl -s https://codecov.io/bash) -f $CIRCLE_TEST_REPORTS/jest-coverage/coverage-final.json
 
 dependencies:
   pre:
@@ -44,7 +44,7 @@ dependencies:
     - ~/.yarn
   override:
     - yarn install
-    # - yarn global add flow-coverage-report
+    - yarn global add flow-coverage-report
     - ./bin/update-docker
 
 general:

--- a/circle.yml
+++ b/circle.yml
@@ -20,19 +20,19 @@ test:
     - greenkeeper-lockfile-update
   override:
     - mkdir -p $CIRCLE_TEST_REPORTS/mocha
-    - mkdir -p $CIRCLE_TEST_REPORTS/flow-coverage
-    - mkdir -p $CIRCLE_TEST_REPORTS/jest-coverage
-    - jest -i --testResultsProcessor jest-junit-reporter --coverage --coverageDirectory=$CIRCLE_TEST_REPORTS/jest-coverage
-    - yarn license-check
-    - yarn lint-css
-    - yarn lint-js
-    - yarn lint-md
-    - yarn flow
-    - ./bin/run-mochitests-docker
+    # - mkdir -p $CIRCLE_TEST_REPORTS/flow-coverage
+    # - mkdir -p $CIRCLE_TEST_REPORTS/jest-coverage
+    # - jest -i --testResultsProcessor jest-junit-reporter --coverage --coverageDirectory=$CIRCLE_TEST_REPORTS/jest-coverage
+    # - yarn license-check
+    # - yarn lint-css
+    # - yarn lint-js
+    # - yarn lint-md
+    # - yarn flow
+    # - ./bin/run-mochitests-docker
   post:
-    - yarn flow-coverage -- -t json -o $CIRCLE_TEST_REPORTS/flow-coverage
-    - yarn check --integrity
-    - bash <(curl -s https://codecov.io/bash) -f $CIRCLE_TEST_REPORTS/jest-coverage/coverage-final.json
+    # - yarn flow-coverage -- -t json -o $CIRCLE_TEST_REPORTS/flow-coverage
+    # - yarn check --integrity
+    # - bash <(curl -s https://codecov.io/bash) -f $CIRCLE_TEST_REPORTS/jest-coverage/coverage-final.json
 
 dependencies:
   pre:
@@ -44,7 +44,7 @@ dependencies:
     - ~/.yarn
   override:
     - yarn install
-    - yarn global add flow-coverage-report
+    # - yarn global add flow-coverage-report
     - ./bin/update-docker
 
 general:


### PR DESCRIPTION
This would switch us from my custom docker image which is really old to janitor, which would be more up to date:

1. we need to get the image
2. we need to add the config
...

In the future we could switch to circle 2 and use this image as the base