### PR TITLE
ChromeScopes: import react

### DIFF
--- a/src/components/SecondaryPanes/ChromeScopes.js
+++ b/src/components/SecondaryPanes/ChromeScopes.js
@@ -1,5 +1,5 @@
 // @flow
-import { PropTypes, Component } from "react";
+import React, { PropTypes, Component } from "react";
 import ImPropTypes from "react-immutable-proptypes";
 import { bindActionCreators } from "redux";
 import { connect } from "react-redux";


### PR DESCRIPTION
In a remote session with @codehag I found that ChromeScopes component throws Error because react is not defined.