### PR TITLE
autofix simple eslint errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "links": "ls -l node_modules/ | grep ^l || echo 'no linked packages'",
     "lint": "run-p lint-css lint-js lint-md",
     "lint-css": "stylelint \"src/components/**/*.css\"",
-    "lint-js": "eslint *.js \"src/**/*.js\"",
+    "lint-js": "eslint *.js \"src/**/*.js\" --fix",
     "lint-md": "remark -qf *.md src configs docs",
     "lint-fix": "yarn lint-js -- --fix",
     "mochi": "node bin/mochi.js",


### PR DESCRIPTION
this will automatically fix things like incorrectly declared vars, missing semicolons, etc

it will not automatically fix things that are more complex, so eslint might still throw errors that need human intervention. 

Why: this will save everyone frustration from eslint!

filed under codehealth!