### PR TITLE
Clear BPs

### DIFF
--- a/src/actions/tests/pending-breakpoints.spec.js
+++ b/src/actions/tests/pending-breakpoints.spec.js
@@ -104,7 +104,7 @@ describe("when adding breakpoints", () => {
       await dispatch(actions.removeBreakpoint(breakpoint1.location));
 
       const pendingBps = selectors.getPendingBreakpoints(getState());
-      expect(pendingBps.has(breakpointLocationId1)).not.toBe(true);
+      expect(pendingBps.has(breakpointLocationId1)).toBe(false);
       expect(pendingBps.has(breakpointLocationId2)).toBe(true);
     });
   });

--- a/src/reducers/pending-breakpoints.js
+++ b/src/reducers/pending-breakpoints.js
@@ -106,7 +106,13 @@ function updateBreakpoint(state, action) {
 
 function removeBreakpoint(state, action) {
   const { breakpoint } = action;
+
   const locationId = makePendingLocationId(breakpoint.location);
+  const pendingBp = state.getIn(["pendingBreakpoints", locationId]);
+
+  if (!pendingBp && action.status == "start") {
+    return state.set("pendingBreakpoints", I.Map());
+  }
 
   return state.deleteIn(["pendingBreakpoints", locationId]);
 }


### PR DESCRIPTION
Associated Issue: #3971 

### Summary of Changes

This clears the pending breakpoints state when the breakpoint state is corrupted.

**what is corrupted?** we define corrupted as a state where we cannot find a pending bp in the store.

**Why not clear the breakpoints store too?** We could, but keeping the breakpoints in the store means that there is no user-visible change in the current debugging session.

Lets see an example:

1. the user gets into a bad state by adding a bp and reloading/opening and closing a lot
2. the user removes the bp by clicking on the bp in the gutter
  - the debugger removes the bp in the bp reducer
  - the debugger tries to remove the bp in the pending bp reducer, fails, and therefore clears the store. This will also clear the pending bp pref
  - at this point, the other bps will still work. the user can also add/remove bps
3. the user closes and re-opens the debugger
  - the user will see the breakpoints they created after removing the corrupted bp. *(I need to verify this behavior)* it might not show those BPs either. Either way, the important thing is that removing a corrupted bp will clear the bad state.

### STR

1. clone https://github.com/devtools-html/perf.html
2. npm install
3. npm start
4. add a bp on arrowPanel.js in the constructor function
5. add a /***/ comment spanning 500 lines in `actions/app.js`
6. reload debuggee / open close the debugger
7. remove the bp 
8. close / open the debugger

ER: the bp should be gone