### PR TITLE
Update label case for tab and editor context menus

### DIFF
--- a/assets/panel/debugger.properties
+++ b/assets/panel/debugger.properties
@@ -21,7 +21,7 @@ copySource.accesskey=y
 
 # LOCALIZATION NOTE (copySourceUrl): This is the text that appears in the
 # context menu to copy the source URL of file open.
-copySourceUrl=Copy Source Url
+copySourceUrl=Copy Source URL
 copySourceUrl.accesskey=u
 
 # LOCALIZATION NOTE (copyStackTrace): This is the text that appears in the
@@ -337,7 +337,7 @@ editor.conditionalPanel.close=Cancel edit breakpoint and close
 
 # LOCALIZATION NOTE (editor.jumpToMappedLocation1): Context menu item
 # for navigating to a source mapped location
-editor.jumpToMappedLocation1=Jump to %S location
+editor.jumpToMappedLocation1=Jump to %S Location
 
 # LOCALIZATION NOTE (framework.disableGrouping): This is the text that appears in the
 # context menu to disable framework grouping.
@@ -350,10 +350,10 @@ framework.enableGrouping=Enable Framework Grouping
 framework.enableGrouping.accesskey=u
 
 # LOCALIZATION NOTE (generated): Source Map term for a server source location
-generated=generated
+generated=Generated
 
 # LOCALIZATION NOTE (original): Source Map term for a debugger UI source location
-original=original
+original=Original
 
 # LOCALIZATION NOTE (expressions.placeholder): Placeholder text for expression
 # input element
@@ -361,22 +361,22 @@ expressions.placeholder=Add Watch Expression
 
 # LOCALIZATION NOTE (sourceTabs.closeTab): Editor source tab context menu item
 # for closing the selected tab below the mouse.
-sourceTabs.closeTab=Close tab
+sourceTabs.closeTab=Close Tab
 sourceTabs.closeTab.accesskey=c
 
 # LOCALIZATION NOTE (sourceTabs.closeOtherTabs): Editor source tab context menu item
 # for closing the other tabs.
-sourceTabs.closeOtherTabs=Close others
+sourceTabs.closeOtherTabs=Close Other Tabs
 sourceTabs.closeOtherTabs.accesskey=o
 
 # LOCALIZATION NOTE (sourceTabs.closeTabsToEnd): Editor source tab context menu item
 # for closing the tabs to the end (the right for LTR languages) of the selected tab.
-sourceTabs.closeTabsToEnd=Close tabs to the right
+sourceTabs.closeTabsToEnd=Close Tabs to the Right
 sourceTabs.closeTabsToEnd.accesskey=e
 
 # LOCALIZATION NOTE (sourceTabs.closeAllTabs): Editor source tab context menu item
 # for closing all tabs.
-sourceTabs.closeAllTabs=Close all tabs
+sourceTabs.closeAllTabs=Close All Tabs
 sourceTabs.closeAllTabs.accesskey=a
 
 # LOCALIZATION NOTE (sourceTabs.revealInTree): Editor source tab context menu item


### PR DESCRIPTION
I have an issue open for case auditing but as we move closer to 57 I wanted to get this in.

Firefox itself uses uppercase labels so, for the sake of consistency, I'm going with that.