### PR TITLE
add source search filtering

### DIFF
--- a/src/components/ProjectSearch/SourceSearch.js
+++ b/src/components/ProjectSearch/SourceSearch.js
@@ -1,6 +1,6 @@
 import React, { Component, PropTypes } from "react";
 
-import { isPretty, getSourcePath } from "../../utils/source";
+import { isPretty, getSourcePath, isThirdParty } from "../../utils/source";
 import { endTruncateStr } from "../../utils/utils";
 
 import Autocomplete from "../shared/Autocomplete";
@@ -20,11 +20,11 @@ export default class SourceSearch extends Component {
 
   toggleSourceSearch: Function;
 
-  searchResults(sourceMap: SourcesMap) {
-    return sourceMap
+  searchResults(sources: SourcesMap) {
+    return sources
       .valueSeq()
       .toJS()
-      .filter(source => !isPretty(source))
+      .filter(source => !isPretty(source) && !isThirdParty(source))
       .map(source => ({
         value: getSourcePath(source),
         title: getSourcePath(source)

--- a/src/utils/source.js
+++ b/src/utils/source.js
@@ -74,6 +74,14 @@ function isPretty(source: Source): boolean {
   return source.url ? /formatted$/.test(source.url) : false;
 }
 
+function isThirdParty(source: Source) {
+  if (!source.url) {
+    return false;
+  }
+
+  return !!source.url.match(/(node_modules|bower_components)/);
+}
+
 /**
  * @memberof utils/source
  * @static
@@ -212,6 +220,7 @@ function isLoaded(source: Source) {
 export {
   isJavaScript,
   isPretty,
+  isThirdParty,
   shouldPrettyPrint,
   getPrettySourceURL,
   getRawSourceURL,

--- a/src/utils/tests/source.spec.js
+++ b/src/utils/tests/source.spec.js
@@ -1,4 +1,9 @@
-import { getFilename, getMode, getSourceLineCount } from "../source.js";
+import {
+  getFilename,
+  getMode,
+  getSourceLineCount,
+  isThirdParty
+} from "../source.js";
 
 describe("sources", () => {
   describe("getFilename", () => {
@@ -14,6 +19,20 @@ describe("sources", () => {
           id: ""
         })
       ).toBe("hello.html");
+    });
+  });
+
+  describe("isThirdParty", () => {
+    it("node_modules", () => {
+      expect(isThirdParty({ url: "/node_modules/foo.js" })).toBe(true);
+    });
+
+    it("bower_components", () => {
+      expect(isThirdParty({ url: "/bower_components/foo.js" })).toBe(true);
+    });
+
+    it("not third party", () => {
+      expect(isThirdParty({ url: "/bar/foo.js" })).toBe(false);
     });
   });
 


### PR DESCRIPTION
Associated Issue: #3987 

### Summary of Changes

* adds a new 3rd party function
* excludes 3rd party files from source search

Should we add an option to see 3rd party files it back?  Perhaps, but i think it's less important given there's a source tree.

Is this faster? Oh man, it's now blazing fast!

### Test Plan

unit tests