### PR TITLE
fix hidden tabs click not showing the source

### DIFF
--- a/src/components/Editor/Tabs.js
+++ b/src/components/Editor/Tabs.js
@@ -314,13 +314,10 @@ class SourceTabs extends PureComponent {
   }
 
   renderDropdownSource(source: SourceRecord) {
-    const { moveTab } = this.props;
+    const { selectSource } = this.props;
     const filename = getFilename(source.toJS());
 
-    const onClick = () => {
-      const tabIndex = 0;
-      moveTab(source.get("url"), tabIndex);
-    };
+    const onClick = () => selectSource(source.get("id"));
     return (
       <li key={source.get("id")} onClick={onClick}>
         {filename}


### PR DESCRIPTION
Associated Issue: #3910

Here's the Pull Request Doc
https://devtools-html.github.io/debugger.html/CONTRIBUTING.html#pull-requests

### Summary of Changes

* Use the `selectSource` instead as it moves the tab to the first spot and also selects the source.

### Test Plan

Tell us a little a bit about how you tested your patch.

Example test plan:

1. Launch Firefox.
2. Access the https://devtools-html.github.io/debugger-examples/examples/todomvc/ webpage.
3. Open multiple files from the source list pane.
4. Open the list view dropdown.
5. Select a file from the dropdown.

[Expected result]:
The selected file is focused and it's code is displayed in the Source pane.

[Actual result]:
The selected file is not focused and the code from the previously selected file is displayed in the source pane.

### Screenshots/Videos 
![](http://g.recordit.co/b1TNsQORK5.gif)
