### PR TITLE
Show mapped names in scopes bindings

### DIFF
--- a/flow-typed/debugger-html.js
+++ b/flow-typed/debugger-html.js
@@ -112,6 +112,7 @@ declare module "debugger-html" {
     id: FrameId,
     displayName: string,
     location: Location,
+    generatedLocation: Location,
     source?: Source,
     scope: Scope,
     // FIXME Define this type more clearly
@@ -264,11 +265,14 @@ declare module "debugger-html" {
  */
   declare type Scope = {
     actor: ActorId,
-    parent: Scope,
+    parent: ?Scope,
     bindings: {
       // FIXME Define these types more clearly
       arguments: Array<Object>,
       variables: Object
+    },
+    sourceBindings?: {
+      [originalName: string]: string
     },
     object: Object,
     function: {

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "devtools-launchpad": "^0.0.98",
     "devtools-linters": "^0.0.3",
     "devtools-reps": "^0.12.3",
+    "devtools-map-bindings": "^0.2.0",
     "devtools-source-editor": "0.0.6",
     "devtools-source-map": "^0.13.0",
     "devtools-splitter": "^0.0.3",

--- a/src/actions/ast.js
+++ b/src/actions/ast.js
@@ -9,12 +9,45 @@ import {
   getPreview
 } from "../selectors";
 
+import { ensureParserHasSourceText } from "./sources";
+
 import { PROMISE } from "../utils/redux/middleware/promise";
-import * as parser from "../utils/parser";
+import {
+  getScopes,
+  getSymbols,
+  getEmptyLines,
+  getOutOfScopeLocations
+} from "../utils/parser";
+
+import { isGeneratedId } from "devtools-source-map";
+import { replaceOriginalVariableName } from "devtools-map-bindings/src/utils";
 
 import type { SourceId } from "debugger-html";
 import type { ThunkArgs } from "./types";
 import type { AstLocation } from "../utils/parser";
+
+/**
+ * Gets information about original variable names from the source map
+ * and replaces all posible generated names.
+ */
+async function getSourcemapedExpression(
+  { sourceMaps },
+  generatedLocation: Location,
+  expression: string
+): Promise<string> {
+  const astScopes = await getScopes(generatedLocation);
+
+  const generatedScopes = await sourceMaps.getLocationScopes(
+    generatedLocation,
+    astScopes
+  );
+
+  if (!generatedScopes) {
+    return expression;
+  }
+
+  return replaceOriginalVariableName(expression, generatedScopes);
+}
 
 export function setSymbols(sourceId: SourceId) {
   return async ({ dispatch, getState }: ThunkArgs) => {
@@ -28,7 +61,7 @@ export function setSymbols(sourceId: SourceId) {
       return;
     }
 
-    const symbols = await parser.getSymbols(source);
+    const symbols = await getSymbols(source);
 
     dispatch({
       type: "SET_SYMBOLS",
@@ -50,7 +83,7 @@ export function setEmptyLines(sourceId: SourceId) {
       return;
     }
 
-    const emptyLines = await parser.getEmptyLines(source);
+    const emptyLines = await getEmptyLines(source);
 
     dispatch({
       type: "SET_EMPTY_LINES",
@@ -76,10 +109,7 @@ export function setOutOfScopeLocations() {
       });
     }
 
-    const locations = await parser.getOutOfScopeLocations(
-      source.toJS(),
-      location
-    );
+    const locations = await getOutOfScopeLocations(source.toJS(), location);
 
     return dispatch({
       type: "OUT_OF_SCOPE_LOCATIONS",
@@ -123,7 +153,7 @@ export function setPreview(
   tokenPos: AstLocation,
   cursorPos: any
 ) {
-  return async ({ dispatch, getState, client }: ThunkArgs) => {
+  return async ({ dispatch, getState, client, sourceMaps }: ThunkArgs) => {
     const currentSelection = getPreview(getState());
     if (currentSelection && currentSelection.updating) {
       return;
@@ -133,17 +163,34 @@ export function setPreview(
       type: "SET_PREVIEW",
       [PROMISE]: (async function() {
         const source = getSelectedSource(getState());
-        const _symbols = await parser.getSymbols(source.toJS());
+        const _symbols = await getSymbols(source.toJS());
 
         const found = findBestMatch(_symbols, tokenPos, token);
         if (!found) {
           return;
         }
 
-        const { expression, location } = found;
+        let { expression, location } = found;
 
         if (!expression) {
           return;
+        }
+
+        const sourceId = source.get("id");
+        if (location && !isGeneratedId(sourceId)) {
+          const generatedLocation = await sourceMaps.getGeneratedLocation(
+            { ...location.start, sourceId },
+            source.toJS()
+          );
+
+          const generatedSourceId = generatedLocation.sourceId;
+          await dispatch(ensureParserHasSourceText(generatedSourceId));
+
+          expression = await getSourcemapedExpression(
+            { dispatch, sourceMaps },
+            generatedLocation,
+            expression
+          );
         }
 
         const selectedFrame = getSelectedFrame(getState());

--- a/src/actions/tests/expressions.spec.js
+++ b/src/actions/tests/expressions.spec.js
@@ -79,7 +79,12 @@ describe("expressions", () => {
     expect(selectors.getExpression(getState(), "foo").value).toBe(null);
     expect(selectors.getExpression(getState(), "bar").value).toBe(null);
 
-    await dispatch(actions.selectFrame({ id: 2, location: { line: 3 } }));
+    await dispatch(
+      actions.selectFrame({
+        id: 2,
+        location: { sourceId: "example.js", line: 3 }
+      })
+    );
     await dispatch(actions.evaluateExpressions("boo"));
 
     expect(selectors.getExpression(getState(), "foo").value).toBe("boo");

--- a/src/client/chrome/create.js
+++ b/src/client/chrome/create.js
@@ -26,6 +26,7 @@ export function createFrame(frame: any) {
     id: frame.callFrameId,
     displayName: frame.functionName,
     scopeChain: frame.scopeChain,
+    generatedLocation: frame.location,
     location: fromServerLocation(frame.location)
   };
 }

--- a/src/client/firefox/create.js
+++ b/src/client/firefox/create.js
@@ -18,15 +18,16 @@ export function createFrame(frame: FramePacket): Frame {
   } else {
     title = `(${frame.type})`;
   }
-
+  const location = {
+    sourceId: frame.where.source.actor,
+    line: frame.where.line,
+    column: frame.where.column
+  };
   return {
     id: frame.actor,
     displayName: title,
-    location: {
-      sourceId: frame.where.source.actor,
-      line: frame.where.line,
-      column: frame.where.column
-    },
+    location,
+    generatedLocation: location,
     this: frame.this,
     scope: frame.environment
   };

--- a/src/test/mochitest/browser.ini
+++ b/src/test/mochitest/browser.ini
@@ -16,6 +16,9 @@ support-files =
   examples/wasm-sourcemaps/average.wasm.map
   examples/wasm-sourcemaps/average.c
   examples/wasm-sourcemaps/utils.js
+  examples/sum/sum.js
+  examples/sum/sum.min.js
+  examples/sum/sum.min.js.map
   examples/doc-async.html
   examples/doc-asm.html
   examples/doc-scripts.html
@@ -26,6 +29,7 @@ support-files =
   examples/doc-frames.html
   examples/doc-debugger-statements.html
   examples/doc-minified.html
+  examples/doc-minified2.html
   examples/doc-sourcemaps.html
   examples/doc-sourcemaps2.html
   examples/doc-sourcemap-bogus.html
@@ -78,6 +82,7 @@ skip-if = os == "linux" # bug 1351952
 [browser_dbg-pause-exceptions.js]
 skip-if = true # Bug 1393121
 [browser_dbg-navigation.js]
+[browser_dbg-minified.js]
 [browser_dbg-pretty-print.js]
 [browser_dbg-pretty-print-console.js]
 [browser_dbg-pretty-print-paused.js]

--- a/src/test/mochitest/browser_dbg-minified.js
+++ b/src/test/mochitest/browser_dbg-minified.js
@@ -1,0 +1,37 @@
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
+
+// Tests minfied + source maps.
+
+async function foo() {
+  return new Promise(r => setTimeout(r, 3000000));
+}
+
+function getScopeNodeLabel(dbg, index) {
+  return findElement(dbg, "scopeNode", index).innerText;
+}
+
+function getScopeNodeValue(dbg, index) {
+  return findElement(dbg, "scopeValue", index).innerText;
+}
+
+add_task(async function() {
+  const dbg = await initDebugger("doc-minified2.html");
+
+  await waitForSources(dbg, "sum.js");
+
+  await selectSource(dbg, "sum.js");
+  await addBreakpoint(dbg, "sum.js", 2);
+
+  invokeInTab("test");
+  await waitForPaused(dbg);
+
+  is(getScopeNodeLabel(dbg, 1), "sum");
+  is(getScopeNodeLabel(dbg, 2), "<this>");
+  is(getScopeNodeLabel(dbg, 3), "arguments");
+
+  is(getScopeNodeLabel(dbg, 4), "first");
+  is(getScopeNodeValue(dbg, 4), "40");
+  is(getScopeNodeLabel(dbg, 5), "second");
+  is(getScopeNodeValue(dbg, 5), "2");
+});

--- a/src/test/mochitest/examples/doc-minified2.html
+++ b/src/test/mochitest/examples/doc-minified2.html
@@ -1,0 +1,20 @@
+<!-- Any copyright is dedicated to the Public Domain.
+     http://creativecommons.org/publicdomain/zero/1.0/ -->
+<!doctype html>
+
+<html>
+  <head>
+    <meta charset="utf-8"/>
+    <title>Debugger test page</title>
+    <script src="sum/sum.min.js"></script>
+  </head>
+
+  <body>
+    <script>
+      function test() {
+        console.log(sum(40, 2));
+      }
+    </script>
+    <button onclick="test()">test</button>
+  </body>
+</html>

--- a/src/test/mochitest/examples/sum/sum.js
+++ b/src/test/mochitest/examples/sum/sum.js
@@ -1,0 +1,3 @@
+function sum(first, second) {
+  return first + second;
+}

--- a/src/test/mochitest/examples/sum/sum.min.js
+++ b/src/test/mochitest/examples/sum/sum.min.js
@@ -1,0 +1,2 @@
+function sum(n,u){return n+u}
+//# sourceMappingURL=sum.min.js.map

--- a/src/test/mochitest/examples/sum/sum.min.js.map
+++ b/src/test/mochitest/examples/sum/sum.min.js.map
@@ -1,0 +1,1 @@
+{"version":3,"sources":["sum.js"],"names":["sum","first","second"],"mappings":"AAAA,SAASA,IAAIC,EAAOC,GAClB,OAAOD,EAAQC"}

--- a/src/utils/pause.js
+++ b/src/utils/pause.js
@@ -1,6 +1,9 @@
 // @flow
-import type { Pause, Frame } from "../types";
+import type { Pause, Frame, Location } from "../types";
 import { get } from "lodash";
+import { getScopes } from "./parser";
+
+import type { Scope, MappedScopeBindings } from "debugger-html";
 
 export function updateFrameLocations(
   frames: Frame[],
@@ -14,11 +17,45 @@ export function updateFrameLocations(
     frames.map(frame => {
       return sourceMaps.getOriginalLocation(frame.location).then(loc => {
         return Object.assign({}, frame, {
-          location: loc
+          location: loc,
+          generatedLocation: frame.location
         });
       });
     })
   );
+}
+
+function extendScope(
+  scope: ?Scope,
+  generatedScopes: MappedScopeBindings[],
+  index: number
+): ?Scope {
+  if (!scope) {
+    return undefined;
+  }
+  if (index >= generatedScopes.length) {
+    return scope;
+  }
+  return Object.assign({}, scope, {
+    parent: extendScope(scope.parent, generatedScopes, index + 1),
+    sourceBindings: generatedScopes[index].bindings
+  });
+}
+
+export async function updateScopeBindings(
+  scope: any,
+  location: Location,
+  sourceMaps: any
+) {
+  const astScopes = await getScopes(location);
+  const generatedScopes = await sourceMaps.getLocationScopes(
+    location,
+    astScopes
+  );
+  if (!generatedScopes) {
+    return scope;
+  }
+  return extendScope(scope, generatedScopes, 0);
 }
 
 // Map protocol pause "why" reason to a valid L10N key

--- a/yarn.lock
+++ b/yarn.lock
@@ -2979,6 +2979,19 @@ devtools-map-bindings@0.1.0:
     jest "^19.0.2"
     source-map "^0.5.6"
 
+devtools-map-bindings@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/devtools-map-bindings/-/devtools-map-bindings-0.2.0.tgz#0fe50f198d73b16a457430e41d5c673ee4047782"
+  dependencies:
+    babel-plugin-transform-async-to-generator "^6.22.0"
+    babel-plugin-transform-flow-strip-types "^6.22.0"
+    babel-traverse "^6.26.0"
+    babel-types "^6.26.0"
+    babylon "^6.18.0"
+    devtools-utils "0.0.8"
+    jest "^19.0.2"
+    source-map "^0.5.6"
+
 devtools-modules@^0.0.31:
   version "0.0.31"
   resolved "https://registry.yarnpkg.com/devtools-modules/-/devtools-modules-0.0.31.tgz#06749ffa7b78cf2826467ffcce9d2edbbba3ced7"


### PR DESCRIPTION
Associated Issue: #3427

### Summary of Changes

* adds the `generatedLocation` to a frame
* adds building of scopes database for the generated source
* updates/adds original mapped names to the scopes

### Test Plan

Tell us a little a bit about how you tested your patch.

Example test plan:

- [x] Open JavaScript code with source maps that have mangled names (for simplicity sequence_print.min.js in http://firefox-dev.tools/debugger-examples/examples/sequence-print/sequence_print.html)
- [x] In original source, sequence_print.js, at line 4 (`buffer.push(current)`) set breakpoint
- [x] Reload sequence_print.html app
- [x] Observe scopes

The top scope needs to have `current`, `buffer` variables shown.

<del>P.S. needs some modification to the devtools-source-map</del>