### PR TITLE
Fix project search test

### DIFF
--- a/src/actions/sources.js
+++ b/src/actions/sources.js
@@ -36,7 +36,7 @@ import {
   removeSourcesFromTabList,
   removeSourceFromTabList,
   getTextSearchQuery,
-  getActiveSearchState
+  getActiveSearch
 } from "../selectors";
 
 import type { Source } from "../types";
@@ -187,7 +187,7 @@ export function selectSource(id: string, options: SelectSourceOptions = {}) {
       return dispatch({ type: "CLEAR_SELECTED_SOURCE" });
     }
 
-    const activeSearch = getActiveSearchState(getState());
+    const activeSearch = getActiveSearch(getState());
     if (activeSearch !== "file") {
       dispatch({ type: "TOGGLE_ACTIVE_SEARCH", value: null });
     }

--- a/src/actions/tests/ui.spec.js
+++ b/src/actions/tests/ui.spec.js
@@ -1,7 +1,7 @@
 import { createStore, selectors, actions } from "../../utils/test-head";
 
 const {
-  getActiveSearchState,
+  getActiveSearch,
   getFileSearchQueryState,
   getFileSearchModifierState,
   getFrameworkGroupingState,
@@ -14,24 +14,24 @@ const {
 describe("ui", () => {
   it("should toggle the visible state of project search", () => {
     const { dispatch, getState } = createStore();
-    expect(getActiveSearchState(getState())).toBe(null);
+    expect(getActiveSearch(getState())).toBe(null);
     dispatch(actions.setActiveSearch("project"));
-    expect(getActiveSearchState(getState())).toBe("project");
+    expect(getActiveSearch(getState())).toBe("project");
   });
 
   it("should close project search", () => {
     const { dispatch, getState } = createStore();
-    expect(getActiveSearchState(getState())).toBe(null);
+    expect(getActiveSearch(getState())).toBe(null);
     dispatch(actions.setActiveSearch("project"));
     dispatch(actions.closeActiveSearch());
-    expect(getActiveSearchState(getState())).toBe(null);
+    expect(getActiveSearch(getState())).toBe(null);
   });
 
   it("should toggle the visible state of file search", () => {
     const { dispatch, getState } = createStore();
-    expect(getActiveSearchState(getState())).toBe(null);
+    expect(getActiveSearch(getState())).toBe(null);
     dispatch(actions.setActiveSearch("file"));
-    expect(getActiveSearchState(getState())).toBe("file");
+    expect(getActiveSearch(getState())).toBe("file");
   });
 
   it("should update search results", () => {
@@ -50,10 +50,10 @@ describe("ui", () => {
 
   it("should close file search", () => {
     const { dispatch, getState } = createStore();
-    expect(getActiveSearchState(getState())).toBe(null);
+    expect(getActiveSearch(getState())).toBe(null);
     dispatch(actions.setActiveSearch("file"));
     dispatch(actions.closeActiveSearch());
-    expect(getActiveSearchState(getState())).toBe(null);
+    expect(getActiveSearch(getState())).toBe(null);
   });
 
   it("should update the file search query", () => {
@@ -76,9 +76,9 @@ describe("ui", () => {
 
   it("should toggle the symbol search state", () => {
     const { dispatch, getState } = createStore();
-    expect(getActiveSearchState(getState())).toBe(null);
+    expect(getActiveSearch(getState())).toBe(null);
     dispatch(actions.setActiveSearch("symbol"));
-    expect(getActiveSearchState(getState())).toBe("symbol");
+    expect(getActiveSearch(getState())).toBe("symbol");
   });
 
   it("should change the selected symbol type", () => {

--- a/src/actions/ui.js
+++ b/src/actions/ui.js
@@ -1,18 +1,27 @@
 // @flow
-import { getSource, getActiveSearchState } from "../selectors";
+import { getSource, getActiveSearch } from "../selectors";
 import type { ThunkArgs } from "./types";
 import type { ActiveSearchType, SymbolSearchType } from "../reducers/ui";
+import { clearSourceSearchQuery } from "./source-search";
 
 export function closeActiveSearch() {
-  return {
-    type: "TOGGLE_ACTIVE_SEARCH",
-    value: null
+  return ({ getState, dispatch }: ThunkArgs) => {
+    const activeSearch = getActiveSearch(getState());
+
+    if (activeSearch == "source") {
+      dispatch(clearSourceSearchQuery());
+    }
+
+    dispatch({
+      type: "TOGGLE_ACTIVE_SEARCH",
+      value: null
+    });
   };
 }
 
 export function setActiveSearch(activeSearch?: ActiveSearchType) {
   return ({ dispatch, getState }: ThunkArgs) => {
-    const activeSearchState = getActiveSearchState(getState());
+    const activeSearchState = getActiveSearch(getState());
     if (activeSearchState === activeSearch) {
       return;
     }

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -4,7 +4,11 @@ import React, { PropTypes, Component } from "react";
 import { connect } from "react-redux";
 import { bindActionCreators } from "redux";
 import actions from "../actions";
-import { getSelectedSource, getPaneCollapse } from "../selectors";
+import {
+  getSelectedSource,
+  getPaneCollapse,
+  getActiveSearch
+} from "../selectors";
 import type { SourceRecord } from "../reducers/sources";
 import { isVisible } from "../utils/ui";
 
@@ -38,7 +42,10 @@ type Props = {
   selectSource: Function,
   selectedSource: SourceRecord,
   startPanelCollapsed: boolean,
-  endPanelCollapsed: boolean
+  closeActiveSearch: () => void,
+  endPanelCollapsed: boolean,
+  activeSearch: string,
+  setActiveSearch: string => void
 };
 
 class App extends Component {
@@ -53,6 +60,8 @@ class App extends Component {
   getChildContext: Function;
   renderEditorPane: Function;
   renderVerticalLayout: Function;
+  toggleSymbolModal: Function;
+  onEscape: Function;
 
   constructor(props) {
     super(props);
@@ -64,8 +73,10 @@ class App extends Component {
 
     this.getChildContext = this.getChildContext.bind(this);
     this.onLayoutChange = this.onLayoutChange.bind(this);
+    this.toggleSymbolModal = this.toggleSymbolModal.bind(this);
     this.renderEditorPane = this.renderEditorPane.bind(this);
     this.renderVerticalLayout = this.renderVerticalLayout.bind(this);
+    this.onEscape = this.onEscape.bind(this);
   }
 
   getChildContext() {
@@ -74,10 +85,51 @@ class App extends Component {
 
   componentDidMount() {
     verticalLayoutBreakpoint.addListener(this.onLayoutChange);
+    shortcuts.on(
+      L10N.getStr("symbolSearch.search.key2"),
+      this.toggleSymbolModal
+    );
+    shortcuts.on("Escape", this.onEscape);
   }
 
   componentWillUnmount() {
     verticalLayoutBreakpoint.removeListener(this.onLayoutChange);
+    shortcuts.off(
+      L10N.getStr("symbolSearch.search.key2"),
+      this.toggleSymbolModal
+    );
+    shortcuts.off("Escape", this.onEscape);
+  }
+
+  onEscape(_, e) {
+    const { activeSearch, closeActiveSearch } = this.props;
+
+    if (activeSearch) {
+      e.preventDefault();
+      closeActiveSearch();
+    }
+  }
+
+  toggleSymbolModal(_, e: SyntheticEvent) {
+    const {
+      selectedSource,
+      activeSearch,
+      closeActiveSearch,
+      setActiveSearch
+    } = this.props;
+
+    if (!selectedSource) {
+      return;
+    }
+
+    e.preventDefault();
+    e.stopPropagation();
+
+    if (activeSearch == "symbol") {
+      return closeActiveSearch();
+    }
+
+    setActiveSearch("symbol");
   }
 
   onLayoutChange() {
@@ -179,9 +231,22 @@ class App extends Component {
     );
   }
 
-  render() {
-    const { selectSource, selectedSource } = this.props;
+  renderSymbolModal() {
+    const { selectSource, selectedSource, activeSearch } = this.props;
 
+    if (activeSearch !== "symbol") {
+      return;
+    }
+
+    return (
+      <SymbolModal
+        selectSource={selectSource}
+        selectedSource={selectedSource}
+      />
+    );
+  }
+
+  render() {
     return (
       <div className="debugger">
         {this.state.horizontal ? (
@@ -189,10 +254,7 @@ class App extends Component {
         ) : (
           this.renderVerticalLayout()
         )}
-        <SymbolModal
-          selectSource={selectSource}
-          selectedSource={selectedSource}
-        />
+        {this.renderSymbolModal()}
       </div>
     );
   }
@@ -206,7 +268,8 @@ export default connect(
   state => ({
     selectedSource: getSelectedSource(state),
     startPanelCollapsed: getPaneCollapse(state, "start"),
-    endPanelCollapsed: getPaneCollapse(state, "end")
+    endPanelCollapsed: getPaneCollapse(state, "end"),
+    activeSearch: getActiveSearch(state)
   }),
   dispatch => bindActionCreators(actions, dispatch)
 )(App);

--- a/src/components/Editor/SearchBar.js
+++ b/src/components/Editor/SearchBar.js
@@ -7,7 +7,7 @@ import { bindActionCreators } from "redux";
 import Svg from "../shared/Svg";
 import actions from "../../actions";
 import {
-  getActiveSearchState,
+  getActiveSearch,
   getFileSearchQueryState,
   getFileSearchModifierState,
   getSearchResults
@@ -434,7 +434,7 @@ SearchBar.contextTypes = {
 export default connect(
   state => {
     return {
-      searchOn: getActiveSearchState(state) === "file",
+      searchOn: getActiveSearch(state) === "file",
       query: getFileSearchQueryState(state),
       modifiers: getFileSearchModifierState(state),
       searchResults: getSearchResults(state)

--- a/src/components/Editor/Tabs.js
+++ b/src/components/Editor/Tabs.js
@@ -8,7 +8,7 @@ import * as I from "immutable";
 import {
   getSelectedSource,
   getSourcesForTabs,
-  getActiveSearchState,
+  getActiveSearch,
   getSearchTabs
 } from "../../selectors";
 import { isVisible } from "../../utils/ui";
@@ -513,8 +513,8 @@ export default connect(
       selectedSource: getSelectedSource(state),
       searchTabs: getSearchTabs(state),
       sourceTabs: getSourcesForTabs(state),
-      activeSearch: getActiveSearchState(state),
-      searchOn: getActiveSearchState(state) === "source"
+      activeSearch: getActiveSearch(state),
+      searchOn: getActiveSearch(state) === "source"
     };
   },
   dispatch => bindActionCreators(actions, dispatch)

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -15,7 +15,7 @@ import { isLoaded } from "../../utils/source";
 import { isEmptyLineInSource } from "../../reducers/ast";
 
 import {
-  getActiveSearchState,
+  getActiveSearch,
   getSelectedLocation,
   getSelectedFrame,
   getSelectedSource,
@@ -758,7 +758,7 @@ export default connect(
       selectedLocation,
       selectedSource,
       highlightedLineRange: getHighlightedLineRange(state),
-      searchOn: getActiveSearchState(state) === "file",
+      searchOn: getActiveSearch(state) === "file",
       loadedObjects: getLoadedObjects(state),
       breakpoints: getVisibleBreakpoints(state),
       hitCount: getHitCountForSource(state, sourceId),

--- a/src/components/PrimaryPanes/index.js
+++ b/src/components/PrimaryPanes/index.js
@@ -5,7 +5,7 @@ import { bindActionCreators } from "redux";
 import { connect } from "react-redux";
 import { formatKeyShortcut } from "../../utils/text";
 import actions from "../../actions";
-import { getSources, getActiveSearchState } from "../../selectors";
+import { getSources, getActiveSearch } from "../../selectors";
 import { isEnabled } from "devtools-config";
 import "./Sources.css";
 import classnames from "classnames";
@@ -130,7 +130,7 @@ PrimaryPanes.displayName = "PrimaryPanes";
 export default connect(
   state => ({
     sources: getSources(state),
-    sourceSearchOn: getActiveSearchState(state) === "source"
+    sourceSearchOn: getActiveSearch(state) === "source"
   }),
   dispatch => bindActionCreators(actions, dispatch)
 )(PrimaryPanes);

--- a/src/components/ProjectSearch/SourceSearch.js
+++ b/src/components/ProjectSearch/SourceSearch.js
@@ -18,32 +18,7 @@ export default class SourceSearch extends Component {
     clearQuery: () => void
   };
 
-  onEscape: Function;
-  close: Function;
   toggleSourceSearch: Function;
-
-  constructor(props: Props) {
-    super(props);
-
-    this.close = this.close.bind(this);
-  }
-
-  componentWillUnmount() {
-    const shortcuts = this.context.shortcuts;
-    shortcuts.off("Escape", this.onEscape);
-  }
-
-  componentDidMount() {
-    const shortcuts = this.context.shortcuts;
-    shortcuts.on("Escape", this.onEscape);
-  }
-
-  onEscape(shortcut, e) {
-    if (this.isProjectSearchEnabled()) {
-      e.preventDefault();
-      this.close();
-    }
-  }
 
   searchResults(sourceMap: SourcesMap) {
     return sourceMap
@@ -60,11 +35,6 @@ export default class SourceSearch extends Component {
       }));
   }
 
-  close() {
-    this.props.clearQuery();
-    this.props.closeActiveSearch();
-  }
-
   render() {
     const {
       sources,
@@ -77,9 +47,9 @@ export default class SourceSearch extends Component {
       <Autocomplete
         selectItem={(e, result) => {
           selectSource(result.id);
-          this.close();
+          this.props.closeActiveSearch();
         }}
-        close={this.close}
+        close={this.props.closeActiveSearch}
         items={this.searchResults(sources)}
         inputValue={query}
         placeholder={L10N.getStr("sourceSearch.search")}

--- a/src/components/ProjectSearch/TextSearch.js
+++ b/src/components/ProjectSearch/TextSearch.js
@@ -24,9 +24,9 @@ export default class TextSearch extends Component {
     this.inputOnChange = this.inputOnChange.bind(this);
     this.onKeyDown = this.onKeyDown.bind(this);
     this.onEnterPress = this.onEnterPress.bind(this);
-    this.close = this.close.bind(this);
     this.selectMatchItem = this.selectMatchItem.bind(this);
   }
+
   componentDidMount() {
     const shortcuts = this.context.shortcuts;
     shortcuts.on("Enter", this.onEnterPress);
@@ -35,10 +35,6 @@ export default class TextSearch extends Component {
   componentWillUnmount() {
     const shortcuts = this.context.shortcuts;
     shortcuts.off("Enter", this.onEnterPress);
-  }
-
-  close() {
-    this.props.closeActiveSearch();
   }
 
   selectMatchItem(matchItem) {
@@ -61,7 +57,12 @@ export default class TextSearch extends Component {
   }
 
   onKeyDown(e) {
+    if (e.key === "Escape") {
+      return;
+    }
+
     e.stopPropagation();
+
     if (e.key !== "Enter") {
       return;
     }
@@ -222,7 +223,7 @@ export default class TextSearch extends Component {
         onFocus={() => (this.inputFocused = true)}
         onBlur={() => (this.inputFocused = false)}
         onKeyDown={e => this.onKeyDown(e)}
-        handleClose={this.close}
+        handleClose={this.props.closeActiveSearch}
         ref="searchInput"
       />
     );

--- a/src/components/ProjectSearch/index.js
+++ b/src/components/ProjectSearch/index.js
@@ -9,10 +9,10 @@ import TextSearch from "./TextSearch";
 import SourceSearch from "./SourceSearch";
 import ToggleSearch from "./ToggleSearch";
 
-import { prefs } from "../../utils/prefs";
+import { features } from "../../utils/prefs";
 import {
   getSources,
-  getActiveSearchState,
+  getActiveSearch,
   getTextSearchResults,
   getTextSearchQuery,
   getSourceSearchQuery
@@ -61,7 +61,6 @@ class ProjectSearch extends Component {
       L10N.getStr("sources.search.alt.key")
     ];
     searchKeys.forEach(key => shortcuts.off(key, this.toggleSourceSearch));
-    shortcuts.off("Escape", this.onEscape);
   }
 
   toggleProjectTextSearch(key, e) {
@@ -70,7 +69,7 @@ class ProjectSearch extends Component {
       e.preventDefault();
     }
 
-    if (!prefs.projectTextSearchEnabled) {
+    if (!features.projectTextSearch) {
       return;
     }
 
@@ -189,7 +188,7 @@ ProjectSearch.displayName = "ProjectSearch";
 export default connect(
   state => ({
     sources: getSources(state),
-    activeSearch: getActiveSearchState(state),
+    activeSearch: getActiveSearch(state),
     results: getTextSearchResults(state),
     textSearchQuery: getTextSearchQuery(state),
     sourceSearchQuery: getSourceSearchQuery(state)

--- a/src/components/SymbolModal.js
+++ b/src/components/SymbolModal.js
@@ -5,7 +5,7 @@ import { connect } from "react-redux";
 import { bindActionCreators } from "redux";
 import { filter } from "fuzzaldrin-plus";
 import {
-  getActiveSearchState,
+  getActiveSearch,
   getSymbolSearchType,
   getSelectedSource,
   getSymbols
@@ -90,19 +90,9 @@ class SymbolModal extends Component {
     self.buildSummaryMsg = this.buildSummaryMsg.bind(this);
     self.buildPlaceHolder = this.buildPlaceHolder.bind(this);
     self.selectResultItem = this.selectResultItem.bind(this);
-    self.openSymbolModal = this.openSymbolModal.bind(this);
-  }
-
-  componentWillUnmount() {
-    const shortcuts = this.context.shortcuts;
-    shortcuts.off(L10N.getStr("symbolSearch.search.key2"));
-    shortcuts.off("Escape");
   }
 
   componentDidMount() {
-    const shortcuts = this.context.shortcuts;
-    shortcuts.on(L10N.getStr("symbolSearch.search.key2"), this.openSymbolModal);
-    shortcuts.on("Escape", this.closeModal);
     this.updateResults(this.state.query);
   }
 
@@ -114,12 +104,6 @@ class SymbolModal extends Component {
     if (!prevProps.enabled && this.props.enabled) {
       this.updateResults(this.state.query);
     }
-  }
-
-  openSymbolModal(_, e: SyntheticEvent) {
-    e.preventDefault();
-    e.stopPropagation();
-    this.props.setActiveSearch("symbol");
   }
 
   onClick(e: SyntheticEvent) {
@@ -139,7 +123,6 @@ class SymbolModal extends Component {
   closeModal() {
     this.props.closeActiveSearch();
     this.props.clearHighlightLineRange();
-    this.setState({ query: "" });
   }
 
   selectResultItem(e: SyntheticEvent, item: ?FormattedSymbolDeclaration) {
@@ -326,7 +309,7 @@ export default connect(
   state => {
     const source = getSelectedSource(state);
     return {
-      enabled: Boolean(getActiveSearchState(state) === "symbol" && source),
+      enabled: Boolean(getActiveSearch(state) === "symbol" && source),
       symbolType: getSymbolSearchType(state),
       symbols: _getFormattedSymbols(state, source)
     };

--- a/src/reducers/ui.js
+++ b/src/reducers/ui.js
@@ -154,7 +154,7 @@ function update(
 // https://github.com/devtools-html/debugger.html/blob/master/src/reducers/sources.js#L179-L185
 type OuterState = { ui: Record<UIState> };
 
-export function getActiveSearchState(state: OuterState): ActiveSearchType {
+export function getActiveSearch(state: OuterState): ActiveSearchType {
   return state.ui.get("activeSearch");
 }
 

--- a/src/test/mochitest/browser_dbg-console.js
+++ b/src/test/mochitest/browser_dbg-console.js
@@ -25,7 +25,7 @@ function getSplitConsole(dbg) {
   });
 }
 
-add_task(function* () {
+add_task(function*() {
   Services.prefs.setBoolPref("devtools.toolbox.splitconsoleEnabled", true);
   const dbg = yield initDebugger("doc-script-switching.html");
 
@@ -36,9 +36,10 @@ add_task(function* () {
   ok(dbg.toolbox.splitConsole, "Split console is shown.");
 
   // close the console
-  clickElement(dbg, "codeMirror");
+  yield clickElement(dbg, "codeMirror");
   // First time to focus out of text area
   pressKey(dbg, "Escape");
+
   // Second time to hide console
   pressKey(dbg, "Escape");
   ok(!dbg.toolbox.splitConsole, "Split console is hidden.");

--- a/src/test/mochitest/browser_dbg-search-file.js
+++ b/src/test/mochitest/browser_dbg-search-file.js
@@ -24,11 +24,11 @@ add_task(function*() {
 
   const cm = getCM(dbg);
   pressKey(dbg, "fileSearch");
-  is(dbg.selectors.getActiveSearchState(dbg.getState()), "file");
+  is(dbg.selectors.getActiveSearch(dbg.getState()), "file");
 
   // test closing and re-opening
   pressKey(dbg, "Escape");
-  is(dbg.selectors.getActiveSearchState(dbg.getState()), null);
+  is(dbg.selectors.getActiveSearch(dbg.getState()), null);
 
   pressKey(dbg, "fileSearch");
 

--- a/src/test/mochitest/browser_dbg-search-project.js
+++ b/src/test/mochitest/browser_dbg-search-project.js
@@ -5,23 +5,18 @@ function openProjectSearch(dbg) {
   synthesizeKeyShortcut("CmdOrCtrl+Shift+F");
   return waitForState(
     dbg,
-    state => dbg.selectors.getActiveSearchState(state) === "project"
+    state => dbg.selectors.getActiveSearch(state) === "project"
   );
 }
 
 function closeProjectSearch(dbg) {
   pressKey(dbg, "Escape");
-  return waitForState(dbg, state => !dbg.selectors.getActiveSearchState(state));
-}
-
-function getResult(dbg) {
-  return findElementWithSelector(dbg, ".managed-tree .result");
+  return waitForState(dbg, state => !dbg.selectors.getActiveSearch(state));
 }
 
 async function selectResult(dbg) {
-  const item = getResult(dbg);
   const select = waitForDispatch(dbg, "SELECT_SOURCE");
-  item.click();
+  clickElement(dbg, "fileMatch");
   return select;
 }
 
@@ -57,7 +52,8 @@ add_task(function*() {
   yield waitForState(dbg, () => getResultsCount(dbg) === 1);
 
   yield selectResult(dbg);
-  is(dbg.selectors.getActiveSearchState(dbg.getState()), null);
+
+  is(dbg.selectors.getActiveSearch(dbg.getState()), null);
 
   const selectedSource = dbg.selectors.getSelectedSource(dbg.getState());
   ok(selectedSource.get("url").includes("switching-01"));

--- a/src/test/mochitest/browser_dbg-search-sources.js
+++ b/src/test/mochitest/browser_dbg-search-sources.js
@@ -7,9 +7,9 @@ add_task(function*() {
 
   // test opening and closing
   pressKey(dbg, "sourceSearch");
-  is(dbg.selectors.getActiveSearchState(dbg.getState()), "source");
+  is(dbg.selectors.getActiveSearch(dbg.getState()), "source");
   pressKey(dbg, "Escape");
-  is(dbg.selectors.getActiveSearchState(dbg.getState()), null);
+  is(dbg.selectors.getActiveSearch(dbg.getState()), null);
 
   pressKey(dbg, "sourceSearch");
   yield waitForElement(dbg, "input");

--- a/src/test/mochitest/browser_dbg-search-symbols.js
+++ b/src/test/mochitest/browser_dbg-search-symbols.js
@@ -18,9 +18,9 @@ add_task(function*() {
 
   // test opening and closing
   yield openFunctionSearch(dbg);
-  is(dbg.selectors.getActiveSearchState(dbg.getState()), "symbol");
+  is(dbg.selectors.getActiveSearch(dbg.getState()), "symbol");
   pressKey(dbg, "Escape");
-  is(dbg.selectors.getActiveSearchState(dbg.getState()), null);
+  is(dbg.selectors.getActiveSearch(dbg.getState()), null);
 
   yield openFunctionSearch(dbg);
   is(resultCount(dbg), 1);

--- a/src/test/mochitest/browser_dbg-sources.js
+++ b/src/test/mochitest/browser_dbg-sources.js
@@ -20,10 +20,10 @@ add_task(function*() {
   // Expand nodes and make sure more sources appear.
   is(findAllElements(dbg, "sourceNodes").length, 2);
 
-  clickElement(dbg, "sourceArrow", 2);
+  yield clickElement(dbg, "sourceArrow", 2);
   is(findAllElements(dbg, "sourceNodes").length, 7);
 
-  clickElement(dbg, "sourceArrow", 3);
+  yield clickElement(dbg, "sourceArrow", 3);
   is(findAllElements(dbg, "sourceNodes").length, 8);
 
   // Select a source.
@@ -32,14 +32,16 @@ add_task(function*() {
     "Source is not focused"
   );
   const selected = waitForDispatch(dbg, "SELECT_SOURCE");
-  clickElement(dbg, "sourceNode", 4);
+  yield clickElement(dbg, "sourceNode", 4);
   yield selected;
   ok(
     findElementWithSelector(dbg, ".sources-list .focused"),
     "Source is focused"
   );
   ok(
-    getSelectedSource(getState()).get("url").includes("nested-source.js"),
+    getSelectedSource(getState())
+      .get("url")
+      .includes("nested-source.js"),
     "The right source is selected"
   );
 
@@ -78,7 +80,7 @@ add_task(function*() {
 
   // work around: the folder is rendered at the bottom, so we close the
   // root folder and open the (no domain) folder
-  clickElement(dbg, "sourceArrow", 3);
+  yield clickElement(dbg, "sourceArrow", 3);
   yield waitForSourceCount(dbg, 4);
 
   is(

--- a/src/test/mochitest/head.js
+++ b/src/test/mochitest/head.js
@@ -211,8 +211,9 @@ function waitForSource(dbg, url) {
   });
 }
 
-function waitForElement(dbg, selector) {
-  return waitUntil(() => findElementWithSelector(dbg, selector));
+async function waitForElement(dbg, selector) {
+  await waitUntil(() => findElementWithSelector(dbg, selector));
+  return findElementWithSelector(dbg, selector);
 }
 
 function waitForSelectedSource(dbg, sourceId) {
@@ -290,7 +291,9 @@ function assertHighlightLocation(dbg, source, line) {
     "Highlighted line is visible"
   );
   ok(
-    getCM(dbg).lineInfo(line - 1).wrapClass.includes("highlight-line"),
+    getCM(dbg)
+      .lineInfo(line - 1)
+      .wrapClass.includes("highlight-line"),
     "Line is highlighted"
   );
 }
@@ -730,7 +733,8 @@ const selectors = {
   sourceNode: i => `.sources-list .tree-node:nth-child(${i})`,
   sourceNodes: ".sources-list .tree-node",
   sourceArrow: i => `.sources-list .tree-node:nth-child(${i}) .arrow`,
-  resultItems: `.result-list .result-item`
+  resultItems: `.result-list .result-item`,
+  fileMatch: `.managed-tree .result`
 };
 
 function getSelector(elementName, ...args) {
@@ -770,12 +774,17 @@ function findAllElements(dbg, elementName, ...args) {
  * @return {Promise}
  * @static
  */
-function clickElement(dbg, elementName, ...args) {
+async function clickElement(dbg, elementName, ...args) {
   const selector = getSelector(elementName, ...args);
-  const el = findElement(dbg, elementName, ...args);
+  const el = await waitForElement(dbg, selector);
+
   el.scrollIntoView();
 
-  return EventUtils.synthesizeMouseAtCenter(
+  return clickElementWithSelector(dbg, selector);
+}
+
+function clickElementWithSelector(dbg, selector) {
+  EventUtils.synthesizeMouseAtCenter(
     findElementWithSelector(dbg, selector),
     {},
     dbg.win

--- a/src/utils/prefs.js
+++ b/src/utils/prefs.js
@@ -44,16 +44,12 @@ export const prefs = new PrefsHelper("devtools", {
   fileSearchCaseSensitive: ["Bool", "debugger.file-search-case-sensitive"],
   fileSearchWholeWord: ["Bool", "debugger.file-search-whole-word"],
   fileSearchRegexMatch: ["Bool", "debugger.file-search-regex-match"],
-  debuggerPrefsSchemaVersion: ["Char", "debugger.prefs-schema-version"],
-  projectTextSearchEnabled: [
-    "Bool",
-    "debugger.project-text-search-enabled",
-    false
-  ]
+  debuggerPrefsSchemaVersion: ["Char", "debugger.prefs-schema-version"]
 });
 
 export const features = new PrefsHelper("devtools.debugger.features", {
-  asyncStepping: ["Bool", "async-stepping", true]
+  asyncStepping: ["Bool", "async-stepping", true],
+  projectTextSearch: ["Bool", "debugger.project-text-search-enabled", true]
 });
 
 if (prefs.debuggerPrefsSchemaVersion !== prefsSchemaVersion) {


### PR DESCRIPTION
### Summary of Changes

While looking into why the project search test would time out I found that we had some funky escape handling. It turned out that Symbol Modal never un-mounted, which meant that it was always handling escape keys.

* the symbol modal is now conditionally rendered
* Escape handling is now in App.js
* some custom handling has been moved to clearActiveSearch 
* project and text search are a bit cleaner now too