### PR TITLE
Mochi async

### DIFF
--- a/src/actions/breakpoints/tests/syncing.js
+++ b/src/actions/breakpoints/tests/syncing.js
@@ -25,7 +25,7 @@ jest.mock("../../../utils/breakpoint/astBreakpointLocation", () => ({
   getASTLocation: jest.fn()
 }));
 
-// eslint-disable-next-line prettier/prettier
+// eslint-disable-next-line
 import { findScopeByName } from "../../../utils/breakpoint/astBreakpointLocation";
 
 import { syncClientBreakpoint } from "../../breakpoints/syncBreakpoint.js";

--- a/src/test/mochitest/browser_dbg-breaking-from-console.js
+++ b/src/test/mochitest/browser_dbg-breaking-from-console.js
@@ -9,16 +9,16 @@ async function waitOnToolbox(toolbox, event) {
   return new Promise(resolve => toolbox.on(event, resolve));
 }
 
-add_task(function*() {
+add_task(async function() {
   const url = EXAMPLE_URL + "doc-script-switching.html";
-  const toolbox = yield openNewTabAndToolbox(url, "webconsole");
+  const toolbox = await openNewTabAndToolbox(url, "webconsole");
 
   // Type "debugger" into console
   let jsterm = toolbox.getPanel("webconsole").hud.jsterm;
   jsterm.execute("debugger");
 
   // Wait for the debugger to be selected and make sure it's paused
-  yield waitOnToolbox(toolbox, "jsdebugger-selected");
+  await waitOnToolbox(toolbox, "jsdebugger-selected");
   is(toolbox.threadClient.state, "paused");
 
   // Create a dbg context
@@ -26,7 +26,7 @@ add_task(function*() {
   const { selectors: { getSelectedSource }, getState } = dbg;
 
   // Make sure the thread is paused in the right source and location
-  yield waitForDispatch(dbg, "LOAD_SOURCE_TEXT");
+  await waitForDispatch(dbg, "LOAD_SOURCE_TEXT");
   is(dbg.win.cm.getValue(), "debugger");
   const source = getSelectedSource(getState()).toJS();
   assertPausedLocation(dbg);

--- a/src/test/mochitest/browser_dbg-breaking.js
+++ b/src/test/mochitest/browser_dbg-breaking.js
@@ -3,30 +3,30 @@
 
 // Tests the breakpoints are hit in various situations.
 
-add_task(function*() {
-  const dbg = yield initDebugger("doc-scripts.html");
+add_task(async function() {
+  const dbg = await initDebugger("doc-scripts.html");
   const { selectors: { getSelectedSource }, getState } = dbg;
 
   // Make sure we can set a top-level breakpoint and it will be hit on
   // reload.
-  yield addBreakpoint(dbg, "scripts.html", 18);
+  await addBreakpoint(dbg, "scripts.html", 18);
   reload(dbg);
-  yield waitForPaused(dbg);
+  await waitForPaused(dbg);
   assertPausedLocation(dbg);
-  yield resume(dbg);
+  await resume(dbg);
 
   const paused = waitForPaused(dbg);
 
   // Create an eval script that pauses itself.
   invokeInTab("doEval");
 
-  yield paused;
-  yield resume(dbg);
+  await paused;
+  await resume(dbg);
   const source = getSelectedSource(getState()).toJS();
   ok(!source.url, "It is an eval source");
 
-  yield addBreakpoint(dbg, source, 5);
+  await addBreakpoint(dbg, source, 5);
   invokeInTab("evaledFunc");
-  yield waitForPaused(dbg);
+  await waitForPaused(dbg);
   assertPausedLocation(dbg);
 });

--- a/src/test/mochitest/browser_dbg-breakpoints-cond.js
+++ b/src/test/mochitest/browser_dbg-breakpoints-cond.js
@@ -24,49 +24,47 @@ function assertEditorBreakpoint(dbg, line, shouldExist) {
   );
 }
 
-function setConditionalBreakpoint(dbg, index, condition) {
-  return Task.spawn(function*() {
-    rightClickElement(dbg, "gutter", index);
-    selectMenuItem(dbg, 2);
-    yield waitForElement(dbg, ".conditional-breakpoint-panel input");
-    findElementWithSelector(dbg, ".conditional-breakpoint-panel input").focus();
-    // Position cursor reliably at the end of the text.
-    pressKey(dbg, "End");
-    type(dbg, condition);
-    pressKey(dbg, "Enter");
-  });
+async function setConditionalBreakpoint(dbg, index, condition) {
+  rightClickElement(dbg, "gutter", index);
+  selectMenuItem(dbg, 2);
+  await waitForElement(dbg, ".conditional-breakpoint-panel input");
+  findElementWithSelector(dbg, ".conditional-breakpoint-panel input").focus();
+  // Position cursor reliably at the end of the text.
+  pressKey(dbg, "End");
+  type(dbg, condition);
+  pressKey(dbg, "Enter");
 }
 
-add_task(function*() {
-  const dbg = yield initDebugger("doc-scripts.html");
-  yield selectSource(dbg, "simple2");
+add_task(async function() {
+  const dbg = await initDebugger("doc-scripts.html");
+  await selectSource(dbg, "simple2");
 
   // Adding a conditional Breakpoint
-  yield setConditionalBreakpoint(dbg, 5, "1");
-  yield waitForDispatch(dbg, "ADD_BREAKPOINT");
+  await setConditionalBreakpoint(dbg, 5, "1");
+  await waitForDispatch(dbg, "ADD_BREAKPOINT");
   let bp = findBreakpoint(dbg, "simple2", 5);
   is(bp.condition, "1", "breakpoint is created with the condition");
   assertEditorBreakpoint(dbg, 5, true);
 
   // Editing a conditional Breakpoint
-  yield setConditionalBreakpoint(dbg, 5, "2");
-  yield waitForDispatch(dbg, "SET_BREAKPOINT_CONDITION");
+  await setConditionalBreakpoint(dbg, 5, "2");
+  await waitForDispatch(dbg, "SET_BREAKPOINT_CONDITION");
   bp = findBreakpoint(dbg, "simple2", 5);
   is(bp.condition, "12", "breakpoint is created with the condition");
   assertEditorBreakpoint(dbg, 5, true);
 
   // Removing a conditional breakpoint
   clickElement(dbg, "gutter", 5);
-  yield waitForDispatch(dbg, "REMOVE_BREAKPOINT");
+  await waitForDispatch(dbg, "REMOVE_BREAKPOINT");
   bp = findBreakpoint(dbg, "simple2", 5);
   is(bp, null, "breakpoint was removed");
   assertEditorBreakpoint(dbg, 5, false);
 
   // Adding a condition to a breakpoint
   clickElement(dbg, "gutter", 5);
-  yield waitForDispatch(dbg, "ADD_BREAKPOINT");
-  yield setConditionalBreakpoint(dbg, 5, "1");
-  yield waitForDispatch(dbg, "SET_BREAKPOINT_CONDITION");
+  await waitForDispatch(dbg, "ADD_BREAKPOINT");
+  await setConditionalBreakpoint(dbg, 5, "1");
+  await waitForDispatch(dbg, "SET_BREAKPOINT_CONDITION");
 
   bp = findBreakpoint(dbg, "simple2", 5);
   is(bp.condition, "1", "breakpoint is created with the condition");

--- a/src/test/mochitest/browser_dbg-breakpoints-reloading.js
+++ b/src/test/mochitest/browser_dbg-breakpoints-reloading.js
@@ -23,21 +23,21 @@ function assertEditorBreakpoint(dbg, line) {
   ok(exists, `Breakpoint exists on line ${line}`);
 }
 
-add_task(function*() {
+add_task(async function() {
   requestLongerTimeout(3);
 
-  const dbg = yield initDebugger("doc-scripts.html");
+  const dbg = await initDebugger("doc-scripts.html");
   const { selectors: { getBreakpoints, getBreakpoint }, getState } = dbg;
   const source = findSource(dbg, "simple1.js");
 
-  yield selectSource(dbg, source.url);
-  yield addBreakpoint(dbg, 5);
-  yield addBreakpoint(dbg, 4);
+  await selectSource(dbg, source.url);
+  await addBreakpoint(dbg, 5);
+  await addBreakpoint(dbg, 4);
 
   const syncedBps = waitForDispatch(dbg, "SYNC_BREAKPOINT", 2);
-  yield reload(dbg, "simple1");
-  yield waitForSelectedSource(dbg);
-  yield syncedBps;
+  await reload(dbg, "simple1");
+  await waitForSelectedSource(dbg);
+  await syncedBps;
 
   assertEditorBreakpoint(dbg, 4);
   assertEditorBreakpoint(dbg, 5);

--- a/src/test/mochitest/browser_dbg-breakpoints.js
+++ b/src/test/mochitest/browser_dbg-breakpoints.js
@@ -7,26 +7,20 @@ function toggleBreakpoint(dbg, index) {
   input.click();
 }
 
-function removeBreakpoint(dbg, index) {
-  return Task.spawn(function*() {
-    const bp = findElement(dbg, "breakpointItem", index);
-    bp.querySelector(".close-btn").click();
-    yield waitForDispatch(dbg, "REMOVE_BREAKPOINT");
-  });
+async function removeBreakpoint(dbg, index) {
+  const bp = findElement(dbg, "breakpointItem", index);
+  bp.querySelector(".close-btn").click();
+  await waitForDispatch(dbg, "REMOVE_BREAKPOINT");
 }
 
-function disableBreakpoint(dbg, index) {
-  return Task.spawn(function*() {
-    toggleBreakpoint(dbg, index);
-    yield waitForDispatch(dbg, "DISABLE_BREAKPOINT");
-  });
+async function disableBreakpoint(dbg, index) {
+  toggleBreakpoint(dbg, index);
+  await waitForDispatch(dbg, "DISABLE_BREAKPOINT");
 }
 
-function enableBreakpoint(dbg, index) {
-  return Task.spawn(function*() {
-    toggleBreakpoint(dbg, index);
-    yield waitForDispatch(dbg, "ENABLE_BREAKPOINT");
-  });
+async function enableBreakpoint(dbg, index) {
+  toggleBreakpoint(dbg, index);
+  await waitForDispatch(dbg, "ENABLE_BREAKPOINT");
 }
 
 function toggleBreakpoints(dbg, count) {
@@ -54,54 +48,54 @@ function findBreakpoints(dbg) {
   return getBreakpoints(getState());
 }
 
-add_task(function*() {
-  const dbg = yield initDebugger("doc-scripts.html");
+add_task(async function() {
+  const dbg = await initDebugger("doc-scripts.html");
 
   // Create two breakpoints
-  yield selectSource(dbg, "simple2");
-  yield addBreakpoint(dbg, "simple2", 3);
-  yield addBreakpoint(dbg, "simple2", 5);
+  await selectSource(dbg, "simple2");
+  await addBreakpoint(dbg, "simple2", 3);
+  await addBreakpoint(dbg, "simple2", 5);
 
   // Disable the first one
-  yield disableBreakpoint(dbg, 1);
+  await disableBreakpoint(dbg, 1);
   let bp1 = findBreakpoint(dbg, "simple2", 3);
   let bp2 = findBreakpoint(dbg, "simple2", 5);
   is(bp1.disabled, true, "first breakpoint is disabled");
   is(bp2.disabled, false, "second breakpoint is enabled");
 
   // Disable and Re-Enable the second one
-  yield disableBreakpoint(dbg, 2);
-  yield enableBreakpoint(dbg, 2);
+  await disableBreakpoint(dbg, 2);
+  await enableBreakpoint(dbg, 2);
   bp2 = findBreakpoint(dbg, "simple2", 5);
   is(bp2.disabled, false, "second breakpoint is enabled");
 });
 
 // toggle all
-add_task(function*() {
-  const dbg = yield initDebugger("doc-scripts.html");
+add_task(async function() {
+  const dbg = await initDebugger("doc-scripts.html");
 
   // Create two breakpoints
-  yield selectSource(dbg, "simple2");
-  yield addBreakpoint(dbg, "simple2", 3);
-  yield addBreakpoint(dbg, "simple2", 5);
+  await selectSource(dbg, "simple2");
+  await addBreakpoint(dbg, "simple2", 3);
+  await addBreakpoint(dbg, "simple2", 5);
 
   // Disable all of the breakpoints
-  yield disableBreakpoints(dbg, 2);
+  await disableBreakpoints(dbg, 2);
   let bp1 = findBreakpoint(dbg, "simple2", 3);
   let bp2 = findBreakpoint(dbg, "simple2", 5);
   is(bp1.disabled, true, "first breakpoint is disabled");
   is(bp2.disabled, true, "second breakpoint is disabled");
 
   // Enable all of the breakpoints
-  yield enableBreakpoints(dbg, 2);
+  await enableBreakpoints(dbg, 2);
   bp1 = findBreakpoint(dbg, "simple2", 3);
   bp2 = findBreakpoint(dbg, "simple2", 5);
   is(bp1.disabled, false, "first breakpoint is enabled");
   is(bp2.disabled, false, "second breakpoint is enabled");
 
   // Remove the breakpoints
-  yield removeBreakpoint(dbg, 1);
-  yield removeBreakpoint(dbg, 1);
+  await removeBreakpoint(dbg, 1);
+  await removeBreakpoint(dbg, 1);
   const bps = findBreakpoints(dbg);
   is(bps.size, 0, "breakpoints are removed");
 });

--- a/src/test/mochitest/browser_dbg-call-stack.js
+++ b/src/test/mochitest/browser_dbg-call-stack.js
@@ -17,8 +17,8 @@ function toggleButton(dbg) {
   return callStackBody.querySelector(".show-more");
 }
 
-add_task(function* () {
-  const dbg = yield initDebugger("doc-script-switching.html");
+add_task(async function() {
+  const dbg = await initDebugger("doc-script-switching.html");
 
   toggleCallStack(dbg);
 
@@ -26,7 +26,7 @@ add_task(function* () {
   is(notPaused, "Not Paused", "Not paused message is shown");
 
   invokeInTab("firstCall");
-  yield waitForPaused(dbg);
+  await waitForPaused(dbg);
 
   ok(isFrameSelected(dbg, 1, "secondCall"), "the first frame is selected");
 
@@ -34,13 +34,13 @@ add_task(function* () {
   ok(!button, "toggle button shouldn't be there");
 });
 
-add_task(function* () {
-  const dbg = yield initDebugger("doc-frames.html");
+add_task(async function() {
+  const dbg = await initDebugger("doc-frames.html");
 
   toggleCallStack(dbg);
 
   invokeInTab("startRecursion");
-  yield waitForPaused(dbg);
+  await waitForPaused(dbg);
 
   ok(isFrameSelected(dbg, 1, "recurseA"), "the first frame is selected");
 

--- a/src/test/mochitest/browser_dbg-chrome-create.js
+++ b/src/test/mochitest/browser_dbg-chrome-create.js
@@ -42,12 +42,12 @@ registerCleanupFunction(function() {
   gProcess = null;
 });
 
-add_task(function*() {
+add_task(async function() {
   // Windows XP and 8.1 test slaves are terribly slow at this test.
   requestLongerTimeout(5);
   Services.prefs.setBoolPref("devtools.debugger.remote-enabled", true);
 
-  gProcess = yield initChromeDebugger();
+  gProcess = await initChromeDebugger();
 
   ok(
     gProcess._dbgProcess,
@@ -81,5 +81,5 @@ add_task(function*() {
 
   info("profile path: " + gProcess._dbgProfilePath);
 
-  yield gProcess.close();
+  await gProcess.close();
 });

--- a/src/test/mochitest/browser_dbg-chrome-debugging.js
+++ b/src/test/mochitest/browser_dbg-chrome-debugging.js
@@ -68,21 +68,21 @@ registerCleanupFunction(function() {
   DebuggerServer = null;
 });
 
-add_task(function*() {
+add_task(async function() {
   gClient = initDebuggerClient();
 
-  const [type] = yield gClient.connect();
+  const [type] = await gClient.connect();
   is(type, "browser", "Root actor should identify itself as a browser.");
 
-  const response = yield gClient.getProcess();
+  const response = await gClient.getProcess();
   let actor = response.form.actor;
-  gThreadClient = yield attachThread(gClient, actor);
+  gThreadClient = await attachThread(gClient, actor);
   gBrowser.selectedTab = BrowserTestUtils.addTab(gBrowser, "about:mozilla");
 
   // listen for a new source and global
   gThreadClient.addListener("newSource", onNewSource);
   gClient.addListener("newGlobal", onNewGlobal);
-  yield promise.all([gNewGlobal.promise, gNewChromeSource.promise]);
+  await promise.all([gNewGlobal.promise, gNewChromeSource.promise]);
 
-  yield resumeAndCloseConnection();
+  await resumeAndCloseConnection();
 });

--- a/src/test/mochitest/browser_dbg-console.js
+++ b/src/test/mochitest/browser_dbg-console.js
@@ -25,18 +25,18 @@ function getSplitConsole(dbg) {
   });
 }
 
-add_task(function*() {
+add_task(async function() {
   Services.prefs.setBoolPref("devtools.toolbox.splitconsoleEnabled", true);
-  const dbg = yield initDebugger("doc-script-switching.html");
+  const dbg = await initDebugger("doc-script-switching.html");
 
-  yield selectSource(dbg, "switching-01");
+  await selectSource(dbg, "switching-01");
 
   // open the console
-  yield getSplitConsole(dbg);
+  await getSplitConsole(dbg);
   ok(dbg.toolbox.splitConsole, "Split console is shown.");
 
   // close the console
-  yield clickElement(dbg, "codeMirror");
+  await clickElement(dbg, "codeMirror");
   // First time to focus out of text area
   pressKey(dbg, "Escape");
 

--- a/src/test/mochitest/browser_dbg-debugger-buttons.js
+++ b/src/test/mochitest/browser_dbg-debugger-buttons.js
@@ -24,31 +24,31 @@ function clickStepOut(dbg) {
  *  4. stepOver to the end of a function
  *  5. stepUp at the end of a function
  */
-add_task(function*() {
-  const dbg = yield initDebugger("doc-debugger-statements.html");
+add_task(async function() {
+  const dbg = await initDebugger("doc-debugger-statements.html");
 
-  yield reload(dbg);
-  yield waitForPaused(dbg);
+  await reload(dbg);
+  await waitForPaused(dbg);
   assertPausedLocation(dbg);
 
   // resume
   clickElement(dbg, "resume");
-  yield waitForPaused(dbg);
+  await waitForPaused(dbg);
   assertPausedLocation(dbg);
 
   // step over
-  yield clickStepOver(dbg);
+  await clickStepOver(dbg);
   assertPausedLocation(dbg);
 
   // step into
-  yield clickStepIn(dbg);
+  await clickStepIn(dbg);
   assertPausedLocation(dbg);
 
   // step over
-  yield clickStepOver(dbg);
+  await clickStepOver(dbg);
   assertPausedLocation(dbg);
 
   // step out
-  yield clickStepOut(dbg);
+  await clickStepOut(dbg);
   assertPausedLocation(dbg);
 });

--- a/src/test/mochitest/browser_dbg-editor-gutter.js
+++ b/src/test/mochitest/browser_dbg-editor-gutter.js
@@ -25,22 +25,22 @@ function assertEditorBreakpoint(dbg, line, shouldExist) {
   );
 }
 
-add_task(function*() {
-  const dbg = yield initDebugger("doc-scripts.html");
+add_task(async function() {
+  const dbg = await initDebugger("doc-scripts.html");
   const { selectors: { getBreakpoints, getBreakpoint }, getState } = dbg;
   const source = findSource(dbg, "simple1.js");
 
-  yield selectSource(dbg, source.url);
+  await selectSource(dbg, source.url);
 
   // Make sure that clicking the gutter creates a breakpoint icon.
   clickGutter(dbg, 4);
-  yield waitForDispatch(dbg, "ADD_BREAKPOINT");
+  await waitForDispatch(dbg, "ADD_BREAKPOINT");
   is(getBreakpoints(getState()).size, 1, "One breakpoint exists");
   assertEditorBreakpoint(dbg, 4, true);
 
   // Make sure clicking at the same place removes the icon.
   clickGutter(dbg, 4);
-  yield waitForDispatch(dbg, "REMOVE_BREAKPOINT");
+  await waitForDispatch(dbg, "REMOVE_BREAKPOINT");
   is(getBreakpoints(getState()).size, 0, "No breakpoints exist");
   assertEditorBreakpoint(dbg, 4, false);
 });

--- a/src/test/mochitest/browser_dbg-editor-highlight.js
+++ b/src/test/mochitest/browser_dbg-editor-highlight.js
@@ -5,8 +5,8 @@
 // matter if the source text doesn't exist yet or even if the source
 // doesn't exist.
 
-add_task(function*() {
-  const dbg = yield initDebugger("doc-scripts.html");
+add_task(async function() {
+  const dbg = await initDebugger("doc-scripts.html");
   const { selectors: { getSource }, getState } = dbg;
   const sourceUrl = EXAMPLE_URL + "long.js";
 
@@ -17,19 +17,19 @@ add_task(function*() {
 
   // Wait for the source text to load and make sure we're in the right
   // place.
-  yield waitForDispatch(dbg, "LOAD_SOURCE_TEXT");
+  await waitForDispatch(dbg, "LOAD_SOURCE_TEXT");
 
   // TODO: revisit highlighting lines when the debugger opens
   //assertHighlightLocation(dbg, "long.js", 66);
 
   // Jump to line 16 and make sure the editor scrolled.
-  yield selectSource(dbg, "long.js", 16);
+  await selectSource(dbg, "long.js", 16);
   assertHighlightLocation(dbg, "long.js", 16);
 
   // Make sure only one line is ever highlighted and the flash
   // animation is cancelled on old lines.
-  yield selectSource(dbg, "long.js", 17);
-  yield selectSource(dbg, "long.js", 18);
+  await selectSource(dbg, "long.js", 17);
+  await selectSource(dbg, "long.js", 18);
   assertHighlightLocation(dbg, "long.js", 18);
   is(
     findAllElements(dbg, "highlightLine").length,
@@ -45,7 +45,7 @@ add_task(function*() {
   // fully loaded, and check the highlighted line.
   const simple1 = findSource(dbg, "simple1.js");
   ok(getSource(getState(), simple1.id).get("loadedState"));
-  yield waitForDispatch(dbg, "LOAD_SOURCE_TEXT");
+  await waitForDispatch(dbg, "LOAD_SOURCE_TEXT");
   ok(getSource(getState(), simple1.id).get("text"));
   assertHighlightLocation(dbg, "simple1.js", 6);
 });

--- a/src/test/mochitest/browser_dbg-editor-mode.js
+++ b/src/test/mochitest/browser_dbg-editor-mode.js
@@ -3,12 +3,12 @@
 
 // Tests that the editor sets the correct mode for different file
 // types
-add_task(function* () {
-  const dbg = yield initDebugger("doc-scripts.html");
+add_task(async function() {
+  const dbg = await initDebugger("doc-scripts.html");
 
-  yield selectSource(dbg, "simple1.js");
+  await selectSource(dbg, "simple1.js");
   is(dbg.win.cm.getOption("mode").name, "javascript", "Mode is correct");
 
-  yield selectSource(dbg, "doc-scripts.html");
+  await selectSource(dbg, "doc-scripts.html");
   is(dbg.win.cm.getOption("mode").name, "htmlmixed", "Mode is correct");
 });

--- a/src/test/mochitest/browser_dbg-editor-select.js
+++ b/src/test/mochitest/browser_dbg-editor-select.js
@@ -11,44 +11,44 @@ function isElementVisible(dbg, elementName) {
   return bpLine && isVisibleWithin(cm, bpLine);
 }
 
-add_task(function*() {
+add_task(async function() {
   // This test runs too slowly on linux debug. I'd like to figure out
   // which is the slowest part of this and make it run faster, but to
   // fix a frequent failure allow a longer timeout.
   requestLongerTimeout(2);
 
-  const dbg = yield initDebugger("doc-scripts.html");
+  const dbg = await initDebugger("doc-scripts.html");
   const { selectors: { getSelectedSource }, getState } = dbg;
   const simple1 = findSource(dbg, "simple1.js");
   const simple2 = findSource(dbg, "simple2.js");
 
   // Set the initial breakpoint.
-  yield addBreakpoint(dbg, simple1, 4);
+  await addBreakpoint(dbg, simple1, 4);
   ok(!getSelectedSource(getState()), "No selected source");
 
   // Call the function that we set a breakpoint in.
   invokeInTab("main");
-  yield waitForPaused(dbg);
+  await waitForPaused(dbg);
   assertPausedLocation(dbg);
 
   // Step through to another file and make sure it's paused in the
   // right place.
-  yield stepIn(dbg);
+  await stepIn(dbg);
   assertPausedLocation(dbg);
 
   // Step back out to the initial file.
-  yield stepOut(dbg);
-  yield stepOut(dbg);
+  await stepOut(dbg);
+  await stepOut(dbg);
   assertPausedLocation(dbg);
-  yield resume(dbg);
+  await resume(dbg);
 
   // Make sure that we can set a breakpoint on a line out of the
   // viewport, and that pausing there scrolls the editor to it.
   let longSrc = findSource(dbg, "long.js");
-  yield addBreakpoint(dbg, longSrc, 66);
+  await addBreakpoint(dbg, longSrc, 66);
 
   invokeInTab("testModel");
-  yield waitForPaused(dbg);
+  await waitForPaused(dbg);
   assertPausedLocation(dbg);
   ok(isElementVisible(dbg, "breakpoint"), "Breakpoint is visible");
 });

--- a/src/test/mochitest/browser_dbg-expressions.js
+++ b/src/test/mochitest/browser_dbg-expressions.js
@@ -53,32 +53,32 @@ async function editExpression(dbg, input) {
   await waitForDispatch(dbg, "EVALUATE_EXPRESSION");
 }
 
-add_task(function*() {
-  const dbg = yield initDebugger("doc-script-switching.html");
+add_task(async function() {
+  const dbg = await initDebugger("doc-script-switching.html");
 
   invokeInTab("firstCall");
-  yield waitForPaused(dbg);
+  await waitForPaused(dbg);
 
-  yield addExpression(dbg, "f");
+  await addExpression(dbg, "f");
   is(getLabel(dbg, 1), "f");
   is(getValue(dbg, 1), "(unavailable)");
 
-  yield editExpression(dbg, "oo");
+  await editExpression(dbg, "oo");
   is(getLabel(dbg, 1), "foo()");
 
   // There is no "value" element for functions.
   assertEmptyValue(dbg, 1);
 
-  yield addExpression(dbg, "location");
+  await addExpression(dbg, "location");
   is(getLabel(dbg, 2), "location");
   ok(getValue(dbg, 2).includes("Location"), "has a value");
 
   // can expand an expression
   toggleExpression(dbg, 2);
-  yield waitForDispatch(dbg, "LOAD_OBJECT_PROPERTIES");
+  await waitForDispatch(dbg, "LOAD_OBJECT_PROPERTIES");
 
-  yield deleteExpression(dbg, "foo");
-  yield deleteExpression(dbg, "location");
+  await deleteExpression(dbg, "foo");
+  await deleteExpression(dbg, "location");
 
   is(findAllElements(dbg, "expressionNodes").length, 0);
 });

--- a/src/test/mochitest/browser_dbg-iframes.js
+++ b/src/test/mochitest/browser_dbg-iframes.js
@@ -6,21 +6,21 @@
  *  1. pause in the main thread
  *  2. pause in the iframe
  */
-add_task(function*() {
-  const dbg = yield initDebugger("doc-iframes.html");
+add_task(async function() {
+  const dbg = await initDebugger("doc-iframes.html");
 
   // test pausing in the main thread
-  yield reload(dbg);
-  yield waitForPaused(dbg);
+  await reload(dbg);
+  await waitForPaused(dbg);
   assertPausedLocation(dbg);
 
   // test pausing in the iframe
-  yield resume(dbg);
-  yield waitForPaused(dbg);
+  await resume(dbg);
+  await waitForPaused(dbg);
   assertPausedLocation(dbg);
 
   // test pausing in the iframe
-  yield resume(dbg);
-  yield waitForPaused(dbg);
+  await resume(dbg);
+  await waitForPaused(dbg);
   assertPausedLocation(dbg);
 });

--- a/src/test/mochitest/browser_dbg-navigation.js
+++ b/src/test/mochitest/browser_dbg-navigation.js
@@ -10,26 +10,26 @@ function countSources(dbg) {
  * Test navigating
  * navigating while paused will reset the pause state and sources
  */
-add_task(function*() {
-  const dbg = yield initDebugger("doc-script-switching.html");
+add_task(async function() {
+  const dbg = await initDebugger("doc-script-switching.html");
   const { selectors: { getSelectedSource, getPause }, getState } = dbg;
 
   invokeInTab("firstCall");
-  yield waitForPaused(dbg);
+  await waitForPaused(dbg);
 
-  yield navigate(dbg, "doc-scripts.html", "simple1.js");
-  yield addBreakpoint(dbg, "simple1.js", 4);
+  await navigate(dbg, "doc-scripts.html", "simple1.js");
+  await addBreakpoint(dbg, "simple1.js", 4);
   invokeInTab("main");
-  yield waitForPaused(dbg);
+  await waitForPaused(dbg);
   assertPausedLocation(dbg);
   is(countSources(dbg), 4, "4 sources are loaded.");
 
-  yield navigate(dbg, "about:blank");
-  yield waitForDispatch(dbg, "NAVIGATE");
+  await navigate(dbg, "about:blank");
+  await waitForDispatch(dbg, "NAVIGATE");
   is(countSources(dbg), 0, "0 sources are loaded.");
   ok(!getPause(getState()), "No pause state exists");
 
-  yield navigate(
+  await navigate(
     dbg,
     "doc-scripts.html",
     "simple1.js",
@@ -41,10 +41,12 @@ add_task(function*() {
   is(countSources(dbg), 4, "4 sources are loaded.");
 
   // Test that the current select source persists across reloads
-  yield selectSource(dbg, "long.js");
-  yield reload(dbg, "long.js");
+  await selectSource(dbg, "long.js");
+  await reload(dbg, "long.js");
   ok(
-    getSelectedSource(getState()).get("url").includes("long.js"),
+    getSelectedSource(getState())
+      .get("url")
+      .includes("long.js"),
     "Selected source is long.js"
   );
 });

--- a/src/test/mochitest/browser_dbg-pause-exceptions.js
+++ b/src/test/mochitest/browser_dbg-pause-exceptions.js
@@ -16,30 +16,30 @@ function caughtException() {
   3. pause on a caught error
   4. skip a caught error
 */
-add_task(function*() {
-  const dbg = yield initDebugger("doc-exceptions.html");
+add_task(async function() {
+  const dbg = await initDebugger("doc-exceptions.html");
 
   // test skipping an uncaught exception
-  yield uncaughtException();
+  await uncaughtException();
   ok(!isPaused(dbg));
 
   // Test pausing on an uncaught exception
-  yield togglePauseOnExceptions(dbg, true, false);
+  await togglePauseOnExceptions(dbg, true, false);
   uncaughtException();
-  yield waitForPaused(dbg);
+  await waitForPaused(dbg);
   assertPausedLocation(dbg);
-  yield resume(dbg);
+  await resume(dbg);
 
   // Test pausing on a caught Error
   caughtException();
-  yield waitForPaused(dbg);
+  await waitForPaused(dbg);
   assertPausedLocation(dbg);
-  yield resume(dbg);
+  await resume(dbg);
 
   // Test skipping a caught error
-  yield togglePauseOnExceptions(dbg, true, true);
+  await togglePauseOnExceptions(dbg, true, true);
   caughtException();
-  yield waitForPaused(dbg);
+  await waitForPaused(dbg);
   assertPausedLocation(dbg);
-  yield resume(dbg);
+  await resume(dbg);
 });

--- a/src/test/mochitest/browser_dbg-pretty-print-paused.js
+++ b/src/test/mochitest/browser_dbg-pretty-print-paused.js
@@ -3,21 +3,21 @@
 
 // Tests pretty-printing a source that is currently paused.
 
-add_task(function*() {
-  const dbg = yield initDebugger("doc-minified.html");
+add_task(async function() {
+  const dbg = await initDebugger("doc-minified.html");
 
-  yield selectSource(dbg, "math.min.js");
-  yield addBreakpoint(dbg, "math.min.js", 2);
+  await selectSource(dbg, "math.min.js");
+  await addBreakpoint(dbg, "math.min.js", 2);
 
   invokeInTab("arithmetic");
-  yield waitForPaused(dbg);
+  await waitForPaused(dbg);
   assertPausedLocation(dbg);
 
   clickElement(dbg, "prettyPrintButton");
-  yield waitForDispatch(dbg, "SELECT_SOURCE");
+  await waitForDispatch(dbg, "SELECT_SOURCE");
 
   // this doesnt work yet
   // assertPausedLocation(dbg);
 
-  yield resume(dbg);
+  await resume(dbg);
 });

--- a/src/test/mochitest/browser_dbg-pretty-print.js
+++ b/src/test/mochitest/browser_dbg-pretty-print.js
@@ -3,13 +3,13 @@
 
 // Tests basic pretty-printing functionality.
 
-add_task(function*() {
-  const dbg = yield initDebugger("doc-minified.html");
+add_task(async function() {
+  const dbg = await initDebugger("doc-minified.html");
 
-  yield selectSource(dbg, "math.min.js", 2);
+  await selectSource(dbg, "math.min.js", 2);
   clickElement(dbg, "prettyPrintButton");
 
-  yield waitForSource(dbg, "math.min.js:formatted");
+  await waitForSource(dbg, "math.min.js:formatted");
   const ppSrc = findSource(dbg, "math.min.js:formatted");
 
   ok(ppSrc, "Pretty-printed source exists");
@@ -17,19 +17,19 @@ add_task(function*() {
   // this is not implemented yet
   // assertHighlightLocation(dbg, "math.min.js:formatted", 18);
 
-  yield addBreakpoint(dbg, ppSrc, 18);
+  await addBreakpoint(dbg, ppSrc, 18);
 
   invokeInTab("arithmetic");
-  yield waitForPaused(dbg);
+  await waitForPaused(dbg);
   assertPausedLocation(dbg);
-  yield stepOver(dbg);
+  await stepOver(dbg);
   assertPausedLocation(dbg);
-  yield resume(dbg);
+  await resume(dbg);
 
   // The pretty-print button should go away in the pretty-printed
   // source.
   ok(!findElement(dbg, "editorFooter"), "Footer is hidden");
 
-  yield selectSource(dbg, "math.min.js");
+  await selectSource(dbg, "math.min.js");
   ok(findElement(dbg, "editorFooter"), "Footer is hidden");
 });

--- a/src/test/mochitest/browser_dbg-scopes-mutations.js
+++ b/src/test/mochitest/browser_dbg-scopes-mutations.js
@@ -23,14 +23,14 @@ function onLoadObjectProperties(dbg) {
   return waitForDispatch(dbg, "LOAD_OBJECT_PROPERTIES");
 }
 
-add_task(function*() {
-  const dbg = yield initDebugger("doc-script-mutate.html");
+add_task(async function() {
+  const dbg = await initDebugger("doc-script-mutate.html");
 
   toggleScopes(dbg);
 
   let onPaused = waitForPaused(dbg);
   invokeInTab("mutate");
-  yield onPaused;
+  await onPaused;
 
   is(
     getScopeNodeLabel(dbg, 2),
@@ -44,7 +44,7 @@ add_task(function*() {
   );
 
   info("Expand `phonebook`");
-  yield expandNode(dbg, 3);
+  await expandNode(dbg, 3);
   is(
     getScopeNodeLabel(dbg, 4),
     "S",
@@ -52,7 +52,7 @@ add_task(function*() {
   );
 
   info("Expand `S`");
-  yield expandNode(dbg, 4);
+  await expandNode(dbg, 4);
   is(
     getScopeNodeLabel(dbg, 5),
     "sarah",
@@ -65,7 +65,7 @@ add_task(function*() {
   );
 
   info("Expand `sarah`");
-  yield expandNode(dbg, 5);
+  await expandNode(dbg, 5);
   is(
     getScopeNodeLabel(dbg, 6),
     "lastName",
@@ -79,8 +79,8 @@ add_task(function*() {
 
   info("Resuming");
   onPaused = waitForPaused(dbg);
-  yield resume(dbg);
-  yield onPaused;
+  await resume(dbg);
+  await onPaused;
 
   is(
     getScopeNodeLabel(dbg, 2),

--- a/src/test/mochitest/browser_dbg-scopes.js
+++ b/src/test/mochitest/browser_dbg-scopes.js
@@ -9,23 +9,23 @@ function getLabel(dbg, index) {
   return findElement(dbg, "scopeNode", index).innerText;
 }
 
-add_task(function*() {
-  const dbg = yield initDebugger("doc-script-switching.html");
+add_task(async function() {
+  const dbg = await initDebugger("doc-script-switching.html");
 
   toggleScopes(dbg);
 
   invokeInTab("firstCall");
-  yield waitForPaused(dbg);
+  await waitForPaused(dbg);
 
   is(getLabel(dbg, 1), "secondCall");
   is(getLabel(dbg, 2), "<this>");
   is(getLabel(dbg, 4), "foo()");
 
   toggleNode(dbg, 4);
-  yield waitForDispatch(dbg, "LOAD_OBJECT_PROPERTIES");
+  await waitForDispatch(dbg, "LOAD_OBJECT_PROPERTIES");
   is(getLabel(dbg, 5), "arguments");
 
-  yield stepOver(dbg);
+  await stepOver(dbg);
   is(getLabel(dbg, 4), "foo()");
   is(getLabel(dbg, 5), "Window");
 });

--- a/src/test/mochitest/browser_dbg-search-file.js
+++ b/src/test/mochitest/browser_dbg-search-file.js
@@ -12,15 +12,15 @@ function getFocusedEl(dbg) {
   return doc.activeElement;
 }
 
-add_task(function*() {
-  const dbg = yield initDebugger("doc-scripts.html");
+add_task(async function() {
+  const dbg = await initDebugger("doc-scripts.html");
   const {
     selectors: { getBreakpoints, getBreakpoint, getActiveSearch },
     getState
   } = dbg;
   const source = findSource(dbg, "simple1.js");
 
-  yield selectSource(dbg, source.url);
+  await selectSource(dbg, source.url);
 
   const cm = getCM(dbg);
   pressKey(dbg, "fileSearch");
@@ -35,7 +35,7 @@ add_task(function*() {
   const el = getFocusedEl(dbg);
 
   type(dbg, "con");
-  yield waitForSearchState(dbg);
+  await waitForSearchState(dbg);
 
   const state = cm.state.search;
 
@@ -55,7 +55,7 @@ add_task(function*() {
   is(state.posFrom.line, 4);
 
   // selecting another source keeps search open
-  yield selectSource(dbg, "simple2");
+  await selectSource(dbg, "simple2");
   pressKey(dbg, "Enter");
   is(state.posFrom.line, 0);
 });

--- a/src/test/mochitest/browser_dbg-search-project.js
+++ b/src/test/mochitest/browser_dbg-search-project.js
@@ -16,7 +16,7 @@ function closeProjectSearch(dbg) {
 
 async function selectResult(dbg) {
   const select = waitForDispatch(dbg, "SELECT_SOURCE");
-  clickElement(dbg, "fileMatch");
+  await clickElement(dbg, "fileMatch");
   return select;
 }
 
@@ -31,27 +31,27 @@ function getResultsCount(dbg) {
 }
 
 // Testing project search
-add_task(function*() {
+add_task(async function() {
   Services.prefs.setBoolPref(
     "devtools.debugger.project-text-search-enabled",
     true
   );
 
-  const dbg = yield initDebugger("doc-script-switching.html", "switching-01");
+  const dbg = await initDebugger("doc-script-switching.html", "switching-01");
 
-  yield selectSource(dbg, "switching-01");
+  await selectSource(dbg, "switching-01");
 
   // test opening and closing
-  yield openProjectSearch(dbg);
-  yield closeProjectSearch(dbg);
+  await openProjectSearch(dbg);
+  await closeProjectSearch(dbg);
 
-  yield openProjectSearch(dbg);
+  await openProjectSearch(dbg);
   type(dbg, "first");
   pressKey(dbg, "Enter");
 
-  yield waitForState(dbg, () => getResultsCount(dbg) === 1);
+  await waitForState(dbg, () => getResultsCount(dbg) === 1);
 
-  yield selectResult(dbg);
+  await selectResult(dbg);
 
   is(dbg.selectors.getActiveSearch(dbg.getState()), null);
 

--- a/src/test/mochitest/browser_dbg-search-project.js
+++ b/src/test/mochitest/browser_dbg-search-project.js
@@ -15,7 +15,10 @@ function closeProjectSearch(dbg) {
 }
 
 async function selectResult(dbg) {
-  const select = waitForDispatch(dbg, "SELECT_SOURCE");
+  const select = waitForState(
+    dbg,
+    () => !dbg.selectors.getActiveSearch(dbg.getState())
+  );
   await clickElement(dbg, "fileMatch");
   return select;
 }

--- a/src/test/mochitest/browser_dbg-search-sources.js
+++ b/src/test/mochitest/browser_dbg-search-sources.js
@@ -2,8 +2,8 @@
  * http://creativecommons.org/publicdomain/zero/1.0/ */
 
 // Testing source search
-add_task(function*() {
-  const dbg = yield initDebugger("doc-script-switching.html");
+add_task(async function() {
+  const dbg = await initDebugger("doc-script-switching.html");
 
   // test opening and closing
   pressKey(dbg, "sourceSearch");
@@ -12,12 +12,12 @@ add_task(function*() {
   is(dbg.selectors.getActiveSearch(dbg.getState()), null);
 
   pressKey(dbg, "sourceSearch");
-  yield waitForElement(dbg, "input");
+  await waitForElement(dbg, "input");
   findElementWithSelector(dbg, "input").focus();
   type(dbg, "sw");
   pressKey(dbg, "Enter");
 
-  yield waitForDispatch(dbg, "LOAD_SOURCE_TEXT");
+  await waitForDispatch(dbg, "LOAD_SOURCE_TEXT");
   let source = dbg.selectors.getSelectedSource(dbg.getState());
   ok(source.get("url").match(/switching-01/), "first source is selected");
 
@@ -28,7 +28,7 @@ add_task(function*() {
   pressKey(dbg, "Down");
   pressKey(dbg, "Enter");
 
-  yield waitForDispatch(dbg, "LOAD_SOURCE_TEXT");
+  await waitForDispatch(dbg, "LOAD_SOURCE_TEXT");
   source = dbg.selectors.getSelectedSource(dbg.getState());
   ok(source.get("url").match(/switching-02/), "second source is selected");
 });

--- a/src/test/mochitest/browser_dbg-search-symbols.js
+++ b/src/test/mochitest/browser_dbg-search-symbols.js
@@ -11,18 +11,18 @@ function resultCount(dbg) {
 }
 
 // Testing function search
-add_task(function*() {
-  const dbg = yield initDebugger("doc-script-switching.html", "switching-01");
+add_task(async function() {
+  const dbg = await initDebugger("doc-script-switching.html", "switching-01");
 
-  yield selectSource(dbg, "switching-01");
+  await selectSource(dbg, "switching-01");
 
   // test opening and closing
-  yield openFunctionSearch(dbg);
+  await openFunctionSearch(dbg);
   is(dbg.selectors.getActiveSearch(dbg.getState()), "symbol");
   pressKey(dbg, "Escape");
   is(dbg.selectors.getActiveSearch(dbg.getState()), null);
 
-  yield openFunctionSearch(dbg);
+  await openFunctionSearch(dbg);
   is(resultCount(dbg), 1);
 
   type(dbg, "x");

--- a/src/test/mochitest/browser_dbg-sourcemaps-bogus.js
+++ b/src/test/mochitest/browser_dbg-sourcemaps-bogus.js
@@ -4,20 +4,20 @@
 // Test that an error while loading a sourcemap does not break
 // debugging.
 
-add_task(function*() {
+add_task(async function() {
   // NOTE: the CORS call makes the test run times inconsistent
   requestLongerTimeout(2);
 
-  const dbg = yield initDebugger("doc-sourcemap-bogus.html");
+  const dbg = await initDebugger("doc-sourcemap-bogus.html");
   const { selectors: { getSources }, getState } = dbg;
 
-  yield selectSource(dbg, "bogus-map.js");
+  await selectSource(dbg, "bogus-map.js");
 
   // We should still be able to set breakpoints and pause in the
   // generated source.
-  yield addBreakpoint(dbg, "bogus-map.js", 4);
+  await addBreakpoint(dbg, "bogus-map.js", 4);
   invokeInTab("runCode");
-  yield waitForPaused(dbg);
+  await waitForPaused(dbg);
   assertPausedLocation(dbg);
 
   // Make sure that only the single generated source exists. The

--- a/src/test/mochitest/browser_dbg-sourcemaps-reloading.js
+++ b/src/test/mochitest/browser_dbg-sourcemaps-reloading.js
@@ -1,18 +1,18 @@
 /* Any copyright is dedicated to the Public Domain.
  * http://creativecommons.org/publicdomain/zero/1.0/ */
 
-add_task(function*() {
+add_task(async function() {
   // NOTE: the CORS call makes the test run times inconsistent
   requestLongerTimeout(2);
 
-  const dbg = yield initDebugger("doc-sourcemaps.html");
+  const dbg = await initDebugger("doc-sourcemaps.html");
   const { selectors: { getBreakpoint, getBreakpoints }, getState } = dbg;
 
-  yield waitForSources(dbg, "entry.js", "output.js", "times2.js", "opts.js");
+  await waitForSources(dbg, "entry.js", "output.js", "times2.js", "opts.js");
   ok(true, "Original sources exist");
   const entrySrc = findSource(dbg, "entry.js");
 
-  yield selectSource(dbg, entrySrc);
+  await selectSource(dbg, entrySrc);
   ok(
     dbg.win.cm.getValue().includes("window.keepMeAlive"),
     "Original source text loaded correctly"
@@ -20,19 +20,19 @@ add_task(function*() {
 
   // Test that breakpoint sliding is not attempted. The breakpoint
   // should not move anywhere.
-  yield addBreakpoint(dbg, entrySrc, 13);
+  await addBreakpoint(dbg, entrySrc, 13);
   is(getBreakpoints(getState()).size, 1, "One breakpoint exists");
   ok(
     getBreakpoint(getState(), { sourceId: entrySrc.id, line: 13 }),
     "Breakpoint has correct line"
   );
 
-  yield addBreakpoint(dbg, entrySrc, 15);
-  yield disableBreakpoint(dbg, entrySrc, 15);
+  await addBreakpoint(dbg, entrySrc, 15);
+  await disableBreakpoint(dbg, entrySrc, 15);
 
   // Test reloading the debugger
-  yield reload(dbg, "opts.js");
-  yield waitForDispatch(dbg, "LOAD_SOURCE_TEXT");
+  await reload(dbg, "opts.js");
+  await waitForDispatch(dbg, "LOAD_SOURCE_TEXT");
 
   is(getBreakpoints(getState()).size, 2, "One breakpoint exists");
 

--- a/src/test/mochitest/browser_dbg-sourcemaps.js
+++ b/src/test/mochitest/browser_dbg-sourcemaps.js
@@ -33,30 +33,30 @@ function clickGutter(dbg, line) {
   clickElement(dbg, "gutter", line);
 }
 
-add_task(function*() {
+add_task(async function() {
   // NOTE: the CORS call makes the test run times inconsistent
   requestLongerTimeout(2);
 
-  const dbg = yield initDebugger("doc-sourcemaps.html");
+  const dbg = await initDebugger("doc-sourcemaps.html");
   const { selectors: { getBreakpoint, getBreakpoints }, getState } = dbg;
 
-  yield waitForSources(dbg, "entry.js", "output.js", "times2.js", "opts.js");
+  await waitForSources(dbg, "entry.js", "output.js", "times2.js", "opts.js");
   ok(true, "Original sources exist");
   const bundleSrc = findSource(dbg, "bundle.js");
 
-  yield selectSource(dbg, bundleSrc);
+  await selectSource(dbg, bundleSrc);
 
-  yield clickGutter(dbg, 13);
-  yield waitForDispatch(dbg, "ADD_BREAKPOINT");
+  await clickGutter(dbg, 13);
+  await waitForDispatch(dbg, "ADD_BREAKPOINT");
   assertEditorBreakpoint(dbg, 13, true);
 
-  yield clickGutter(dbg, 13);
-  yield waitForDispatch(dbg, "REMOVE_BREAKPOINT");
+  await clickGutter(dbg, 13);
+  await waitForDispatch(dbg, "REMOVE_BREAKPOINT");
   is(getBreakpoints(getState()).size, 0, "No breakpoints exists");
 
   const entrySrc = findSource(dbg, "entry.js");
 
-  yield selectSource(dbg, entrySrc);
+  await selectSource(dbg, entrySrc);
   ok(
     dbg.win.cm.getValue().includes("window.keepMeAlive"),
     "Original source text loaded correctly"
@@ -64,25 +64,25 @@ add_task(function*() {
 
   // Test that breakpoint sliding is not attempted. The breakpoint
   // should not move anywhere.
-  yield addBreakpoint(dbg, entrySrc, 13);
+  await addBreakpoint(dbg, entrySrc, 13);
   is(getBreakpoints(getState()).size, 1, "One breakpoint exists");
   assertBreakpointExists(dbg, entrySrc, 13);
 
   // Test breaking on a breakpoint
-  yield addBreakpoint(dbg, "entry.js", 15);
+  await addBreakpoint(dbg, "entry.js", 15);
   is(getBreakpoints(getState()).size, 2, "Two breakpoints exist");
   assertBreakpointExists(dbg, entrySrc, 15);
 
   invokeInTab("keepMeAlive");
-  yield waitForPaused(dbg);
+  await waitForPaused(dbg);
   assertPausedLocation(dbg);
 
-  yield stepIn(dbg);
+  await stepIn(dbg);
   assertPausedLocation(dbg);
-  yield stepOver(dbg);
+  await stepOver(dbg);
   assertPausedLocation(dbg);
 
-  yield stepOut(dbg);
-  yield stepOut(dbg);
+  await stepOut(dbg);
+  await stepOut(dbg);
   assertPausedLocation(dbg);
 });

--- a/src/test/mochitest/browser_dbg-sourcemaps2.js
+++ b/src/test/mochitest/browser_dbg-sourcemaps2.js
@@ -6,22 +6,22 @@
 
 // This source map does not have source contents, so it's fetched separately
 
-add_task(function*() {
+add_task(async function() {
   // NOTE: the CORS call makes the test run times inconsistent
   requestLongerTimeout(2);
 
-  const dbg = yield initDebugger("doc-sourcemaps2.html");
+  const dbg = await initDebugger("doc-sourcemaps2.html");
   const { selectors: { getBreakpoint, getBreakpoints }, getState } = dbg;
 
-  yield waitForSources(dbg, "main.js", "main.min.js");
+  await waitForSources(dbg, "main.js", "main.min.js");
 
   ok(true, "Original sources exist");
   const mainSrc = findSource(dbg, "main.js");
 
-  yield selectSource(dbg, mainSrc);
+  await selectSource(dbg, mainSrc);
 
   // Test that breakpoint is not off by a line.
-  yield addBreakpoint(dbg, mainSrc, 4);
+  await addBreakpoint(dbg, mainSrc, 4);
   is(getBreakpoints(getState()).size, 1, "One breakpoint exists");
   ok(
     getBreakpoint(getState(), { sourceId: mainSrc.id, line: 4, column: 2 }),
@@ -30,6 +30,6 @@ add_task(function*() {
 
   invokeInTab("logMessage");
 
-  yield waitForPaused(dbg);
+  await waitForPaused(dbg);
   assertPausedLocation(dbg);
 });

--- a/src/test/mochitest/browser_dbg-sources.js
+++ b/src/test/mochitest/browser_dbg-sources.js
@@ -3,27 +3,27 @@
 
 // Tests that the source tree works.
 
-function* waitForSourceCount(dbg, i) {
+async function waitForSourceCount(dbg, i) {
   // We are forced to wait until the DOM nodes appear because the
   // source tree batches its rendering.
-  yield waitUntil(() => {
+  await waitUntil(() => {
     return findAllElements(dbg, "sourceNodes").length === i;
   });
 }
 
-add_task(function*() {
-  const dbg = yield initDebugger("doc-sources.html");
+add_task(async function() {
+  const dbg = await initDebugger("doc-sources.html");
   const { selectors: { getSelectedSource }, getState } = dbg;
 
-  yield waitForSources(dbg, "simple1", "simple2", "nested-source", "long.js");
+  await waitForSources(dbg, "simple1", "simple2", "nested-source", "long.js");
 
   // Expand nodes and make sure more sources appear.
   is(findAllElements(dbg, "sourceNodes").length, 2);
 
-  yield clickElement(dbg, "sourceArrow", 2);
+  await clickElement(dbg, "sourceArrow", 2);
   is(findAllElements(dbg, "sourceNodes").length, 7);
 
-  yield clickElement(dbg, "sourceArrow", 3);
+  await clickElement(dbg, "sourceArrow", 3);
   is(findAllElements(dbg, "sourceNodes").length, 8);
 
   // Select a source.
@@ -32,8 +32,8 @@ add_task(function*() {
     "Source is not focused"
   );
   const selected = waitForDispatch(dbg, "SELECT_SOURCE");
-  yield clickElement(dbg, "sourceNode", 4);
-  yield selected;
+  await clickElement(dbg, "sourceNode", 4);
+  await selected;
   ok(
     findElementWithSelector(dbg, ".sources-list .focused"),
     "Source is focused"
@@ -52,7 +52,7 @@ add_task(function*() {
     content.document.body.appendChild(script);
   });
 
-  yield waitForSourceCount(dbg, 9);
+  await waitForSourceCount(dbg, 9);
   is(
     findElement(dbg, "sourceNode", 7).textContent,
     "math.min.js",
@@ -62,16 +62,16 @@ add_task(function*() {
   // Make sure named eval sources appear in the list.
 });
 
-add_task(function*() {
-  const dbg = yield initDebugger("doc-sources.html");
+add_task(async function() {
+  const dbg = await initDebugger("doc-sources.html");
   const { selectors: { getSelectedSource }, getState } = dbg;
 
-  yield waitForSources(dbg, "simple1", "simple2", "nested-source", "long.js");
+  await waitForSources(dbg, "simple1", "simple2", "nested-source", "long.js");
 
   ContentTask.spawn(gBrowser.selectedBrowser, null, function() {
     content.eval("window.evaledFunc = function() {} //# sourceURL=evaled.js");
   });
-  yield waitForSourceCount(dbg, 3);
+  await waitForSourceCount(dbg, 3);
   is(
     findElement(dbg, "sourceNode", 3).textContent,
     "(no domain)",
@@ -80,8 +80,8 @@ add_task(function*() {
 
   // work around: the folder is rendered at the bottom, so we close the
   // root folder and open the (no domain) folder
-  yield clickElement(dbg, "sourceArrow", 3);
-  yield waitForSourceCount(dbg, 4);
+  await clickElement(dbg, "sourceArrow", 3);
+  await waitForSourceCount(dbg, 4);
 
   is(
     findElement(dbg, "sourceNode", 4).textContent,

--- a/src/test/mochitest/browser_dbg-tabs.js
+++ b/src/test/mochitest/browser_dbg-tabs.js
@@ -7,33 +7,33 @@ function countTabs(dbg) {
   return findElement(dbg, "sourceTabs").children.length;
 }
 
-add_task(function*() {
-  let dbg = yield initDebugger("doc-scripts.html");
+add_task(async function() {
+  let dbg = await initDebugger("doc-scripts.html");
 
-  yield selectSource(dbg, "simple1");
-  yield selectSource(dbg, "simple2");
+  await selectSource(dbg, "simple1");
+  await selectSource(dbg, "simple2");
   is(countTabs(dbg), 2);
 
   // Test reloading the debugger
-  yield reload(dbg, "simple1", "simple2");
+  await reload(dbg, "simple1", "simple2");
   is(countTabs(dbg), 2);
-  yield waitForSelectedSource(dbg);
+  await waitForSelectedSource(dbg);
 
   // Test reloading the debuggee a second time
-  yield reload(dbg, "simple1", "simple2");
+  await reload(dbg, "simple1", "simple2");
   is(countTabs(dbg), 2);
-  yield waitForSelectedSource(dbg);
+  await waitForSelectedSource(dbg);
 });
 
-add_task(function*() {
-  let dbg = yield initDebugger("doc-scripts.html", "simple1", "simple2");
+add_task(async function() {
+  let dbg = await initDebugger("doc-scripts.html", "simple1", "simple2");
 
-  yield selectSource(dbg, "simple1");
-  yield selectSource(dbg, "simple2");
+  await selectSource(dbg, "simple1");
+  await selectSource(dbg, "simple2");
   closeTab(dbg, "simple1");
   closeTab(dbg, "simple2");
 
   // Test reloading the debugger
-  yield reload(dbg, "simple1", "simple2");
+  await reload(dbg, "simple1", "simple2");
   is(countTabs(dbg), 0);
 });

--- a/src/test/mochitest/browser_dbg-toggling-tools.js
+++ b/src/test/mochitest/browser_dbg-toggling-tools.js
@@ -25,10 +25,10 @@ function getSplitConsole(dbg) {
   });
 }
 
-add_task(function*() {
-  const dbg = yield initDebugger("doc-scripts.html");
+add_task(async function() {
+  const dbg = await initDebugger("doc-scripts.html");
 
-  yield selectSource(dbg, "long");
+  await selectSource(dbg, "long");
   dbg.win.cm.scrollTo(0, 284);
 
   pressKey(dbg, "inspector");

--- a/src/test/mochitest/browser_dbg_keyboard-shortcuts.js
+++ b/src/test/mochitest/browser_dbg_keyboard-shortcuts.js
@@ -25,22 +25,22 @@ function pressStepOut(dbg) {
   return waitForPaused(dbg);
 }
 
-add_task(function*() {
-  const dbg = yield initDebugger("doc-debugger-statements.html");
+add_task(async function() {
+  const dbg = await initDebugger("doc-debugger-statements.html");
 
-  yield reload(dbg);
-  yield waitForPaused(dbg);
+  await reload(dbg);
+  await waitForPaused(dbg);
   assertPausedLocation(dbg);
 
-  yield pressResume(dbg);
+  await pressResume(dbg);
   assertPausedLocation(dbg);
 
-  yield pressStepIn(dbg);
+  await pressStepIn(dbg);
   assertPausedLocation(dbg);
 
-  yield pressStepOut(dbg);
+  await pressStepOut(dbg);
   assertPausedLocation(dbg);
 
-  yield pressStepOver(dbg);
+  await pressStepOver(dbg);
   assertPausedLocation(dbg);
 });

--- a/src/test/mochitest/browser_dbg_keyboard_navigation.js
+++ b/src/test/mochitest/browser_dbg_keyboard_navigation.js
@@ -3,27 +3,36 @@
 
 // Tests that keyboard navigation into and out of debugger code editor
 
-add_task(function* () {
-  const dbg = yield initDebugger("doc-scripts.html");
+add_task(async function() {
+  const dbg = await initDebugger("doc-scripts.html");
   let doc = dbg.win.document;
 
-  yield selectSource(dbg, "simple2");
+  await selectSource(dbg, "simple2");
 
-  yield waitForElement(dbg, ".CodeMirror");
+  await waitForElement(dbg, ".CodeMirror");
   findElementWithSelector(dbg, ".CodeMirror").focus();
 
   // Enter code editor
   pressKey(dbg, "Enter");
-  is(findElementWithSelector(dbg, "textarea"), doc.activeElement,
-    "Editor is enabled");
+  is(
+    findElementWithSelector(dbg, "textarea"),
+    doc.activeElement,
+    "Editor is enabled"
+  );
 
   // Exit code editor and focus on container
   pressKey(dbg, "Escape");
-  is(findElementWithSelector(dbg, ".CodeMirror"), doc.activeElement,
-    "Focused on container");
+  is(
+    findElementWithSelector(dbg, ".CodeMirror"),
+    doc.activeElement,
+    "Focused on container"
+  );
 
   // Enter code editor
   pressKey(dbg, "Tab");
-  is(findElementWithSelector(dbg, "textarea"), doc.activeElement,
-    "Editor is enabled");
+  is(
+    findElementWithSelector(dbg, "textarea"),
+    doc.activeElement,
+    "Editor is enabled"
+  );
 });


### PR DESCRIPTION
This PR builds on top of the fix for "escape" handling to quickly refactor our mochitests to use async functions over generator syntax. Why? Why Not! Seriously, though, most people are more familiar with async/await now than that crazy generator thing.