### PR TITLE
Use --theme-selection-background for the focused node in the managed …

### DIFF
--- a/src/components/shared/ManagedTree.css
+++ b/src/components/shared/ManagedTree.css
@@ -22,7 +22,6 @@
 .managed-tree .tree .node.focused {
   color: white;
   background-color: var(--theme-selection-background);
-  padding-bottom: 2px;
 }
 
 html:not([dir="rtl"]) .managed-tree .tree .node > div {

--- a/src/components/shared/ManagedTree.css
+++ b/src/components/shared/ManagedTree.css
@@ -25,11 +25,6 @@
   padding-bottom: 2px;
 }
 
-.theme-dark .managed-tree .tree .node.focused {
-  background-color: var(--theme-selection-background-hover);
-  padding-bottom: 2px;
-}
-
 html:not([dir="rtl"]) .managed-tree .tree .node > div {
   margin-left: 10px;
 }


### PR DESCRIPTION
…tree in the dark theme (#3920)

Associated Issue: #3920

### Summary of Changes

* Remove
.theme-dark .managed-tree .tree .node.focused {
background-color: var(--theme-selection-background-hover);
padding-bottom: 2px;
}
* Use --theme-selection-background for the focused node in the dark theme

### Screenshots/Videos (OPTIONAL)

Before:
<img width="840" alt="screen shot 2017-09-06 at 11 11 33 pm" src="https://user-images.githubusercontent.com/1190888/30144390-eb7ce082-9358-11e7-819c-ee04fe1df9c0.png">

After:
<img width="840" alt="screen shot 2017-09-06 at 11 12 15 pm" src="https://user-images.githubusercontent.com/1190888/30144377-d69753f0-9358-11e7-9b21-7a1e20861cfb.png">
4095.png">
