### PR TITLE
Fix #4046 - Prevent scrollbars for watch expression items

### DIFF
--- a/src/components/SecondaryPanes/Expressions.css
+++ b/src/components/SecondaryPanes/Expressions.css
@@ -63,8 +63,8 @@
   position: relative;
 }
 
-.expression-container .close-btn {
-  display: none;
+.expression-content .tree-node {
+  overflow-x: hidden;
 }
 
 .expression-container:hover .close-btn {


### PR DESCRIPTION
This prevents scrollbars on expression items all together.  Coupled with an ellipsis (https://github.com/devtools-html/debugger.html/issues/3901), this will look great!  