### PR TITLE
[WIP] Stealing Atom look and feel for the Search UI

### DIFF
--- a/src/components/ProjectSearch/TextSearch.css
+++ b/src/components/ProjectSearch/TextSearch.css
@@ -23,8 +23,7 @@
 }
 
 .project-text-search .result.focused {
-  background-color: var(--popup-shadow-color);
-  color: var(--theme-selection-color);
+  background-color: var(--search-overlays-semitransparent);
 }
 
 .project-text-search .result .query-match {
@@ -37,7 +36,6 @@
 
 .project-text-search .result.focused .line-number {
   font-weight: bolder;
-  color: var(--theme-selection-color);
 }
 
 .project-text-search .result .line-number {
@@ -59,7 +57,6 @@
   cursor: default;
   padding: 2px 0 2px 5px;
   font-size: 12px;
-  background-color: var(--search-overlays-semitransparent);
 }
 
 .project-text-search .file-result .arrow {
@@ -67,7 +64,7 @@
 }
 
 .project-text-search .file-result.focused {
-  background-color: var(--theme-codemirror-gutter-background);
+  background-color: var(--search-overlays-semitransparent);
 }
 
 .project-text-search .line-match {

--- a/src/components/ProjectSearch/TextSearch.css
+++ b/src/components/ProjectSearch/TextSearch.css
@@ -23,7 +23,8 @@
 }
 
 .project-text-search .result.focused {
-  background-color: var(--theme-codemirror-gutter-background);
+  background-color: var(--popup-shadow-color);
+  color: var(--theme-selection-color);
 }
 
 .project-text-search .result .query-match {
@@ -36,11 +37,13 @@
 
 .project-text-search .result.focused .line-number {
   font-weight: bolder;
+  color: var(--theme-selection-color);
 }
 
 .project-text-search .result .line-number {
   margin-right: 1em;
   width: 2em;
+  margin-left: 0.8em;
 }
 
 .project-text-search .no-result-msg {
@@ -56,6 +59,7 @@
   cursor: default;
   padding: 2px 0 2px 5px;
   font-size: 12px;
+  background-color: var(--search-overlays-semitransparent);
 }
 
 .project-text-search .file-result .arrow {


### PR DESCRIPTION
Associated Issue: #3651
An attempt at making the ProjectSearch Look and Feel UI look like Atom's Search UI 

### Summary of Changes

* changed the text color on  a focused result
* changed the text color for the line number of a focused result
* changed the margin for focused item to align it to the file path
* changed the text color for the file path of a search result

### Test Plan
Opened the debugger and chose a project to debug
- [x] Command-P opens the panel
- [x] Typing in a search term to get some results
- [x] Scroll through the results to see changes
- [x] Clicking "x" closes the panel

### Screenshots/Videos (OPTIONAL)
![screen shot 2017-08-30 at 9 48 13 pm](https://user-images.githubusercontent.com/897731/29891886-f6916772-8dcc-11e7-9535-b6b7f3cea96c.png)

