### PR TITLE
don't load if we're not paused

### DIFF
--- a/src/actions/pause.js
+++ b/src/actions/pause.js
@@ -243,7 +243,7 @@ export function loadObjectProperties(object: any) {
   return ({ dispatch, client, getState }: ThunkArgs) => {
     const objectId = object.actor || object.objectId;
 
-    if (getLoadedObject(getState(), objectId)) {
+    if (!getPause(getState()) || getLoadedObject(getState(), objectId)) {
       return;
     }
 


### PR DESCRIPTION

### Summary of Changes

When I was making the 9-13 bundle i noticed we were getting an intermittent because we didn't check to see if we were fetching properties when we weren't paused.