### PR TITLE
Bug/3460 firefox becomes unresponsive when searching across very long lines

### DIFF
--- a/src/components/Editor/Highlight.css
+++ b/src/components/Editor/Highlight.css
@@ -20,22 +20,6 @@
 
 .cm-highlight-full::before {
   border: 1px solid var(--theme-comment-alt);
-}
-
-.cm-highlight-start::before {
-  border-left-width: 1px;
-  border-left-style: solid;
-  border-left-color: var(--theme-comment-alt);
-  margin: 0 0 -1px -1px;
-  border-top-left-radius: 2px;
-  border-bottom-left-radius: 2px;
-}
-
-.cm-highlight-end::before {
-  border-right-width: 1px;
-  border-right-style: solid;
-  border-right-color: var(--theme-comment-alt);
-  margin: 0 -1px -1px 0;
-  border-top-right-radius: 2px;
-  border-bottom-right-radius: 2px;
+  border-radius: 2px;
+  margin: 0 -1px -1px -1px;
 }

--- a/src/components/Editor/SearchBar.js
+++ b/src/components/Editor/SearchBar.js
@@ -134,7 +134,6 @@ class SearchBar extends Component {
   }
 
   componentDidUpdate(prevProps: any, prevState: any) {
-    const { selectedSource, query, modifiers, searchOn } = this.props;
     const searchInput = this.searchInput();
 
     if (searchInput) {
@@ -143,20 +142,6 @@ class SearchBar extends Component {
 
     if (this.refs.resultList && this.refs.resultList.refs) {
       scrollList(this.refs.resultList.refs, this.state.selectedResultIndex);
-    }
-
-    const hasLoaded = selectedSource && isLoaded(selectedSource.toJS());
-    const wasLoading =
-      prevProps.selectedSource && isLoaded(prevProps.selectedSource.toJS());
-
-    const doneLoading = wasLoading && hasLoaded;
-    const changedFiles =
-      selectedSource != prevProps.selectedSource && hasLoaded;
-    const modifiersUpdated =
-      modifiers && !modifiers.equals(prevProps.modifiers);
-
-    if (searchOn && (doneLoading || changedFiles || modifiersUpdated)) {
-      this.doSearch(query);
     }
   }
 

--- a/src/components/Editor/SearchBar.js
+++ b/src/components/Editor/SearchBar.js
@@ -16,7 +16,6 @@ import {
 import { find, findNext, findPrev, removeOverlay } from "../../utils/editor";
 
 import { getMatches } from "../../utils/search";
-import { isLoaded } from "../../utils/source";
 
 import { scrollList } from "../../utils/result-list";
 import classnames from "classnames";

--- a/src/utils/editor/source-search.js
+++ b/src/utils/editor/source-search.js
@@ -52,41 +52,29 @@ function isWhitespace(query) {
  */
 function searchOverlay(query, modifiers) {
   const regexQuery = buildQuery(query, modifiers, {
-    ignoreSpaces: true
+    ignoreSpaces: true,
+    // regex must be global for the overlay
+    isGlobal: true
   });
 
-  let matchLength = null;
-
   return {
-    token: function(stream) {
-      if (stream.column() === 0) {
-        matchLength = null;
-      }
-      if (matchLength !== null) {
-        if (matchLength > 2) {
-          for (let i = 0; i < matchLength - 2; ++i) {
-            stream.next();
-          }
-          matchLength = 1;
-          return "highlight";
-        }
-        stream.next();
-        matchLength = null;
-        return "highlight highlight-end";
-      }
-
-      const match = stream.match(regexQuery, false);
-      if (match) {
-        stream.next();
-        const len = match[0].length;
-        if (len === 1) {
-          return "highlight highlight-full";
-        }
-        matchLength = len;
-        return "highlight highlight-start";
-      }
-      while (!stream.match(regexQuery, false) && stream.peek()) {
-        stream.next();
+    token: function(stream, state) {
+      // set the last index to be the current stream position
+      // this acts as an offset
+      regexQuery.lastIndex = stream.pos;
+      const match = regexQuery.exec(stream.string);
+      if (match && match.index === stream.pos) {
+        // if we have a match at the current stream position
+        // set the class for a match
+        stream.pos += match[0].length || 1;
+        return "highlight highlight-full";
+      } else if (match) {
+        // if we have a match somewhere in the line, go to that point in the
+        // stream
+        stream.pos = match.index;
+      } else {
+        // if we have no matches in this line, skip to the end of the line
+        stream.skipToEnd();
       }
     }
   };
@@ -145,6 +133,7 @@ function doSearch(ctx, rev, query, keepSelection, modifiers: SearchModifiers) {
 
   return cm.operation(function() {
     if (!query || isWhitespace(query)) {
+      clearSearch(cm, query, modifiers);
       return;
     }
 

--- a/src/utils/search/build-query.js
+++ b/src/utils/search/build-query.js
@@ -19,7 +19,7 @@ function ignoreWhiteSpace(str: string): string {
 }
 
 function wholeMatch(query: string, wholeWord: boolean): string {
-  if (query == "" || !wholeWord) {
+  if (query === "" || !wholeWord) {
     return query;
   }
 
@@ -49,7 +49,7 @@ export default function buildQuery(
 ): RegExp {
   const { caseSensitive, regexMatch, wholeWord } = modifiers;
 
-  if (originalQuery == "") {
+  if (originalQuery === "") {
     return new RegExp(originalQuery);
   }
 

--- a/src/utils/search/get-matches.js
+++ b/src/utils/search/get-matches.js
@@ -1,5 +1,4 @@
 import buildQuery from "./build-query";
-const MAX_LENGTH = 100000;
 
 export default function getMatches(
   query: string,
@@ -17,12 +16,8 @@ export default function getMatches(
   for (let i = 0; i < lines.length; i++) {
     let singleMatch;
     const line = lines[i];
-    if (line.length <= MAX_LENGTH) {
-      while ((singleMatch = regexQuery.exec(line)) !== null) {
-        matchedLocations.push({ line: i, ch: singleMatch.index });
-      }
-    } else {
-      return [];
+    while ((singleMatch = regexQuery.exec(line)) !== null) {
+      matchedLocations.push({ line: i, ch: singleMatch.index });
     }
   }
   return matchedLocations;


### PR DESCRIPTION
Associated Issue: #3738 #3736 #3460

We had a couple of things happening when we loaded files; both related with search. The boolean in componentDidUpdate always returned true for the doSearch action. this resulted in a component update, which in turn triggered a doSearch function again. This is effectively an infinite loop, so i have removed the check for changes to modifiers and files -- we rather should implement this again, in a better way that does not rely on component did mount. As a postmortem -- we should make our checking of componentDidUpdate functions to make sure that no function within it is setting state.

the second issue was that our search overlay was not very efficient. we went character by character as we matched our elements, even if the text had nothing to do with our query. if there was a match, we added a class to each character. now - we are skipping to the point in the text where there is a match, applying a single class to the full match, and skipping to the next match. 

these two things should solve the above three bugs