### PR TITLE
Added CSS reset and fixed the sizes of the toolbar, headers and foote…

### DIFF
--- a/src/components/App.css
+++ b/src/components/App.css
@@ -1,3 +1,7 @@
+* {
+  box-sizing: border-box;
+}
+
 .debugger {
   display: flex;
   flex: 1;

--- a/src/components/Editor/Editor.css
+++ b/src/components/Editor/Editor.css
@@ -42,7 +42,7 @@
   width: calc(100% - 1.5px);
   top: 30px;
   left: 0px;
-  --editor-footer-height: 27px;
+  --editor-footer-height: 24px;
 }
 
 html[dir="rtl"] .editor-mount {

--- a/src/components/Editor/Tabs.css
+++ b/src/components/Editor/Tabs.css
@@ -1,7 +1,7 @@
 .source-header {
   border-bottom: 1px solid var(--theme-splitter-color);
   width: 100%;
-  height: 30px;
+  height: 29px;
   display: flex;
   align-items: flex-end;
 }

--- a/src/components/PrimaryPanes/Sources.css
+++ b/src/components/PrimaryPanes/Sources.css
@@ -12,7 +12,7 @@
 }
 
 .sources-header {
-  height: 30px;
+  height: 29px;
   background-color: var(--theme-toolbar-background);
   border-bottom: 1px solid var(--theme-splitter-color);
   padding-top: 0px;

--- a/src/components/SecondaryPanes/CommandBar.css
+++ b/src/components/SecondaryPanes/CommandBar.css
@@ -1,8 +1,8 @@
 .command-bar {
-  flex: 0 0 30px;
+  flex: 0 0 29px;
   border-bottom: 1px solid var(--theme-splitter-color);
   display: flex;
-  height: 30px;
+  height: 29px;
   overflow: hidden;
   position: sticky;
   top: 0;

--- a/src/components/shared/Accordion.css
+++ b/src/components/shared/Accordion.css
@@ -10,6 +10,7 @@
   padding: 4px;
   transition: all 0.25s ease;
   width: 100%;
+  height: 24px;
   align-items: center;
 
   -webkit-user-select: none;


### PR DESCRIPTION
…r to match the photon spec. (#3869)

Associated Issue: #3869 

### Summary of Changes

* Added CSS reset
* Made the toolbar 29px in height
* Made the accordion 24px in height
* Made the footer 24px in height

### Test Plan

Inspect that each toolbar, accordion header and footer is as described. This is the total height including the border. 