### PR TITLE
[ProjectSearch] Fix initial search

### DIFF
--- a/src/actions/project-text-search.js
+++ b/src/actions/project-text-search.js
@@ -14,7 +14,6 @@ import { getSources, getSource } from "../selectors";
 import { isThirdParty, isLoaded } from "../utils/source";
 import { loadAllSources } from "./sources";
 
-import type { Source } from "../types";
 import type { ThunkArgs } from "./types";
 
 export function addSearchQuery(query: string) {

--- a/src/actions/project-text-search.js
+++ b/src/actions/project-text-search.js
@@ -10,9 +10,8 @@
  */
 
 import { findSourceMatches } from "../utils/search";
-
-import { getSources } from "../selectors";
-
+import { getSources, getSource } from "../selectors";
+import { isThirdParty, isLoaded } from "../utils/source";
 import { loadAllSources } from "./sources";
 
 import type { Source } from "../types";
@@ -44,17 +43,23 @@ export function searchSources(query: string) {
     const sources = getSources(getState());
     const validSources = sources
       .valueSeq()
-      .filter(source => source.has("text"))
+      .filter(source => isLoaded(source.toJS()) && !isThirdParty(source.toJS()))
       .toJS();
 
     for (const source of validSources) {
-      await dispatch(searchSource(source, query));
+      await dispatch(searchSource(source.id, query));
     }
   };
 }
 
-export function searchSource(source: Source, query: string) {
+export function searchSource(sourceId: string, query: string) {
   return async ({ dispatch, getState }: ThunkArgs) => {
+    const sourceRecord = getSource(getState(), sourceId);
+    if (!sourceRecord) {
+      return;
+    }
+
+    const source = sourceRecord.toJS();
     const matches = await findSourceMatches(source, query);
     dispatch({
       type: "ADD_SEARCH_RESULT",

--- a/src/actions/sources.js
+++ b/src/actions/sources.js
@@ -24,6 +24,7 @@ import { loadSourceText } from "./sources/loadSourceText";
 
 import { prefs } from "../utils/prefs";
 import { removeDocument } from "../utils/editor";
+import { isThirdParty } from "../utils/source";
 
 import {
   getSource,
@@ -125,13 +126,17 @@ function loadSourceMap(generatedSource) {
     }
 
     const state = getState();
-    const originalSources = urls.map(originalUrl => {
-      return {
-        url: originalUrl,
-        id: sourceMaps.generatedToOriginalId(generatedSource.id, originalUrl),
-        isPrettyPrinted: false
-      };
-    });
+    const originalSources = urls.map(
+      originalUrl =>
+        ({
+          url: originalUrl,
+          id: sourceMaps.generatedToOriginalId(generatedSource.id, originalUrl),
+          isPrettyPrinted: false,
+          isWasm: false,
+          isBlackBoxed: false,
+          loadedState: "unloaded"
+        }: Source)
+    );
 
     dispatch({ type: "ADD_SOURCES", sources: originalSources });
 
@@ -371,11 +376,15 @@ export function loadAllSources() {
     const query = getTextSearchQuery(getState());
     for (const [, src] of sources) {
       const source = src.toJS();
+      if (isThirdParty(source)) {
+        continue;
+      }
+
       await dispatch(loadSourceText(source));
       // If there is a current search query we search
       // each of the source texts as they get loaded
       if (query) {
-        await dispatch(searchSource(source, query));
+        await dispatch(searchSource(source.id, query));
       }
     }
   };

--- a/src/actions/sources/loadSourceText.js
+++ b/src/actions/sources/loadSourceText.js
@@ -1,7 +1,6 @@
 // @flow
 import { PROMISE } from "../../utils/redux/middleware/promise";
 import { setEmptyLines, setSymbols } from "../ast";
-import { isLoaded } from "../../utils/source";
 import type { Source } from "../../types";
 import type { ThunkArgs } from "../types";
 /**

--- a/src/actions/sources/loadSourceText.js
+++ b/src/actions/sources/loadSourceText.js
@@ -11,7 +11,7 @@ import type { ThunkArgs } from "../types";
 export function loadSourceText(source: Source) {
   return async ({ dispatch, getState, client, sourceMaps }: ThunkArgs) => {
     // Fetch the source text only once.
-    if (isLoaded(source)) {
+    if (source.text) {
       return Promise.resolve(source);
     }
 

--- a/src/actions/sources/loadSourceText.js
+++ b/src/actions/sources/loadSourceText.js
@@ -1,6 +1,7 @@
 // @flow
 import { PROMISE } from "../../utils/redux/middleware/promise";
 import { setEmptyLines, setSymbols } from "../ast";
+import { isLoaded } from "../../utils/source";
 import type { Source } from "../../types";
 import type { ThunkArgs } from "../types";
 /**
@@ -10,7 +11,7 @@ import type { ThunkArgs } from "../types";
 export function loadSourceText(source: Source) {
   return async ({ dispatch, getState, client, sourceMaps }: ThunkArgs) => {
     // Fetch the source text only once.
-    if (source.text) {
+    if (isLoaded(source)) {
       return Promise.resolve(source);
     }
 

--- a/src/actions/tests/__snapshots__/project-text-search.spec.js.snap
+++ b/src/actions/tests/__snapshots__/project-text-search.spec.js.snap
@@ -4,7 +4,32 @@ exports[`project text search should clear all the search results 1`] = `
 Immutable.List [
   Object {
     "filepath": "http://localhost:8000/examples/foo1",
-    "matches": Array [],
+    "matches": Array [
+      Object {
+        "column": 9,
+        "line": 1,
+        "match": "foo",
+        "sourceId": "foo1",
+        "text": "function foo1() {",
+        "value": "function foo1() {",
+      },
+      Object {
+        "column": 8,
+        "line": 2,
+        "match": "foo",
+        "sourceId": "foo1",
+        "text": "  const foo = 5; return foo;",
+        "value": "  const foo = 5; return foo;",
+      },
+      Object {
+        "column": 24,
+        "line": 2,
+        "match": "foo",
+        "sourceId": "foo1",
+        "text": "  const foo = 5; return foo;",
+        "value": "  const foo = 5; return foo;",
+      },
+    ],
     "sourceId": "foo1",
   },
   Object {
@@ -68,12 +93,46 @@ exports[`project text search should search all the loaded sources based on the q
 Immutable.List [
   Object {
     "filepath": "http://localhost:8000/examples/foo1",
-    "matches": Array [],
+    "matches": Array [
+      Object {
+        "column": 9,
+        "line": 1,
+        "match": "foo",
+        "sourceId": "foo1",
+        "text": "function foo1() {",
+        "value": "function foo1() {",
+      },
+      Object {
+        "column": 8,
+        "line": 2,
+        "match": "foo",
+        "sourceId": "foo1",
+        "text": "  const foo = 5; return foo;",
+        "value": "  const foo = 5; return foo;",
+      },
+      Object {
+        "column": 24,
+        "line": 2,
+        "match": "foo",
+        "sourceId": "foo1",
+        "text": "  const foo = 5; return foo;",
+        "value": "  const foo = 5; return foo;",
+      },
+    ],
     "sourceId": "foo1",
   },
   Object {
     "filepath": "http://localhost:8000/examples/foo2",
-    "matches": Array [],
+    "matches": Array [
+      Object {
+        "column": 9,
+        "line": 1,
+        "match": "foo",
+        "sourceId": "foo2",
+        "text": "function foo2(x, y) {",
+        "value": "function foo2(x, y) {",
+      },
+    ],
     "sourceId": "foo2",
   },
   Object {

--- a/src/actions/tests/project-text-search.spec.js
+++ b/src/actions/tests/project-text-search.spec.js
@@ -75,9 +75,12 @@ describe("project text search", () => {
 
     await dispatch(actions.newSource(makeSource("bar")));
     await dispatch(actions.loadSourceText({ id: "bar" }));
+
     dispatch(actions.addSearchQuery("bla"));
+
     const sourceId = getSource(getState(), "bar").get("id");
-    await dispatch(actions.searchSource(sourceId, "bar"), "bla");
+
+    await dispatch(actions.searchSource(sourceId, "bla"), "bla");
 
     const results = getTextSearchResults(getState());
 

--- a/src/actions/tests/project-text-search.spec.js
+++ b/src/actions/tests/project-text-search.spec.js
@@ -76,9 +76,8 @@ describe("project text search", () => {
     await dispatch(actions.newSource(makeSource("bar")));
     await dispatch(actions.loadSourceText({ id: "bar" }));
     dispatch(actions.addSearchQuery("bla"));
-    await dispatch(
-      actions.searchSource(getSource(getState(), "bar").toJS(), "bla")
-    );
+    const sourceId = getSource(getState(), "bar").get("id");
+    await dispatch(actions.searchSource(sourceId, "bar"), "bla");
 
     const results = getTextSearchResults(getState());
 

--- a/src/components/Editor/tests/Editor.spec.js
+++ b/src/components/Editor/tests/Editor.spec.js
@@ -24,7 +24,8 @@ function generateDefaults(overrides) {
       regexMatch: false,
       wholeWord: false
     })(),
-    clearPreview: jest.fn
+    clearPreview: jest.fn,
+    toggleConditionalBreakpointPanel: jest.fn
   };
 }
 

--- a/src/components/Editor/tests/__snapshots__/Editor.spec.js.snap
+++ b/src/components/Editor/tests/__snapshots__/Editor.spec.js.snap
@@ -63,6 +63,7 @@ ShallowWrapper {
         }
         setBreakpointCondition={[Function]}
         toggleBreakpoint={[Function]}
+        toggleConditionalBreakpointPanel={[Function]}
         toggleDisabledBreakpoint={[Function]}
 />,
       "_debugID": 1,
@@ -101,6 +102,7 @@ ShallowWrapper {
           },
           "setBreakpointCondition": [Function],
           "toggleBreakpoint": [Function],
+          "toggleConditionalBreakpointPanel": [Function],
           "toggleDisabledBreakpoint": [Function],
         },
         "refs": Object {},
@@ -186,6 +188,7 @@ ShallowWrapper {
     }
     setBreakpointCondition={[Function]}
     toggleBreakpoint={[Function]}
+    toggleConditionalBreakpointPanel={[Function]}
     toggleDisabledBreakpoint={[Function]}
 />,
 }

--- a/src/utils/source.js
+++ b/src/utils/source.js
@@ -75,7 +75,7 @@ function isPretty(source: Source): boolean {
 }
 
 function isThirdParty(source: Source) {
-  if (!source.url) {
+  if (!source || !source.url) {
     return false;
   }
 


### PR DESCRIPTION
### Summary of Changes

The initial project search fails after loading one source. This is because of some edge cases w/ how we switch source loaded state. This should fix that by updating the loaded state field and also adding some other necessary fields. 

It also adds 3rd party filtering so we only search first party code.

STR:

1. get perf.html
2. open, cmd+shift+f
3. search for `this`

you'll see: failed to get name from undefined

### Test Plan

unit tests