### PR TITLE
Source header and Command bar should use the toolbar background color…

### DIFF
--- a/src/components/PrimaryPanes/Sources.css
+++ b/src/components/PrimaryPanes/Sources.css
@@ -13,6 +13,7 @@
 
 .sources-header {
   height: 30px;
+  background-color: var(--theme-toolbar-background);
   border-bottom: 1px solid var(--theme-splitter-color);
   padding-top: 0px;
   padding-bottom: 0px;

--- a/src/components/SecondaryPanes/CommandBar.css
+++ b/src/components/SecondaryPanes/CommandBar.css
@@ -7,7 +7,7 @@
   position: sticky;
   top: 0;
   z-index: 1;
-  background-color: var(--theme-body-background);
+  background-color: var(--theme-toolbar-background);
 }
 
 .command-bar.vertical {


### PR DESCRIPTION
Associated Issue: #3866 

### Summary of Changes

* Source header and command bar should use the --theme-toolbar-background color

### Test Plan

Check that the top toolbar are all the same background color and matches the --theme-toolbar-background color variable.