### PR TITLE
clear ast tree on navigate

### DIFF
--- a/src/actions/navigation.js
+++ b/src/actions/navigation.js
@@ -3,6 +3,7 @@ import { getSources } from "../reducers/sources";
 import { waitForMs } from "../utils/utils";
 import { newSources } from "./sources";
 import { clearSymbols } from "../utils/parser";
+import { clearASTs } from "../utils/parser";
 import { clearWasmStates } from "../utils/wasm";
 
 /**
@@ -20,6 +21,7 @@ export function willNavigate(_, event) {
     clearWasmStates();
     clearDocuments();
     clearSymbols();
+    clearASTs();
 
     dispatch(navigate(event.url));
   };

--- a/src/utils/parser/index.js
+++ b/src/utils/parser/index.js
@@ -12,6 +12,7 @@ export const getSymbols = dispatcher.task("getSymbols");
 export const getVariablesInScope = dispatcher.task("getVariablesInScope");
 export const getOutOfScopeLocations = dispatcher.task("getOutOfScopeLocations");
 export const clearSymbols = dispatcher.task("clearSymbols");
+export const clearASTs = dispatcher.task("clearASTs");
 export const getNextStep = dispatcher.task("getNextStep");
 export const getEmptyLines = dispatcher.task("getEmptyLines");
 

--- a/src/utils/parser/utils/ast.js
+++ b/src/utils/parser/utils/ast.js
@@ -7,7 +7,7 @@ import isEmpty from "lodash/isEmpty";
 
 import type { Source } from "debugger-html";
 
-const ASTs = new Map();
+let ASTs = new Map();
 
 function _parse(code, opts) {
   return babylon.parse(
@@ -60,6 +60,10 @@ export function getAst(source: Source) {
 
   ASTs.set(source.id, ast);
   return ast;
+}
+
+export function clearASTs() {
+  ASTs = new Map();
 }
 
 type Visitor = { enter: Function };

--- a/src/utils/parser/worker.js
+++ b/src/utils/parser/worker.js
@@ -1,6 +1,7 @@
 import { getClosestExpression } from "./utils/closest";
 import { getVariablesInScope } from "./scopes";
 import getSymbols, { clearSymbols } from "./getSymbols";
+import { clearASTs } from "./utils/ast";
 import getOutOfScopeLocations from "./getOutOfScopeLocations";
 import { getNextStep } from "./steps";
 import getEmptyLines from "./getEmptyLines";
@@ -13,6 +14,7 @@ self.onmessage = workerHandler({
   getOutOfScopeLocations,
   getSymbols,
   clearSymbols,
+  clearASTs,
   getVariablesInScope,
   getNextStep,
   getEmptyLines


### PR DESCRIPTION
We were not clearing the AST on navigate. this resulted in a stale ast tree when a source was reloaded and changed.