### PR TITLE
Search results order

### DIFF
--- a/src/actions/project-text-search.js
+++ b/src/actions/project-text-search.js
@@ -31,7 +31,7 @@ export function clearSearchQuery() {
 }
 
 export function clearSearchResults() {
-  return ({ dispatch }) => {
+  return ({ dispatch, getState }: ThunkArgs) => {
     dispatch({ type: "CLEAR_SEARCH_RESULTS" });
   };
 }

--- a/src/actions/project-text-search.js
+++ b/src/actions/project-text-search.js
@@ -30,8 +30,15 @@ export function clearSearchQuery() {
   };
 }
 
+export function clearSearchResults() {
+  return ({ dispatch }) => {
+    dispatch({ type: "CLEAR_SEARCH_RESULTS" });
+  };
+}
+
 export function searchSources(query: string) {
   return async ({ dispatch, getState }: ThunkArgs) => {
+    await dispatch(clearSearchResults());
     await dispatch(addSearchQuery(query));
     await dispatch(loadAllSources());
     const sources = getSources(getState());

--- a/src/actions/tests/__snapshots__/project-text-search.spec.js.snap
+++ b/src/actions/tests/__snapshots__/project-text-search.spec.js.snap
@@ -1,25 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`project text search should search a specific source 1`] = `
-Object {
-  "filepath": "http://localhost:8000/examples/bar",
-  "matches": Array [
-    Object {
-      "column": 9,
-      "line": 1,
-      "match": "bla",
-      "sourceId": "bar",
-      "text": "function bla(x, y) {",
-      "value": "function bla(x, y) {",
-    },
-  ],
-  "sourceId": "bar",
-}
-`;
-
-exports[`project text search should search all the loaded sources based on the query 1`] = `
-Immutable.Map {
-  foo1: Object {
+exports[`project text search should clear all the search results 1`] = `
+Immutable.List [
+  Object {
+    "filepath": "http://localhost:8000/examples/foo1",
+    "matches": Array [],
+    "sourceId": "foo1",
+  },
+  Object {
     "filepath": "http://localhost:8000/examples/foo1",
     "matches": Array [
       Object {
@@ -49,7 +37,76 @@ Immutable.Map {
     ],
     "sourceId": "foo1",
   },
-  foo2: Object {
+]
+`;
+
+exports[`project text search should clear all the search results 2`] = `
+Immutable.List [
+]
+`;
+
+exports[`project text search should search a specific source 1`] = `
+Immutable.List [
+  Object {
+    "filepath": "http://localhost:8000/examples/bar",
+    "matches": Array [
+      Object {
+        "column": 9,
+        "line": 1,
+        "match": "bla",
+        "sourceId": "bar",
+        "text": "function bla(x, y) {",
+        "value": "function bla(x, y) {",
+      },
+    ],
+    "sourceId": "bar",
+  },
+]
+`;
+
+exports[`project text search should search all the loaded sources based on the query 1`] = `
+Immutable.List [
+  Object {
+    "filepath": "http://localhost:8000/examples/foo1",
+    "matches": Array [],
+    "sourceId": "foo1",
+  },
+  Object {
+    "filepath": "http://localhost:8000/examples/foo2",
+    "matches": Array [],
+    "sourceId": "foo2",
+  },
+  Object {
+    "filepath": "http://localhost:8000/examples/foo1",
+    "matches": Array [
+      Object {
+        "column": 9,
+        "line": 1,
+        "match": "foo",
+        "sourceId": "foo1",
+        "text": "function foo1() {",
+        "value": "function foo1() {",
+      },
+      Object {
+        "column": 8,
+        "line": 2,
+        "match": "foo",
+        "sourceId": "foo1",
+        "text": "  const foo = 5; return foo;",
+        "value": "  const foo = 5; return foo;",
+      },
+      Object {
+        "column": 24,
+        "line": 2,
+        "match": "foo",
+        "sourceId": "foo1",
+        "text": "  const foo = 5; return foo;",
+        "value": "  const foo = 5; return foo;",
+      },
+    ],
+    "sourceId": "foo1",
+  },
+  Object {
     "filepath": "http://localhost:8000/examples/foo2",
     "matches": Array [
       Object {
@@ -63,5 +120,5 @@ Immutable.Map {
     ],
     "sourceId": "foo2",
   },
-}
+]
 `;

--- a/src/actions/tests/project-text-search.spec.js
+++ b/src/actions/tests/project-text-search.spec.js
@@ -85,10 +85,23 @@ describe("project text search", () => {
       actions.searchSource(getSource(getState(), "bar").toJS(), "bla")
     );
 
-    const result = getTextSearchResult(getState(), "bar");
+    const results = getTextSearchResults(getState());
 
-    expect(getTextSearchResults(getState()).size).toEqual(1);
+    expect(results).toMatchSnapshot();
+    expect(results.size).toEqual(1);
+  });
 
-    expect(result).toMatchSnapshot();
+  it("should clear all the search results", async () => {
+    const { dispatch, getState } = createStore(threadClient);
+    const mockQuery = "foo";
+
+    await dispatch(actions.newSource(makeSource("foo1")));
+    await dispatch(actions.searchSources(mockQuery));
+
+    expect(getTextSearchResults(getState())).toMatchSnapshot();
+
+    await dispatch(actions.clearSearchResults());
+
+    expect(getTextSearchResults(getState())).toMatchSnapshot();
   });
 });

--- a/src/actions/tests/project-text-search.spec.js
+++ b/src/actions/tests/project-text-search.spec.js
@@ -5,12 +5,7 @@ import {
   makeSource
 } from "../../utils/test-head";
 
-const {
-  getTextSearchQuery,
-  getTextSearchResults,
-  getTextSearchResult,
-  getSource
-} = selectors;
+const { getTextSearchQuery, getTextSearchResults, getSource } = selectors;
 
 const threadClient = {
   sourceContents: function(sourceId) {

--- a/src/components/ProjectSearch/TextSearch.js
+++ b/src/components/ProjectSearch/TextSearch.js
@@ -15,16 +15,18 @@ import { getRelativePath } from "../../utils/sources-tree";
 // for specific properties) as the node passed in.
 
 function getMatchingFocusNode(results, node) {
-  if (node === null) {
+  if (node == null) {
     return null;
   }
-  return results.find(result => {
+  let matchingNode = null;
+  results.some(result => {
     if (node.filepath) {
       if (node.sourceId === result.sourceId) {
-        return result;
+        matchingNode = result;
+        return true;
       }
     } else {
-      return result.matches.some(match => {
+      matchingNode = result.matches.find(match => {
         if (
           node.sourceId === match.sourceId &&
           node.column === match.column &&
@@ -33,6 +35,7 @@ function getMatchingFocusNode(results, node) {
           return match;
         }
       });
+      return true;
     }
   });
 }
@@ -41,11 +44,11 @@ export default class TextSearch extends Component {
   constructor(props: Props) {
     super(props);
     this.state = {
-      inputValue: this.props.query || "",
-      inputFocused: false
+      inputValue: this.props.query || ""
     };
 
     this.focusedItem = null;
+    this.inputFocused = false;
 
     this.inputOnChange = this.inputOnChange.bind(this);
     this.onKeyDown = this.onKeyDown.bind(this);
@@ -111,7 +114,7 @@ export default class TextSearch extends Component {
   }
 
   onEnterPress() {
-    if (this.focusedItem && !this.state.inputFocused) {
+    if (this.focusedItem && !this.inputFocused) {
       const { setExpanded, file, expanded, match } = this.focusedItem;
       if (setExpanded) {
         setExpanded(file, !expanded);
@@ -211,10 +214,10 @@ export default class TextSearch extends Component {
   renderResults() {
     const results = this.getResults();
     results = results.filter(result => result.matches.length > 0);
-    function getFilePath(item) {
+    function getFilePath(item, index) {
       return item.filepath
-        ? `${item.sourceId}`
-        : `${item.sourceId}-${item.line}-${item.column}`;
+        ? `${item.sourceId}-${index}`
+        : `${item.sourceId}-${item.line}-${item.column}-${index}`;
     }
 
     const renderItem = (item, depth, focused, _, expanded, { setExpanded }) => {
@@ -260,8 +263,8 @@ export default class TextSearch extends Component {
         size="big"
         summaryMsg={summaryMsg}
         onChange={e => this.inputOnChange(e)}
-        onFocus={() => this.setState({ inputFocused: true })}
-        onBlur={() => this.setState({ inputFocused: false })}
+        onFocus={() => (this.inputFocused = true)}
+        onBlur={() => (this.inputFocused = false)}
         onKeyDown={e => this.onKeyDown(e)}
         handleClose={this.close}
         ref="searchInput"

--- a/src/components/ProjectSearch/TextSearch.js
+++ b/src/components/ProjectSearch/TextSearch.js
@@ -11,35 +11,6 @@ import "./TextSearch.css";
 
 import { getRelativePath } from "../../utils/sources-tree";
 
-// This finds a node that matches (has the same values
-// for specific properties) as the node passed in.
-
-function getMatchingFocusNode(results, node) {
-  if (node == null) {
-    return null;
-  }
-  let matchingNode = null;
-  results.some(result => {
-    if (node.filepath) {
-      if (node.sourceId === result.sourceId) {
-        matchingNode = result;
-        return true;
-      }
-    } else {
-      matchingNode = result.matches.find(match => {
-        if (
-          node.sourceId === match.sourceId &&
-          node.column === match.column &&
-          node.line === match.line
-        ) {
-          return match;
-        }
-      });
-      return true;
-    }
-  });
-}
-
 export default class TextSearch extends Component {
   constructor(props: Props) {
     super(props);
@@ -64,21 +35,6 @@ export default class TextSearch extends Component {
   componentWillUnmount() {
     const shortcuts = this.context.shortcuts;
     shortcuts.off("Enter", this.onEnterPress);
-  }
-
-  componentWillReceiveProps(nextProps) {
-    if (nextProps.results !== this.props.results) {
-      if (this.focusedItem === null) {
-        return;
-      }
-      const { file, match } = this.focusedItem;
-      const focusedItemType = file && !match ? "file" : "match";
-
-      this.focusedItem[focusedItemType] = getMatchingFocusNode(
-        nextProps.results,
-        file || match
-      );
-    }
   }
 
   close() {

--- a/src/components/ProjectSearch/index.js
+++ b/src/components/ProjectSearch/index.js
@@ -137,7 +137,7 @@ class ProjectSearch extends Component {
     return (
       <TextSearch
         sources={sources}
-        results={results.valueSeq().toJS()}
+        results={results.toJS()}
         searchSources={searchSources}
         closeActiveSearch={closeActiveSearch}
         selectSource={selectSource}

--- a/src/reducers/project-text-search.js
+++ b/src/reducers/project-text-search.js
@@ -13,7 +13,7 @@ import makeRecord from "../utils/makeRecord";
 
 import type { ProjectTextSearchAction } from "../actions/types";
 import type { Record } from "../utils/makeRecord";
-import type { Map } from "immutable";
+import type { List } from "immutable";
 
 export type Search = {
   id: string,
@@ -22,15 +22,15 @@ export type Search = {
 };
 
 export type ResultRecord = Record<Search>;
-export type ResultMap = Map<string, ResultRecord>;
+export type ResultList = List<string, ResultRecord>;
 export type ProjectTextSearchState = {
   query: string,
-  results: ResultMap
+  results: ResultList
 };
 
 export function InitialState(): Record<ProjectTextSearchState> {
   return makeRecord(
-    ({ query: "", results: I.Map() }: ProjectTextSearchState)
+    ({ query: "", results: I.List() }: ProjectTextSearchState)
   )();
 }
 
@@ -46,10 +46,13 @@ function update(
       return state.remove("query");
 
     case "ADD_SEARCH_RESULT":
-      return state.updateIn(
-        ["results", action.result.sourceId],
-        value => action.result
-      );
+      let results = state.get("results");
+      return state.merge({ results: results.push(action.result) });
+
+    case "CLEAR_SEARCH_RESULTS":
+      return state.merge({
+        results: state.get("results").clear()
+      });
   }
   return state;
 }
@@ -58,10 +61,6 @@ type OuterState = { projectTextSearch: Record<ProjectTextSearchState> };
 
 export function getTextSearchResults(state: OuterState) {
   return state.projectTextSearch.get("results");
-}
-
-export function getTextSearchResult(state: OuterState, id: string) {
-  return state.projectTextSearch.getIn(["results", id]);
 }
 
 export function getTextSearchQuery(state: OuterState) {

--- a/src/reducers/project-text-search.js
+++ b/src/reducers/project-text-search.js
@@ -22,7 +22,7 @@ export type Search = {
 };
 
 export type ResultRecord = Record<Search>;
-export type ResultList = List<string, ResultRecord>;
+export type ResultList = List<ResultRecord>;
 export type ProjectTextSearchState = {
   query: string,
   results: ResultList


### PR DESCRIPTION
Associated Issue: #3876

### Summary of Changes

* Change the results from a `Map` to a `List` for order consistensy
* Added new action and reducer to clear search results for every new search
* Added test for `clearSearchResults`
* Remove unused `getTextSearchResult` selector
* There was need for `inputFocused` to be a state property, it was causing unnecessary re-renders
*  Fixed the focused issue. it should now focus on the first match of the first result found by default

### Screenshots/Videos (OPTIONAL)
#### Before
- New results get added any where (ordered by the sourceId), so the initially focused item moves
![](http://g.recordit.co/UFPfb2uiET.gif)

#### After
- New results always get added to the bottom (in order of how the results are found), so the focused node is always at the top 
![](http://g.recordit.co/ny0sB7txDD.gif)
