### PR TITLE
add travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,30 @@
+language: python
+node_js: "8.4.0"
+
+cache:
+  directories:
+    - node_modules
+
+env:
+  - DISPLAY=':99.0'
+
+addons:
+  apt:
+    packages:
+      - autoconf2.13
+      - sshpass
+      - p7zip-full
+
+install:
+  - pip install --upgrade pip
+  - pip install -U mercurial
+  - ./bin/ci/clone-gecko.sh
+  - npm install
+
+before_script:
+  - ./bin/ci/build-firefox.sh
+  - sh -e /etc/init.d/xvfb start
+
+script:
+  - echo $TRAVIS_COMMIT_RANGE
+  - ./bin/ci/run-tests.sh $TRAVIS_COMMIT_RANGE

--- a/bin/ci/build-firefox.sh
+++ b/bin/ci/build-firefox.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+cd gecko
+# We have to set that env variable otherwise
+# ./mach build is going to be interactive and expect <ENTER>
+# to be pressed to continue. Here travis would just be stuck...
+export MOZBUILD_STATE_PATH=$(pwd)/mozbuild-state
+[ -d $MOZBUILD_STATE_PATH ] || mkdir $MOZBUILD_STATE_PATH
+echo $MOZBUILD_STATE_PATH
+
+echo "ac_add_options --enable-artifact-builds" > mozconfig
+echo "mk_add_options AUTOCLOBBER=1" >> mozconfig
+./mach build
+cd ..

--- a/bin/ci/clone-gecko.sh
+++ b/bin/ci/clone-gecko.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+hg --version
+if [ ! -d "gecko/.hg" ]; then
+  rm -rf gecko/
+  hg clone https://hg.mozilla.org/mozilla-unified/ gecko
+else
+  cd gecko
+  hg strip --no-backup 'roots(outgoing())'
+  hg pull -u
+  cd ..
+fi

--- a/bin/ci/run-tests.sh
+++ b/bin/ci/run-tests.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+node ./bin/copy-assets.js --mc gecko
+
+cd gecko
+
+./mach mochitest devtools/client/debugger/new
+
+cd ..


### PR DESCRIPTION
Associated Issue #3986 

### Summary

This switches our mochitests to travis.

**advantages**

* tests run in parallel 
* we don't use docker
* mc is up to date 