### PR TITLE
[ProjectSearch][3924] - Add 'No Results' state in ProjectSearch - Search in File

### DIFF
--- a/assets/panel/debugger.properties
+++ b/assets/panel/debugger.properties
@@ -151,6 +151,10 @@ functionSearch.key=CmdOrCtrl+Shift+O
 # when searching across all of the files in a project.
 projectTextSearch.placeholder=Find in files…
 
+# LOCALIZATION NOTE (projectTextSearch.noResults): The center pane Text Search
+# message when the query did not match any text of all files in a project.
+projectTextSearch.noResults=No results found
+
 # LOCALIZATION NOTE (sources.noSourcesAvailable): Text shown when the debugger
 # does not have any sources.
 sources.noSourcesAvailable=This page has no sources

--- a/src/components/ProjectSearch/TextSearch.css
+++ b/src/components/ProjectSearch/TextSearch.css
@@ -43,6 +43,13 @@
   width: 2em;
 }
 
+.project-text-search .no-result-msg {
+  color: var(--theme-body-color-inactive);
+  font-size: 24px;
+  padding: 4px;
+  word-break: break-all;
+}
+
 .project-text-search .file-result {
   font-weight: bold;
   line-height: 20px;

--- a/src/components/ProjectSearch/TextSearch.js
+++ b/src/components/ProjectSearch/TextSearch.js
@@ -158,18 +158,26 @@ export default class TextSearch extends Component {
         : this.renderMatch(item, focused);
     };
 
-    return (
-      <ManagedTree
-        getRoots={() => results}
-        getChildren={file => file.matches || []}
-        itemHeight={24}
-        autoExpand={1}
-        autoExpandDepth={1}
-        getParent={item => null}
-        getPath={getFilePath}
-        renderItem={renderItem}
-      />
-    );
+    if (results.length) {
+      return (
+        <ManagedTree
+          getRoots={() => results}
+          getChildren={file => file.matches || []}
+          itemHeight={24}
+          autoExpand={1}
+          autoExpandDepth={1}
+          getParent={item => null}
+          getPath={getFilePath}
+          renderItem={renderItem}
+        />
+      );
+    } else if (this.props.query && !results.length) {
+      return (
+        <div className="no-result-msg absolute-center">
+          {L10N.getStr("projectTextSearch.noResults")}
+        </div>
+      );
+    }
   }
 
   renderInput() {

--- a/src/components/ProjectSearch/tests/TextSearch.js
+++ b/src/components/ProjectSearch/tests/TextSearch.js
@@ -1,0 +1,44 @@
+import React from "react";
+import { shallow } from "enzyme";
+import TextSearchComponent from "../TextSearch.js";
+const TextSearch = React.createFactory(TextSearchComponent);
+
+function render(overrides = {}) {
+  const defaultProps = {
+    sources: {},
+    results: [],
+    query: "foo",
+    closeActiveSearch: jest.fn(),
+    searchSources: jest.fn(),
+    selectSource: jest.fn(),
+    searchBottomBar: {}
+  };
+  const props = Object.assign({}, defaultProps, overrides);
+
+  const component = shallow(new TextSearch(props));
+  return component;
+}
+
+describe("TextSearch", () => {
+  it("found no search results", () => {
+    const component = render();
+    expect(component).toMatchSnapshot();
+  });
+
+  it("found search results", () => {
+    const component = render({
+      query: "match",
+      results: [
+        {
+          filepath: "testFilePath1",
+          matches: ["match1", "match2", "match3"]
+        },
+        {
+          filepath: "testFilePath2",
+          matches: ["match4", "match5"]
+        }
+      ]
+    });
+    expect(component).toMatchSnapshot();
+  });
+});

--- a/src/components/ProjectSearch/tests/__snapshots__/TextSearch.js.snap
+++ b/src/components/ProjectSearch/tests/__snapshots__/TextSearch.js.snap
@@ -1,0 +1,477 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TextSearch found no search results 1`] = `
+ShallowWrapper {
+  "complexSelector": ComplexSelector {
+    "buildPredicate": [Function],
+    "childrenOfNode": [Function],
+    "findWhereUnwrapped": [Function],
+  },
+  "length": 1,
+  "node": <div
+    className="project-text-search"
+>
+    <div
+        className="header"
+    >
+        <SearchInput
+            count={0}
+            handleClose={[Function]}
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            placeholder="Find in files…"
+            query="foo"
+            showErrorEmoji={true}
+            size="big"
+            summaryMsg="0 results"
+        />
+        Object {}
+    </div>
+    <div
+        className="no-result-msg absolute-center"
+    >
+        No results found
+    </div>
+</div>,
+  "nodes": Array [
+    <div
+      className="project-text-search"
+>
+      <div
+            className="header"
+      >
+            <SearchInput
+                  count={0}
+                  handleClose={[Function]}
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  placeholder="Find in files…"
+                  query="foo"
+                  showErrorEmoji={true}
+                  size="big"
+                  summaryMsg="0 results"
+            />
+            Object {}
+      </div>
+      <div
+            className="no-result-msg absolute-center"
+      >
+            No results found
+      </div>
+</div>,
+  ],
+  "options": Object {},
+  "renderer": ReactShallowRenderer {
+    "_instance": ShallowComponentWrapper {
+      "_calledComponentWillUnmount": false,
+      "_compositeType": 0,
+      "_context": Object {},
+      "_currentElement": <TextSearch
+        closeActiveSearch={[Function]}
+        query="foo"
+        results={Array []}
+        searchBottomBar={Object {}}
+        searchSources={[Function]}
+        selectSource={[Function]}
+        sources={Object {}}
+/>,
+      "_debugID": 1,
+      "_hostContainerInfo": null,
+      "_hostParent": null,
+      "_instance": TextSearch {
+        "_reactInternalInstance": [Circular],
+        "context": Object {
+          "shortcuts": undefined,
+        },
+        "focusedItem": null,
+        "inputFocused": false,
+        "inputOnChange": [Function],
+        "onEnterPress": [Function],
+        "onKeyDown": [Function],
+        "props": Object {
+          "closeActiveSearch": [Function],
+          "query": "foo",
+          "results": Array [],
+          "searchBottomBar": Object {},
+          "searchSources": [Function],
+          "selectSource": [Function],
+          "sources": Object {},
+        },
+        "refs": Object {},
+        "selectMatchItem": [Function],
+        "state": Object {
+          "inputValue": "foo",
+        },
+        "updater": Object {
+          "enqueueCallback": [Function],
+          "enqueueCallbackInternal": [Function],
+          "enqueueElementInternal": [Function],
+          "enqueueForceUpdate": [Function],
+          "enqueueReplaceState": [Function],
+          "enqueueSetState": [Function],
+          "isMounted": [Function],
+          "validateCallback": [Function],
+        },
+      },
+      "_mountOrder": 1,
+      "_pendingCallbacks": null,
+      "_pendingElement": null,
+      "_pendingForceUpdate": false,
+      "_pendingReplaceState": false,
+      "_pendingStateQueue": null,
+      "_renderedComponent": Object {
+        "_currentElement": <div
+          className="project-text-search"
+>
+          <div
+                    className="header"
+          >
+                    <SearchInput
+                              count={0}
+                              handleClose={[Function]}
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              onFocus={[Function]}
+                              onKeyDown={[Function]}
+                              placeholder="Find in files…"
+                              query="foo"
+                              showErrorEmoji={true}
+                              size="big"
+                              summaryMsg="0 results"
+                    />
+                    Object {}
+          </div>
+          <div
+                    className="no-result-msg absolute-center"
+          >
+                    No results found
+          </div>
+</div>,
+        "_debugID": 2,
+        "_renderedOutput": <div
+          className="project-text-search"
+>
+          <div
+                    className="header"
+          >
+                    <SearchInput
+                              count={0}
+                              handleClose={[Function]}
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              onFocus={[Function]}
+                              onKeyDown={[Function]}
+                              placeholder="Find in files…"
+                              query="foo"
+                              showErrorEmoji={true}
+                              size="big"
+                              summaryMsg="0 results"
+                    />
+                    Object {}
+          </div>
+          <div
+                    className="no-result-msg absolute-center"
+          >
+                    No results found
+          </div>
+</div>,
+      },
+      "_renderedNodeType": 0,
+      "_rootNodeID": 0,
+      "_topLevelWrapper": null,
+      "_updateBatchNumber": null,
+      "_warnedAboutRefsInRender": false,
+    },
+    "getRenderOutput": [Function],
+    "render": [Function],
+  },
+  "root": [Circular],
+  "unrendered": <TextSearch
+    closeActiveSearch={[Function]}
+    query="foo"
+    results={Array []}
+    searchBottomBar={Object {}}
+    searchSources={[Function]}
+    selectSource={[Function]}
+    sources={Object {}}
+/>,
+}
+`;
+
+exports[`TextSearch found search results 1`] = `
+ShallowWrapper {
+  "complexSelector": ComplexSelector {
+    "buildPredicate": [Function],
+    "childrenOfNode": [Function],
+    "findWhereUnwrapped": [Function],
+  },
+  "length": 1,
+  "node": <div
+    className="project-text-search"
+>
+    <div
+        className="header"
+    >
+        <SearchInput
+            count={5}
+            handleClose={[Function]}
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            placeholder="Find in files…"
+            query="match"
+            showErrorEmoji={true}
+            size="big"
+            summaryMsg="5 results"
+        />
+        Object {}
+    </div>
+    <ManagedTree
+        autoExpand={1}
+        autoExpandDepth={1}
+        getChildren={[Function]}
+        getParent={[Function]}
+        getPath={[Function]}
+        getRoots={[Function]}
+        itemHeight={24}
+        renderItem={[Function]}
+    />
+</div>,
+  "nodes": Array [
+    <div
+      className="project-text-search"
+>
+      <div
+            className="header"
+      >
+            <SearchInput
+                  count={5}
+                  handleClose={[Function]}
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  placeholder="Find in files…"
+                  query="match"
+                  showErrorEmoji={true}
+                  size="big"
+                  summaryMsg="5 results"
+            />
+            Object {}
+      </div>
+      <ManagedTree
+            autoExpand={1}
+            autoExpandDepth={1}
+            getChildren={[Function]}
+            getParent={[Function]}
+            getPath={[Function]}
+            getRoots={[Function]}
+            itemHeight={24}
+            renderItem={[Function]}
+      />
+</div>,
+  ],
+  "options": Object {},
+  "renderer": ReactShallowRenderer {
+    "_instance": ShallowComponentWrapper {
+      "_calledComponentWillUnmount": false,
+      "_compositeType": 0,
+      "_context": Object {},
+      "_currentElement": <TextSearch
+        closeActiveSearch={[Function]}
+        query="match"
+        results={
+                Array [
+                        Object {
+                          "filepath": "testFilePath1",
+                          "matches": Array [
+                            "match1",
+                            "match2",
+                            "match3",
+                          ],
+                        },
+                        Object {
+                          "filepath": "testFilePath2",
+                          "matches": Array [
+                            "match4",
+                            "match5",
+                          ],
+                        },
+                      ]
+        }
+        searchBottomBar={Object {}}
+        searchSources={[Function]}
+        selectSource={[Function]}
+        sources={Object {}}
+/>,
+      "_debugID": 3,
+      "_hostContainerInfo": null,
+      "_hostParent": null,
+      "_instance": TextSearch {
+        "_reactInternalInstance": [Circular],
+        "context": Object {
+          "shortcuts": undefined,
+        },
+        "focusedItem": null,
+        "inputFocused": false,
+        "inputOnChange": [Function],
+        "onEnterPress": [Function],
+        "onKeyDown": [Function],
+        "props": Object {
+          "closeActiveSearch": [Function],
+          "query": "match",
+          "results": Array [
+            Object {
+              "filepath": "testFilePath1",
+              "matches": Array [
+                "match1",
+                "match2",
+                "match3",
+              ],
+            },
+            Object {
+              "filepath": "testFilePath2",
+              "matches": Array [
+                "match4",
+                "match5",
+              ],
+            },
+          ],
+          "searchBottomBar": Object {},
+          "searchSources": [Function],
+          "selectSource": [Function],
+          "sources": Object {},
+        },
+        "refs": Object {},
+        "selectMatchItem": [Function],
+        "state": Object {
+          "inputValue": "match",
+        },
+        "updater": Object {
+          "enqueueCallback": [Function],
+          "enqueueCallbackInternal": [Function],
+          "enqueueElementInternal": [Function],
+          "enqueueForceUpdate": [Function],
+          "enqueueReplaceState": [Function],
+          "enqueueSetState": [Function],
+          "isMounted": [Function],
+          "validateCallback": [Function],
+        },
+      },
+      "_mountOrder": 2,
+      "_pendingCallbacks": null,
+      "_pendingElement": null,
+      "_pendingForceUpdate": false,
+      "_pendingReplaceState": false,
+      "_pendingStateQueue": null,
+      "_renderedComponent": Object {
+        "_currentElement": <div
+          className="project-text-search"
+>
+          <div
+                    className="header"
+          >
+                    <SearchInput
+                              count={5}
+                              handleClose={[Function]}
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              onFocus={[Function]}
+                              onKeyDown={[Function]}
+                              placeholder="Find in files…"
+                              query="match"
+                              showErrorEmoji={true}
+                              size="big"
+                              summaryMsg="5 results"
+                    />
+                    Object {}
+          </div>
+          <ManagedTree
+                    autoExpand={1}
+                    autoExpandDepth={1}
+                    getChildren={[Function]}
+                    getParent={[Function]}
+                    getPath={[Function]}
+                    getRoots={[Function]}
+                    itemHeight={24}
+                    renderItem={[Function]}
+          />
+</div>,
+        "_debugID": 4,
+        "_renderedOutput": <div
+          className="project-text-search"
+>
+          <div
+                    className="header"
+          >
+                    <SearchInput
+                              count={5}
+                              handleClose={[Function]}
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              onFocus={[Function]}
+                              onKeyDown={[Function]}
+                              placeholder="Find in files…"
+                              query="match"
+                              showErrorEmoji={true}
+                              size="big"
+                              summaryMsg="5 results"
+                    />
+                    Object {}
+          </div>
+          <ManagedTree
+                    autoExpand={1}
+                    autoExpandDepth={1}
+                    getChildren={[Function]}
+                    getParent={[Function]}
+                    getPath={[Function]}
+                    getRoots={[Function]}
+                    itemHeight={24}
+                    renderItem={[Function]}
+          />
+</div>,
+      },
+      "_renderedNodeType": 0,
+      "_rootNodeID": 0,
+      "_topLevelWrapper": null,
+      "_updateBatchNumber": null,
+      "_warnedAboutRefsInRender": false,
+    },
+    "getRenderOutput": [Function],
+    "render": [Function],
+  },
+  "root": [Circular],
+  "unrendered": <TextSearch
+    closeActiveSearch={[Function]}
+    query="match"
+    results={
+        Array [
+            Object {
+              "filepath": "testFilePath1",
+              "matches": Array [
+                "match1",
+                "match2",
+                "match3",
+              ],
+            },
+            Object {
+              "filepath": "testFilePath2",
+              "matches": Array [
+                "match4",
+                "match5",
+              ],
+            },
+          ]
+    }
+    searchBottomBar={Object {}}
+    searchSources={[Function]}
+    selectSource={[Function]}
+    sources={Object {}}
+/>,
+}
+`;


### PR DESCRIPTION
Associated Issue: #3924 
Here's the Pull Request Doc
https://devtools-html.github.io/debugger.html/CONTRIBUTING.html#pull-requests

### Summary of Changes

* Added 'No-Results' state in ProjectSearch - Search in File
* Added TextSearch unit-test - snapshot file checked in

### Test Plan

Tell us a little a bit about how you tested your patch.

- [x] Ctrl+Shift+F opens File search in Debugger
- [x] Enter some search text
- [x] Press Enter
- [x] Observe that 'No Results' message is shown when no search results are found
- [x] Run tests to check if snapshot is generated correctly 
