### PR TITLE
Make Expression line height equal to likewise labels

### DIFF
--- a/src/components/SecondaryPanes/Expressions.css
+++ b/src/components/SecondaryPanes/Expressions.css
@@ -23,7 +23,7 @@
 .expressions-list {
   /* TODO: add normalize */
   margin: 0;
-  padding: 0.5em 0;
+  padding: 0;
 }
 .expression-input-container {
   padding: 0.5em;


### PR DESCRIPTION
At present the Expressions list has more padding than likewise child list labels:

Before:

<img width="315" alt="watchbefore" src="https://user-images.githubusercontent.com/46655/29999631-bb4bb76c-9015-11e7-8618-a69238759849.png">


After:

<img width="310" alt="watchafter" src="https://user-images.githubusercontent.com/46655/29999632-bfbb79ae-9015-11e7-9aa9-ac427055101f.png">
