### PR TITLE
Tweak source-map prefs in prefs.js

### DIFF
--- a/assets/panel/prefs.js
+++ b/assets/panel/prefs.js
@@ -17,10 +17,10 @@ pref("devtools.debugger.remote-timeout", 20000);
 pref("devtools.debugger.pause-on-exceptions", false);
 pref("devtools.debugger.ignore-caught-exceptions", false);
 pref("devtools.debugger.source-maps-enabled", true);
-
-// Enable client-side mapping service for source maps
-pref("devtools.source-map.client-service.enabled", true);
-
+// Temporarily leave this in place, even though it is unused, so the
+// options pane doesn't break.
+// https://bugzilla.mozilla.org/show_bug.cgi?id=1371849
+pref("devtools.debugger.client-source-maps-enabled", true);
 pref("devtools.debugger.pretty-print-enabled", true);
 pref("devtools.debugger.auto-pretty-print", false);
 pref("devtools.debugger.auto-black-box", true);


### PR DESCRIPTION
Julian pointed out that prefs.js is only used in the panel, so we don't
need to define the shared pref here.

Also, we need to temporarily leave the old pref in place until
https://bugzilla.mozilla.org/show_bug.cgi?id=1371849 lands, to avoid
errors from the options pane.
