### PR TITLE
remove auto-focus on the search results

### DIFF
--- a/src/components/ProjectSearch/TextSearch.js
+++ b/src/components/ProjectSearch/TextSearch.js
@@ -158,13 +158,6 @@ export default class TextSearch extends Component {
         : this.renderMatch(item, focused);
     };
 
-    const getFocusedItem = () => {
-      if (this.focusedItem === null) {
-        return results[0] ? results[0].matches[0] : null;
-      }
-      return this.focusedItem.file || this.focusedItem.match;
-    };
-
     return (
       <ManagedTree
         getRoots={() => results}
@@ -172,7 +165,6 @@ export default class TextSearch extends Component {
         itemHeight={24}
         autoExpand={1}
         autoExpandDepth={1}
-        focused={getFocusedItem()}
         getParent={item => null}
         getPath={getFilePath}
         renderItem={renderItem}


### PR DESCRIPTION
Associated Issue: #3926

### Summary of Changes

* Remove auto-focus on search results
* Now the focus remains in the search input box until the user tabs to move the the result list

### Test Plan

Tell us a little a bit about how you tested your patch.

Example test plan:

- [x] Cmd + shift + F
- [x] Enter search query
- [x] Press tab to got to the result list

### Screenshots/Videos
![](http://g.recordit.co/hlGyXah5d4.gif)
