### PR TITLE
add prefer-const rule to eslint

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -212,6 +212,10 @@
     // Disallow use of multiline strings (use template strings instead).
     "no-multi-str": 2,
     "prefer-template": "error",
+    "prefer-const": ["error", {
+      "destructuring": "all",
+      "ignoreReadBeforeAssign": false
+    }],
     // Disallow reassignments of native objects.
     "no-native-reassign": 2,
     // Disallow nested ternary expressions, they make the code hard to read.

--- a/src/actions/breakpoints.js
+++ b/src/actions/breakpoints.js
@@ -106,7 +106,7 @@ export function addHiddenBreakpoint(location: Location) {
  */
 export function removeBreakpoint(location: Location) {
   return ({ dispatch, getState, client }: ThunkArgs) => {
-    let bp = getBreakpoint(getState(), location);
+    const bp = getBreakpoint(getState(), location);
     if (!bp) {
       throw new Error("attempt to remove breakpoint that does not exist");
     }
@@ -169,7 +169,7 @@ export function enableBreakpoint(location: Location) {
  */
 export function disableBreakpoint(location: Location) {
   return async ({ dispatch, getState, client }: ThunkArgs) => {
-    let bp = getBreakpoint(getState(), location);
+    const bp = getBreakpoint(getState(), location);
 
     if (!bp) {
       throw new Error("attempt to disable a breakpoint that does not exist");
@@ -200,7 +200,7 @@ export function disableBreakpoint(location: Location) {
 export function toggleAllBreakpoints(shouldDisableBreakpoints: boolean) {
   return async ({ dispatch, getState }: ThunkArgs) => {
     const breakpoints = getBreakpoints(getState());
-    for (let [, breakpoint] of breakpoints) {
+    for (const [, breakpoint] of breakpoints) {
       if (shouldDisableBreakpoints) {
         await dispatch(disableBreakpoint(breakpoint.location));
       } else {
@@ -221,7 +221,7 @@ export function toggleBreakpoints(
   breakpoints: BreakpointsMap
 ) {
   return async ({ dispatch }: ThunkArgs) => {
-    for (let [, breakpoint] of breakpoints) {
+    for (const [, breakpoint] of breakpoints) {
       if (shouldDisableBreakpoints) {
         await dispatch(disableBreakpoint(breakpoint.location));
       } else {
@@ -240,7 +240,7 @@ export function toggleBreakpoints(
 export function removeAllBreakpoints() {
   return async ({ dispatch, getState }: ThunkArgs) => {
     const breakpoints = getBreakpoints(getState());
-    for (let [, breakpoint] of breakpoints) {
+    for (const [, breakpoint] of breakpoints) {
       await dispatch(removeBreakpoint(breakpoint.location));
     }
   };
@@ -254,7 +254,7 @@ export function removeAllBreakpoints() {
  */
 export function removeBreakpoints(breakpoints: BreakpointsMap) {
   return async ({ dispatch }: ThunkArgs) => {
-    for (let [, breakpoint] of breakpoints) {
+    for (const [, breakpoint] of breakpoints) {
       await dispatch(removeBreakpoint(breakpoint.location));
     }
   };

--- a/src/actions/event-listeners.js
+++ b/src/actions/event-listeners.js
@@ -102,9 +102,9 @@ async function _getEventListeners(threadClient) {
   response.listeners.sort((a, b) => (a.type > b.type ? 1 : -1));
 
   // Add all the listeners in the debugger view event linsteners container.
-  let fetchedDefinitions = new Map();
-  let listeners = [];
-  for (let listener of response.listeners) {
+  const fetchedDefinitions = new Map();
+  const listeners = [];
+  for (const listener of response.listeners) {
     let definitionSite;
     if (fetchedDefinitions.has(listener.function.actor)) {
       definitionSite = fetchedDefinitions.get(listener.function.actor);

--- a/src/actions/expressions.js
+++ b/src/actions/expressions.js
@@ -89,7 +89,7 @@ export function evaluateExpressions(frameId: frameIdType) {
       const selectedFrame = getSelectedFrame(getState());
       frameId = selectedFrame ? selectedFrame.id : null;
     }
-    for (let expression of expressions) {
+    for (const expression of expressions) {
       await dispatch(evaluateExpression(expression, frameId));
     }
   };

--- a/src/actions/sources.js
+++ b/src/actions/sources.js
@@ -73,7 +73,7 @@ async function checkPendingBreakpoints(state, dispatch, source) {
   }
 
   const pendingBreakpointsArray = pendingBreakpoints.valueSeq().toJS();
-  for (let pendingBreakpoint of pendingBreakpointsArray) {
+  for (const pendingBreakpoint of pendingBreakpointsArray) {
     await checkPendingBreakpoint(state, dispatch, pendingBreakpoint, source);
   }
 }
@@ -101,7 +101,7 @@ export function newSources(sources: Source[]) {
       source => !getSource(getState(), source.id)
     );
 
-    for (let source of filteredSources) {
+    for (const source of filteredSources) {
       await dispatch(newSource(source));
     }
   };
@@ -119,7 +119,7 @@ function loadSourceMap(generatedSource) {
       return;
     }
 
-    let state = getState();
+    const state = getState();
     const originalSources = urls.map(originalUrl => {
       return {
         url: originalUrl,
@@ -179,7 +179,7 @@ export function selectSource(id: string, options: SelectSourceOptions = {}) {
       return;
     }
 
-    let source = getSource(getState(), id);
+    const source = getSource(getState(), id);
     if (!source) {
       // If there is no source we deselect the current selected source
       return dispatch({ type: "CLEAR_SELECTED_SOURCE" });

--- a/src/client/chrome/commands.js
+++ b/src/client/chrome/commands.js
@@ -65,7 +65,7 @@ function sourceContents(sourceId: string) {
 }
 
 async function setBreakpoint(location: Location, condition: string) {
-  let {
+  const {
     breakpointId,
     serverLocation
   }: setBreakpointResponseType = await debuggerAgent.setBreakpoint({

--- a/src/client/firefox.js
+++ b/src/client/firefox.js
@@ -13,7 +13,7 @@ export async function onConnect(connection: any, actions: Object) {
     return;
   }
 
-  let supportsWasm =
+  const supportsWasm =
     isEnabled("wasm") && !!debuggerClient.mainRoot.traits.wasmBinarySource;
 
   setupCommands({

--- a/src/client/firefox/commands.js
+++ b/src/client/firefox/commands.js
@@ -146,7 +146,7 @@ function setBreakpointCondition(
   condition: boolean,
   noSliding: boolean
 ) {
-  let bpClient = bpClients[breakpointId];
+  const bpClient = bpClients[breakpointId];
   delete bpClients[breakpointId];
 
   return bpClient

--- a/src/client/firefox/create.js
+++ b/src/client/firefox/create.js
@@ -12,7 +12,7 @@ import type {
 export function createFrame(frame: FramePacket): Frame {
   let title;
   if (frame.type == "call") {
-    let c = frame.callee;
+    const c = frame.callee;
     title = c.name || c.userDisplayName || c.displayName || "(anonymous)";
   } else {
     title = `(${frame.type})`;

--- a/src/components/Editor/ConditionalPanel.js
+++ b/src/components/Editor/ConditionalPanel.js
@@ -14,7 +14,7 @@ function renderConditionalPanel({
   closePanel: Function,
   setBreakpoint: Function
 }) {
-  let panel = document.createElement("div");
+  const panel = document.createElement("div");
   let input = null;
 
   function setInput(node) {

--- a/src/components/Editor/EditorMenu.js
+++ b/src/components/Editor/EditorMenu.js
@@ -95,7 +95,7 @@ function getMenuItems(
     return [blackBoxMenuItem];
   }
 
-  let menuItems = [
+  const menuItems = [
     copySource,
     copySourceUrl,
     jumpLabel,

--- a/src/components/Editor/GutterMenu.js
+++ b/src/components/Editor/GutterMenu.js
@@ -65,7 +65,7 @@ export default function GutterMenu({
       : gutterItems.addConditional
   );
 
-  let items = [toggleBreakpointItem, conditionalBreakpoint];
+  const items = [toggleBreakpointItem, conditionalBreakpoint];
 
   if (breakpoint) {
     const disableBreakpoint = Object.assign(

--- a/src/components/Editor/HitMarker.js
+++ b/src/components/Editor/HitMarker.js
@@ -1,10 +1,10 @@
 // @flow
 import { Component } from "react";
 
-let markerEl = document.createElement("div");
+const markerEl = document.createElement("div");
 
 function makeMarker() {
-  let marker = markerEl.cloneNode(true);
+  const marker = markerEl.cloneNode(true);
   marker.className = "editor hit-marker";
   return marker;
 }

--- a/src/components/Editor/Preview/Popup.js
+++ b/src/components/Editor/Preview/Popup.js
@@ -196,7 +196,7 @@ export class Popup extends Component {
   render() {
     const { popoverPos, onClose, value, expression } = this.props;
 
-    let type = this.getPreviewType(value);
+    const type = this.getPreviewType(value);
 
     return (
       <Popover targetPosition={popoverPos} onMouseLeave={onClose} type={type}>

--- a/src/components/Editor/Tabs.js
+++ b/src/components/Editor/Tabs.js
@@ -65,7 +65,7 @@ function getHiddenTabs(sourceTabs: SourcesList, sourceTabEls) {
  * https://dxr.mozilla.org/mozilla-central/source/devtools/shared/platform/content/clipboard.js
  */
 function copyToTheClipboard(string) {
-  let doCopy = function(e: any) {
+  const doCopy = function(e: any) {
     e.clipboardData.setData("text/plain", string);
     e.preventDefault();
   };
@@ -490,7 +490,7 @@ class SourceTabs extends PureComponent {
   }
 
   getSourceAnnotation(source) {
-    let sourceObj = source.toJS();
+    const sourceObj = source.toJS();
 
     if (isPretty(sourceObj)) {
       return Svg("prettyPrint");

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -270,9 +270,9 @@ class Editor extends PureComponent {
 
   onKeyDown(e) {
     const { codeMirror } = this.state.editor;
-    let { key, target } = e;
-    let codeWrapper = codeMirror.getWrapperElement();
-    let textArea = codeWrapper.querySelector("textArea");
+    const { key, target } = e;
+    const codeWrapper = codeMirror.getWrapperElement();
+    const textArea = codeWrapper.querySelector("textArea");
 
     if (key === "Escape" && target == textArea) {
       e.stopPropagation();
@@ -459,7 +459,7 @@ class Editor extends PureComponent {
     }
 
     const { sourceId, line: sourceLine } = this.pendingJumpLocation;
-    let line = toEditorLine(sourceId, sourceLine);
+    const line = toEditorLine(sourceId, sourceLine);
     this.state.editor.alignLine(line);
 
     // We only want to do the flashing animation if it's not a debug
@@ -488,7 +488,7 @@ class Editor extends PureComponent {
   getInlineEditorStyles() {
     const { selectedSource, horizontal, searchOn } = this.props;
 
-    let subtractions = [];
+    const subtractions = [];
 
     if (shouldShowFooter(selectedSource, horizontal)) {
       subtractions.push(cssVars.footerHeight);

--- a/src/components/PrimaryPanes/SourcesTree.js
+++ b/src/components/PrimaryPanes/SourcesTree.js
@@ -142,7 +142,7 @@ class SourcesTree extends Component {
     // later time, all expanded state is lost.
     let sourceTree = this.state.sourceTree;
     if (newSet.size > 0) {
-      for (let source of newSet) {
+      for (const source of newSet) {
         addToTree(uncollapsedTree, source, this.props.debuggeeUrl);
       }
       const unsortedTree = collapseTree(uncollapsedTree);

--- a/src/components/ProjectSearch/TextSearch.js
+++ b/src/components/ProjectSearch/TextSearch.js
@@ -124,8 +124,8 @@ export default class TextSearch extends Component {
     const { inputValue } = this.state;
     let match;
     const len = inputValue.length;
-    let matchIndexes = [];
-    let matches = [];
+    const matchIndexes = [];
+    const matches = [];
     const re = new RegExp(escapeRegExp(inputValue), "g");
     while ((match = re.exec(value)) !== null) {
       matchIndexes.push(match.index);

--- a/src/components/SecondaryPanes/Frames/index.js
+++ b/src/components/SecondaryPanes/Frames/index.js
@@ -150,7 +150,7 @@ class Frames extends Component {
   }
 
   renderToggleButton(frames: LocalFrame[]) {
-    let buttonMessage = this.state.showAllFrames
+    const buttonMessage = this.state.showAllFrames
       ? L10N.getStr("callStack.collapse")
       : L10N.getStr("callStack.expand");
 

--- a/src/components/shared/Autocomplete.js
+++ b/src/components/shared/Autocomplete.js
@@ -49,7 +49,7 @@ export default class Autocomplete extends Component {
   }
 
   getSearchResults() {
-    let inputValue = this.state.inputValue;
+    const inputValue = this.state.inputValue;
 
     if (inputValue == "") {
       return [];

--- a/src/components/shared/ResultList.js
+++ b/src/components/shared/ResultList.js
@@ -58,7 +58,7 @@ export default class ResultList extends Component {
   }
 
   render() {
-    let { size, items } = this.props;
+    const { size, items } = this.props;
 
     return (
       <ul className={classnames("result-list", size)}>

--- a/src/components/shared/previewFunction.js
+++ b/src/components/shared/previewFunction.js
@@ -29,7 +29,7 @@ function renderFunctionName(func: FunctionType) {
 
 function renderParams(func: FunctionType) {
   const { parameterNames = [] } = func;
-  let params = parameterNames
+  const params = parameterNames
     .filter(i => i)
     .map(param => dom.span({ className: "param" }, param));
 

--- a/src/components/stories/Preview.js
+++ b/src/components/stories/Preview.js
@@ -212,7 +212,7 @@ storiesOf("Preview", module)
     );
   })
   .add("Object with window keys", () => {
-    let grip = createObjectGrip("foo");
+    const grip = createObjectGrip("foo");
     grip.ownProperties.arr = createArrayPreview("arr");
     grip.ownProperties.location = createObjectPreview("location");
     return (
@@ -224,7 +224,7 @@ storiesOf("Preview", module)
     );
   })
   .add("Window Preview", () => {
-    let grip = createObjectGrip("foo");
+    const grip = createObjectGrip("foo");
     grip.class = "Window";
     grip.ownProperties.arr = createArrayPreview("arr");
     grip.ownProperties.location = createObjectPreview("location");
@@ -237,7 +237,7 @@ storiesOf("Preview", module)
     );
   })
   .add("Function Preview", () => {
-    let grip = createFunctionGrip("renderFoo", ["props", "state"]);
+    const grip = createFunctionGrip("renderFoo", ["props", "state"]);
     return (
       <PreviewFactory
         value={grip}

--- a/src/reducers/pause.js
+++ b/src/reducers/pause.js
@@ -49,7 +49,7 @@ function update(state: PauseState = State(), action: Action): PauseState {
       const frameScopes = { [selectedFrameId]: scopes };
 
       // turn this into an object keyed by object id
-      let objectMap = {};
+      const objectMap = {};
       loadedObjects.forEach(obj => {
         objectMap[obj.value.objectId] = obj;
       });

--- a/src/reducers/sources.js
+++ b/src/reducers/sources.js
@@ -190,7 +190,7 @@ export function removeSourcesFromTabList(tabs: any, urls: Array<string>) {
 }
 
 function restoreTabs() {
-  let prefsTabs = prefs.tabs || [];
+  const prefsTabs = prefs.tabs || [];
   if (prefsTabs.length == 0) {
     return;
   }

--- a/src/utils/DevToolsUtils.js
+++ b/src/utils/DevToolsUtils.js
@@ -1,7 +1,7 @@
 import assert from "./assert";
 
 export function reportException(who, exception) {
-  let msg = `${who} threw an exception: `;
+  const msg = `${who} threw an exception: `;
   console.error(msg, exception);
 }
 

--- a/src/utils/breakpoint/index.js
+++ b/src/utils/breakpoint/index.js
@@ -16,7 +16,7 @@ import type { SourceRecord, State } from "../../reducers/types";
 // Return the first argument that is a string, or null if nothing is a
 // string.
 export function firstString(...args: string[]) {
-  for (let arg of args) {
+  for (const arg of args) {
     if (typeof arg === "string") {
       return arg;
     }

--- a/src/utils/clipboard.js
+++ b/src/utils/clipboard.js
@@ -3,7 +3,7 @@
  * https://dxr.mozilla.org/mozilla-central/source/devtools/shared/platform/content/clipboard.js
  */
 function copyToTheClipboard(string) {
-  let doCopy = function(e) {
+  const doCopy = function(e) {
     e.clipboardData.setData("text/plain", string);
     e.preventDefault();
   };

--- a/src/utils/editor/source-documents.js
+++ b/src/utils/editor/source-documents.js
@@ -24,7 +24,7 @@ function clearDocuments() {
 }
 
 function resetLineNumberFormat(editor: Object) {
-  let cm = editor.codeMirror;
+  const cm = editor.codeMirror;
   cm.setOption("lineNumberFormatter", number => number);
 }
 
@@ -33,8 +33,8 @@ function updateLineNumberFormat(editor: Object, sourceId: string) {
     resetLineNumberFormat(editor);
     return;
   }
-  let cm = editor.codeMirror;
-  let lineNumberFormatter = getWasmLineNumberFormatter(sourceId);
+  const cm = editor.codeMirror;
+  const lineNumberFormatter = getWasmLineNumberFormatter(sourceId);
   cm.setOption("lineNumberFormatter", lineNumberFormatter);
 }
 

--- a/src/utils/editor/source-search.js
+++ b/src/utils/editor/source-search.js
@@ -28,7 +28,7 @@ function SearchState() {
  * @static
  */
 function getSearchState(cm: any, query, modifiers) {
-  let state = cm.state.search || (cm.state.search = new SearchState());
+  const state = cm.state.search || (cm.state.search = new SearchState());
   return state;
 }
 
@@ -175,10 +175,10 @@ function getCursorPos(newQuery, rev, state) {
  * @static
  */
 function searchNext(ctx, rev, query, newQuery, modifiers) {
-  let { cm, ed } = ctx;
+  const { cm, ed } = ctx;
   let nextMatch;
   cm.operation(function() {
-    let state = getSearchState(cm, query, modifiers);
+    const state = getSearchState(cm, query, modifiers);
     const pos = getCursorPos(newQuery, rev, state);
 
     if (!state.query) {
@@ -218,7 +218,7 @@ function searchNext(ctx, rev, query, newQuery, modifiers) {
  * @static
  */
 function removeOverlay(ctx: any, query: string, modifiers: SearchModifiers) {
-  let state = getSearchState(ctx.cm, query, modifiers);
+  const state = getSearchState(ctx.cm, query, modifiers);
   ctx.cm.removeOverlay(state.overlay);
   const { line, ch } = ctx.cm.getCursor();
   ctx.cm.doc.setSelection({ line, ch }, { line, ch }, { scroll: false });
@@ -231,7 +231,7 @@ function removeOverlay(ctx: any, query: string, modifiers: SearchModifiers) {
  * @static
  */
 function clearSearch(cm, query: string, modifiers: SearchModifiers) {
-  let state = getSearchState(cm, query, modifiers);
+  const state = getSearchState(cm, query, modifiers);
 
   state.results = [];
 

--- a/src/utils/frame.js
+++ b/src/utils/frame.js
@@ -219,8 +219,8 @@ export function simplifyDisplayName(displayName: string) {
     annonymousProperty
   ];
 
-  for (let reg of scenarios) {
-    let match = reg.exec(displayName);
+  for (const reg of scenarios) {
+    const match = reg.exec(displayName);
     if (match) {
       return match[1];
     }

--- a/src/utils/pause.js
+++ b/src/utils/pause.js
@@ -48,7 +48,7 @@ export function getPauseReason(pauseInfo: Pause): string | null {
     return null;
   }
 
-  let reasonType = get(pauseInfo, "why.type", null);
+  const reasonType = get(pauseInfo, "why.type", null);
   if (!reasons[reasonType]) {
     console.log("Please file an issue: reasonType=", reasonType);
   }

--- a/src/utils/pretty-print/worker.js
+++ b/src/utils/pretty-print/worker.js
@@ -39,7 +39,7 @@ function prettyPrint({ url, indent, source }) {
 
 function invertMappings(mappings: Mappings) {
   return mappings._array.map((m: Mapping) => {
-    let mapping: InvertedMapping = {
+    const mapping: InvertedMapping = {
       generated: {
         line: m.originalLine,
         column: m.originalColumn

--- a/src/utils/redux/middleware/wait-service.js
+++ b/src/utils/redux/middleware/wait-service.js
@@ -28,15 +28,15 @@ export function waitUntilService({ dispatch, getState }: ThunkArgs) {
   let pending = [];
 
   function checkPending(action) {
-    let readyRequests = [];
-    let stillPending = [];
+    const readyRequests = [];
+    const stillPending = [];
 
     // Find the pending requests whose predicates are satisfied with
     // this action. Wait to run the requests until after we update the
     // pending queue because the request handler may synchronously
     // dispatch again and run this service (that use case is
     // completely valid).
-    for (let request of pending) {
+    for (const request of pending) {
       if (request.predicate(action)) {
         readyRequests.push(request);
       } else {
@@ -45,7 +45,7 @@ export function waitUntilService({ dispatch, getState }: ThunkArgs) {
     }
 
     pending = stillPending;
-    for (let request of readyRequests) {
+    for (const request of readyRequests) {
       request.run(dispatch, getState, action);
     }
   }
@@ -55,7 +55,7 @@ export function waitUntilService({ dispatch, getState }: ThunkArgs) {
       pending.push(action);
       return null;
     }
-    let result = next(action);
+    const result = next(action);
     checkPending(action);
     return result;
   };

--- a/src/utils/scopes.js
+++ b/src/utils/scopes.js
@@ -24,9 +24,9 @@ function getBindingVariables(bindings, parentName) {
 }
 
 export function getSpecialVariables(pauseInfo: Pause, path: string) {
-  let thrown = get(pauseInfo, "why.frameFinished.throw", undefined);
+  const thrown = get(pauseInfo, "why.frameFinished.throw", undefined);
 
-  let returned = get(pauseInfo, "why.frameFinished.return", undefined);
+  const returned = get(pauseInfo, "why.frameFinished.return", undefined);
 
   const vars = [];
 
@@ -86,7 +86,7 @@ export function getScopes(
   const scopes = [];
 
   let scope = selectedScope;
-  let pausedScopeActor = get(pauseInfo, "frame.scope.actor");
+  const pausedScopeActor = get(pauseInfo, "frame.scope.actor");
   let scopeIndex = 1;
 
   do {
@@ -109,7 +109,7 @@ export function getScopes(
       }
 
       if (scope.actor === selectedScope.actor) {
-        let this_ = getThisVariable(selectedFrame, key);
+        const this_ = getThisVariable(selectedFrame, key);
 
         if (this_) {
           vars.push(this_);

--- a/src/utils/source.js
+++ b/src/utils/source.js
@@ -19,11 +19,11 @@ import type { Source } from "../types";
  * @static
  */
 function trimUrlQuery(url: string): string {
-  let length = url.length;
-  let q1 = url.indexOf("?");
-  let q2 = url.indexOf("&");
-  let q3 = url.indexOf("#");
-  let q = Math.min(
+  const length = url.length;
+  const q1 = url.indexOf("?");
+  const q2 = url.indexOf("&");
+  const q3 = url.indexOf("#");
+  const q = Math.min(
     q1 != -1 ? q1 : length,
     q2 != -1 ? q2 : length,
     q3 != -1 ? q3 : length
@@ -107,7 +107,7 @@ function getFilenameFromURL(url: string) {
  * @static
  */
 function getFilename(source: Source) {
-  let { url, id } = source;
+  const { url, id } = source;
   if (!url) {
     const sourceId = id.split("/")[1];
     return `SOURCE${sourceId}`;

--- a/src/utils/sources-tree/createTree.js
+++ b/src/utils/sources-tree/createTree.js
@@ -9,7 +9,7 @@ import type { SourcesMap } from "../../reducers/types";
 
 export function createTree(sources: SourcesMap, debuggeeUrl: string) {
   const uncollapsedTree = createNode("root", "", []);
-  for (let source of sources.valueSeq()) {
+  for (const source of sources.valueSeq()) {
     addToTree(uncollapsedTree, source, debuggeeUrl);
   }
 

--- a/src/utils/sources-tree/getDirectories.js
+++ b/src/utils/sources-tree/getDirectories.js
@@ -8,7 +8,7 @@ function findSource(sourceTree: Node, sourceUrl: string): Node {
   let returnTarget = null;
   function _traverse(subtree) {
     if (nodeHasChildren(subtree)) {
-      for (let child of subtree.contents) {
+      for (const child of subtree.contents) {
         _traverse(child);
       }
     } else if (!returnTarget) {
@@ -38,7 +38,7 @@ export function getDirectories(sourceUrl: string, sourceTree: Node) {
   }
 
   let node = source;
-  let directories = [];
+  const directories = [];
   directories.push(source);
   while (true) {
     node = parentMap.get(node);

--- a/src/utils/sources-tree/getURL.js
+++ b/src/utils/sources-tree/getURL.js
@@ -17,7 +17,7 @@ export function getFilenameFromPath(pathname?: string) {
 
 export function getURL(sourceUrl: string): { path: string, group: string } {
   const url = sourceUrl;
-  let def = { path: "", group: "", filename: "" };
+  const def = { path: "", group: "", filename: "" };
   if (!url) {
     return def;
   }

--- a/src/utils/sources-tree/tests/addToTree.spec.js
+++ b/src/utils/sources-tree/tests/addToTree.spec.js
@@ -54,15 +54,15 @@ describe("sources-tree", () => {
       addToTree(tree, source1);
       expect(tree.contents.length).toBe(1);
 
-      let base = tree.contents[0];
+      const base = tree.contents[0];
       expect(base.name).toBe("example.com");
       expect(base.contents.length).toBe(1);
 
-      let fooNode = base.contents[0];
+      const fooNode = base.contents[0];
       expect(fooNode.name).toBe("foo");
       expect(fooNode.contents.length).toBe(1);
 
-      let source1Node = fooNode.contents[0];
+      const source1Node = fooNode.contents[0];
       expect(source1Node.name).toBe("source1.js");
     });
 
@@ -125,10 +125,10 @@ describe("sources-tree", () => {
       addToTree(tree, source2);
       addToTree(tree, source3);
 
-      let base = tree.contents[0];
+      const base = tree.contents[0];
       expect(tree.contents.length).toBe(1);
 
-      let source1Node = base.contents[0];
+      const source1Node = base.contents[0];
       expect(source1Node.name).toBe("source1.js");
       expect(formatTree(tree)).toMatchSnapshot();
     });
@@ -143,7 +143,7 @@ describe("sources-tree", () => {
       addToTree(tree, source);
       expect(tree.contents.length).toBe(1);
 
-      let base = tree.contents[0];
+      const base = tree.contents[0];
       expect(base.name).toBe("file://");
       expect(base.contents.length).toBe(1);
 

--- a/src/utils/sources-tree/tests/sortTree.spec.js
+++ b/src/utils/sources-tree/tests/sortTree.spec.js
@@ -26,17 +26,17 @@ describe("sources-tree", () => {
       addToTree(_tree, source3);
       const tree = sortEntireTree(_tree);
 
-      let base = tree.contents[0];
-      let fooNode = base.contents[0];
+      const base = tree.contents[0];
+      const fooNode = base.contents[0];
       expect(fooNode.name).toBe("foo");
       expect(fooNode.contents.length).toBe(2);
 
-      let source1Node = base.contents[1];
+      const source1Node = base.contents[1];
       expect(source1Node.name).toBe("source1.js");
 
       // source2 should be after source1 alphabetically
-      let source2Node = fooNode.contents[1];
-      let source3Node = fooNode.contents[0];
+      const source2Node = fooNode.contents[1];
+      const source3Node = fooNode.contents[0];
       expect(source2Node.name).toBe("b_source2.js");
       expect(source3Node.name).toBe("a_source3.js");
       expect(formatTree(tree)).toMatchSnapshot();

--- a/src/utils/sources-tree/utils.js
+++ b/src/utils/sources-tree/utils.js
@@ -62,7 +62,7 @@ export function createParentMap(tree: Node): WeakMap<Node, Node> {
 
   function _traverse(subtree) {
     if (nodeHasChildren(subtree)) {
-      for (let child of subtree.contents) {
+      for (const child of subtree.contents) {
         map.set(child, subtree);
         _traverse(child);
       }

--- a/src/utils/wasm.js
+++ b/src/utils/wasm.js
@@ -15,18 +15,18 @@ var wasmStates: { [string]: WasmState } = Object.create(null);
  * @static
  */
 function getWasmText(sourceId: string, data: Uint8Array) {
-  let parser = new BinaryReader();
+  const parser = new BinaryReader();
   parser.setData(data.buffer, 0, data.length);
-  let dis = new WasmDisassembler();
+  const dis = new WasmDisassembler();
   dis.addOffsets = true;
-  let done = dis.disassembleChunk(parser);
+  const done = dis.disassembleChunk(parser);
   let result = dis.getResult();
   if (result.lines.length === 0) {
     result = { lines: ["No luck with wast conversion"], offsets: [0], done };
   }
 
-  let offsets = result.offsets,
-    lines = [];
+  const offsets = result.offsets;
+  const lines = [];
   for (let i = 0; i < offsets.length; i++) {
     lines[offsets[i]] = i;
   }
@@ -43,7 +43,7 @@ function getWasmText(sourceId: string, data: Uint8Array) {
 function getWasmLineNumberFormatter(sourceId: string) {
   const codeOf0 = 48,
     codeOfA = 65;
-  let buffer = [
+  const buffer = [
     codeOf0,
     codeOf0,
     codeOf0,
@@ -55,13 +55,13 @@ function getWasmLineNumberFormatter(sourceId: string) {
   ];
   let last0 = 7;
   return function(number: number) {
-    let offset = lineToWasmOffset(sourceId, number - 1);
+    const offset = lineToWasmOffset(sourceId, number - 1);
     if (offset == undefined) {
       return "";
     }
     let i = 7;
     for (let n = offset; n !== 0 && i >= 0; n >>= 4, i--) {
-      let nibble = n & 15;
+      const nibble = n & 15;
       buffer[i] = nibble < 10 ? codeOf0 + nibble : codeOfA - 10 + nibble;
     }
     for (let j = i; j > last0; j--) {
@@ -85,7 +85,7 @@ function isWasm(sourceId: string) {
  * @static
  */
 function lineToWasmOffset(sourceId: string, number: number): ?number {
-  let wasmState = wasmStates[sourceId];
+  const wasmState = wasmStates[sourceId];
   if (!wasmState) {
     return undefined;
   }
@@ -101,7 +101,7 @@ function lineToWasmOffset(sourceId: string, number: number): ?number {
  * @static
  */
 function wasmOffsetToLine(sourceId: string, offset: number): ?number {
-  let wasmState = wasmStates[sourceId];
+  const wasmState = wasmStates[sourceId];
   if (!wasmState) {
     return undefined;
   }
@@ -118,11 +118,11 @@ function clearWasmStates() {
 
 function renderWasmText(sourceId: string, { binary }: Object) {
   // binary does not survive as Uint8Array, converting from string
-  let data = new Uint8Array(binary.length);
+  const data = new Uint8Array(binary.length);
   for (let i = 0; i < data.length; i++) {
     data[i] = binary.charCodeAt(i);
   }
-  let { lines } = getWasmText(sourceId, data);
+  const { lines } = getWasmText(sourceId, data);
   const MAX_LINES = 100000;
   if (lines.length > MAX_LINES) {
     lines.splice(MAX_LINES, lines.length - MAX_LINES);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,7 +15,7 @@ function getEntry(filename) {
   return [path.join(projectPath, filename)];
 }
 
-let webpackConfig = {
+const webpackConfig = {
   entry: {
     debugger: getEntry("main.js"),
     "parser-worker": getEntry("utils/parser/worker.js"),
@@ -43,7 +43,7 @@ let webpackConfig = {
 };
 
 function buildConfig(envConfig) {
-  let extra = {};
+  const extra = {};
   if (isDevelopment()) {
     webpackConfig.plugins = [];
   } else {


### PR DESCRIPTION
This adds prefer-const to the eslint config. This will throw an error if a variable that is never reassigned is assigned via let. I kept the rule loose, so if you have an array destructuring or similar it will not complain (though we might want to revisit it, and enforce it there too);

Why: this will improve fast reading of the code. You will be able to rely on `let` to indicate a variable that will change over the course of the block you are looking at, which allows you to save brain processing power.

filed under code health!