### PR TITLE
Mochi exit

### DIFF
--- a/bin/mochi.js
+++ b/bin/mochi.js
@@ -252,10 +252,14 @@ function runMochitests(args) {
   const command = `./mach mochitest ${args.join(" ")}`;
   console.log(chalk.blue(command));
 
-  const child = shell.exec(command, {
-    async: true,
-    silent: true
-  });
+  const child = shell.exec(
+    command,
+    {
+      async: true,
+      silent: true
+    },
+    code => shell.exit(code)
+  );
 
   let testData = { mode: "starting" };
 

--- a/bin/mochi.js
+++ b/bin/mochi.js
@@ -1,6 +1,7 @@
 const shell = require("shelljs");
 const chalk = require("chalk");
 const path = require("path");
+const fs = require("fs");
 
 // const minimist = require("minimist");
 
@@ -323,8 +324,15 @@ if (process.mainModule.filename.includes("bin/mochi.js")) {
     ? process.argv.slice(2)
     : process.argv;
 
-  args = updateArgs(args);
-  run(args);
+  if (args[0] == "--read") {
+    const file = args[1];
+    const _path = path.join(__dirname, "..", file);
+    const text = fs.readFileSync(_path, { encoding: "utf8" });
+    console.log(readOutput(text).join("\n"));
+  } else {
+    args = updateArgs(args);
+    run(args);
+  }
 }
 
 module.exports = { run, readOutput };

--- a/bin/run-mochitests-docker
+++ b/bin/run-mochitests-docker
@@ -18,4 +18,12 @@ docker run -it \
   -e "DISPLAY=unix$DISPLAY" \
   --ipc host \
   jryans/debugger-gecko \
-  /bin/bash -c "export SHELL=/bin/bash; touch devtools/client/debugger/new/test/mochitest/browser.ini && ./mach build && ./mach mochitest --subsuite devtools devtools/client/debugger/new/test/mochitest/"
+  /bin/bash -c "export SHELL=/bin/bash; \
+    touch devtools/client/debugger/new/test/mochitest/browser.ini \
+    && ./mach build \
+    && ./mach mochitest --subsuite devtools devtools/client/debugger/new/test/mochitest/" \
+  > output.txt
+test_exit_code=$?
+
+node ./bin/mochi.js --read output.txt
+exit $test_exit_code;


### PR DESCRIPTION
Associated Issue: #3660

### Summary of Changes

Mochitests are now be formatted w/ mochi. 

PROs:
* the 40K file you had to download to see you can now skim
* test errors are easier to find

CONs:
* the full run will be saved as an artifact, but not as discoverable


<img width="1193" alt="screen shot 2017-08-23 at 11 17 31 pm" src="https://user-images.githubusercontent.com/254562/29647862-5580c882-8859-11e7-8a73-ae991efaf09d.png">
<img width="1366" alt="screen shot 2017-08-23 at 11 17 19 pm" src="https://user-images.githubusercontent.com/254562/29647863-55b87b88-8859-11e7-907b-d6b9946a8366.png">
