### PR TITLE
Remove devtools.debugger.client-source-maps-enabled pref

### DIFF
--- a/assets/panel/prefs.js
+++ b/assets/panel/prefs.js
@@ -17,7 +17,6 @@ pref("devtools.debugger.remote-timeout", 20000);
 pref("devtools.debugger.pause-on-exceptions", false);
 pref("devtools.debugger.ignore-caught-exceptions", false);
 pref("devtools.debugger.source-maps-enabled", true);
-pref("devtools.debugger.client-source-maps-enabled", true);
 pref("devtools.debugger.pretty-print-enabled", true);
 pref("devtools.debugger.auto-pretty-print", false);
 pref("devtools.debugger.auto-black-box", true);

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -97,26 +97,26 @@ User preferences are stored in Prefs. Prefs uses localStorage locally and firefo
 **Setting a default value**
 
 ```js
-pref("devtools.debugger.client-source-maps-enabled", true);
+pref("devtools.debugger.example", true);
 ```
 
 **Adding a pref**
 ```js
 const prefs = new PrefsHelper("devtools", {
-  clientSourceMapsEnabled: ["Bool", "debugger.client-source-maps-enabled"],
+  examplePrefEnabled: ["Bool", "debugger.example"],
 });
 ```
 
 **Reading a pref**
 ```js
 const { prefs } = require("./utils/prefs");
-console.log(prefs.clientSourceMapsEnabled)
+console.log(prefs.examplePrefEnabled)
 ```
 
 **Setting a pref**
 ```js
 const { prefs } = require("./utils/prefs");
-prefs.clientSourceMapsEnabled = false;
+prefs.examplePrefEnabled = false;
 ```
 
 ### SVGs

--- a/src/actions/sources.js
+++ b/src/actions/sources.js
@@ -87,9 +87,7 @@ export function newSource(source: Source) {
   return async ({ dispatch, getState }: ThunkArgs) => {
     dispatch({ type: "ADD_SOURCE", source });
 
-    if (prefs.clientSourceMapsEnabled) {
-      await dispatch(loadSourceMap(source));
-    }
+    await dispatch(loadSourceMap(source));
 
     await checkSelectedSource(getState(), dispatch, source);
     await checkPendingBreakpoints(getState(), dispatch, source);

--- a/src/utils/prefs.js
+++ b/src/utils/prefs.js
@@ -8,7 +8,6 @@ const prefsSchemaVersion = "1.0.2";
 const pref = Services.pref;
 
 if (isDevelopment()) {
-  pref("devtools.debugger.client-source-maps-enabled", true);
   pref("devtools.debugger.pause-on-exceptions", false);
   pref("devtools.debugger.ignore-caught-exceptions", false);
   pref("devtools.debugger.call-stack-visible", false);
@@ -29,7 +28,6 @@ if (isDevelopment()) {
 }
 
 export const prefs = new PrefsHelper("devtools", {
-  clientSourceMapsEnabled: ["Bool", "debugger.client-source-maps-enabled"],
   pauseOnExceptions: ["Bool", "debugger.pause-on-exceptions"],
   ignoreCaughtExceptions: ["Bool", "debugger.ignore-caught-exceptions"],
   callStackVisible: ["Bool", "debugger.call-stack-visible"],


### PR DESCRIPTION
This removes the debugger.debugger.client-source-maps-enabled pref.
There was no UI for disabling this pref, and it is only checked in a
single spot.  In M-C I am going to unify all the source-map prefs, and I
don't think the debugger needs to react to changes to the shared pref;
so removing this one seemed best.
