### PR TITLE
Make the source tab hover effects feel more responsive

### DIFF
--- a/src/components/Editor/Tabs.css
+++ b/src/components/Editor/Tabs.css
@@ -41,7 +41,7 @@
   display: inline-flex;
   align-items: flex-end;
   position: relative;
-  transition: all 0.25s ease;
+  transition: all 0.15s ease;
   min-width: 40px;
   overflow: hidden;
   padding: 5px;

--- a/src/components/shared/Button/Close.css
+++ b/src/components/shared/Button/Close.css
@@ -5,7 +5,7 @@
 .close-btn .close {
   width: 14px;
   height: 14px;
-  transition: all 0.25s ease-in-out;
+  transition: all 0.15s ease-in-out;
   border: 1px solid transparent;
   border-radius: 2px;
   padding: 0;


### PR DESCRIPTION
This is just a rough proposal.  My opinion is that the tab hover transitions are slow and appear labored.  The labored feeling is due to speed, so I drastically sped up the transitions and they seem much more quick and elegant.

I know the project has loads of transitions so I guess I'd like to hear some opinions on this faster effect and see if we'd like to speed things up globally.