### PR TITLE
Fix 'copySource.accesskey' error when right-clicking

### DIFF
--- a/assets/panel/debugger.properties
+++ b/assets/panel/debugger.properties
@@ -20,7 +20,7 @@ copySource=Copy
 
 # LOCALIZATION NOTE (copy.accesskey): Access key to copy the source of a file from
 # the context menu.
-copySource=y
+copySource.accesskey=y
 
 # LOCALIZATION NOTE (copySourceUrl): This is the text that appears in the
 # context menu to copy the source URL of file open.


### PR DESCRIPTION
Right-clicking in the source area is currently triggering an error.  Looks like we accidentally mis-named a localization key.