### PR TITLE
Fix Margin around view-source tab

### DIFF
--- a/src/components/PrimaryPanes/Sources.css
+++ b/src/components/PrimaryPanes/Sources.css
@@ -106,7 +106,7 @@
   transition: all 0.25s ease;
   overflow: hidden;
   padding: 5px;
-  margin-bottom: 4px;
+  margin-bottom: 0px;
   margin-top: -1px;
 }
 


### PR DESCRIPTION
Associated Issue: #3758 

### Summary of Changes

* Changed margin around source view tab from 4px to 0px

### Screenshot

![screenshot-2017-8-29 debugger](https://user-images.githubusercontent.com/21259802/29820525-5ef82fbc-8ce2-11e7-8806-9e350ae7722c.png)

