### PR TITLE
Accordion header should have a height of 24px (#3868)

### DIFF
--- a/src/components/shared/Accordion.css
+++ b/src/components/shared/Accordion.css
@@ -7,7 +7,7 @@
   background-color: var(--theme-toolbar-background);
   border-bottom: 1px solid var(--theme-splitter-color);
   font-size: 12px;
-  padding: 5px;
+  padding: 4px;
   transition: all 0.25s ease;
   width: 100%;
   align-items: center;


### PR DESCRIPTION
Associated Issue: #3868 

### Summary of Changes

* Changed the padding from 5px to 4px for the accordion header. We need to apply a box-sizing: border-box CSS reset to the whole panel to get the 24px in height that we want. That is being done in issue #3869 
