### PR TITLE
[themes] Update the sidebar and accordion colors for the dark theme (…

### DIFF
--- a/src/components/PrimaryPanes/Sources.css
+++ b/src/components/PrimaryPanes/Sources.css
@@ -43,6 +43,7 @@
 }
 
 .sources-list {
+  background-color: var(--theme-sidebar-background);
   flex: 1;
   display: flex;
   overflow-x: hidden;

--- a/src/components/PrimaryPanes/Sources.css
+++ b/src/components/PrimaryPanes/Sources.css
@@ -1,6 +1,7 @@
 .sources-panel {
-  flex: 1;
+  background-color: var(--theme-sidebar-background);
   display: flex;
+  flex: 1;
   flex-direction: column;
   overflow: hidden;
   position: relative;
@@ -43,7 +44,6 @@
 }
 
 .sources-list {
-  background-color: var(--theme-sidebar-background);
   flex: 1;
   display: flex;
   overflow-x: hidden;

--- a/src/components/SecondaryPanes/Expressions.css
+++ b/src/components/SecondaryPanes/Expressions.css
@@ -2,7 +2,7 @@
   width: 100%;
   margin: 0px;
   border: 1px;
-  background-color: var(--theme-body-background);
+  background-color: var(--theme-sidebar-background);
   font-size: 12px;
   padding: 0px 20px;
   color: var(--theme-body-color);

--- a/src/components/shared/Accordion.css
+++ b/src/components/shared/Accordion.css
@@ -1,11 +1,20 @@
+:root {
+  --accordion-header-background: var(--theme-toolbar-background);
+}
+
+:root.theme-dark {
+  --accordion-header-background: #141416;
+}
+
 .accordion {
-  background-color: var(--theme-body-background);
+  background-color: var(--theme-sidebar-background);
   width: 100%;
 }
 
 .accordion ._header {
-  background-color: var(--theme-toolbar-background);
+  background-color: var(--accordion-header-background);
   border-bottom: 1px solid var(--theme-splitter-color);
+  display: flex;
   font-size: 12px;
   padding: 4px;
   transition: all 0.25s ease;
@@ -18,10 +27,6 @@
   -ms-user-select: none;
   -o-user-select: none;
   user-select: none;
-}
-
-.accordion ._header {
-  display: flex;
 }
 
 .accordion ._header:hover {


### PR DESCRIPTION
…#3909)

Associated Issue: #3909 

### Summary of Changes

* In the dark theme, Sidebar background color is var(--grey-90) and Accordion header background color is #141416.
* In the sources list, and add watch expression button, the background color needs to be var(--theme-sidebar-background).
* The accordion header needs to be #141416 only in the dark theme and var(--theme-toolbar-background) in the light.

### Screenshots

Before:
<img width="1258" alt="screen shot 2017-09-06 at 4 48 56 pm" src="https://user-images.githubusercontent.com/1190888/30133855-4becddd6-9323-11e7-91a0-929d1e8dde1b.png">

After:
<img width="1065" alt="screen shot 2017-09-06 at 4 37 00 pm" src="https://user-images.githubusercontent.com/1190888/30133866-548bda46-9323-11e7-997a-e2f2b72536c1.png">

