### PR TITLE
Save source-search query in store

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -10,6 +10,7 @@ import * as ui from "./ui";
 import * as ast from "./ast";
 import * as coverage from "./coverage";
 import * as projectTextSearch from "./project-text-search";
+import * as sourceSearch from "./source-search";
 
 export default Object.assign(
   {},
@@ -22,5 +23,6 @@ export default Object.assign(
   ui,
   ast,
   coverage,
-  projectTextSearch
+  projectTextSearch,
+  sourceSearch
 );

--- a/src/actions/source-search.js
+++ b/src/actions/source-search.js
@@ -1,0 +1,18 @@
+import type { ThunkArgs } from "./types";
+
+export function setSourceSearchQueryString(queryString: string) {
+  return ({ dispatch, getState }: ThunkArgs) => {
+    dispatch({
+      type: "SET_QUERY_STRING",
+      queryString
+    });
+  };
+}
+
+export function clearSourceSearchQueryString() {
+  return ({ dispatch, getState }: ThunkArgs) => {
+    dispatch({
+      type: "CLEAR_QUERY_STRING"
+    });
+  };
+}

--- a/src/actions/source-search.js
+++ b/src/actions/source-search.js
@@ -1,6 +1,6 @@
 import type { ThunkArgs } from "./types";
 
-export function setSourceSearchQueryString(queryString: string) {
+export function setSourceSearchQuery(queryString: string) {
   return ({ dispatch, getState }: ThunkArgs) => {
     dispatch({
       type: "SET_QUERY_STRING",
@@ -9,7 +9,7 @@ export function setSourceSearchQueryString(queryString: string) {
   };
 }
 
-export function clearSourceSearchQueryString() {
+export function clearSourceSearchQuery() {
   return ({ dispatch, getState }: ThunkArgs) => {
     dispatch({
       type: "CLEAR_QUERY_STRING"

--- a/src/components/ProjectSearch/SourceSearch.js
+++ b/src/components/ProjectSearch/SourceSearch.js
@@ -14,7 +14,7 @@ export default class SourceSearch extends Component {
     sources: Object,
     searchBottomBar: Object,
     queryString: string,
-    queryStringChangeHandler: (queryString: string) => void,
+    setSourceSearchQuery: (queryString: string) => void,
     clearQueryString: () => void
   };
 
@@ -69,7 +69,7 @@ export default class SourceSearch extends Component {
       searchBottomBar,
       selectSource,
       queryString,
-      queryStringChangeHandler
+      setSourceSearchQuery
     } = this.props;
     return (
       <Autocomplete
@@ -81,7 +81,7 @@ export default class SourceSearch extends Component {
         items={this.searchResults(sources)}
         inputValue={queryString}
         placeholder={L10N.getStr("sourceSearch.search")}
-        onChangeHandler={queryStringChangeHandler}
+        onChangeHandler={setSourceSearchQuery}
         size="big"
       >
         {searchBottomBar}

--- a/src/components/ProjectSearch/SourceSearch.js
+++ b/src/components/ProjectSearch/SourceSearch.js
@@ -13,9 +13,9 @@ export default class SourceSearch extends Component {
     selectSource: string => any,
     sources: Object,
     searchBottomBar: Object,
-    queryString: string,
-    setSourceSearchQuery: (queryString: string) => void,
-    clearQueryString: () => void
+    query: string,
+    setQuery: (query: string) => void,
+    clearQuery: () => void
   };
 
   onEscape: Function;
@@ -52,14 +52,16 @@ export default class SourceSearch extends Component {
       .filter(source => !isPretty(source))
       .map(source => ({
         value: getSourcePath(source),
-        title: getSourcePath(source).split("/").pop(),
+        title: getSourcePath(source)
+          .split("/")
+          .pop(),
         subtitle: endTruncateStr(getSourcePath(source), 100),
         id: source.id
       }));
   }
 
   close() {
-    this.props.clearQueryString();
+    this.props.clearQuery();
     this.props.closeActiveSearch();
   }
 
@@ -68,8 +70,8 @@ export default class SourceSearch extends Component {
       sources,
       searchBottomBar,
       selectSource,
-      queryString,
-      setSourceSearchQuery
+      query,
+      setQuery
     } = this.props;
     return (
       <Autocomplete
@@ -79,9 +81,9 @@ export default class SourceSearch extends Component {
         }}
         close={this.close}
         items={this.searchResults(sources)}
-        inputValue={queryString}
+        inputValue={query}
         placeholder={L10N.getStr("sourceSearch.search")}
-        onChangeHandler={setSourceSearchQuery}
+        onChangeHandler={setQuery}
         size="big"
       >
         {searchBottomBar}

--- a/src/components/ProjectSearch/SourceSearch.js
+++ b/src/components/ProjectSearch/SourceSearch.js
@@ -58,7 +58,7 @@ export default class SourceSearch extends Component {
   }
 
   close() {
-    this.setState({ inputValue: "" });
+    this.props.clearSourceSearchQueryString();
     this.props.closeActiveSearch();
   }
 

--- a/src/components/ProjectSearch/SourceSearch.js
+++ b/src/components/ProjectSearch/SourceSearch.js
@@ -12,7 +12,9 @@ export default class SourceSearch extends Component {
     closeActiveSearch: () => any,
     selectSource: string => any,
     sources: Object,
-    searchBottomBar: Object
+    searchBottomBar: Object,
+    queryString: string,
+    queryStringChangeHandler: (queryString: string) => void
   };
 
   onEscape: Function;
@@ -23,10 +25,6 @@ export default class SourceSearch extends Component {
     super(props);
 
     this.close = this.close.bind(this);
-
-    this.state = {
-      inputValue: ""
-    };
   }
 
   componentWillUnmount() {
@@ -65,7 +63,13 @@ export default class SourceSearch extends Component {
   }
 
   render() {
-    const { sources, searchBottomBar, selectSource } = this.props;
+    const {
+      sources,
+      searchBottomBar,
+      selectSource,
+      queryString,
+      queryStringChangeHandler
+    } = this.props;
     return (
       <Autocomplete
         selectItem={(e, result) => {
@@ -74,8 +78,9 @@ export default class SourceSearch extends Component {
         }}
         close={this.close}
         items={this.searchResults(sources)}
-        inputValue={this.state.inputValue}
+        inputValue={queryString}
         placeholder={L10N.getStr("sourceSearch.search")}
+        onChangeHandler={queryStringChangeHandler}
         size="big"
       >
         {searchBottomBar}

--- a/src/components/ProjectSearch/SourceSearch.js
+++ b/src/components/ProjectSearch/SourceSearch.js
@@ -15,7 +15,7 @@ export default class SourceSearch extends Component {
     searchBottomBar: Object,
     queryString: string,
     queryStringChangeHandler: (queryString: string) => void,
-    clearSourceSearchQueryString: () => void
+    clearQueryString: () => void
   };
 
   onEscape: Function;
@@ -59,7 +59,7 @@ export default class SourceSearch extends Component {
   }
 
   close() {
-    this.props.clearSourceSearchQueryString();
+    this.props.clearQueryString();
     this.props.closeActiveSearch();
   }
 

--- a/src/components/ProjectSearch/SourceSearch.js
+++ b/src/components/ProjectSearch/SourceSearch.js
@@ -14,7 +14,8 @@ export default class SourceSearch extends Component {
     sources: Object,
     searchBottomBar: Object,
     queryString: string,
-    queryStringChangeHandler: (queryString: string) => void
+    queryStringChangeHandler: (queryString: string) => void,
+    clearSourceSearchQueryString: () => void
   };
 
   onEscape: Function;

--- a/src/components/ProjectSearch/index.js
+++ b/src/components/ProjectSearch/index.js
@@ -172,7 +172,10 @@ ProjectSearch.propTypes = {
   closeActiveSearch: PropTypes.func.isRequired,
   searchSources: PropTypes.func,
   activeSearch: PropTypes.string,
-  selectSource: PropTypes.func.isRequired
+  selectSource: PropTypes.func.isRequired,
+  sourceSearchQueryString: PropTypes.string,
+  setSourceSearchQueryString: PropTypes.func,
+  clearSourceSearchQueryString: PropTypes.func
 };
 
 ProjectSearch.contextTypes = {

--- a/src/components/ProjectSearch/index.js
+++ b/src/components/ProjectSearch/index.js
@@ -100,7 +100,13 @@ class ProjectSearch extends Component {
   }
 
   renderSourceSearch() {
-    const { sources, selectSource, closeActiveSearch } = this.props;
+    const {
+      sources,
+      selectSource,
+      closeActiveSearch,
+      query,
+      addSearchQuery
+    } = this.props;
     return (
       <SourceSearch
         sources={sources}
@@ -109,6 +115,8 @@ class ProjectSearch extends Component {
         searchBottomBar={
           <ToggleSearch kind="sources" toggle={this.toggleProjectTextSearch} />
         }
+        queryString={query}
+        queryStringChangeHandler={addSearchQuery}
       />
     );
   }
@@ -175,7 +183,7 @@ export default connect(
     sources: getSources(state),
     activeSearch: getActiveSearchState(state),
     results: getTextSearchResults(state),
-    query: getTextSearchQuery(state)
+    query: getTextSearchQuery(state) || ""
   }),
   dispatch => bindActionCreators(actions, dispatch)
 )(ProjectSearch);

--- a/src/components/ProjectSearch/index.js
+++ b/src/components/ProjectSearch/index.js
@@ -106,8 +106,8 @@ class ProjectSearch extends Component {
       selectSource,
       closeActiveSearch,
       sourceSearchQueryString,
-      setSourceSearchQueryString,
-      clearSourceSearchQueryString
+      setSourceSearchQuery,
+      clearSourceSearchQuery
     } = this.props;
     return (
       <SourceSearch
@@ -118,8 +118,8 @@ class ProjectSearch extends Component {
           <ToggleSearch kind="sources" toggle={this.toggleProjectTextSearch} />
         }
         queryString={sourceSearchQueryString}
-        queryStringChangeHandler={setSourceSearchQueryString}
-        clearQueryString={clearSourceSearchQueryString}
+        setSourceSearchQuery={setSourceSearchQuery}
+        clearQueryString={clearSourceSearchQuery}
       />
     );
   }
@@ -174,8 +174,8 @@ ProjectSearch.propTypes = {
   activeSearch: PropTypes.string,
   selectSource: PropTypes.func.isRequired,
   sourceSearchQueryString: PropTypes.string,
-  setSourceSearchQueryString: PropTypes.func,
-  clearSourceSearchQueryString: PropTypes.func
+  setSourceSearchQuery: PropTypes.func,
+  clearSourceSearchQuery: PropTypes.func
 };
 
 ProjectSearch.contextTypes = {

--- a/src/components/ProjectSearch/index.js
+++ b/src/components/ProjectSearch/index.js
@@ -15,7 +15,7 @@ import {
   getActiveSearchState,
   getTextSearchResults,
   getTextSearchQuery,
-  getSourceSearchQueryString
+  getSourceSearchQuery
 } from "../../selectors";
 
 import "./ProjectSearch.css";
@@ -105,7 +105,7 @@ class ProjectSearch extends Component {
       sources,
       selectSource,
       closeActiveSearch,
-      sourceSearchQueryString,
+      sourceSearchQuery,
       setSourceSearchQuery,
       clearSourceSearchQuery
     } = this.props;
@@ -117,9 +117,9 @@ class ProjectSearch extends Component {
         searchBottomBar={
           <ToggleSearch kind="sources" toggle={this.toggleProjectTextSearch} />
         }
-        queryString={sourceSearchQueryString}
-        setSourceSearchQuery={setSourceSearchQuery}
-        clearQueryString={clearSourceSearchQuery}
+        query={sourceSearchQuery}
+        setQuery={setSourceSearchQuery}
+        clearQuery={clearSourceSearchQuery}
       />
     );
   }
@@ -131,7 +131,7 @@ class ProjectSearch extends Component {
       searchSources,
       closeActiveSearch,
       selectSource,
-      textSearchQueryString
+      textSearchQuery
     } = this.props;
 
     return (
@@ -141,7 +141,7 @@ class ProjectSearch extends Component {
         searchSources={searchSources}
         closeActiveSearch={closeActiveSearch}
         selectSource={selectSource}
-        query={textSearchQueryString}
+        query={textSearchQuery}
         searchBottomBar={
           <ToggleSearch kind="project" toggle={this.toggleSourceSearch} />
         }
@@ -156,9 +156,11 @@ class ProjectSearch extends Component {
 
     return (
       <div className="search-container">
-        {this.isProjectSearchEnabled()
-          ? this.renderTextSearch()
-          : this.renderSourceSearch()}
+        {this.isProjectSearchEnabled() ? (
+          this.renderTextSearch()
+        ) : (
+          this.renderSourceSearch()
+        )}
       </div>
     );
   }
@@ -167,13 +169,13 @@ class ProjectSearch extends Component {
 ProjectSearch.propTypes = {
   sources: PropTypes.object.isRequired,
   results: PropTypes.object,
-  textSearchQueryString: PropTypes.string,
+  textSearchQuery: PropTypes.string,
   setActiveSearch: PropTypes.func.isRequired,
   closeActiveSearch: PropTypes.func.isRequired,
   searchSources: PropTypes.func,
   activeSearch: PropTypes.string,
   selectSource: PropTypes.func.isRequired,
-  sourceSearchQueryString: PropTypes.string,
+  sourceSearchQuery: PropTypes.string,
   setSourceSearchQuery: PropTypes.func,
   clearSourceSearchQuery: PropTypes.func
 };
@@ -189,8 +191,8 @@ export default connect(
     sources: getSources(state),
     activeSearch: getActiveSearchState(state),
     results: getTextSearchResults(state),
-    textSearchQueryString: getTextSearchQuery(state),
-    sourceSearchQueryString: getSourceSearchQueryString(state)
+    textSearchQuery: getTextSearchQuery(state),
+    sourceSearchQuery: getSourceSearchQuery(state)
   }),
   dispatch => bindActionCreators(actions, dispatch)
 )(ProjectSearch);

--- a/src/components/ProjectSearch/index.js
+++ b/src/components/ProjectSearch/index.js
@@ -14,7 +14,8 @@ import {
   getSources,
   getActiveSearchState,
   getTextSearchResults,
-  getTextSearchQuery
+  getTextSearchQuery,
+  getSourceSearchQueryString
 } from "../../selectors";
 
 import "./ProjectSearch.css";
@@ -104,19 +105,21 @@ class ProjectSearch extends Component {
       sources,
       selectSource,
       closeActiveSearch,
-      query,
-      addSearchQuery
+      sourceSearchQueryString,
+      setSourceSearchQueryString,
+      clearSourceSearchQueryString
     } = this.props;
     return (
       <SourceSearch
         sources={sources}
         selectSource={selectSource}
         closeActiveSearch={closeActiveSearch}
+        clearSourceSearchQueryString={clearSourceSearchQueryString}
         searchBottomBar={
           <ToggleSearch kind="sources" toggle={this.toggleProjectTextSearch} />
         }
-        queryString={query}
-        queryStringChangeHandler={addSearchQuery}
+        queryString={sourceSearchQueryString}
+        queryStringChangeHandler={setSourceSearchQueryString}
       />
     );
   }
@@ -128,7 +131,7 @@ class ProjectSearch extends Component {
       searchSources,
       closeActiveSearch,
       selectSource,
-      query
+      textSearchQueryString
     } = this.props;
 
     return (
@@ -138,7 +141,7 @@ class ProjectSearch extends Component {
         searchSources={searchSources}
         closeActiveSearch={closeActiveSearch}
         selectSource={selectSource}
-        query={query}
+        query={textSearchQueryString}
         searchBottomBar={
           <ToggleSearch kind="project" toggle={this.toggleSourceSearch} />
         }
@@ -164,7 +167,7 @@ class ProjectSearch extends Component {
 ProjectSearch.propTypes = {
   sources: PropTypes.object.isRequired,
   results: PropTypes.object,
-  query: PropTypes.string,
+  textSearchQueryString: PropTypes.string,
   setActiveSearch: PropTypes.func.isRequired,
   closeActiveSearch: PropTypes.func.isRequired,
   searchSources: PropTypes.func,
@@ -183,7 +186,8 @@ export default connect(
     sources: getSources(state),
     activeSearch: getActiveSearchState(state),
     results: getTextSearchResults(state),
-    query: getTextSearchQuery(state) || ""
+    textSearchQueryString: getTextSearchQuery(state),
+    sourceSearchQueryString: getSourceSearchQueryString(state)
   }),
   dispatch => bindActionCreators(actions, dispatch)
 )(ProjectSearch);

--- a/src/components/ProjectSearch/index.js
+++ b/src/components/ProjectSearch/index.js
@@ -114,12 +114,12 @@ class ProjectSearch extends Component {
         sources={sources}
         selectSource={selectSource}
         closeActiveSearch={closeActiveSearch}
-        clearSourceSearchQueryString={clearSourceSearchQueryString}
         searchBottomBar={
           <ToggleSearch kind="sources" toggle={this.toggleProjectTextSearch} />
         }
         queryString={sourceSearchQueryString}
         queryStringChangeHandler={setSourceSearchQueryString}
+        clearQueryString={clearSourceSearchQueryString}
       />
     );
   }

--- a/src/components/shared/Autocomplete.js
+++ b/src/components/shared/Autocomplete.js
@@ -136,6 +136,9 @@ export default class Autocomplete extends Component {
       onChange:
         (e => {
           this.props.onChangeHandler(e.target.value);
+          this.setState({
+            selectedIndex: 0
+          });
         }) ||
         (e =>
           this.setState({

--- a/src/components/shared/Autocomplete.js
+++ b/src/components/shared/Autocomplete.js
@@ -23,6 +23,7 @@ type Props = {
   inputValue: string,
   placeholder: string,
   size: string,
+  onChangeHandler: (queryString: string) => void,
   children: any
 };
 
@@ -49,13 +50,12 @@ export default class Autocomplete extends Component {
   }
 
   getSearchResults() {
-    const inputValue = this.state.inputValue;
-
+    const inputValue = this.props.inputValue || this.state.inputValue;
     if (inputValue == "") {
       return [];
     }
 
-    return filter(this.props.items, this.state.inputValue, {
+    return filter(this.props.items, inputValue, {
       key: "value"
     });
   }
@@ -127,17 +127,21 @@ export default class Autocomplete extends Component {
     );
 
     const searchProps = {
-      query: this.state.inputValue,
+      query: this.props.inputValue || this.state.inputValue,
       count: searchResults.length,
       placeholder: this.props.placeholder,
       size,
       showErrorEmoji: true,
       summaryMsg,
-      onChange: e =>
-        this.setState({
-          inputValue: e.target.value,
-          selectedIndex: 0
-        }),
+      onChange:
+        (e => {
+          this.props.onChangeHandler(e.target.value);
+        }) ||
+        (e =>
+          this.setState({
+            inputValue: e.target.value,
+            selectedIndex: 0
+          })),
       onFocus: () => this.setState({ focused: true }),
       onBlur: () => this.setState({ focused: false }),
       onKeyDown: this.onKeyDown,

--- a/src/components/shared/Autocomplete.js
+++ b/src/components/shared/Autocomplete.js
@@ -10,7 +10,6 @@ import SearchInput from "./SearchInput";
 import ResultList from "./ResultList";
 
 type State = {
-  inputValue: string,
   selectedIndex: number,
   focused: boolean
 };
@@ -37,7 +36,6 @@ export default class Autocomplete extends Component {
 
     (this: any).onKeyDown = this.onKeyDown.bind(this);
     this.state = {
-      inputValue: props.inputValue,
       selectedIndex: 0,
       focused: false
     };
@@ -50,7 +48,7 @@ export default class Autocomplete extends Component {
   }
 
   getSearchResults() {
-    const inputValue = this.props.inputValue || this.state.inputValue;
+    const inputValue = this.props.inputValue;
     if (inputValue == "") {
       return [];
     }
@@ -85,11 +83,11 @@ export default class Autocomplete extends Component {
       if (searchResults.length) {
         this.props.selectItem(e, searchResults[this.state.selectedIndex]);
       } else {
-        this.props.close(this.state.inputValue);
+        this.props.close(this.props.inputValue);
       }
       e.preventDefault();
     } else if (e.key === "Tab") {
-      this.props.close(this.state.inputValue);
+      this.props.close(this.props.inputValue);
       e.preventDefault();
     }
   }
@@ -108,7 +106,7 @@ export default class Autocomplete extends Component {
       };
 
       return <ResultList {...props} />;
-    } else if (this.state.inputValue && !results.length) {
+    } else if (this.props.inputValue && !results.length) {
       return (
         <div className="no-result-msg absolute-center">
           {L10N.getStr("sourceSearch.noResults2")}
@@ -127,24 +125,18 @@ export default class Autocomplete extends Component {
     );
 
     const searchProps = {
-      query: this.props.inputValue || this.state.inputValue,
+      query: this.props.inputValue,
       count: searchResults.length,
       placeholder: this.props.placeholder,
       size,
       showErrorEmoji: true,
       summaryMsg,
-      onChange:
-        (e => {
-          this.props.onChangeHandler(e.target.value);
-          this.setState({
-            selectedIndex: 0
-          });
-        }) ||
-        (e =>
-          this.setState({
-            inputValue: e.target.value,
-            selectedIndex: 0
-          })),
+      onChange: e => {
+        this.props.onChangeHandler(e.target.value);
+        this.setState({
+          selectedIndex: 0
+        });
+      },
       onFocus: () => this.setState({ focused: true }),
       onBlur: () => this.setState({ focused: false }),
       onKeyDown: this.onKeyDown,

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -13,6 +13,7 @@ import ui from "./ui";
 import ast from "./ast";
 import coverage from "./coverage";
 import projectTextSearch from "./project-text-search";
+import sourceSearch from "./source-search";
 
 export default {
   expressions,
@@ -25,5 +26,6 @@ export default {
   ui,
   ast,
   coverage,
-  projectTextSearch
+  projectTextSearch,
+  sourceSearch
 };

--- a/src/reducers/source-search.js
+++ b/src/reducers/source-search.js
@@ -30,6 +30,6 @@ type OuterState = {
   sourceSearch: Record<SourceSearchState>
 };
 
-export function getSourceSearchQueryString(state: OuterState) {
+export function getSourceSearchQuery(state: OuterState) {
   return state.sourceSearch.get("queryString");
 }

--- a/src/reducers/source-search.js
+++ b/src/reducers/source-search.js
@@ -3,14 +3,12 @@ import type { SourceSearchAction } from "../actions/types";
 import type { Record } from "../utils/makeRecord";
 
 type SourceSearchState = {
-  queryString: string,
-  selectedItem: number
+  queryString: string
 };
 
 function InitialState(): Record<SourceSearchState> {
   return makeRecord({
-    queryString: "",
-    selectedItem: 0
+    queryString: ""
   })();
 }
 

--- a/src/reducers/source-search.js
+++ b/src/reducers/source-search.js
@@ -1,0 +1,37 @@
+import makeRecord from "../utils/makeRecord";
+import type { SourceSearchAction } from "../actions/types";
+import type { Record } from "../utils/makeRecord";
+
+type SourceSearchState = {
+  queryString: string,
+  selectedItem: number
+};
+
+function InitialState(): Record<SourceSearchState> {
+  return makeRecord({
+    queryString: "",
+    selectedItem: 0
+  })();
+}
+
+export default function update(
+  state: Record<SourceSearchState> = InitialState(),
+  action: SourceSearchAction
+): Record<SourceSearchState> {
+  switch (action.type) {
+    case "SET_QUERY_STRING":
+      return state.update("queryString", value => action.queryString);
+    case "CLEAR_QUERY_STRING":
+      return state.update("queryString", value => "");
+    default:
+      return state;
+  }
+}
+
+type OuterState = {
+  sourceSearch: Record<SourceSearchState>
+};
+
+export function getSourceSearchQueryString(state: OuterState) {
+  return state.sourceSearch.get("queryString");
+}

--- a/src/selectors.js
+++ b/src/selectors.js
@@ -9,6 +9,7 @@ import * as ui from "./reducers/ui";
 import * as ast from "./reducers/ast";
 import * as coverage from "./reducers/coverage";
 import * as projectTextSearch from "./reducers/project-text-search";
+import * as sourceSearch from "./reducers/source-search";
 
 import getBreakpointAtLocation from "./selectors/breakpointAtLocation";
 import getInScopeLines from "./selectors/linesInScope";
@@ -31,6 +32,7 @@ module.exports = Object.assign(
   ast,
   coverage,
   projectTextSearch,
+  sourceSearch,
   {
     getBreakpointAtLocation,
     getInScopeLines,


### PR DESCRIPTION
Associated Issue: #3714 

### Summary of Changes

* Added actions and reducer functions to set and clear source-search query string in store.
* Update Autocomplete.js to allow execution of above actions.

### Test Plan

- use Command-P to open search panel.
- enter a query string in the search bar.
- resize browser to below responsive breakpoint.
- confirm the query string is preserved.

