### PR TITLE
Show parameter signature within outline

### DIFF
--- a/src/components/PrimaryPanes/Outline.js
+++ b/src/components/PrimaryPanes/Outline.js
@@ -38,7 +38,7 @@ export class Outline extends Component {
   }
 
   renderFunction(func: SymbolDeclaration) {
-    const { name, location } = func;
+    const { name, location, parameterNames } = func;
 
     return (
       <li
@@ -46,7 +46,7 @@ export class Outline extends Component {
         className="outline-list__element"
         onClick={() => this.selectItem(location)}
       >
-        <PreviewFunction func={{ name }} />
+        <PreviewFunction func={{ name, parameterNames }} />
       </li>
     );
   }

--- a/src/components/tests/__snapshots__/Outline.spec.js.snap
+++ b/src/components/tests/__snapshots__/Outline.spec.js.snap
@@ -22,6 +22,7 @@ ShallowWrapper {
                 func={
                     Object {
                         "name": "my_example_function1",
+                        "parameterNames": undefined,
                       }
                 }
             />
@@ -34,6 +35,7 @@ ShallowWrapper {
                 func={
                     Object {
                         "name": "my_example_function2",
+                        "parameterNames": undefined,
                       }
                 }
             />
@@ -55,6 +57,7 @@ ShallowWrapper {
                         func={
                               Object {
                                     "name": "my_example_function1",
+                                    "parameterNames": undefined,
                                   }
                         }
                   />
@@ -67,6 +70,7 @@ ShallowWrapper {
                         func={
                               Object {
                                     "name": "my_example_function2",
+                                    "parameterNames": undefined,
                                   }
                         }
                   />
@@ -182,6 +186,7 @@ ShallowWrapper {
                                         func={
                                                   Object {
                                                             "name": "my_example_function1",
+                                                            "parameterNames": undefined,
                                                           }
                                         }
                               />
@@ -194,6 +199,7 @@ ShallowWrapper {
                                         func={
                                                   Object {
                                                             "name": "my_example_function2",
+                                                            "parameterNames": undefined,
                                                           }
                                         }
                               />
@@ -215,6 +221,7 @@ ShallowWrapper {
                                         func={
                                                   Object {
                                                             "name": "my_example_function1",
+                                                            "parameterNames": undefined,
                                                           }
                                         }
                               />
@@ -227,6 +234,7 @@ ShallowWrapper {
                                         func={
                                                   Object {
                                                             "name": "my_example_function2",
+                                                            "parameterNames": undefined,
                                                           }
                                         }
                               />
@@ -302,6 +310,7 @@ ShallowWrapper {
                 func={
                     Object {
                         "name": "my_example_function1",
+                        "parameterNames": undefined,
                       }
                 }
             />
@@ -323,6 +332,7 @@ ShallowWrapper {
                         func={
                               Object {
                                     "name": "my_example_function1",
+                                    "parameterNames": undefined,
                                   }
                         }
                   />
@@ -438,6 +448,7 @@ ShallowWrapper {
                                         func={
                                                   Object {
                                                             "name": "my_example_function1",
+                                                            "parameterNames": undefined,
                                                           }
                                         }
                               />
@@ -459,6 +470,7 @@ ShallowWrapper {
                                         func={
                                                   Object {
                                                             "name": "my_example_function1",
+                                                            "parameterNames": undefined,
                                                           }
                                         }
                               />


### PR DESCRIPTION
I enjoy a function list but I find that list not very helpful without knowing also knowing the parameter names.

<img width="496" alt="outline-args" src="https://user-images.githubusercontent.com/46655/30090828-988d9570-927b-11e7-9cd0-8917d6be53f3.png">

This requires a test fix but I wanted to take the temperature on adding paramaters to the outline panel.  I much prefer it.