### PR TITLE
Ignore new identical sources

### DIFF
--- a/src/actions/sources.js
+++ b/src/actions/sources.js
@@ -88,6 +88,11 @@ async function checkPendingBreakpoints(state, dispatch, source) {
  */
 export function newSource(source: Source) {
   return async ({ dispatch, getState }: ThunkArgs) => {
+    const _source = getSource(getState(), source.id);
+    if (_source) {
+      return;
+    }
+
     dispatch({ type: "ADD_SOURCE", source });
 
     if (prefs.clientSourceMapsEnabled) {

--- a/src/actions/tests/sources.spec.js
+++ b/src/actions/tests/sources.spec.js
@@ -30,6 +30,15 @@ describe("sources", () => {
     expect(jquery.get("id")).toEqual("jquery.js");
   });
 
+  it("should not add multiple identical sources", async () => {
+    const { dispatch, getState } = createStore();
+
+    await dispatch(actions.newSource(makeSource("base.js")));
+    await dispatch(actions.newSource(makeSource("base.js")));
+
+    expect(getSources(getState()).size).toEqual(1);
+  });
+
   it("should select a source", async () => {
     // Note that we pass an empty client in because the action checks
     // if it exists.


### PR DESCRIPTION
Associated Issue: #3899 

### Summary of Changes

Extension evals all have the same source actor id. This causes the debugger to try to add the same source every time react devtools evals (once a second). 

We should bail early when we see the same source again, because the server treats it as the same source.

Lets not land this until we have tests for this behavior