### PR TITLE
Update async stepping

### DIFF
--- a/assets/panel/prefs.js
+++ b/assets/panel/prefs.js
@@ -43,5 +43,5 @@ pref("devtools.debugger.expressions", "[]");
 pref("devtools.debugger.file-search-case-sensitive", false);
 pref("devtools.debugger.file-search-whole-word", false);
 pref("devtools.debugger.file-search-regex-match", false);
-pref("devtools.debugger.features.async-stepping", false)
+pref("devtools.debugger.features.async-stepping", true)
 pref("devtools.debugger.project-text-search-enabled", true);

--- a/src/test/mochitest/browser_dbg-async-stepping.js
+++ b/src/test/mochitest/browser_dbg-async-stepping.js
@@ -1,10 +1,7 @@
 /* Any copyright is dedicated to the Public Domain.
  * http://creativecommons.org/publicdomain/zero/1.0/ */
 
-// Tests async stepping will:
-// 1. step over await statements
-// 2. step into async functions
-// 3. step out of async functions
+// Tests async stepping will step over await statements
 add_task(async function test() {
   Services.prefs.setBoolPref("devtools.debugger.features.async-stepping", true);
   const dbg = await initDebugger("doc-async.html", "async");

--- a/src/test/mochitest/examples/doc-async.html
+++ b/src/test/mochitest/examples/doc-async.html
@@ -9,5 +9,7 @@
   </head>
 
   <body>
+
+    <button onclick="main()">Main</button>
   </body>
 </html>

--- a/src/utils/parser/tests/fixtures/async.js
+++ b/src/utils/parser/tests/fixtures/async.js
@@ -1,0 +1,10 @@
+async function foo() {
+  return new Promise(resolve => {
+    setTimeout(resolve, 10);
+  });
+}
+
+async function stuff() {
+  await foo(1);
+  await foo(2);
+}

--- a/src/utils/parser/tests/steps.spec.js
+++ b/src/utils/parser/tests/steps.spec.js
@@ -1,0 +1,35 @@
+import { getNextStep } from "../steps";
+import { getSource } from "./helpers";
+
+describe("getNextStep", () => {
+  it("first await call", () => {
+    const source = getSource("async");
+    const pausePosition = { line: 8, column: 2, sourceId: "async" };
+    expect(getNextStep(source, pausePosition)).toEqual({
+      ...pausePosition,
+      line: 9
+    });
+  });
+
+  it("first await call expression", () => {
+    const source = getSource("async");
+    const pausePosition = { line: 8, column: 9, sourceId: "async" };
+    expect(getNextStep(source, pausePosition)).toEqual({
+      ...pausePosition,
+      line: 9,
+      column: 2
+    });
+  });
+
+  it("second await call", () => {
+    const source = getSource("async");
+    const pausePosition = { line: 9, column: 2, sourceId: "async" };
+    expect(getNextStep(source, pausePosition)).toEqual(null);
+  });
+
+  it("second call expression", () => {
+    const source = getSource("async");
+    const pausePosition = { line: 9, column: 9, sourceId: "async" };
+    expect(getNextStep(source, pausePosition)).toEqual(null);
+  });
+});

--- a/src/utils/prefs.js
+++ b/src/utils/prefs.js
@@ -25,7 +25,7 @@ if (isDevelopment()) {
   pref("devtools.debugger.file-search-regex-match", false);
   pref("devtools.debugger.prefs-schema-version", "1.0.1");
   pref("devtools.debugger.project-text-search-enabled", true);
-  pref("devtools.debugger.features.async-stepping", false);
+  pref("devtools.debugger.features.async-stepping", true);
 }
 
 export const prefs = new PrefsHelper("devtools", {
@@ -53,7 +53,7 @@ export const prefs = new PrefsHelper("devtools", {
 });
 
 export const features = new PrefsHelper("devtools.debugger.features", {
-  asyncStepping: ["Bool", "async-stepping", false]
+  asyncStepping: ["Bool", "async-stepping", true]
 });
 
 if (prefs.debuggerPrefsSchemaVersion !== prefsSchemaVersion) {


### PR DESCRIPTION
Associated Issue: #3807 

### Summary of Changes

* adds support for last statement awaits
* adds support for landing in call expressions (helps when stepping out of the async function
* refactors astcommand to do the next step deciding
* uses babel paths internally a lot more see `getSibling` `getFunctionParent`
* turns it on 💚 
* adds some unit tests