### PR TITLE
Fixup Tab CSS

### DIFF
--- a/src/components/Editor/Tabs.css
+++ b/src/components/Editor/Tabs.css
@@ -46,7 +46,7 @@
   overflow: hidden;
   padding: 5px;
   margin-inline-start: 3px;
-  margin-top: 4px;
+  margin-top: 3px;
   cursor: default;
 }
 


### PR DESCRIPTION
Fixes a photon css bug w/ tabs
#### before
![after - tabs](https://user-images.githubusercontent.com/254562/30457743-8e9d8f64-9976-11e7-9e91-e990f0458cf5.png)

#### after
![before - tabs](https://user-images.githubusercontent.com/254562/30457744-8e9ee97c-9976-11e7-9e23-3971d564e419.png)
