### PR TITLE
Pausing due to an errored watch expression

### DIFF
--- a/src/actions/expressions.js
+++ b/src/actions/expressions.js
@@ -38,7 +38,8 @@ export function addExpression(input: string) {
 
     const selectedFrame = getSelectedFrame(getState());
     const selectedFrameId = selectedFrame ? selectedFrame.id : null;
-    dispatch(evaluateExpression({ input }, selectedFrameId));
+    const newExpression = getExpression(getState(), input);
+    dispatch(evaluateExpression(newExpression, selectedFrameId));
   };
 }
 
@@ -95,7 +96,7 @@ export function evaluateExpressions(frameId: frameIdType) {
   };
 }
 
-function evaluateExpression(expression, frameId: frameIdType) {
+function evaluateExpression(expression: Expression, frameId: frameIdType) {
   return function({ dispatch, getState, client }: ThunkArgs) {
     if (!expression.input) {
       console.warn("Expressions should not be empty");

--- a/src/actions/pause.js
+++ b/src/actions/pause.js
@@ -63,6 +63,7 @@ export function continueToHere(line: number) {
         sourceId: source.id
       })
     );
+
     dispatch(command("resume"));
   };
 }
@@ -97,6 +98,8 @@ export function paused(pauseInfo: Pause) {
       dispatch(removeBreakpoint(hiddenBreakpointLocation));
     }
 
+    // NOTE: We don't want to re-evaluate watch expressions
+    // if we're paused due to an excpression exception #3597
     if (!hasWatchExpressionErrored(getState())) {
       dispatch(evaluateExpressions(frame.id));
     }

--- a/src/actions/pause.js
+++ b/src/actions/pause.js
@@ -7,7 +7,9 @@ import {
   getPause,
   getLoadedObject,
   isStepping,
-  getSelectedSource
+  isPaused,
+  getSelectedSource,
+  hasWatchExpressionErrored
 } from "../selectors";
 import { updateFrameLocations, getPausedPosition } from "../utils/pause";
 import { evaluateExpressions } from "./expressions";
@@ -35,6 +37,10 @@ type CommandType = string;
  */
 export function resumed() {
   return ({ dispatch, client, getState }: ThunkArgs) => {
+    if (!isPaused(getState())) {
+      return;
+    }
+
     dispatch({
       type: "RESUME",
       value: undefined
@@ -91,7 +97,9 @@ export function paused(pauseInfo: Pause) {
       dispatch(removeBreakpoint(hiddenBreakpointLocation));
     }
 
-    dispatch(evaluateExpressions(frame.id));
+    if (!hasWatchExpressionErrored(getState())) {
+      dispatch(evaluateExpressions(frame.id));
+    }
 
     dispatch(
       selectSource(frame.location.sourceId, { line: frame.location.line })

--- a/src/actions/sources.js
+++ b/src/actions/sources.js
@@ -322,7 +322,7 @@ export function togglePrettyPrint(sourceId: string) {
   return async ({ dispatch, getState, client, sourceMaps }: ThunkArgs) => {
     const source = getSource(getState(), sourceId).toJS();
 
-    if (source && !isLoaded(source)) {
+    if (!source || !isLoaded(source)) {
       return {};
     }
 

--- a/src/actions/tests/pause.spec.js
+++ b/src/actions/tests/pause.spec.js
@@ -1,12 +1,22 @@
-import { actions, selectors, createStore } from "../../utils/test-head";
+import {
+  actions,
+  selectors,
+  createStore,
+  getHistory
+} from "../../utils/test-head";
 
-const { isStepping } = selectors;
+const { isStepping, hasWatchExpressionErrored } = selectors;
 
 let stepInResolve = null;
+let evaluateResolve = null;
 const mockThreadClient = {
   stepIn: () =>
     new Promise(_resolve => {
       stepInResolve = _resolve;
+    }),
+  evaluate: () =>
+    new Promise(_resolve => {
+      evaluateResolve = _resolve;
     }),
   getFrameScopes: frame => frame.scope,
   sourceContents: sourceId => {
@@ -22,28 +32,66 @@ const mockThreadClient = {
   }
 };
 
-describe("pause", () => {
-  it("should set and clear the command", async () => {
-    const { dispatch, getState } = createStore(mockThreadClient);
-    const mockPauseInfo = {
-      frames: [{ id: 1, scope: [], location: { sourceId: "foo1", line: 4 } }],
-      loadedObjects: [],
-      why: {}
-    };
+function createPauseInfo(overrides = {}) {
+  return {
+    frames: [{ id: 1, scope: [], location: { sourceId: "foo1", line: 4 } }],
+    loadedObjects: [],
+    why: {},
+    ...overrides
+  };
+}
 
-    await dispatch(actions.paused(mockPauseInfo));
-    dispatch(actions.stepIn());
-    expect(isStepping(getState())).toBeTruthy();
-    await stepInResolve();
-    expect(isStepping(getState())).toBeFalsy();
+describe("pause", () => {
+  describe("paused", () => {
+    // eslint-disable-next-line
+    it("should detect when we're paused due to an expression exception", async () => {
+      const { dispatch, getState } = createStore(mockThreadClient);
+      const mockPauseInfo = createPauseInfo({ why: { type: "exception" } });
+      dispatch(actions.addExpression("foo.bar"));
+      dispatch(actions.evaluateExpressions({ frameId: 2 }));
+      await dispatch(actions.paused(mockPauseInfo));
+      expect(hasWatchExpressionErrored(getState())).toBe(true);
+      evaluateResolve();
+    });
   });
 
-  it("should not evaluate expression while stepping", async () => {
-    const client = { evaluate: jest.fn() };
-    const { dispatch } = createStore(client);
+  describe("stepping", () => {
+    it("should set and clear the command", async () => {
+      const { dispatch, getState } = createStore(mockThreadClient);
+      const mockPauseInfo = createPauseInfo();
 
-    dispatch(actions.stepIn());
-    await dispatch(actions.resumed());
-    expect(client.evaluate.mock.calls.length).toEqual(0);
+      await dispatch(actions.paused(mockPauseInfo));
+      dispatch(actions.stepIn());
+      expect(isStepping(getState())).toBeTruthy();
+      await stepInResolve();
+      expect(isStepping(getState())).toBeFalsy();
+    });
+  });
+
+  describe("resumed", () => {
+    it("should not evaluate expression while stepping", async () => {
+      const client = { evaluate: jest.fn() };
+      const { dispatch } = createStore(client);
+
+      dispatch(actions.stepIn());
+      await dispatch(actions.resumed());
+      expect(client.evaluate.mock.calls.length).toEqual(0);
+    });
+
+    it("resuming", async () => {
+      const { dispatch } = createStore(mockThreadClient);
+      const mockPauseInfo = createPauseInfo();
+
+      await dispatch(actions.paused(mockPauseInfo));
+      await dispatch(actions.resumed());
+
+      expect(getHistory("RESUME").length).toEqual(1);
+    });
+
+    it("resuming when not paused", async () => {
+      const { dispatch } = createStore(mockThreadClient);
+      await dispatch(actions.resumed());
+      expect(getHistory("RESUME").length).toEqual(0);
+    });
   });
 });

--- a/src/reducers/pause.js
+++ b/src/reducers/pause.js
@@ -146,6 +146,12 @@ function update(state: PauseState = State(), action: Action): PauseState {
     case "CLEAR_COMMAND":
       return { ...state, command: "" };
 
+    case "EVALUATE_EXPRESSION":
+      return {
+        ...state,
+        command: action.status === "start" ? "expression" : ""
+      };
+
     case "NAVIGATE":
       return { ...state, debuggeeUrl: action.url };
   }
@@ -178,6 +184,21 @@ export const getLoadedObjects = createSelector(
 
 export function isStepping(state: OuterState) {
   return ["stepIn", "stepOver", "stepOut"].includes(state.pause.command);
+}
+
+export function isPaused(state: OuterState) {
+  return !!getPause(state);
+}
+
+export function isEvaluatingExpression(state: OuterState) {
+  return state.pause.command === "expression";
+}
+
+export function hasWatchExpressionErrored(state: OuterState) {
+  const pause = getPause(state);
+  return (
+    isEvaluatingExpression(state) && pause && pause.why.type === "exception"
+  );
 }
 
 export function getLoadedObject(state: OuterState, objectId: string) {

--- a/src/test/mochitest/browser.ini
+++ b/src/test/mochitest/browser.ini
@@ -60,6 +60,7 @@ skip-if = true # Bug 1383576
 [browser_dbg-breakpoints-cond.js]
 [browser_dbg-call-stack.js]
 [browser_dbg-expressions.js]
+[browser_dbg-expressions-error.js]
 [browser_dbg-scopes.js]
 [browser_dbg-chrome-create.js]
 [browser_dbg-chrome-debugging.js]

--- a/src/test/mochitest/browser_dbg-expressions-error.js
+++ b/src/test/mochitest/browser_dbg-expressions-error.js
@@ -2,11 +2,8 @@
  * http://creativecommons.org/publicdomain/zero/1.0/ */
 
 /**
- * tests the watch expressions component
- * 1. add watch expressions
- * 2. edit watch expressions
- * 3. delete watch expressions
- * 4. expanding properties when not paused
+ * test pausing on an errored watch expression
+ * assert that you can still evalutate expressions
  */
 
 const expressionSelectors = {
@@ -57,38 +54,16 @@ async function editExpression(dbg, input) {
 add_task(async function() {
   const dbg = await initDebugger("doc-script-switching.html");
 
-  invokeInTab("firstCall");
-  await waitForPaused(dbg);
-
-  await addExpression(dbg, "f");
-  is(getLabel(dbg, 1), "f");
-  is(getValue(dbg, 1), "(unavailable)");
-
-  await editExpression(dbg, "oo");
-  is(getLabel(dbg, 1), "foo()");
-
-  // There is no "value" element for functions.
-  assertEmptyValue(dbg, 1);
-
+  await togglePauseOnExceptions(dbg, true, false);
   await addExpression(dbg, "location");
-  is(getLabel(dbg, 2), "location");
-  ok(getValue(dbg, 2).includes("Location"), "has a value");
 
-  // can expand an expression
-  toggleExpression(dbg, 2);
-  await waitForDispatch(dbg, "LOAD_OBJECT_PROPERTIES");
+  const paused = waitForPaused(dbg);
+  addExpression(dbg, "foo.bar");
 
-  await deleteExpression(dbg, "foo");
-  await deleteExpression(dbg, "location");
-  is(findAllElements(dbg, "expressionNodes").length, 0);
+  await paused;
+  ok(dbg.selectors.hasWatchExpressionErrored(dbg.getState()));
 
-  // Test expanding properties when the debuggee is active
-  await resume(dbg);
-  await addExpression(dbg, "location");
   toggleExpression(dbg, 1);
   await waitForDispatch(dbg, "LOAD_OBJECT_PROPERTIES");
   is(findAllElements(dbg, "expressionNodes").length, 17);
-
-  await deleteExpression(dbg, "location");
-  is(findAllElements(dbg, "expressionNodes").length, 0);
 });

--- a/src/test/mochitest/browser_dbg-expressions-error.js
+++ b/src/test/mochitest/browser_dbg-expressions-error.js
@@ -3,7 +3,9 @@
 
 /**
  * test pausing on an errored watch expression
- * assert that you can still evalutate expressions
+ * assert that you can:
+ * 1. resume
+ * 2. still evalutate expressions
  */
 
 const expressionSelectors = {
@@ -59,11 +61,14 @@ add_task(async function() {
 
   const paused = waitForPaused(dbg);
   addExpression(dbg, "foo.bar");
-
   await paused;
   ok(dbg.selectors.hasWatchExpressionErrored(dbg.getState()));
 
+  // Resume, and re-pause in the `foo.bar` exception
+  resume(dbg);
+  await waitForPaused(dbg);
+
   toggleExpression(dbg, 1);
   await waitForDispatch(dbg, "LOAD_OBJECT_PROPERTIES");
-  is(findAllElements(dbg, "expressionNodes").length, 17);
+  is(findAllElements(dbg, "expressionNodes").length, 18);
 });

--- a/src/test/tests-framework.js
+++ b/src/test/tests-framework.js
@@ -12,6 +12,7 @@ import {
 } from "../utils/parser";
 import { startSearchWorker, stopSearchWorker } from "../utils/search";
 import { getValue } from "devtools-config";
+import { clearHistory } from "./utils/history";
 
 global.jasmine.DEFAULT_TIMEOUT_INTERVAL = 20000;
 
@@ -31,4 +32,5 @@ afterAll(() => {
 
 beforeEach(() => {
   clearSymbols();
+  clearHistory();
 });

--- a/src/test/utils/history.js
+++ b/src/test/utils/history.js
@@ -1,0 +1,12 @@
+let logs = [];
+export function getHistory(query: ?string = null) {
+  if (!query) {
+    return logs;
+  }
+
+  return logs.filter(log => log.type === query);
+}
+
+export function clearHistory() {
+  logs = [];
+}

--- a/src/types.js
+++ b/src/types.js
@@ -8,8 +8,7 @@ export type SearchModifiers = {
 
 export type Expression = {
   value: Object,
-  input: string,
-  visible: boolean
+  input: string
 };
 
 export type Worker = {

--- a/src/utils/redux/middleware/history.js
+++ b/src/utils/redux/middleware/history.js
@@ -13,15 +13,11 @@ export const history = (log: Object[] = []) => ({
   dispatch,
   getState
 }: ThunkArgs) => {
-  if (isDevelopment()) {
-    console.warn(
-      "Using history middleware stores all actions in state for " +
-        "testing and devtools is not currently running in test " +
-        "mode. Be sure this is intentional."
-    );
-  }
   return (next: Function) => (action: Object) => {
-    log.push(action);
-    next(action);
+    if (isDevelopment()) {
+      log.push(action);
+    }
+
+    return next(action);
   };
 };

--- a/src/utils/test-head.js
+++ b/src/utils/test-head.js
@@ -10,7 +10,7 @@ import sourceMaps from "devtools-source-map";
 import reducers from "../reducers";
 import actions from "../actions";
 import selectors from "../selectors";
-
+import { getHistory } from "../test/utils/history";
 import configureStore from "../utils/create-store";
 
 /**
@@ -20,6 +20,7 @@ import configureStore from "../utils/create-store";
 function createStore(client: any, initialState: any = {}, sourceMapsMock: any) {
   return configureStore({
     log: false,
+    history: getHistory(),
     makeThunkArgs: args => {
       return Object.assign({}, args, {
         client,
@@ -91,5 +92,6 @@ export {
   commonLog,
   makeSource,
   makeSymbolDeclaration,
-  waitForState
+  waitForState,
+  getHistory
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,8 +7,8 @@
   resolved "https://registry.yarnpkg.com/@hypnosphi/fuse.js/-/fuse.js-3.0.9.tgz#ea99f6121b4a8f065b4c71f85595db2714498807"
 
 "@percy-io/react-percy-api-client@^0.2.0":
-  version "0.2.4"
-  resolved "https://registry.yarnpkg.com/@percy-io/react-percy-api-client/-/react-percy-api-client-0.2.4.tgz#0fc71183a819ef8a028430159aae51c468ff12a9"
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/@percy-io/react-percy-api-client/-/react-percy-api-client-0.2.5.tgz#c98974d8c1bc53e2ae38c1549b0ec967fdde628f"
   dependencies:
     babel-runtime "^6.26.0"
     debug "^2.6.3"
@@ -288,9 +288,9 @@ ansi-escapes@^1.0.0, ansi-escapes@^1.1.0, ansi-escapes@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-1.4.0.tgz#d3a8a83b319aa67793662b13e761c7911422306e"
 
-ansi-escapes@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-2.0.0.tgz#5bae52be424878dd9783e8910e3fc2922e83c81b"
+ansi-escapes@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.0.0.tgz#ec3e8b4e9f8064fc02c3ac9b65f1c275bda8ef92"
 
 ansi-html@0.0.7, ansi-html@^0.0.7:
   version "0.0.7"
@@ -812,11 +812,11 @@ babel-plugin-dynamic-import-node@1.0.2:
     babel-types "^6.24.1"
 
 babel-plugin-istanbul@^4.0.0:
-  version "4.1.4"
-  resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.4.tgz#18dde84bf3ce329fddf3f4103fae921456d8e587"
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.5.tgz#6760cdd977f411d3e175bb064f2bc327d99b2b6e"
   dependencies:
     find-up "^2.1.0"
-    istanbul-lib-instrument "^1.7.2"
+    istanbul-lib-instrument "^1.7.5"
     test-exclude "^4.1.1"
 
 babel-plugin-jest-hoist@^19.0.0:
@@ -1677,8 +1677,8 @@ bcrypt-pbkdf@^1.0.0:
     tweetnacl "^0.14.3"
 
 big.js@^3.1.3:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/big.js/-/big.js-3.1.3.tgz#4cada2193652eb3ca9ec8e55c9015669c9806978"
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/big.js/-/big.js-3.2.0.tgz#a5fc298b81b9e0dca2e458824784b65c52ba588e"
 
 binary-extensions@^1.0.0:
   version "1.10.0"
@@ -1740,7 +1740,7 @@ boom@2.x.x:
   dependencies:
     hoek "2.x.x"
 
-bowser@^1.0.0, bowser@^1.6.0:
+bowser@^1.0.0, bowser@^1.7.3:
   version "1.7.3"
   resolved "https://registry.yarnpkg.com/bowser/-/bowser-1.7.3.tgz#504bdb43118ca8db9cbbadf28fd60f265af96e4f"
 
@@ -1970,12 +1970,12 @@ caniuse-api@^1.5.2:
     lodash.uniq "^4.5.0"
 
 caniuse-db@^1.0.30000529, caniuse-db@^1.0.30000634, caniuse-db@^1.0.30000639:
-  version "1.0.30000727"
-  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000727.tgz#4e22593089b0f35c1b2adcfc28234493a21a4b2e"
+  version "1.0.30000733"
+  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000733.tgz#3a625bc41c7a9f99d59d64552857dd1af0edd9d4"
 
 caniuse-lite@^1.0.30000718, caniuse-lite@^1.0.30000726:
-  version "1.0.30000727"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000727.tgz#20c895768398ded5f98a4beab4a76c285def41d2"
+  version "1.0.30000733"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000733.tgz#ebfc48254117cc0c66197a4536cb4397a6cfbccd"
 
 capture-stack-trace@^1.0.0:
   version "1.0.0"
@@ -2119,8 +2119,8 @@ circular-json@^0.3.1:
   resolved "https://registry.yarnpkg.com/circular-json/-/circular-json-0.3.3.tgz#815c99ea84f6809529d2f45791bdf82711352d66"
 
 clap@^1.0.9:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/clap/-/clap-1.2.0.tgz#59c90fe3e137104746ff19469a27a634ff68c857"
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/clap/-/clap-1.2.2.tgz#683f6f93a320794d129386d74b2a1d2d66fede7e"
   dependencies:
     chalk "^1.1.3"
 
@@ -2539,9 +2539,9 @@ css-color-names@0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/css-color-names/-/css-color-names-0.0.4.tgz#808adc2e79cf84738069b646cb20ec27beb629e0"
 
-css-in-js-utils@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/css-in-js-utils/-/css-in-js-utils-1.0.3.tgz#9ac7e02f763cf85d94017666565ed68a5b5f3215"
+css-in-js-utils@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/css-in-js-utils/-/css-in-js-utils-2.0.0.tgz#5af1dd70f4b06b331f48d22a3d86e0786c0b9435"
   dependencies:
     hyphenate-style-name "^1.0.2"
 
@@ -2696,7 +2696,7 @@ debug@2.6.8, debug@^2.1.1, debug@^2.2.0, debug@^2.3.3, debug@^2.6.3, debug@^2.6.
   dependencies:
     ms "2.0.0"
 
-debug@^3.0.0:
+debug@^3.0.0, debug@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.0.1.tgz#0564c612b521dc92d9f2988f0549e34f9c98db64"
   dependencies:
@@ -3037,8 +3037,8 @@ doctrine@^2.0.0:
     isarray "^1.0.0"
 
 documentation@^5.2.1:
-  version "5.3.1"
-  resolved "https://registry.yarnpkg.com/documentation/-/documentation-5.3.1.tgz#f7fda4b65ad96b7686976173b0c573f53448ed3e"
+  version "5.3.2"
+  resolved "https://registry.yarnpkg.com/documentation/-/documentation-5.3.2.tgz#45a106cd58bcb74ec0446431e5777a063fab6731"
   dependencies:
     ansi-html "^0.0.7"
     babel-core "^6.17.0"
@@ -3321,7 +3321,7 @@ es6-map@^0.1.3:
     es6-symbol "~3.1.1"
     event-emitter "~0.3.5"
 
-es6-promise-pool@^2.4.4:
+es6-promise-pool@^2.4.4, es6-promise-pool@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/es6-promise-pool/-/es6-promise-pool-2.5.0.tgz#147c612b36b47f105027f9d2bf54a598a99d9ccb"
 
@@ -3384,8 +3384,8 @@ escope@3.6.0, escope@^3.6.0:
     estraverse "^4.1.1"
 
 eslint-config-prettier@^2.3.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-2.4.0.tgz#fb7cf29c0ab2ba61af5164fb1930f9bef3be2872"
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-2.5.0.tgz#9ecb9296bae4e2e59a3ce361a96c9f825fe67b75"
   dependencies:
     get-stdin "^5.0.1"
 
@@ -3411,11 +3411,11 @@ eslint-plugin-mozilla@0.4.3:
     sax "1.2.4"
 
 eslint-plugin-prettier@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-2.2.0.tgz#f2837ad063903d73c621e7188fb3d41486434088"
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-2.3.1.tgz#e7a746c67e716f335274b88295a9ead9f544e44d"
   dependencies:
     fast-diff "^1.1.1"
-    jest-docblock "^20.0.1"
+    jest-docblock "^21.0.0"
 
 eslint-plugin-react@^6.7.1:
   version "6.10.3"
@@ -3484,18 +3484,18 @@ eslint@^3.12.0:
     user-home "^2.0.0"
 
 eslint@^4.2.0:
-  version "4.6.1"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-4.6.1.tgz#ddc7fc7fd70bf93205b0b3449bb16a1e9e7d4950"
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-4.7.0.tgz#d35fc07c472520be3de85b3da11e99c576afd515"
   dependencies:
     ajv "^5.2.0"
     babel-code-frame "^6.22.0"
     chalk "^2.1.0"
     concat-stream "^1.6.0"
     cross-spawn "^5.1.0"
-    debug "^2.6.8"
+    debug "^3.0.1"
     doctrine "^2.0.0"
     eslint-scope "^3.7.1"
-    espree "^3.5.0"
+    espree "^3.5.1"
     esquery "^1.0.0"
     estraverse "^4.2.0"
     esutils "^2.0.2"
@@ -3516,7 +3516,7 @@ eslint@^4.2.0:
     natural-compare "^1.4.0"
     optionator "^0.8.2"
     path-is-inside "^1.0.2"
-    pluralize "^4.0.0"
+    pluralize "^7.0.0"
     progress "^2.0.0"
     require-uncached "^1.0.3"
     semver "^5.3.0"
@@ -3532,9 +3532,9 @@ espree@3.4.3:
     acorn "^5.0.1"
     acorn-jsx "^3.0.0"
 
-espree@^3.4.0, espree@^3.5.0:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/espree/-/espree-3.5.0.tgz#98358625bdd055861ea27e2867ea729faf463d8d"
+espree@^3.4.0, espree@^3.5.1:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-3.5.1.tgz#0c988b8ab46db53100a1954ae4ba995ddd27d87e"
   dependencies:
     acorn "^5.1.1"
     acorn-jsx "^3.0.0"
@@ -3774,8 +3774,8 @@ fast-deep-equal@^1.0.0:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz#96256a3bc975595eb36d82e9929d060d893439ff"
 
 fast-diff@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.1.1.tgz#0aea0e4e605b6a2189f0e936d4b7fbaf1b7cfd9b"
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.1.2.tgz#4b62c42b8e03de3f848460b639079920695d0154"
 
 fast-levenshtein@~2.0.4:
   version "2.0.6"
@@ -3892,14 +3892,14 @@ fill-range@^4.0.0:
     to-regex-range "^2.1.0"
 
 finalhandler@~1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/finalhandler/-/finalhandler-1.0.4.tgz#18574f2e7c4b98b8ae3b230c21f201f31bdb3fb7"
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/finalhandler/-/finalhandler-1.0.5.tgz#a701303d257a1bc82fea547a33e5ae89531723df"
   dependencies:
     debug "2.6.8"
     encodeurl "~1.0.1"
     escape-html "~1.0.3"
     on-finished "~2.3.0"
-    parseurl "~1.3.1"
+    parseurl "~1.3.2"
     statuses "~1.3.1"
     unpipe "~1.0.0"
 
@@ -3997,8 +3997,8 @@ format@^0.2.2:
   resolved "https://registry.yarnpkg.com/format/-/format-0.2.2.tgz#d6170107e9efdc4ed30c9dc39016df942b5cb58b"
 
 forwarded@~0.1.0:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.1.1.tgz#8a4e30c640b05395399a3549c730257728048961"
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.1.2.tgz#98c23dab1175657b8c0573e8ceccd91b0ff18c84"
 
 fragment-cache@^0.2.1:
   version "0.2.1"
@@ -4592,7 +4592,7 @@ https-browserify@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-0.0.1.tgz#3f91365cabe60b77ed0ebba24b454e3e09d95a82"
 
-husky@^0.14.2:
+husky@^0.14.2, husky@^0.14.3:
   version "0.14.3"
   resolved "https://registry.yarnpkg.com/husky/-/husky-0.14.3.tgz#c69ed74e2d2779769a17ba8399b54ce0b63c12c3"
   dependencies:
@@ -4687,11 +4687,11 @@ inline-style-prefixer@^2.0.5:
     hyphenate-style-name "^1.0.1"
 
 inline-style-prefixer@^3.0.6:
-  version "3.0.7"
-  resolved "https://registry.yarnpkg.com/inline-style-prefixer/-/inline-style-prefixer-3.0.7.tgz#0ccc92e5902fe6e0d28d975c4258443f880615f8"
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/inline-style-prefixer/-/inline-style-prefixer-3.0.8.tgz#8551b8e5b4d573244e66a34b04f7d32076a2b534"
   dependencies:
-    bowser "^1.6.0"
-    css-in-js-utils "^1.0.3"
+    bowser "^1.7.3"
+    css-in-js-utils "^2.0.0"
 
 inquirer@^0.12.0:
   version "0.12.0"
@@ -4712,10 +4712,10 @@ inquirer@^0.12.0:
     through "^2.3.6"
 
 inquirer@^3.0.6:
-  version "3.2.3"
-  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-3.2.3.tgz#1c7b1731cf77b934ec47d22c9ac5aa8fe7fbe095"
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-3.3.0.tgz#9dd2f2ad765dcab1ff0443b491442a20ba227dc9"
   dependencies:
-    ansi-escapes "^2.0.0"
+    ansi-escapes "^3.0.0"
     chalk "^2.0.0"
     cli-cursor "^2.1.0"
     cli-width "^2.0.0"
@@ -5152,7 +5152,7 @@ istanbul-lib-hook@^1.0.7:
   dependencies:
     append-transform "^0.4.0"
 
-istanbul-lib-instrument@^1.1.1, istanbul-lib-instrument@^1.4.2, istanbul-lib-instrument@^1.7.2, istanbul-lib-instrument@^1.8.0:
+istanbul-lib-instrument@^1.1.1, istanbul-lib-instrument@^1.4.2, istanbul-lib-instrument@^1.7.5, istanbul-lib-instrument@^1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-1.8.0.tgz#66f6c9421cc9ec4704f76f2db084ba9078a2b532"
   dependencies:
@@ -5310,9 +5310,13 @@ jest-diff@^20.0.3:
     jest-matcher-utils "^20.0.3"
     pretty-format "^20.0.3"
 
-jest-docblock@^20.0.1, jest-docblock@^20.0.3:
+jest-docblock@^20.0.3:
   version "20.0.3"
   resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-20.0.3.tgz#17bea984342cc33d83c50fbe1545ea0efaa44712"
+
+jest-docblock@^21.0.0:
+  version "21.1.0"
+  resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-21.1.0.tgz#43154be2441fb91403e36bb35cb791a5017cea81"
 
 jest-environment-jsdom@^19.0.2:
   version "19.0.2"
@@ -5842,9 +5846,9 @@ license-checker@^9.0.3:
     semver "^5.3.0"
     treeify "^1.0.1"
 
-lint-staged@^4.0.1:
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-4.1.3.tgz#07c592e4b8dee914450a183c761187dc53d079e2"
+lint-staged@^4.0.1, lint-staged@^4.1.3:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-4.2.1.tgz#5c79818c500d9b24248dccad4ac9609c01951522"
   dependencies:
     app-root-path "^2.0.0"
     chalk "^2.1.0"
@@ -7162,13 +7166,18 @@ pbkdf2@^3.0.3:
     sha.js "^2.4.8"
 
 percy-client@^2.1.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/percy-client/-/percy-client-2.2.0.tgz#b106c2581a09f6d92a619b91796fa6ba4307f9fa"
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/percy-client/-/percy-client-2.3.0.tgz#173bd1ccf65675302698246d94676f5e20a7e9fc"
   dependencies:
     base64-js "^1.1.2"
+    es6-promise-pool "^2.5.0"
     jssha "^2.1.0"
+    regenerator-runtime "^0.11.0"
     request "^2.40.0"
     request-promise "^4.1.1"
+  optionalDependencies:
+    husky "^0.14.3"
+    lint-staged "^4.1.3"
 
 performance-now@^0.2.0:
   version "0.2.0"
@@ -7208,9 +7217,9 @@ pluralize@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-1.2.1.tgz#d1a21483fd22bb41e58a12fa3421823140897c45"
 
-pluralize@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-4.0.0.tgz#59b708c1c0190a2f692f1c7618c446b052fd1762"
+pluralize@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-7.0.0.tgz#298b89df8b93b0221dbf421ad2b1b1ea23fc6777"
 
 podda@^1.2.2:
   version "1.2.2"
@@ -8182,8 +8191,8 @@ redux@^3.6.0:
     symbol-observable "^1.0.3"
 
 regenerate@^1.2.1:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.3.2.tgz#d1941c67bad437e1be76433add5b385f95b19260"
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.3.3.tgz#0c336d3980553d755c39b586ae3b20aa49c82b7f"
 
 regenerator-runtime@^0.10.3, regenerator-runtime@^0.10.5:
   version "0.10.5"
@@ -10222,8 +10231,8 @@ webpack@^2.2.1:
     yargs "^6.0.0"
 
 "webpack@^2.5.1 || ^3.0.0", webpack@^3.3.0, webpack@^3.5.5:
-  version "3.5.6"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-3.5.6.tgz#a492fb6c1ed7f573816f90e00c8fbb5a20cc5c36"
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-3.6.0.tgz#a89a929fbee205d35a4fa2cc487be9cbec8898bc"
   dependencies:
     acorn "^5.0.0"
     acorn-dynamic-import "^2.0.0"


### PR DESCRIPTION
Associated Issue: #3597

### Summary of Changes

* stops evaluating when we're paused at an expression that threw
* bails early when `resumed` is called but we're not paused. This prevents unnecessary evals when a bp is added.

### Test Plan

* a mochitest that shows that watch expressions still work when we we're paused due to an exception in an expression.