### PR TITLE
Add breakpoint or toggle enabled state on Shift+Click

### DIFF
--- a/src/actions/breakpoints.js
+++ b/src/actions/breakpoints.js
@@ -360,6 +360,33 @@ export function toggleBreakpoint(line: number, column?: number) {
   };
 }
 
+export function addOrToggleDisabledBreakpoint(line: number, column?: number) {
+  return ({ dispatch, getState, client, sourceMaps }: ThunkArgs) => {
+    const selectedSource = getSelectedSource(getState());
+    const bp = getBreakpointAtLocation(getState(), { line, column });
+
+    if (bp && bp.loading) {
+      return;
+    }
+
+    if (bp) {
+      // NOTE: it's possible the breakpoint has slid to a column
+      return dispatch(
+        toggleDisabledBreakpoint(line, column || bp.location.column)
+      );
+    }
+
+    return dispatch(
+      addBreakpoint({
+        sourceId: selectedSource.get("id"),
+        sourceUrl: selectedSource.get("url"),
+        line: line,
+        column: column
+      })
+    );
+  };
+}
+
 export function toggleDisabledBreakpoint(line: number, column?: number) {
   return ({ dispatch, getState, client, sourceMaps }: ThunkArgs) => {
     const bp = getBreakpointAtLocation(getState(), { line, column });

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -346,7 +346,7 @@ class Editor extends PureComponent {
   }
 
   onGutterClick(cm, line, gutter, ev) {
-    const { selectedSource, toggleBreakpoint } = this.props;
+    const { selectedSource, toggleBreakpoint, addOrToggleDisabledBreakpoint } = this.props;
 
     // ignore right clicks in the gutter
     if (
@@ -366,7 +366,11 @@ class Editor extends PureComponent {
     }
 
     if (gutter !== "CodeMirror-foldgutter") {
-      toggleBreakpoint(toSourceLine(selectedSource.get("id"), line));
+      if (ev.shiftKey) {
+        addOrToggleDisabledBreakpoint(toSourceLine(selectedSource.get("id"), line));
+      } else {
+        toggleBreakpoint(toSourceLine(selectedSource.get("id"), line));
+      }
     }
   }
 
@@ -707,6 +711,7 @@ Editor.propTypes = {
   endPanelSize: PropTypes.number,
   linesInScope: PropTypes.array,
   toggleBreakpoint: PropTypes.func.isRequired,
+  addOrToggleDisabledBreakpoint: PropTypes.func.isRequired,
   toggleDisabledBreakpoint: PropTypes.func.isRequired
 };
 


### PR DESCRIPTION
Associated Issue: #3801 

I mimic the Chrome behavior:

- add a breakpoint if there is none
- disable or enable breakpoint when Shift+Click on an existing one
![shift_click](https://user-images.githubusercontent.com/2511026/29815002-8020ba5c-8caf-11e7-9bae-414edc4412a2.gif)
