### PR TITLE
Remove unused CSS rules in Expressions.css

### DIFF
--- a/src/components/SecondaryPanes/Expressions.css
+++ b/src/components/SecondaryPanes/Expressions.css
@@ -74,17 +74,3 @@
 .expression-input {
   max-width: 50%;
 }
-
-.expression-separator {
-  padding: 0px 5px;
-}
-
-.expression-value {
-  overflow-x: scroll;
-  color: var(--theme-content-color2);
-  max-width: 50% !important;
-}
-
-.expression-error {
-  color: var(--theme-highlight-red);
-}


### PR DESCRIPTION
Associated Issue: #3939 

### Summary of Changes

* Remove unused CSS rules in Expressions.css

### Test Plan

* Search for each CSS class name and see no results show up