### PR TITLE
Make case consistent for search sources

### DIFF
--- a/assets/panel/debugger.properties
+++ b/assets/panel/debugger.properties
@@ -454,7 +454,7 @@ welcome.searchFunction=%S to search for functions in file
 
 # LOCALIZATION NOTE (sourceSearch.search): The center pane Source Search
 # prompt for searching for files.
-sourceSearch.search=Search Sources…
+sourceSearch.search=Search sources…
 
 # LOCALIZATION NOTE (sourceSearch.noResults): The center pane Source Search
 # message when the query did not match any of the sources.


### PR DESCRIPTION
Search shows two option:  "Search Sources" and "Find in files".  I find the change in case odd, so changing "sources" to lowercase makes the labels more consistent.