### PR TITLE
Extract file search redux backend

### DIFF
--- a/src/actions/file-search.js
+++ b/src/actions/file-search.js
@@ -1,0 +1,108 @@
+// @flow
+
+import { find, findNext, findPrev, removeOverlay } from "../utils/editor";
+import { getMatches } from "../utils/search";
+import type { ThunkArgs } from "./types";
+
+// import {} from "./index";
+import { getSelectedSource, getFileSearchModifiers } from "../selectors";
+type Match = Object;
+type Editor = Object;
+
+export function doSearch(query: string, editor: Editor) {
+  return ({ getState, dispatch }: ThunkArgs) => {
+    const selectedSource = getSelectedSource(getState());
+    if (!selectedSource || !selectedSource.get("text")) {
+      return;
+    }
+
+    dispatch(setFileSearchQuery(query));
+    dispatch(searchContents(query, editor));
+  };
+}
+
+export function setFileSearchQuery(query: string) {
+  return {
+    type: "UPDATE_FILE_SEARCH_QUERY",
+    query
+  };
+}
+
+export function toggleFileSearchModifier(modifier: string) {
+  return { type: "TOGGLE_FILE_SEARCH_MODIFIER", modifier };
+}
+
+export function updateSearchResults(
+  characterIndex: number,
+  line: number,
+  matches: Match[]
+) {
+  const matchIndex = matches.findIndex(
+    elm => elm.line === line && elm.ch === characterIndex
+  );
+
+  return {
+    type: "UPDATE_SEARCH_RESULTS",
+    matches,
+    matchIndex,
+    count: matches.length,
+    index: characterIndex
+  };
+}
+
+async function searchContents(query: string, editor: Object) {
+  return async ({ getState, dispatch }) => {
+    // const { selectedSource, modifiers, editor: ed } = this.props;
+
+    const modifiers = getFileSearchModifiers(getState());
+    const selectedSource = getSelectedSource(getState());
+
+    if (
+      !query ||
+      !editor ||
+      !selectedSource ||
+      !selectedSource.get("text") ||
+      !modifiers
+    ) {
+      return;
+    }
+
+    const ctx = { ed: editor, cm: editor.codeMirror };
+    const _modifiers = modifiers.toJS();
+    const matches = await getMatches(
+      query,
+      selectedSource.get("text"),
+      _modifiers
+    );
+    const { ch, line } = find(ctx, query, true, _modifiers);
+
+    dispatch(updateSearchResults(ch, line, matches));
+  };
+}
+
+export function traverseResults(rev: boolean, editor: Editor) {
+  return async ({ getState, dispatch }) => {
+    if (!editor) {
+      return;
+    }
+
+    const ctx = { editor: ed, cm: editor.codeMirror };
+
+    const query = getFileSearchQuery(getState());
+    const modifiers = getFileSearchModifiers(getState());
+    const { searchResults: matches } = getFileSearchResults();
+    // const { query, modifiers, searchResults: { matches } } = this.props;
+
+    if (query === "") {
+      this.props.setActiveSearch("file");
+    }
+
+    if (modifiers) {
+      const matchedLocations = matches || [];
+      const { ch, line } = rev
+        ? findPrev(ctx, query, true, modifiers.toJS())
+        : findNext(ctx, query, true, modifiers.toJS());
+      this.updateSearchResults(ch, line, matchedLocations);
+    }
+  };
+}

--- a/src/actions/file-search.js
+++ b/src/actions/file-search.js
@@ -4,8 +4,12 @@ import { find, findNext, findPrev, removeOverlay } from "../utils/editor";
 import { getMatches } from "../utils/search";
 import type { ThunkArgs } from "./types";
 
-// import {} from "./index";
-import { getSelectedSource, getFileSearchModifiers } from "../selectors";
+import {
+  getSelectedSource,
+  getFileSearchModifiers,
+  getFileSearchQuery,
+  getFileSearchResults
+} from "../selectors";
 type Match = Object;
 type Editor = Object;
 
@@ -50,10 +54,8 @@ export function updateSearchResults(
   };
 }
 
-async function searchContents(query: string, editor: Object) {
-  return async ({ getState, dispatch }) => {
-    // const { selectedSource, modifiers, editor: ed } = this.props;
-
+export async function searchContents(query: string, editor: Object) {
+  return async ({ getState, dispatch }: ThunkArgs) => {
     const modifiers = getFileSearchModifiers(getState());
     const selectedSource = getSelectedSource(getState());
 
@@ -81,17 +83,16 @@ async function searchContents(query: string, editor: Object) {
 }
 
 export function traverseResults(rev: boolean, editor: Editor) {
-  return async ({ getState, dispatch }) => {
+  return async ({ getState, dispatch }: ThunkArgs) => {
     if (!editor) {
       return;
     }
 
-    const ctx = { editor: ed, cm: editor.codeMirror };
+    const ctx = { editor, cm: editor.codeMirror };
 
     const query = getFileSearchQuery(getState());
     const modifiers = getFileSearchModifiers(getState());
     const { searchResults: matches } = getFileSearchResults();
-    // const { query, modifiers, searchResults: { matches } } = this.props;
 
     if (query === "") {
       this.props.setActiveSearch("file");

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -11,6 +11,7 @@ import * as ast from "./ast";
 import * as coverage from "./coverage";
 import * as projectTextSearch from "./project-text-search";
 import * as sourceSearch from "./source-search";
+import * as fileSearch from "./file-search";
 import * as sourceTree from "./source-tree";
 import * as loadSourceText from "./sources/loadSourceText";
 import * as debuggee from "./debuggee";
@@ -29,6 +30,7 @@ export default Object.assign(
   coverage,
   projectTextSearch,
   sourceSearch,
+  fileSearch,
   sourceTree,
   loadSourceText,
   debuggee,

--- a/src/actions/tests/file-search.spec.js
+++ b/src/actions/tests/file-search.spec.js
@@ -3,22 +3,28 @@ import { createStore, selectors, actions } from "../../utils/test-head";
 const {
   getFileSearchQuery,
   getFileSearchModifiers,
-  getSearchResults
+  getFileSearchResults
 } = selectors;
 
 describe("file text search", () => {
   it("should update search results", () => {
     const { dispatch, getState } = createStore();
-    expect(getSearchResults(getState())).toEqual({
+    expect(getFileSearchResults(getState())).toEqual({
       matches: [],
       matchIndex: -1,
       index: -1,
       count: 0
     });
 
-    const results = { count: 3, index: 2 };
-    dispatch(actions.updateSearchResults(results));
-    expect(getSearchResults(getState())).toEqual(results);
+    const matches = [{ line: 1, ch: 3 }, { line: 3, ch: 2 }];
+    dispatch(actions.updateSearchResults(2, 3, matches));
+
+    expect(getFileSearchResults(getState())).toEqual({
+      count: 2,
+      index: 2,
+      matchIndex: 1,
+      matches: matches
+    });
   });
 
   it("should update the file search query", () => {

--- a/src/actions/tests/file-search.spec.js
+++ b/src/actions/tests/file-search.spec.js
@@ -1,0 +1,41 @@
+import { createStore, selectors, actions } from "../../utils/test-head";
+
+const {
+  getFileSearchQuery,
+  getFileSearchModifiers,
+  getSearchResults
+} = selectors;
+
+describe("file text search", () => {
+  it("should update search results", () => {
+    const { dispatch, getState } = createStore();
+    expect(getSearchResults(getState())).toEqual({
+      matches: [],
+      matchIndex: -1,
+      index: -1,
+      count: 0
+    });
+
+    const results = { count: 3, index: 2 };
+    dispatch(actions.updateSearchResults(results));
+    expect(getSearchResults(getState())).toEqual(results);
+  });
+
+  it("should update the file search query", () => {
+    const { dispatch, getState } = createStore();
+    let fileSearchQueryState = getFileSearchQuery(getState());
+    expect(fileSearchQueryState).toBe("");
+    dispatch(actions.setFileSearchQuery("foobar"));
+    fileSearchQueryState = getFileSearchQuery(getState());
+    expect(fileSearchQueryState).toBe("foobar");
+  });
+
+  it("should toggle a file search modifier", () => {
+    const { dispatch, getState } = createStore();
+    let fileSearchModState = getFileSearchModifiers(getState());
+    expect(fileSearchModState.get("caseSensitive")).toBe(false);
+    dispatch(actions.toggleFileSearchModifier("caseSensitive"));
+    fileSearchModState = getFileSearchModifiers(getState());
+    expect(fileSearchModState.get("caseSensitive")).toBe(true);
+  });
+});

--- a/src/actions/tests/ui.spec.js
+++ b/src/actions/tests/ui.spec.js
@@ -2,13 +2,10 @@ import { createStore, selectors, actions } from "../../utils/test-head";
 
 const {
   getActiveSearch,
-  getFileSearchQueryState,
-  getFileSearchModifierState,
   getFrameworkGroupingState,
   getPaneCollapse,
   getSymbolSearchType,
-  getHighlightedLineRange,
-  getSearchResults
+  getHighlightedLineRange
 } = selectors;
 
 describe("ui", () => {
@@ -34,44 +31,12 @@ describe("ui", () => {
     expect(getActiveSearch(getState())).toBe("file");
   });
 
-  it("should update search results", () => {
-    const { dispatch, getState } = createStore();
-    expect(getSearchResults(getState())).toEqual({
-      matches: [],
-      matchIndex: -1,
-      index: -1,
-      count: 0
-    });
-
-    const results = { count: 3, index: 2 };
-    dispatch(actions.updateSearchResults(results));
-    expect(getSearchResults(getState())).toEqual(results);
-  });
-
   it("should close file search", () => {
     const { dispatch, getState } = createStore();
     expect(getActiveSearch(getState())).toBe(null);
     dispatch(actions.setActiveSearch("file"));
     dispatch(actions.closeActiveSearch());
     expect(getActiveSearch(getState())).toBe(null);
-  });
-
-  it("should update the file search query", () => {
-    const { dispatch, getState } = createStore();
-    let fileSearchQueryState = getFileSearchQueryState(getState());
-    expect(fileSearchQueryState).toBe("");
-    dispatch(actions.setFileSearchQuery("foobar"));
-    fileSearchQueryState = getFileSearchQueryState(getState());
-    expect(fileSearchQueryState).toBe("foobar");
-  });
-
-  it("should toggle a file search modifier", () => {
-    const { dispatch, getState } = createStore();
-    let fileSearchModState = getFileSearchModifierState(getState());
-    expect(fileSearchModState.get("caseSensitive")).toBe(false);
-    dispatch(actions.toggleFileSearchModifier("caseSensitive"));
-    fileSearchModState = getFileSearchModifierState(getState());
-    expect(fileSearchModState.get("caseSensitive")).toBe(true);
   });
 
   it("should toggle the symbol search state", () => {

--- a/src/actions/types.js
+++ b/src/actions/types.js
@@ -149,10 +149,6 @@ type UIAction =
       value: ?ActiveSearchType
     }
   | {
-      type: "TOGGLE_FILE_SEARCH_MODIFIER",
-      modifier: "caseSensitive" | "wholeWord" | "regexMatch"
-    }
-  | {
       type: "TOGGLE_FRAMEWORK_GROUPING",
       value: boolean
     }
@@ -245,6 +241,27 @@ type ASTAction =
 
 export type SourceTreeAction = { type: "SET_EXPANDED_STATE", expanded: any };
 
+export type Match = Object;
+
+export type FileTextSearchAction =
+  | {
+      type: "TOGGLE_FILE_SEARCH_MODIFIER",
+      modifier: "caseSensitive" | "wholeWord" | "regexMatch"
+    }
+  | {
+      type: "UPDATE_FILE_SEARCH_QUERY",
+      query: string
+    }
+  | {
+      type: "UPDATE_SEARCH_RESULTS",
+      results: {
+        matches: Match[],
+        matchIndex: number,
+        count: number,
+        index: number
+      }
+    };
+
 export type ProjectTextSearchAction = {
   type: "ADD_QUERY",
   query: string
@@ -267,4 +284,6 @@ export type Action =
   | PauseAction
   | NavigateAction
   | UIAction
+  | FileTextSearchAction
+  | ProjectTextSearchAction
   | ASTAction;

--- a/src/actions/ui.js
+++ b/src/actions/ui.js
@@ -51,24 +51,6 @@ export function setSelectedSymbolType(symbolType: SymbolSearchType) {
   };
 }
 
-export function setFileSearchQuery(query: string) {
-  return {
-    type: "UPDATE_FILE_SEARCH_QUERY",
-    query
-  };
-}
-
-export function updateSearchResults(results: Object) {
-  return {
-    type: "UPDATE_SEARCH_RESULTS",
-    results
-  };
-}
-
-export function toggleFileSearchModifier(modifier: string) {
-  return { type: "TOGGLE_FILE_SEARCH_MODIFIER", modifier };
-}
-
 export function showSource(sourceId: string) {
   return ({ dispatch, getState }: ThunkArgs) => {
     const source = getSource(getState(), sourceId);

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -69,7 +69,7 @@ class App extends Component {
   getChildContext: Function;
   renderEditorPane: Function;
   renderVerticalLayout: Function;
-  toggleSymbolModal: Function;
+  toggleVisible: Function;
   onEscape: Function;
 
   constructor(props) {
@@ -83,7 +83,7 @@ class App extends Component {
 
     this.getChildContext = this.getChildContext.bind(this);
     this.onLayoutChange = this.onLayoutChange.bind(this);
-    this.toggleSymbolModal = this.toggleSymbolModal.bind(this);
+    this.toggleVisible = this.toggleVisible.bind(this);
     this.renderEditorPane = this.renderEditorPane.bind(this);
     this.renderVerticalLayout = this.renderVerticalLayout.bind(this);
     this.onEscape = this.onEscape.bind(this);
@@ -97,7 +97,11 @@ class App extends Component {
     verticalLayoutBreakpoint.addListener(this.onLayoutChange);
     shortcuts.on(
       L10N.getStr("symbolSearch.search.key2"),
-      this.toggleSymbolModal
+      this.toggleVisible.bind(this, "symbol")
+    );
+    shortcuts.on(
+      L10N.getStr("sourceSearch.search.key2"),
+      this.toggleVisible.bind(this, "file")
     );
     shortcuts.on("Escape", this.onEscape);
   }
@@ -106,7 +110,11 @@ class App extends Component {
     verticalLayoutBreakpoint.removeListener(this.onLayoutChange);
     shortcuts.off(
       L10N.getStr("symbolSearch.search.key2"),
-      this.toggleSymbolModal
+      this.toggleVisible.bind(this, "symbol")
+    );
+    shortcuts.off(
+      L10N.getStr("sourceSearch.search.key2"),
+      this.toggleVisible.bind(this, "file")
     );
     shortcuts.off("Escape", this.onEscape);
   }
@@ -120,7 +128,7 @@ class App extends Component {
     }
   }
 
-  toggleSymbolModal(_, e: SyntheticEvent) {
+  toggleVisible(elem: string, _, e: SyntheticEvent) {
     const {
       selectedSource,
       activeSearch,
@@ -135,11 +143,11 @@ class App extends Component {
       return;
     }
 
-    if (activeSearch == "symbol") {
+    if (activeSearch == elem) {
       return closeActiveSearch();
     }
 
-    setActiveSearch("symbol");
+    setActiveSearch(elem);
   }
 
   onLayoutChange() {

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -25,8 +25,8 @@ import {
   getCoverageEnabled,
   getLoadedObjects,
   getPause,
-  getFileSearchQueryState,
-  getFileSearchModifierState,
+  getFileSearchQuery,
+  getFileSearchModifiers,
   getVisibleBreakpoints,
   getInScopeLines,
   getConditionalBreakpointPanel,
@@ -798,8 +798,8 @@ export default connect(
       selectedFrame: getSelectedFrame(state),
       pauseData: getPause(state),
       coverageOn: getCoverageEnabled(state),
-      query: getFileSearchQueryState(state),
-      searchModifiers: getFileSearchModifierState(state),
+      query: getFileSearchQuery(state),
+      searchModifiers: getFileSearchModifiers(state),
       linesInScope: getInScopeLines(state),
       getFunctionText: line =>
         findFunctionText(

--- a/src/components/Editor/tests/SearchBar.spec.js
+++ b/src/components/Editor/tests/SearchBar.spec.js
@@ -32,7 +32,8 @@ function generateDefaults() {
       toJS: () => ({ caseSensitive: true, wholeWord: false, regexMatch: false })
     },
     selectedResultIndex: 0,
-    updateSearchResults: jest.fn()
+    updateSearchResults: jest.fn(),
+    doSearch: jest.fn()
   };
 }
 
@@ -56,7 +57,7 @@ describe("doSearch", () => {
     await component
       .find("SearchInput")
       .simulate("change", { target: { value: "query" } });
-    const updateSearchArgs = props.updateSearchResults.mock.calls[0][0];
-    expect(updateSearchArgs).toMatchSnapshot();
+    const doSearchArgs = props.doSearch.mock.calls[0][0];
+    expect(doSearchArgs).toMatchSnapshot();
   });
 });

--- a/src/components/Editor/tests/__snapshots__/SearchBar.spec.js.snap
+++ b/src/components/Editor/tests/__snapshots__/SearchBar.spec.js.snap
@@ -20,6 +20,7 @@ ShallowWrapper {
         onKeyUp={[Function]}
         placeholder="Search in file…"
         query=""
+        refFunc={[Function]}
         showErrorEmoji={true}
         size=""
         summaryMsg=""
@@ -79,6 +80,7 @@ ShallowWrapper {
             onKeyUp={[Function]}
             placeholder="Search in file…"
             query=""
+            refFunc={[Function]}
             showErrorEmoji={true}
             size=""
             summaryMsg=""
@@ -133,6 +135,7 @@ ShallowWrapper {
       "_compositeType": 0,
       "_context": Object {},
       "_currentElement": <SearchBar
+        doSearch={[Function]}
         editor={Object {}}
         modifiers={
                 Object {
@@ -161,15 +164,16 @@ ShallowWrapper {
       "_instance": SearchBar {
         "_reactInternalInstance": [Circular],
         "buildSummaryMsg": [Function],
-        "clearSearch": [Function],
         "closeSearch": [Function],
         "context": Object {
           "shortcuts": undefined,
         },
+        "getInputRef": [Function],
         "onChange": [Function],
         "onEscape": [Function],
         "onKeyUp": [Function],
         "props": Object {
+          "doSearch": [Function],
           "editor": Object {},
           "modifiers": Object {
             "get": [Function],
@@ -190,9 +194,7 @@ ShallowWrapper {
         },
         "refs": Object {},
         "renderSearchModifiers": [Function],
-        "searchInput": [Function],
         "selectSearchInput": [Function],
-        "setSearchValue": [Function],
         "state": Object {
           "count": 0,
           "index": -1,
@@ -228,6 +230,7 @@ ShallowWrapper {
                     onKeyUp={[Function]}
                     placeholder="Search in file…"
                     query=""
+                    refFunc={[Function]}
                     showErrorEmoji={true}
                     size=""
                     summaryMsg=""
@@ -287,6 +290,7 @@ ShallowWrapper {
                     onKeyUp={[Function]}
                     placeholder="Search in file…"
                     query=""
+                    refFunc={[Function]}
                     showErrorEmoji={true}
                     size=""
                     summaryMsg=""
@@ -345,6 +349,7 @@ ShallowWrapper {
   },
   "root": [Circular],
   "unrendered": <SearchBar
+    doSearch={[Function]}
     editor={Object {}}
     modifiers={
         Object {
@@ -370,13 +375,4 @@ ShallowWrapper {
 }
 `;
 
-exports[`doSearch should complete a search 1`] = `
-Object {
-  "count": 1,
-  "index": "1",
-  "matchIndex": -1,
-  "matches": Array [
-    "result",
-  ],
-}
-`;
+exports[`doSearch should complete a search 1`] = `"query"`;

--- a/src/components/Editor/tests/__snapshots__/SearchBar.spec.js.snap
+++ b/src/components/Editor/tests/__snapshots__/SearchBar.spec.js.snap
@@ -166,7 +166,6 @@ ShallowWrapper {
         "context": Object {
           "shortcuts": undefined,
         },
-        "doSearch": [Function],
         "onChange": [Function],
         "onEscape": [Function],
         "onKeyUp": [Function],
@@ -191,7 +190,6 @@ ShallowWrapper {
         },
         "refs": Object {},
         "renderSearchModifiers": [Function],
-        "searchContents": [Function],
         "searchInput": [Function],
         "selectSearchInput": [Function],
         "setSearchValue": [Function],
@@ -200,8 +198,6 @@ ShallowWrapper {
           "index": -1,
           "selectedResultIndex": 0,
         },
-        "toggleSearch": [Function],
-        "traverseResults": [Function],
         "updater": Object {
           "enqueueCallback": [Function],
           "enqueueCallbackInternal": [Function],

--- a/src/components/shared/Autocomplete.js
+++ b/src/components/shared/Autocomplete.js
@@ -47,7 +47,7 @@ export default class Autocomplete extends Component {
     }
   }
 
-  getSearchResults() {
+  getFileSearchResults() {
     const inputValue = this.props.inputValue;
     if (inputValue == "") {
       return [];
@@ -59,7 +59,7 @@ export default class Autocomplete extends Component {
   }
 
   onKeyDown(e: SyntheticKeyboardEvent) {
-    const searchResults = this.getSearchResults(),
+    const searchResults = this.getFileSearchResults(),
       resultCount = searchResults.length;
 
     if (e.key === "ArrowUp") {
@@ -118,7 +118,7 @@ export default class Autocomplete extends Component {
   render() {
     const { focused } = this.state;
     const { size, children } = this.props;
-    const searchResults = this.getSearchResults();
+    const searchResults = this.getFileSearchResults();
     const summaryMsg = L10N.getFormatStr(
       "sourceSearch.resultsSummary1",
       searchResults.length

--- a/src/components/shared/SearchInput.js
+++ b/src/components/shared/SearchInput.js
@@ -37,7 +37,8 @@ class SearchInput extends Component {
     onBlur: () => void,
     size: string,
     handleNext: () => void,
-    handlePrev: () => void
+    handlePrev: () => void,
+    refFunc: () => void
   };
 
   static defaultProps: Object;
@@ -119,7 +120,10 @@ class SearchInput extends Component {
       placeholder,
       value: query,
       spellCheck: false,
-      ref: c => (this.$input = c)
+      ref: c => {
+        this.$input = c;
+        this.props.refFunc != null && this.props.refFunc(c);
+      }
     };
 
     return (

--- a/src/reducers/file-search.js
+++ b/src/reducers/file-search.js
@@ -1,0 +1,118 @@
+// @flow
+
+/**
+ * UI reducer
+ * @module reducers/ui
+ */
+
+import makeRecord from "../utils/makeRecord";
+import { prefs } from "../utils/prefs";
+
+import type { Action, panelPositionType } from "../actions/types";
+import type { Record } from "../utils/makeRecord";
+
+export type Modifiers = Record<{
+  caseSensitive: boolean,
+  wholeWord: boolean,
+  regexMatch: boolean
+}>;
+
+export type MatchedLocations = {
+  line: number,
+  ch: number
+};
+
+export type SearchResults = {
+  matches: Array<MatchedLocations>,
+  matchIndex: number,
+  index: number,
+  count: number
+};
+
+export type UIState = {
+  searchResults: SearchResults,
+  active: boolean,
+  query: string,
+  modifiers: Modifiers
+};
+
+export const State = makeRecord(
+  ({
+    active: false,
+    query: "",
+    searchResults: {
+      matches: [],
+      matchIndex: -1,
+      index: -1,
+      count: 0
+    },
+    modifiers: makeRecord({
+      caseSensitive: prefs.fileSearchCaseSensitive,
+      wholeWord: prefs.fileSearchWholeWord,
+      regexMatch: prefs.fileSearchRegexMatch
+    })()
+  }: UIState)
+);
+
+function update(
+  state: Record<UIState> = State(),
+  action: Action
+): Record<UIState> {
+  switch (action.type) {
+    case "TOGGLE": {
+      return state.set("active", action.value);
+    }
+
+    case "SET_QUERY": {
+      return state.set("query", action.query);
+    }
+
+    case "SET_SEARCH_RESULTS": {
+      return state.set("searchResults", action.results);
+    }
+
+    case "TOGGLE_MODIFIER": {
+      const actionVal = !state.getIn(["modifiers", action.modifier]);
+
+      if (action.modifier == "caseSensitive") {
+        prefs.fileSearchCaseSensitive = actionVal;
+      }
+
+      if (action.modifier == "wholeWord") {
+        prefs.fileSearchWholeWord = actionVal;
+      }
+
+      if (action.modifier == "regexMatch") {
+        prefs.fileSearchRegexMatch = actionVal;
+      }
+
+      return state.setIn(["fileSearchModifiers", action.modifier], actionVal);
+    }
+
+    default: {
+      return state;
+    }
+  }
+}
+
+// NOTE: we'd like to have the app state fully typed
+// https://github.com/devtools-html/debugger.html/blob/master/src/reducers/sources.js#L179-L185
+type OuterState = { fileSearch: Record<UIState> };
+
+export function isFileSearchActive(state: OuterState): boolean {
+  return state.fileSearch.get("active");
+}
+
+export function getFileSearchQuery(state: OuterState): string {
+  return state.fileSearch.get("query");
+}
+
+export function getFileSearchModifiers(state: OuterState): Modifiers {
+  return state.fileSearch.get("modifiers");
+}
+
+export function getSearchResults(state: OuterState) {
+  return state.fileSearch.get("searchResults");
+}
+
+export default update;

--- a/src/reducers/file-search.js
+++ b/src/reducers/file-search.js
@@ -1,8 +1,8 @@
 // @flow
 
 /**
- * UI reducer
- * @module reducers/ui
+ * File Search reducer
+ * @module reducers/fileSearch
  */
 
 import makeRecord from "../utils/makeRecord";
@@ -29,7 +29,7 @@ export type SearchResults = {
   count: number
 };
 
-export type UIState = {
+export type FileSearchState = {
   searchResults: SearchResults,
   query: string,
   modifiers: Modifiers
@@ -49,13 +49,13 @@ export const State = makeRecord(
       wholeWord: prefs.fileSearchWholeWord,
       regexMatch: prefs.fileSearchRegexMatch
     })()
-  }: UIState)
+  }: FileSearchState)
 );
 
 function update(
-  state: Record<UIState> = State(),
+  state: Record<FileSearchState> = State(),
   action: Action
-): Record<UIState> {
+): Record<FileSearchState> {
   switch (action.type) {
     case "UPDATE_FILE_SEARCH_QUERY": {
       return state.set("query", action.query);
@@ -91,7 +91,7 @@ function update(
 
 // NOTE: we'd like to have the app state fully typed
 // https://github.com/devtools-html/debugger.html/blob/master/src/reducers/sources.js#L179-L185
-type OuterState = { fileSearch: Record<UIState> };
+type OuterState = { fileSearch: Record<FileSearchState> };
 
 export function getFileSearchQuery(state: OuterState): string {
   return state.fileSearch.get("query");
@@ -101,7 +101,7 @@ export function getFileSearchModifiers(state: OuterState): Modifiers {
   return state.fileSearch.get("modifiers");
 }
 
-export function getSearchResults(state: OuterState) {
+export function getFileSearchResults(state: OuterState) {
   return state.fileSearch.get("searchResults");
 }
 

--- a/src/reducers/file-search.js
+++ b/src/reducers/file-search.js
@@ -8,7 +8,7 @@
 import makeRecord from "../utils/makeRecord";
 import { prefs } from "../utils/prefs";
 
-import type { Action, panelPositionType } from "../actions/types";
+import type { Action } from "../actions/types";
 import type { Record } from "../utils/makeRecord";
 
 export type Modifiers = Record<{
@@ -31,14 +31,12 @@ export type SearchResults = {
 
 export type UIState = {
   searchResults: SearchResults,
-  active: boolean,
   query: string,
   modifiers: Modifiers
 };
 
 export const State = makeRecord(
   ({
-    active: false,
     query: "",
     searchResults: {
       matches: [],
@@ -59,19 +57,15 @@ function update(
   action: Action
 ): Record<UIState> {
   switch (action.type) {
-    case "TOGGLE": {
-      return state.set("active", action.value);
-    }
-
-    case "SET_QUERY": {
+    case "UPDATE_FILE_SEARCH_QUERY": {
       return state.set("query", action.query);
     }
 
-    case "SET_SEARCH_RESULTS": {
+    case "UPDATE_SEARCH_RESULTS": {
       return state.set("searchResults", action.results);
     }
 
-    case "TOGGLE_MODIFIER": {
+    case "TOGGLE_FILE_SEARCH_MODIFIER": {
       const actionVal = !state.getIn(["modifiers", action.modifier]);
 
       if (action.modifier == "caseSensitive") {
@@ -86,7 +80,7 @@ function update(
         prefs.fileSearchRegexMatch = actionVal;
       }
 
-      return state.setIn(["fileSearchModifiers", action.modifier], actionVal);
+      return state.setIn(["modifiers", action.modifier], actionVal);
     }
 
     default: {
@@ -98,10 +92,6 @@ function update(
 // NOTE: we'd like to have the app state fully typed
 // https://github.com/devtools-html/debugger.html/blob/master/src/reducers/sources.js#L179-L185
 type OuterState = { fileSearch: Record<UIState> };
-
-export function isFileSearchActive(state: OuterState): boolean {
-  return state.fileSearch.get("active");
-}
 
 export function getFileSearchQuery(state: OuterState): string {
   return state.fileSearch.get("query");

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -14,6 +14,7 @@ import ast from "./ast";
 import coverage from "./coverage";
 import projectTextSearch from "./project-text-search";
 import sourceSearch from "./source-search";
+import fileSearch from "./file-search";
 import sourceTree from "./source-tree";
 import debuggee from "./debuggee";
 
@@ -30,6 +31,7 @@ export default {
   coverage,
   projectTextSearch,
   sourceSearch,
+  fileSearch,
   sourceTree,
   debuggee
 };

--- a/src/reducers/ui.js
+++ b/src/reducers/ui.js
@@ -20,24 +20,9 @@ export type FileSearchModifiers = Record<{
 export type SymbolSearchType = "functions" | "variables";
 export type ActiveSearchType = "project" | "source" | "file" | "symbol";
 
-export type MatchedLocations = {
-  line: number,
-  ch: number
-};
-
-export type SearchResults = {
-  matches: Array<MatchedLocations>,
-  matchIndex: number,
-  index: number,
-  count: number
-};
-
 export type UIState = {
   activeSearch: ?ActiveSearchType,
-  fileSearchQuery: string,
-  fileSearchModifiers: FileSearchModifiers,
   symbolSearchType: SymbolSearchType,
-  searchResults: SearchResults,
   shownSource: string,
   startPanelCollapsed: boolean,
   endPanelCollapsed: boolean,
@@ -53,19 +38,7 @@ export type UIState = {
 export const State = makeRecord(
   ({
     activeSearch: null,
-    fileSearchQuery: "",
-    fileSearchModifiers: makeRecord({
-      caseSensitive: prefs.fileSearchCaseSensitive,
-      wholeWord: prefs.fileSearchWholeWord,
-      regexMatch: prefs.fileSearchRegexMatch
-    })(),
     symbolSearchType: "functions",
-    searchResults: {
-      matches: [],
-      matchIndex: -1,
-      index: -1,
-      count: 0
-    },
     shownSource: "",
     startPanelCollapsed: prefs.startPanelCollapsed,
     endPanelCollapsed: prefs.endPanelCollapsed,
@@ -87,32 +60,6 @@ function update(
     case "TOGGLE_FRAMEWORK_GROUPING": {
       prefs.frameworkGroupingOn = action.value;
       return state.set("frameworkGroupingOn", action.value);
-    }
-
-    case "UPDATE_FILE_SEARCH_QUERY": {
-      return state.set("fileSearchQuery", action.query);
-    }
-
-    case "UPDATE_SEARCH_RESULTS": {
-      return state.set("searchResults", action.results);
-    }
-
-    case "TOGGLE_FILE_SEARCH_MODIFIER": {
-      const actionVal = !state.getIn(["fileSearchModifiers", action.modifier]);
-
-      if (action.modifier == "caseSensitive") {
-        prefs.fileSearchCaseSensitive = actionVal;
-      }
-
-      if (action.modifier == "wholeWord") {
-        prefs.fileSearchWholeWord = actionVal;
-      }
-
-      if (action.modifier == "regexMatch") {
-        prefs.fileSearchRegexMatch = actionVal;
-      }
-
-      return state.setIn(["fileSearchModifiers", action.modifier], actionVal);
     }
 
     case "SET_SYMBOL_SEARCH_TYPE": {
@@ -161,20 +108,6 @@ type OuterState = { ui: Record<UIState> };
 
 export function getActiveSearch(state: OuterState): ActiveSearchType {
   return state.ui.get("activeSearch");
-}
-
-export function getFileSearchQueryState(state: OuterState): string {
-  return state.ui.get("fileSearchQuery");
-}
-
-export function getFileSearchModifierState(
-  state: OuterState
-): FileSearchModifiers {
-  return state.ui.get("fileSearchModifiers");
-}
-
-export function getSearchResults(state: OuterState) {
-  return state.ui.get("searchResults");
 }
 
 export function getFrameworkGroupingState(state: OuterState): boolean {

--- a/src/selectors.js
+++ b/src/selectors.js
@@ -11,6 +11,7 @@ import * as ast from "./reducers/ast";
 import * as coverage from "./reducers/coverage";
 import * as projectTextSearch from "./reducers/project-text-search";
 import * as sourceSearch from "./reducers/source-search";
+import * as fileSearch from "./reducers/file-search";
 import * as sourceTree from "./reducers/source-tree";
 
 import getBreakpointAtLocation from "./selectors/breakpointAtLocation";
@@ -36,6 +37,7 @@ module.exports = Object.assign(
   coverage,
   projectTextSearch,
   sourceSearch,
+  fileSearch,
   sourceTree,
   {
     getBreakpointAtLocation,

--- a/src/test/mochitest/browser_dbg-console.js
+++ b/src/test/mochitest/browser_dbg-console.js
@@ -41,6 +41,6 @@ add_task(async function() {
   pressKey(dbg, "Escape");
 
   // Second time to hide console
-  pressKey(dbg, "Escape");
+  pressKey(dbg, "CtrlEscape");
   ok(!dbg.toolbox.splitConsole, "Split console is hidden.");
 });

--- a/src/test/mochitest/browser_dbg-search-file.js
+++ b/src/test/mochitest/browser_dbg-search-file.js
@@ -35,11 +35,12 @@ add_task(async function() {
   const el = getFocusedEl(dbg);
 
   type(dbg, "con");
-  await waitForSearchState(dbg);
 
   const state = cm.state.search;
 
   pressKey(dbg, "Enter");
+  pressKey(dbg, "Enter");
+  await waitForSearchState(dbg);
   is(state.posFrom.line, 3);
 
   pressKey(dbg, "Enter");
@@ -48,7 +49,9 @@ add_task(async function() {
   pressKey(dbg, "ShiftEnter");
   is(state.posFrom.line, 3);
 
+  pressKey(dbg, "Escape");
   pressKey(dbg, "fileSearch");
+  is(dbg.selectors.getActiveSearch(dbg.getState()), "file");
   type(dbg, "fun");
 
   pressKey(dbg, "Enter");

--- a/src/test/mochitest/head.js
+++ b/src/test/mochitest/head.js
@@ -504,7 +504,7 @@ function stepOut(dbg) {
 function resume(dbg) {
   info("Resuming");
   dbg.actions.resume();
-  return waitForState(dbg, (state) => !dbg.selectors.isPaused(state));
+  return waitForState(dbg, state => !dbg.selectors.isPaused(state));
 }
 
 function deleteExpression(dbg, input) {
@@ -661,6 +661,7 @@ const keyMappings = {
   Start: startKey,
   Tab: { code: "VK_TAB" },
   Escape: { code: "VK_ESCAPE" },
+  CtrlEscape: { code: "VK_ESCAPE", modifiers: { ctrlKey: true } },
   Delete: { code: "VK_DELETE" },
   pauseKey: { code: "VK_F8" },
   resumeKey: { code: "VK_F8" },

--- a/src/utils/result-list.js
+++ b/src/utils/result-list.js
@@ -29,39 +29,4 @@ function chromeScrollList(elem, index) {
 
   resultsEl.scrollTop = Math.max(0, scroll);
 }
-
-function handleKeyDown(e: SyntheticKeyboardEvent) {
-  const searchResults = this.getSearchResults(),
-    resultCount = searchResults.length;
-
-  if (e.key === "ArrowUp") {
-    const selectedIndex = Math.max(0, this.state.selectedIndex - 1);
-    this.setState({ selectedIndex });
-    if (this.props.onSelectedItem) {
-      this.props.onSelectedItem(searchResults[selectedIndex]);
-    }
-    e.preventDefault();
-  } else if (e.key === "ArrowDown") {
-    const selectedIndex = Math.min(
-      resultCount - 1,
-      this.state.selectedIndex + 1
-    );
-    this.setState({ selectedIndex });
-    if (this.props.onSelectedItem) {
-      this.props.onSelectedItem(searchResults[selectedIndex]);
-    }
-    e.preventDefault();
-  } else if (e.key === "Enter") {
-    if (searchResults.length) {
-      this.props.selectItem(searchResults[this.state.selectedIndex]);
-    } else {
-      this.props.close(this.state.inputValue);
-    }
-    e.preventDefault();
-  } else if (e.key === "Tab") {
-    this.props.close(this.state.inputValue);
-    e.preventDefault();
-  }
-}
-
-export { scrollList, handleKeyDown };
+export { scrollList };


### PR DESCRIPTION
### Summary of Changes

I realized https://github.com/devtools-html/debugger.html/pull/3888 was too big, so i'm taking the file search redux part out and making it its own PR. 

Why extract:

* I'm realizing now that actions/ui was primarily file search. 
* Now that we have redux backends for project search, text search etc, it only seems fair
* the file search (SearchBar) component is way too complicated
* I'd like to have the search bar component only mounted when it is shown, to do this we need a permanent store. 

Other questions / Musings:

The redux api (actions/selectors) need to be be really long like `setFileSearchQuery` because they are shared among the entire app. It would be really cool if we could begin having sub-apps which are redux backends that are only connected to their root component. 

### Test Plan

Re-use existing tests