### PR TITLE
Remove devtools.debugger.client-source-maps-enabled pref

### DIFF
--- a/assets/panel/prefs.js
+++ b/assets/panel/prefs.js
@@ -17,7 +17,10 @@ pref("devtools.debugger.remote-timeout", 20000);
 pref("devtools.debugger.pause-on-exceptions", false);
 pref("devtools.debugger.ignore-caught-exceptions", false);
 pref("devtools.debugger.source-maps-enabled", true);
-pref("devtools.debugger.client-source-maps-enabled", true);
+
+// Enable client-side mapping service for source maps
+pref("devtools.source-map.client-service.enabled", true);
+
 pref("devtools.debugger.pretty-print-enabled", true);
 pref("devtools.debugger.auto-pretty-print", false);
 pref("devtools.debugger.auto-black-box", true);
@@ -45,4 +48,4 @@ pref("devtools.debugger.file-search-whole-word", false);
 pref("devtools.debugger.file-search-regex-match", false);
 pref("devtools.debugger.features.async-stepping", true);
 pref("devtools.debugger.project-text-search-enabled", true);
-pref("devtools.debugger.features.wasm", true)
+pref("devtools.debugger.features.wasm", true);

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -97,13 +97,13 @@ User preferences are stored in Prefs. Prefs uses localStorage locally and firefo
 **Setting a default value**
 
 ```js
-pref("devtools.debugger.client-source-maps-enabled", true);
+pref("devtools.debugger.pause-on-exceptions", true);
 ```
 
 **Adding a pref**
 ```js
 const prefs = new PrefsHelper("devtools", {
-  clientSourceMapsEnabled: ["Bool", "debugger.client-source-maps-enabled"],
+  clientSourceMapsEnabled: ["Bool", "debugger.pause-on-exceptions"],
 });
 ```
 

--- a/src/utils/prefs.js
+++ b/src/utils/prefs.js
@@ -8,7 +8,7 @@ const prefsSchemaVersion = "1.0.3";
 const pref = Services.pref;
 
 if (isDevelopment()) {
-  pref("devtools.debugger.client-source-maps-enabled", true);
+  pref("devtools.source-map.client-service.enabled", true);
   pref("devtools.debugger.pause-on-exceptions", false);
   pref("devtools.debugger.ignore-caught-exceptions", false);
   pref("devtools.debugger.call-stack-visible", false);
@@ -30,7 +30,7 @@ if (isDevelopment()) {
 }
 
 export const prefs = new PrefsHelper("devtools", {
-  clientSourceMapsEnabled: ["Bool", "debugger.client-source-maps-enabled"],
+  clientSourceMapsEnabled: ["Bool", "source-map.client-service.enabled"],
   pauseOnExceptions: ["Bool", "debugger.pause-on-exceptions"],
   ignoreCaughtExceptions: ["Bool", "debugger.ignore-caught-exceptions"],
   callStackVisible: ["Bool", "debugger.call-stack-visible"],


### PR DESCRIPTION
This removes the devtools.debugger.client-source-maps-enabled pref, in
favor of the pref that will be used across all tools.

I've copied over the relevant from devtools.js; the next time the
debugger lands, we will want to remove that definition from M-C.

I'll handle other aspects of the unification in M-C; namely, updating
the options panel.
