### PR TITLE
Move code coverage button title to l10n

### DIFF
--- a/assets/panel/debugger.properties
+++ b/assets/panel/debugger.properties
@@ -399,6 +399,10 @@ sourceFooter.unblackbox.accesskey=b
 # with a blackboxed source
 sourceFooter.blackboxed=Blackboxed Source
 
+# LOCALIZATION NOTE (sourceFooter.codeCoverage): Text associated
+# with a code coverage button
+sourceFooter.codeCoverage=Code Coverage
+
 # LOCALIZATION NOTE (sourceTabs.closeTabButtonTooltip): The tooltip that is displayed
 # for close tab button in source tabs.
 sourceTabs.closeTabButtonTooltip=Close tab

--- a/src/components/Editor/Footer.js
+++ b/src/components/Editor/Footer.js
@@ -114,9 +114,9 @@ class SourceFooter extends PureComponent {
     return (
       <button
         className="coverage action"
-        title="Code Coverage"
+        title={L10N.getStr("sourceFooter.codeCoverage")}
         onClick={() => recordCoverage()}
-        aria-label="Code Coverage"
+        aria-label={L10N.getStr("sourceFooter.codeCoverage")}
       >
         C
       </button>


### PR DESCRIPTION
Spotted this, thought it would be best to move to l10n.