### PR TITLE
Make cursors consistent between search options regardless of status

### DIFF
--- a/src/components/ProjectSearch/ProjectSearch.css
+++ b/src/components/ProjectSearch/ProjectSearch.css
@@ -39,9 +39,9 @@
 
 .toggle-search .text {
   margin-left: 1em;
+  cursor: default;
 }
 
 .toggle-search .active {
   color: var(--theme-selection-background);
-  cursor: default;
 }


### PR DESCRIPTION
The "search sources" and "find in files" labels are both clickable, yet the inactive item has the default text cursor instead of default.  As they're both clickable, they should have the same cursor.