### PR TITLE
Add React for CallSites JSX

### DIFF
--- a/src/components/Editor/CallSites.js
+++ b/src/components/Editor/CallSites.js
@@ -1,4 +1,4 @@
-import { Component } from "react";
+import React, { Component } from "react";
 import { connect } from "react-redux";
 import { bindActionCreators } from "redux";
 import { isEnabled } from "devtools-config";


### PR DESCRIPTION
By the book, we're supposed to add `React` to use JSX, so adding it in.