### PR TITLE
Update Expressions Reducer

### DIFF
--- a/flow-typed/debugger-html.js
+++ b/flow-typed/debugger-html.js
@@ -178,8 +178,9 @@ declare module "debugger-html" {
  * @static
  */
   declare type Expression = {
-    id: number,
-    input: string
+    value: Object | null,
+    input: string,
+    updating: boolean
   };
 
   /**

--- a/src/types.js
+++ b/src/types.js
@@ -6,12 +6,6 @@ export type SearchModifiers = {
   regexMatch: boolean
 };
 
-export type Expression = {
-  value: Object,
-  input: string,
-  visible: boolean
-};
-
 export type Mode =
   | String
   | {
@@ -26,6 +20,7 @@ export type Mode =
 export type {
   Breakpoint,
   PendingBreakpoint,
+  Expression,
   Frame,
   Grip,
   LoadedObject,


### PR DESCRIPTION
### Summary of Changes

Historically, we've used makeRecord to instantiate immutable records w/ a flow type.

```js
type ExpressionState = {
  expressions: List<Expression>
};

export const State = makeRecord(
  ({
    expressions: List(restoreExpressions())
  }: ExpressionState)
);
```

The benefits of this approach is that we have a state record, which is shallow typed. It accepts Record fields like `setIn`. It does not provide type checking beyond that.

I'm thinking about using a Record Class, to encapsulate the immutable behavior and provide a typed interface. It's pretty verbose, but the benefit is that we can get deeper type checking 

e.g.: `state.expressions` or `state.setExpressions().expressions`

```js
type State = {|
  expressions: List<Expression>,
  setExpressions: (List<Expression>) => State
|};

class StateClass extends Record({
  expressions: List()
}) {
  get expressions(): List<Expression> {
    return this.expressions;
  }

  setExpressions(expressions: List<Expression>): State {
    return this.set("expressions", expressions);
  }
}

function initialState(): State {
  return new StateClass({
    expressions: List(restoreExpressions())
  });
}
```

I'm curious what others think. Am I going down an unnecessary rabbit hole?
