### PR TITLE
[wip] disable original bp corrections

### DIFF
--- a/src/actions/breakpoints/addBreakpoint.js
+++ b/src/actions/breakpoints/addBreakpoint.js
@@ -8,6 +8,8 @@ import {
 import { getSource } from "../../selectors";
 
 async function _getGeneratedLocation(state, source, sourceMaps, location) {
+  console.log("gen loc", Object.keys(state.sources.sources.toJS()).join("\n"));
+
   const generatedLocation = await getGeneratedLocation(
     source,
     sourceMaps,

--- a/src/actions/breakpoints/syncBreakpoint.js
+++ b/src/actions/breakpoints/syncBreakpoint.js
@@ -59,16 +59,16 @@ export async function syncClientBreakpoint(
   const existingClient = client.getBreakpointByLocation(generatedLocation);
 
   if (existingClient) {
-    const newGeneratedLocation = existingClient.actualLocation;
-    const newLocation = await sourceMaps.getOriginalLocation(
-      newGeneratedLocation
-    );
+    // const newGeneratedLocation = existingClient.actualLocation;
+    // const newLocation = await sourceMaps.getOriginalLocation(
+    //   newGeneratedLocation
+    // );
 
     const breakpoint = {
       ...pendingBreakpoint,
-      id: makeLocationId(newLocation),
-      generatedLocation: newGeneratedLocation,
-      location: newLocation
+      id: makeLocationId(location),
+      generatedLocation: generatedLocation,
+      location: location
     };
 
     assertBreakpoint(breakpoint);

--- a/src/actions/sources.js
+++ b/src/actions/sources.js
@@ -90,6 +90,10 @@ export function newSource(source: Source) {
       await dispatch(loadSourceMap(source));
     }
 
+    console.log(
+      "NEW SOURCE",
+      Object.keys(getState().sources.sources.toJS()).join("\n")
+    );
     checkSelectedSource(getState(), dispatch, source);
     await checkPendingBreakpoints(getState(), dispatch, source);
   };

--- a/src/client/firefox/commands.js
+++ b/src/client/firefox/commands.js
@@ -31,6 +31,8 @@ let tabTarget: TabTarget;
 let debuggerClient: DebuggerClient;
 let supportsWasm: boolean;
 
+window.bpc = bpClients;
+
 type Dependencies = {
   threadClient: ThreadClient,
   tabTarget: TabTarget,


### PR DESCRIPTION
Associated Issue: #3682

### Summary of Changes

* this is a short term fix, which will be easier to uplift. Instead of trying to keep the bp in the same location, we let it move... Should be easier to uplift
