### PR TITLE
Move PrimaryPane tabs to the top

### DIFF
--- a/src/components/PrimaryPanes/Outline.js
+++ b/src/components/PrimaryPanes/Outline.js
@@ -3,7 +3,6 @@
 import React, { Component } from "react";
 import { bindActionCreators } from "redux";
 import { connect } from "react-redux";
-import classnames from "classnames";
 import actions from "../../actions";
 import { getSelectedSource, getSymbols } from "../../selectors";
 import "./Outline.css";
@@ -20,7 +19,6 @@ export class Outline extends Component {
   state: any;
 
   props: {
-    isHidden: boolean,
     symbols: SymbolDeclarations,
     selectSource: (string, { line: number }) => void,
     selectedSource: ?SourceRecord
@@ -67,14 +65,14 @@ export class Outline extends Component {
   }
 
   render() {
-    const { isHidden, symbols } = this.props;
+    const { symbols } = this.props;
 
     const symbolsToDisplay = symbols.functions.filter(
       func => func.name != "anonymous"
     );
 
     return (
-      <div className={classnames("outline", { hidden: isHidden })}>
+      <div className="outline">
         {symbolsToDisplay.length > 0
           ? this.renderFunctions(symbolsToDisplay)
           : this.renderPlaceholder()}

--- a/src/components/PrimaryPanes/Sources.css
+++ b/src/components/PrimaryPanes/Sources.css
@@ -79,6 +79,7 @@
 
 .sources-panel .source-footer {
   position: relative;
+  height: 29px;
 }
 
 .sources-panel .outline {

--- a/src/components/PrimaryPanes/SourcesTree.js
+++ b/src/components/PrimaryPanes/SourcesTree.js
@@ -247,7 +247,6 @@ class SourcesTree extends Component {
   }
 
   render() {
-    const { isHidden } = this.props;
     const {
       focusedItem,
       sourceTree,
@@ -290,10 +289,7 @@ class SourcesTree extends Component {
     };
 
     return (
-      <div
-        className={classnames("sources-list", { hidden: isHidden })}
-        onKeyDown={onKeyDown}
-      >
+      <div className="sources-list" onKeyDown={onKeyDown}>
         {tree}
       </div>
     );
@@ -301,7 +297,6 @@ class SourcesTree extends Component {
 }
 
 SourcesTree.propTypes = {
-  isHidden: PropTypes.bool,
   sources: ImPropTypes.map.isRequired,
   selectSource: PropTypes.func.isRequired,
   shownSource: PropTypes.string,

--- a/src/components/PrimaryPanes/index.js
+++ b/src/components/PrimaryPanes/index.js
@@ -31,7 +31,6 @@ class PrimaryPanes extends Component {
   renderShortcut: Function;
   selectedPane: String;
   showPane: Function;
-  renderFooter: Function;
   renderChildren: Function;
   state: SourcesState;
   props: Props;
@@ -42,14 +41,13 @@ class PrimaryPanes extends Component {
 
     this.renderShortcut = this.renderShortcut.bind(this);
     this.showPane = this.showPane.bind(this);
-    this.renderFooter = this.renderFooter.bind(this);
   }
 
   showPane(selectedPane: string) {
     this.setState({ selectedPane });
   }
 
-  renderOutlineTabs() {
+  renderPrimaryPaneTabs() {
     if (!isEnabled("outline")) {
       return;
     }
@@ -58,7 +56,7 @@ class PrimaryPanes extends Component {
 
     const outline = formatKeyShortcut(L10N.getStr("outline.header"));
 
-    return [
+    const tabItems = [
       <div
         className={classnames("tab", {
           active: this.state.selectedPane === "sources"
@@ -78,10 +76,8 @@ class PrimaryPanes extends Component {
         {outline}
       </div>
     ];
-  }
 
-  renderFooter() {
-    return <div className="source-footer">{this.renderOutlineTabs()}</div>;
+    return <div className="source-footer">{tabItems}</div>;
   }
 
   renderShortcut() {
@@ -111,6 +107,10 @@ class PrimaryPanes extends Component {
     const { selectedPane } = this.state;
     const { sources, selectSource } = this.props;
 
+    const sourcesTreeComp = (
+      <SourcesTree sources={sources} selectSource={selectSource} />
+    );
+
     const outlineComp = isEnabled("outline") ? (
       <Outline
         selectSource={selectSource}
@@ -120,14 +120,9 @@ class PrimaryPanes extends Component {
 
     return (
       <div className="sources-panel">
-        {this.renderHeader()}
-        <SourcesTree
-          sources={sources}
-          selectSource={selectSource}
-          isHidden={selectedPane === "outline"}
-        />
-        {outlineComp}
-        {this.renderFooter()}
+        {this.renderPrimaryPaneTabs()}
+        {selectedPane == "sources" ? this.renderHeader() : null}
+        {selectedPane == "sources" ? sourcesTreeComp : outlineComp}
       </div>
     );
   }

--- a/src/components/PrimaryPanes/index.js
+++ b/src/components/PrimaryPanes/index.js
@@ -28,7 +28,7 @@ type Props = {
 };
 
 class PrimaryPanes extends Component {
-  renderShortcut: Function;
+  renderSourcesShortcut: Function;
   selectedPane: String;
   showPane: Function;
   renderChildren: Function;
@@ -39,7 +39,6 @@ class PrimaryPanes extends Component {
     super(props);
     this.state = { selectedPane: "sources" };
 
-    this.renderShortcut = this.renderShortcut.bind(this);
     this.showPane = this.showPane.bind(this);
   }
 
@@ -48,12 +47,7 @@ class PrimaryPanes extends Component {
   }
 
   renderPrimaryPaneTabs() {
-    if (!isEnabled("outline")) {
-      return;
-    }
-
     const sources = formatKeyShortcut(L10N.getStr("sources.header"));
-
     const outline = formatKeyShortcut(L10N.getStr("outline.header"));
 
     const tabItems = [
@@ -80,7 +74,7 @@ class PrimaryPanes extends Component {
     return <div className="source-footer">{tabItems}</div>;
   }
 
-  renderShortcut() {
+  renderSourcesShortcut() {
     if (this.props.horizontal) {
       const onClick = () => {
         if (this.props.sourceSearchOn) {
@@ -89,40 +83,41 @@ class PrimaryPanes extends Component {
         this.props.setActiveSearch("source");
       };
       return (
-        <span className="sources-header-info" dir="ltr" onClick={onClick}>
-          {L10N.getFormatStr(
-            "sources.search",
-            formatKeyShortcut(L10N.getStr("sources.search.key2"))
-          )}
-        </span>
+        <div className="sources-header">
+          <span className="sources-header-info" dir="ltr" onClick={onClick}>
+            {L10N.getFormatStr(
+              "sources.search",
+              formatKeyShortcut(L10N.getStr("sources.search.key2"))
+            )}
+          </span>
+        </div>
       );
     }
   }
 
-  renderHeader() {
-    return <div className="sources-header">{this.renderShortcut()}</div>;
+  renderSources() {
+    const { sources, selectSource } = this.props;
+    return (
+      <div>
+        {this.renderSourcesShortcut()}
+        <SourcesTree sources={sources} selectSource={selectSource} />
+      </div>
+    );
+  }
+
+  renderOutline() {
+    const { selectSource } = this.props;
+    return <Outline selectSource={selectSource} />;
   }
 
   render() {
     const { selectedPane } = this.state;
-    const { sources, selectSource } = this.props;
-
-    const sourcesTreeComp = (
-      <SourcesTree sources={sources} selectSource={selectSource} />
-    );
-
-    const outlineComp = isEnabled("outline") ? (
-      <Outline
-        selectSource={selectSource}
-        isHidden={selectedPane === "sources"}
-      />
-    ) : null;
-
     return (
       <div className="sources-panel">
-        {this.renderPrimaryPaneTabs()}
-        {selectedPane == "sources" ? this.renderHeader() : null}
-        {selectedPane == "sources" ? sourcesTreeComp : outlineComp}
+        {isEnabled("outline") ? this.renderPrimaryPaneTabs() : null}
+        {selectedPane == "sources"
+          ? this.renderSources()
+          : this.renderOutline()}
       </div>
     );
   }


### PR DESCRIPTION
Associated Issue: #4031 

### Summary of Changes

* Moved PrimaryPane tabs to the top
* Refactored/renamed functions to match their purpose
* Simplified the stucture of PrimaryPane
* removed isHidden prop fromSourceTree & Outline (hiding via css is an antipattern. It should either get rendered or not)
* Don't show "Ctrl P to search" when on the Outline tab
* changed css to make the Tabs height same as Editor header height
* Fix PrimaryPanes display issue when there are no sources and Outline tab is active (see attached screenshot)

![unbenannt](https://user-images.githubusercontent.com/2511026/30519015-b7e8678c-9b8c-11e7-8437-f046b798759e.png)
