### PR TITLE
3824 - ignore =, <, >, +, -, *, / tokens

### DIFF
--- a/src/utils/editor/expression.js
+++ b/src/utils/editor/expression.js
@@ -36,7 +36,8 @@ export function updatePreview(
     }
   }
 
-  const invalidToken = tokenText === "" || tokenText.match(/[(){},.;\s]/);
+  const invalidToken =
+    tokenText === "" || tokenText.match(/[(){},.;=<>\+-/\*\s]/);
   const invalidTarget =
     (target.parentElement &&
       !target.parentElement.closest(".CodeMirror-line")) ||


### PR DESCRIPTION
Associated Issue: #3824

### Summary of Changes

* Add =, <, >, +, -, *, / tokens as invalid tokens when doing `updatePreview`

### Test Plan
1. Visit any website with codes using =, <, >, +, -, *, / tokens
2. Pause on lines having the above invalid tokens
3. Hover mouse over the above invalid tokens and make sure no preview for them triggered

### Screenshots/Videos
Please see [1] for the screenshots gif
[1] https://github.com/devtools-html/debugger.html/issues/3824#issuecomment-328278484
