### PR TITLE
[theme] Welcome box should use a --theme-toolbar-background in the li…

### DIFF
--- a/src/components/WelcomeBox.css
+++ b/src/components/WelcomeBox.css
@@ -10,9 +10,13 @@
   text-align: center;
   font-size: 1.25em;
   color: var(--theme-comment-alt);
-  background-color: var(--theme-body-background);
+  background-color: var(--theme-toolbar-background);
   font-weight: lighter;
   z-index: 100;
+}
+
+.theme-dark .welcomebox {
+  background-color: var(--theme-body-background);
 }
 
 .alignlabel {


### PR DESCRIPTION
…ght theme (#3922)

Associated Issue: #3922 

### Summary of Changes

* For the welcome box, we should use --theme-toolbar-background in the light theme and --theme-body-background in the dark theme.

### Screenshots

Before:
<img width="840" alt="screen shot 2017-09-06 at 11 49 35 pm" src="https://user-images.githubusercontent.com/1190888/30145243-134a0b30-935e-11e7-8e8b-078131e844c5.png">

After:
<img width="840" alt="screen shot 2017-09-06 at 11 49 10 pm" src="https://user-images.githubusercontent.com/1190888/30145244-18171298-935e-11e7-8e9f-50f7ccc4be64.png">

Existing Dark:
<img width="840" alt="screen shot 2017-09-06 at 11 48 36 pm" src="https://user-images.githubusercontent.com/1190888/30145248-1d9bf440-935e-11e7-88ab-b12c337c5f14.png">

