### PR TITLE
Show full editor context menu for blackboxed tab

### DIFF
--- a/src/components/Editor/EditorMenu.js
+++ b/src/components/Editor/EditorMenu.js
@@ -92,10 +92,6 @@ function getMenuItems(
     click: () => showSource(selectedSource.get("id"))
   };
 
-  if (selectedSource && selectedSource.get("isBlackBoxed")) {
-    return [blackBoxMenuItem];
-  }
-
   const menuItems = [
     copySource,
     copySourceUrl,


### PR DESCRIPTION
There's no reason not to show the full context menu for blackboxed sources.  We still want to copy, get the URL, etc.