### PR TITLE
Small style improvements on breakpoint and watch expression

### DIFF
--- a/src/components/SecondaryPanes/Breakpoints.css
+++ b/src/components/SecondaryPanes/Breakpoints.css
@@ -53,16 +53,24 @@ html .breakpoints-list .breakpoint.paused {
   border-color: var(--breakpoint-active-color-hover);
 }
 
-.breakpoints-list .breakpoint-checkbox {
-  margin-inline-start: 0;
-  vertical-align: -2px;
-}
-
 .breakpoints-list .breakpoint-label {
+  max-width: calc(100% - var(--breakpoint-expression-right-clear-space));
   display: inline-block;
   padding-inline-start: 2px;
-  padding-bottom: 4px;
   cursor: default;
+}
+
+.breakpoint-label .breakpoint-checkbox {
+  margin-inline-start: 0;
+  vertical-align: text-bottom;
+}
+
+.breakpoint-label .location {
+  width: 100%;
+  display: inline-block;
+  overflow-x: hidden;
+  text-overflow: ellipsis;
+  padding: 1px 0;
 }
 
 .breakpoints-list .pause-indicator {

--- a/src/components/SecondaryPanes/Breakpoints.js
+++ b/src/components/SecondaryPanes/Breakpoints.js
@@ -345,18 +345,16 @@ class Breakpoints extends PureComponent {
         onClick={() => this.selectBreakpoint(breakpoint)}
         onContextMenu={e => this.showContextMenu(e, breakpoint)}
       >
-        <input
-          type="checkbox"
-          className="breakpoint-checkbox"
-          checked={!isDisabled}
-          onChange={() => this.handleCheckbox(breakpoint)}
-          onClick={ev => ev.stopPropagation()}
-        />
-        <div className="breakpoint-label" title={breakpoint.text}>
-          <div>
-            {renderSourceLocation(breakpoint.location.source, line, column)}
-          </div>
-        </div>
+        <label className="breakpoint-label" title={breakpoint.text}>
+          <input
+            type="checkbox"
+            className="breakpoint-checkbox"
+            checked={!isDisabled}
+            onChange={() => this.handleCheckbox(breakpoint)}
+            onClick={ev => ev.stopPropagation()}
+          />
+          {renderSourceLocation(breakpoint.location.source, line, column)}
+        </label>
         <div className="breakpoint-snippet">{snippet}</div>
         <CloseButton
           handleClick={ev => this.removeBreakpoint(ev, breakpoint)}

--- a/src/components/SecondaryPanes/Expressions.css
+++ b/src/components/SecondaryPanes/Expressions.css
@@ -63,6 +63,11 @@
   position: relative;
 }
 
+.expression-content .tree {
+  overflow-x: hidden;
+  max-width: calc(100% - var(--breakpoint-expression-right-clear-space));
+}
+
 .expression-content .tree-node {
   overflow-x: hidden;
 }

--- a/src/components/SecondaryPanes/SecondaryPanes.css
+++ b/src/components/SecondaryPanes/SecondaryPanes.css
@@ -3,6 +3,7 @@
   flex-direction: column;
   flex: 1;
   white-space: nowrap;
+  --breakpoint-expression-right-clear-space: 36px;
 }
 
 /*


### PR DESCRIPTION
Associated Issue: #4044 

### Summary of Changes

* Handle the overflow case for watch expressions
* Make clicking on label text toggle corresponding checkbox as well
* Adjust the vertical align between label text and checkbox
* Make label text become the ellipsis style when script filename is too long.
  - In Chrome, for a too long script filename, it would have the ellipsis style  
    <img width="326" alt="screen shot 2017-09-17 at 3 42 21 pm" src="https://user-images.githubusercontent.com/5627487/30519429-b998ea84-9bc8-11e7-85eb-10cfb3da41b9.png">
  - But currently, in Firefox debugger page, a long filename would push away the close button out of view and cause a broken payout.
    <img width="506" alt="screen shot 2017-09-17 at 3 00 13 pm" src="https://user-images.githubusercontent.com/5627487/30519453-54fe31be-9bc9-11e7-8436-0ce3bfbbd6f2.png">
    <img width="408" alt="screen shot 2017-09-17 at 4 56 57 pm" src="https://user-images.githubusercontent.com/5627487/30519454-56e72e5e-9bc9-11e7-9847-2a92a186d9ba.png">

### Screenshots/Videos 

* The solution in action
- Screenshot 1
![4044_solution](https://user-images.githubusercontent.com/5627487/30519462-96cff802-9bc9-11e7-911f-21feef9c8f7f.gif)

- Screenshot 2
![screenshot_2](https://user-images.githubusercontent.com/5627487/30590293-83d900ec-9d70-11e7-9960-7606d9b74efc.gif)


