### PR TITLE
change cursor

### DIFF
--- a/src/components/Editor/Tabs.css
+++ b/src/components/Editor/Tabs.css
@@ -47,6 +47,7 @@
   padding: 5px;
   margin-inline-start: 3px;
   margin-top: 4px;
+  cursor: default;
 }
 
 .source-tab:hover {

--- a/src/components/PrimaryPanes/Outline.css
+++ b/src/components/PrimaryPanes/Outline.css
@@ -23,6 +23,7 @@
   padding-left: 1rem;
   padding-right: 0.5rem;
   padding-top: 0.2rem;
+  cursor: default;
 }
 
 .outline-list__element:hover {

--- a/src/components/PrimaryPanes/Sources.css
+++ b/src/components/PrimaryPanes/Sources.css
@@ -41,6 +41,7 @@
   font-weight: lighter;
   white-space: nowrap;
   padding-inline-end: 10px;
+  cursor: default;
 }
 
 .sources-list {
@@ -110,6 +111,7 @@
   padding: 5px;
   margin-bottom: 0px;
   margin-top: -1px;
+  cursor: default;
 }
 
 .source-footer .tab:hover {

--- a/src/components/SecondaryPanes/Breakpoints.css
+++ b/src/components/SecondaryPanes/Breakpoints.css
@@ -63,6 +63,7 @@ html .breakpoints-list .breakpoint.paused {
   display: inline-block;
   padding-inline-start: 2px;
   padding-bottom: 4px;
+  cursor: default;
 }
 
 .breakpoints-list .pause-indicator {

--- a/src/components/SecondaryPanes/Frames/Group.css
+++ b/src/components/SecondaryPanes/Frames/Group.css
@@ -1,6 +1,7 @@
 .frames ul .frames-group .group,
 .frames ul .frames-group .group .location {
   font-weight: 500;
+  cursor: default;
 }
 
 .frames ul .frames-group.expanded .group,

--- a/src/components/SecondaryPanes/Frames/WhyPaused.css
+++ b/src/components/SecondaryPanes/Frames/WhyPaused.css
@@ -9,6 +9,7 @@
   text-align: center;
   font-style: italic;
   font-weight: 300;
+  cursor: default;
 }
 
 .theme-dark .secondary-panes .why-paused {

--- a/src/components/SecondaryPanes/SecondaryPanes.css
+++ b/src/components/SecondaryPanes/SecondaryPanes.css
@@ -30,6 +30,7 @@
   padding: 0.5em;
   -moz-user-select: none;
   user-select: none;
+  cursor: default;
 }
 
 .theme-dark .secondary-panes .accordion .arrow svg {

--- a/src/components/shared/Accordion.css
+++ b/src/components/shared/Accordion.css
@@ -27,6 +27,7 @@
   -ms-user-select: none;
   -o-user-select: none;
   user-select: none;
+  cursor: default;
 }
 
 .accordion ._header:hover {


### PR DESCRIPTION
Associated Issue: #3872

Here's the Pull Request Doc
https://devtools-html.github.io/debugger.html/CONTRIBUTING.html#pull-requests

### Summary of Changes
change cursor style to default in following locations:
* source tab
* accordion (and inside items)
* source footer
* outline

### Test Plan

We searched the app for places with wrong cursor (input cursor) and verified the cursor is now default one (simple arrow)
