### PR TITLE
Fix #4002 - Prevent duel scrollbars in project search

### DIFF
--- a/src/components/ProjectSearch/ProjectSearch.css
+++ b/src/components/ProjectSearch/ProjectSearch.css
@@ -8,7 +8,7 @@
   flex-direction: column;
   z-index: 200;
   background-color: var(--theme-body-background);
-  overflow-y: auto;
+  overflow-y: hidden;
 }
 
 .searchinput-container {


### PR DESCRIPTION
There doesn't appear to be a reason to allow the overall search container to scroll.  Now only one scrollbar is shown when scrolling via mouse or moving via keyboard.