### PR TITLE
Caches line formatter type; resizes gutter after the change.

### DIFF
--- a/src/utils/editor/source-documents.js
+++ b/src/utils/editor/source-documents.js
@@ -4,6 +4,8 @@ import { getMode } from "../source";
 
 import type { Source } from "debugger-html";
 import { isWasm, getWasmLineNumberFormatter, renderWasmText } from "../wasm";
+import { SourceEditorUtils } from "devtools-source-editor";
+const { resizeBreakpointGutter } = SourceEditorUtils;
 
 let sourceDocs = {};
 
@@ -26,16 +28,17 @@ function clearDocuments() {
 function resetLineNumberFormat(editor: Object) {
   const cm = editor.codeMirror;
   cm.setOption("lineNumberFormatter", number => number);
+  resizeBreakpointGutter(cm);
 }
 
 function updateLineNumberFormat(editor: Object, sourceId: string) {
   if (!isWasm(sourceId)) {
-    resetLineNumberFormat(editor);
-    return;
+    return resetLineNumberFormat(editor);
   }
   const cm = editor.codeMirror;
   const lineNumberFormatter = getWasmLineNumberFormatter(sourceId);
   cm.setOption("lineNumberFormatter", lineNumberFormatter);
+  resizeBreakpointGutter(cm);
 }
 
 function updateDocument(editor: Object, sourceId: string) {


### PR DESCRIPTION
Associated Issue: #3383

Here's the Pull Request Doc
https://devtools-html.github.io/debugger.html/CONTRIBUTING.html#pull-requests

### Summary of Changes

* Caches line formatter type, only for wasm source
* Resizes gutter after the change to avoid baby bp

### Test Plan

Tell us a little a bit about how you tested your patch.

Example test plan as listed at #3383
