### PR TITLE
Issue #3795 - create CODEOWNERS file, assign @flodolo to debugger.pro…

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# flod as main contact for string changes - TODO: find more to spread the effort
+assets/panel/debugger.properties @flodolo


### PR DESCRIPTION
Associated Issue: #3795

This adds a CODEOWNERS file for the project, currently only containing a rule for @flodolo and assets/panel/debugger.properties