### PR TITLE
Labels are aligned and keys are bold now

### DIFF
--- a/src/components/WelcomeBox.css
+++ b/src/components/WelcomeBox.css
@@ -15,6 +15,11 @@
   z-index: 100;
 }
 
+.alignlabel {
+  display: inline-block;
+  text-align: left;
+}
+
 .welcomebox .toggle-button-end {
   position: absolute;
   top: auto;

--- a/src/components/WelcomeBox.js
+++ b/src/components/WelcomeBox.js
@@ -39,29 +39,42 @@ class WelcomeBox extends Component {
   }
 
   render() {
-    const searchSourcesLabel = L10N.getFormatStr(
-      "welcome.search",
-      formatKeyShortcut(L10N.getStr("sources.search.key2"))
+    const keyCombinationOne = formatKeyShortcut(
+      L10N.getStr("sources.search.key2")
     );
 
-    const searchProjectLabel = L10N.getFormatStr(
-      "welcome.findInFiles",
-      formatKeyShortcut(L10N.getStr("projectTextSearch.key"))
+    const keyCombinationTwo = formatKeyShortcut(
+      L10N.getStr("projectTextSearch.key")
     );
+
+    const searchSourcesLabel = L10N.getStr("welcome.search").substring(2);
+    const searchProjectLabel = L10N.getStr("welcome.findInFiles").substring(2);
 
     const searchProjectLabelComp = (
       <div>
+        <b>
+          {keyCombinationTwo}
+        </b>
         {searchProjectLabel}
+      </div>
+    );
+
+    const searchSourcesLabelComp = (
+      <div>
+        <b>
+          {keyCombinationOne}
+        </b>
+        {searchSourcesLabel}
       </div>
     );
 
     return (
       <div className="welcomebox">
-        <div>
-          {searchSourcesLabel}
+        <div className="alignlabel">
+          {searchSourcesLabelComp}
+          {isEnabled("searchNav") ? searchProjectLabelComp : null}
+          {this.renderToggleButton()}
         </div>
-        {isEnabled("searchNav") ? searchProjectLabelComp : null}
-        {this.renderToggleButton()}
       </div>
     );
   }


### PR DESCRIPTION
Associated Issue: #3734

### Summary of Changes

* Two text labels are left-aligned 
* Keys Ctrl+P and Ctrl+Shift+F are bold 

### Screenshots/Videos (OPTIONAL)
![screenshot](https://user-images.githubusercontent.com/16086407/29694241-83a14472-8943-11e7-8ae0-a1b996a082a2.png)

