### PR TITLE
Parse the closest class for functions and properties

### DIFF
--- a/src/actions/tests/__snapshots__/ast.spec.js.snap
+++ b/src/actions/tests/__snapshots__/ast.spec.js.snap
@@ -125,6 +125,7 @@ Object {
         "start": 9,
         "type": "Identifier",
       },
+      "klass": null,
       "location": Object {
         "end": Object {
           "column": 21,

--- a/src/utils/parser/getSymbols.js
+++ b/src/utils/parser/getSymbols.js
@@ -371,7 +371,8 @@ export function formatSymbols(source: Source) {
       ? symbol.parameterNames.join(", ")
       : "";
     const expression = symbol.expression || "";
-    return `${loc} ${exprLoc} ${expression} ${symbol.name} ${params}`;
+    const klass = symbol.klass || "";
+    return `${loc} ${exprLoc} ${expression} ${symbol.name} ${params} ${klass}`;
   }
 
   return [

--- a/src/utils/parser/getSymbols.js
+++ b/src/utils/parser/getSymbols.js
@@ -13,6 +13,7 @@ let symbolDeclarations = new Map();
 export type SymbolDeclaration = {|
   name: string,
   expression?: string,
+  klass?: ?string,
   location: BabelLocation,
   expressionLocation?: BabelLocation,
   parameterNames?: string[],
@@ -70,6 +71,16 @@ function getComments(ast) {
   }));
 }
 
+function getClassName(path: NodePath): ?string {
+  const classDeclaration = path.findParent(_p => _p.isClassDeclaration());
+  if (!classDeclaration) {
+    return null;
+  }
+  if (classDeclaration) {
+    return classDeclaration.node.id.name;
+  }
+}
+
 function extractSymbols(source: Source) {
   const functions = [];
   const variables = [];
@@ -87,6 +98,7 @@ function extractSymbols(source: Source) {
       if (isFunction(path)) {
         functions.push({
           name: getFunctionName(path),
+          klass: getClassName(path),
           location: path.node.loc,
           parameterNames: getFunctionParameterNames(path),
           identifier: path.node.id

--- a/src/utils/parser/getSymbols.js
+++ b/src/utils/parser/getSymbols.js
@@ -345,13 +345,7 @@ function getSnippet(path, prevPath, expression = "") {
 }
 
 export function formatSymbols(source: Source) {
-  const {
-    objectProperties,
-    memberExpressions,
-    callExpressions,
-    identifiers,
-    variables
-  } = getSymbols(source);
+  const symbols = getSymbols(source);
 
   function formatLocation(loc) {
     if (!loc) {
@@ -375,22 +369,9 @@ export function formatSymbols(source: Source) {
     return `${loc} ${exprLoc} ${expression} ${symbol.name} ${params} ${klass}`;
   }
 
-  return [
-    "properties",
-    objectProperties.map(summarize).join("\n"),
-
-    "member expressions",
-    memberExpressions.map(summarize).join("\n"),
-
-    "call expressions",
-    callExpressions.map(summarize).join("\n"),
-
-    "identifiers",
-    identifiers.map(summarize).join("\n"),
-
-    "variables",
-    variables.map(summarize).join("\n")
-  ].join("\n");
+  return Object.keys(symbols).map(
+    name => `${name}:\n ${symbols[name].map(summarize).join("\n")}`
+  );
 }
 
 export function clearSymbols() {

--- a/src/utils/parser/getSymbols.js
+++ b/src/utils/parser/getSymbols.js
@@ -76,9 +76,8 @@ function getClassName(path: NodePath): ?string {
   if (!classDeclaration) {
     return null;
   }
-  if (classDeclaration) {
-    return classDeclaration.node.id.name;
-  }
+
+  return classDeclaration.node.id.name;
 }
 
 function extractSymbols(source: Source) {

--- a/src/utils/parser/tests/__snapshots__/getSymbols.spec.js.snap
+++ b/src/utils/parser/tests/__snapshots__/getSymbols.spec.js.snap
@@ -2,81 +2,81 @@
 
 exports[`Parser.getSymbols allSymbols 1`] = `
 "properties
-[(11, 2), (11, 5)]  Obj.foo foo 
-[(15, 2), (15, 14)]  Obj.doOtherThing doOtherThing 
+[(11, 2), (11, 5)]  Obj.foo foo  
+[(15, 2), (15, 14)]  Obj.doOtherThing doOtherThing  
 member expressions
-[(13, 12), (13, 15)] [(13, 4), (13, 15)] console.log log 
-[(20, 4), (20, 12)] [(20, 0), (20, 12)] Obj.property property 
-[(21, 4), (21, 17)] [(21, 0), (21, 17)] Obj.otherProperty otherProperty 
-[(25, 9), (25, 16)] [(25, 4), (25, 16)] this.awesome awesome 
-[(29, 12), (29, 15)] [(29, 4), (29, 15)] console.log log 
+[(13, 12), (13, 15)] [(13, 4), (13, 15)] console.log log  
+[(20, 4), (20, 12)] [(20, 0), (20, 12)] Obj.property property  
+[(21, 4), (21, 17)] [(21, 0), (21, 17)] Obj.otherProperty otherProperty  
+[(25, 9), (25, 16)] [(25, 4), (25, 16)] this.awesome awesome  
+[(29, 12), (29, 15)] [(29, 4), (29, 15)] console.log log  
 call expressions
 
 identifiers
-[(1, 6), (1, 15)]  TIME TIME 
-[(1, 6), (1, 10)]  TIME TIME 
-[(2, 4), (2, 13)]  count count 
-[(2, 4), (2, 9)]  count count 
-[(4, 9), (4, 25)]  incrementCounter incrementCounter 
-[(4, 26), (4, 33)]  counter counter 
-[(5, 9), (5, 16)]  counter counter 
-[(8, 6), (8, 27)]  sum sum 
-[(8, 6), (8, 9)]  sum sum 
-[(8, 13), (8, 14)]  a a 
-[(8, 16), (8, 17)]  b b 
-[(8, 22), (8, 23)]  a a 
-[(8, 26), (8, 27)]  b b 
-[(10, 6), (18, 1)]  Obj Obj 
-[(10, 6), (10, 9)]  Obj Obj 
-[(11, 2), (11, 5)]  foo foo 
-[(12, 2), (12, 9)]  doThing doThing 
-[(13, 4), (13, 11)]  console console 
-[(13, 12), (13, 15)]  log log 
-[(15, 2), (15, 14)]  doOtherThing doOtherThing 
-[(20, 0), (20, 3)]  Obj Obj 
-[(20, 4), (20, 12)]  property property 
-[(21, 0), (21, 3)]  Obj Obj 
-[(21, 4), (21, 17)]  otherProperty otherProperty 
-[(23, 6), (23, 11)]  Ultra Ultra 
-[(24, 2), (24, 13)]  constructor constructor 
-[(25, 4), (25, 8)] [(25, 4), (25, 8)] this this 
-[(25, 9), (25, 16)]  awesome awesome 
-[(28, 2), (28, 11)]  beAwesome beAwesome 
-[(28, 12), (28, 18)]  person person 
-[(29, 4), (29, 11)]  console console 
-[(29, 12), (29, 15)]  log log 
-[(29, 19), (29, 25)]  person person 
+[(1, 6), (1, 15)]  TIME TIME  
+[(1, 6), (1, 10)]  TIME TIME  
+[(2, 4), (2, 13)]  count count  
+[(2, 4), (2, 9)]  count count  
+[(4, 9), (4, 25)]  incrementCounter incrementCounter  
+[(4, 26), (4, 33)]  counter counter  
+[(5, 9), (5, 16)]  counter counter  
+[(8, 6), (8, 27)]  sum sum  
+[(8, 6), (8, 9)]  sum sum  
+[(8, 13), (8, 14)]  a a  
+[(8, 16), (8, 17)]  b b  
+[(8, 22), (8, 23)]  a a  
+[(8, 26), (8, 27)]  b b  
+[(10, 6), (18, 1)]  Obj Obj  
+[(10, 6), (10, 9)]  Obj Obj  
+[(11, 2), (11, 5)]  foo foo  
+[(12, 2), (12, 9)]  doThing doThing  
+[(13, 4), (13, 11)]  console console  
+[(13, 12), (13, 15)]  log log  
+[(15, 2), (15, 14)]  doOtherThing doOtherThing  
+[(20, 0), (20, 3)]  Obj Obj  
+[(20, 4), (20, 12)]  property property  
+[(21, 0), (21, 3)]  Obj Obj  
+[(21, 4), (21, 17)]  otherProperty otherProperty  
+[(23, 6), (23, 11)]  Ultra Ultra  
+[(24, 2), (24, 13)]  constructor constructor  
+[(25, 4), (25, 8)] [(25, 4), (25, 8)] this this  
+[(25, 9), (25, 16)]  awesome awesome  
+[(28, 2), (28, 11)]  beAwesome beAwesome  
+[(28, 12), (28, 18)]  person person  
+[(29, 4), (29, 11)]  console console  
+[(29, 12), (29, 15)]  log log  
+[(29, 19), (29, 25)]  person person  
 variables
-[(1, 6), (1, 15)]   TIME 
-[(2, 4), (2, 13)]   count 
-[(4, 26), (4, 33)]   counter 
-[(8, 6), (8, 27)]   sum 
-[(8, 13), (8, 14)]   a 
-[(8, 16), (8, 17)]   b 
-[(10, 6), (18, 1)]   Obj 
-[(11, 2), (11, 8)]   foo 
-[(23, 0), (31, 1)]   Ultra 
-[(28, 12), (28, 18)]   person "
+[(1, 6), (1, 15)]   TIME  
+[(2, 4), (2, 13)]   count  
+[(4, 26), (4, 33)]   counter  
+[(8, 6), (8, 27)]   sum  
+[(8, 13), (8, 14)]   a  
+[(8, 16), (8, 17)]   b  
+[(10, 6), (18, 1)]   Obj  
+[(11, 2), (11, 8)]   foo  
+[(23, 0), (31, 1)]   Ultra  
+[(28, 12), (28, 18)]   person  "
 `;
 
 exports[`Parser.getSymbols call sites 1`] = `
 "properties
 
 member expressions
-[(4, 3), (4, 7)] [(2, 0), (4, 7)]  ffff 
-[(3, 3), (3, 6)] [(2, 0), (3, 6)]  eee 
+[(4, 3), (4, 7)] [(2, 0), (4, 7)]  ffff  
+[(3, 3), (3, 6)] [(2, 0), (3, 6)]  eee  
 call expressions
-[(1, 0), (1, 3)]   aaa 
-[(1, 4), (1, 7)]   bbb 
-[(1, 11), (1, 14)]   ccc 
-[(2, 0), (2, 4)]   dddd 
+[(1, 0), (1, 3)]   aaa  
+[(1, 4), (1, 7)]   bbb  
+[(1, 11), (1, 14)]   ccc  
+[(2, 0), (2, 4)]   dddd  
 identifiers
-[(1, 0), (1, 3)]  aaa aaa 
-[(1, 4), (1, 7)]  bbb bbb 
-[(1, 11), (1, 14)]  ccc ccc 
-[(2, 0), (2, 4)]  dddd dddd 
-[(3, 3), (3, 6)]  eee eee 
-[(4, 3), (4, 7)]  ffff ffff 
+[(1, 0), (1, 3)]  aaa aaa  
+[(1, 4), (1, 7)]  bbb bbb  
+[(1, 11), (1, 14)]  ccc ccc  
+[(2, 0), (2, 4)]  dddd dddd  
+[(3, 3), (3, 6)]  eee eee  
+[(4, 3), (4, 7)]  ffff ffff  
 variables
 "
 `;
@@ -85,337 +85,337 @@ exports[`Parser.getSymbols class 1`] = `
 "properties
 
 member expressions
-[(3, 9), (3, 12)] [(3, 4), (3, 12)] this.foo foo 
-[(7, 12), (7, 15)] [(7, 4), (7, 15)] console.log log 
+[(3, 9), (3, 12)] [(3, 4), (3, 12)] this.foo foo  
+[(7, 12), (7, 15)] [(7, 4), (7, 15)] console.log log  
 call expressions
 
 identifiers
-[(1, 6), (1, 10)]  Test Test 
-[(2, 2), (2, 13)]  constructor constructor 
-[(3, 4), (3, 8)] [(3, 4), (3, 8)] this this 
-[(3, 9), (3, 12)]  foo foo 
-[(6, 2), (6, 5)]  bar bar 
-[(6, 6), (6, 7)]  a a 
-[(7, 4), (7, 11)]  console console 
-[(7, 12), (7, 15)]  log log 
-[(7, 23), (7, 24)]  a a 
-[(11, 6), (11, 11)]  Test2 Test2 
-[(13, 4), (13, 30)]  expressiveClass expressiveClass 
-[(13, 4), (13, 19)]  expressiveClass expressiveClass 
+[(1, 6), (1, 10)]  Test Test  
+[(2, 2), (2, 13)]  constructor constructor  
+[(3, 4), (3, 8)] [(3, 4), (3, 8)] this this  
+[(3, 9), (3, 12)]  foo foo  
+[(6, 2), (6, 5)]  bar bar  
+[(6, 6), (6, 7)]  a a  
+[(7, 4), (7, 11)]  console console  
+[(7, 12), (7, 15)]  log log  
+[(7, 23), (7, 24)]  a a  
+[(11, 6), (11, 11)]  Test2 Test2  
+[(13, 4), (13, 30)]  expressiveClass expressiveClass  
+[(13, 4), (13, 19)]  expressiveClass expressiveClass  
 variables
-[(1, 0), (9, 1)]   Test 
-[(6, 6), (6, 7)]   a 
-[(11, 0), (11, 14)]   Test2 
-[(13, 4), (13, 30)]   expressiveClass "
+[(1, 0), (9, 1)]   Test  
+[(6, 6), (6, 7)]   a  
+[(11, 0), (11, 14)]   Test2  
+[(13, 4), (13, 30)]   expressiveClass  "
 `;
 
 exports[`Parser.getSymbols component 1`] = `
 "properties
 
 member expressions
-[(6, 9), (6, 16)] [(6, 4), (6, 16)] this.onClick onClick 
-[(6, 32), (6, 36)] [(6, 19), (6, 36)] this.onClick.bind bind 
-[(6, 24), (6, 31)] [(6, 19), (6, 31)] this.onClick onClick 
-[(14, 30), (14, 37)] [(14, 25), (14, 37)] this.onClick onClick 
+[(6, 9), (6, 16)] [(6, 4), (6, 16)] this.onClick onClick  
+[(6, 32), (6, 36)] [(6, 19), (6, 36)] this.onClick.bind bind  
+[(6, 24), (6, 31)] [(6, 19), (6, 31)] this.onClick onClick  
+[(14, 30), (14, 37)] [(14, 25), (14, 37)] this.onClick onClick  
 call expressions
-[(5, 4), (5, 9)]   undefined 
+[(5, 4), (5, 9)]   undefined  
 identifiers
-[(1, 7), (1, 12)]  React React 
-[(1, 16), (1, 25)]  Component Component 
-[(1, 16), (1, 25)]  Component Component 
-[(3, 6), (3, 11)]  Punny Punny 
-[(4, 2), (4, 13)]  constructor constructor 
-[(4, 14), (4, 19)]  props props 
-[(6, 4), (6, 8)] [(6, 4), (6, 8)] this this 
-[(6, 9), (6, 16)]  onClick onClick 
-[(6, 19), (6, 23)] [(6, 19), (6, 23)] this this 
-[(6, 24), (6, 31)]  onClick onClick 
-[(6, 32), (6, 36)]  bind bind 
-[(6, 37), (6, 41)] [(6, 37), (6, 41)] this this 
-[(9, 2), (9, 19)]  componentDidMount componentDidMount 
-[(11, 2), (11, 9)]  onClick onClick 
-[(13, 2), (13, 10)]  renderMe renderMe 
-[(14, 25), (14, 29)] [(14, 25), (14, 29)] this this 
-[(14, 30), (14, 37)]  onClick onClick 
-[(17, 2), (17, 8)]  render render 
-[(3, 20), (3, 29)]  Component Component 
+[(1, 7), (1, 12)]  React React  
+[(1, 16), (1, 25)]  Component Component  
+[(1, 16), (1, 25)]  Component Component  
+[(3, 6), (3, 11)]  Punny Punny  
+[(4, 2), (4, 13)]  constructor constructor  
+[(4, 14), (4, 19)]  props props  
+[(6, 4), (6, 8)] [(6, 4), (6, 8)] this this  
+[(6, 9), (6, 16)]  onClick onClick  
+[(6, 19), (6, 23)] [(6, 19), (6, 23)] this this  
+[(6, 24), (6, 31)]  onClick onClick  
+[(6, 32), (6, 36)]  bind bind  
+[(6, 37), (6, 41)] [(6, 37), (6, 41)] this this  
+[(9, 2), (9, 19)]  componentDidMount componentDidMount  
+[(11, 2), (11, 9)]  onClick onClick  
+[(13, 2), (13, 10)]  renderMe renderMe  
+[(14, 25), (14, 29)] [(14, 25), (14, 29)] this this  
+[(14, 30), (14, 37)]  onClick onClick  
+[(17, 2), (17, 8)]  render render  
+[(3, 20), (3, 29)]  Component Component  
 variables
-[(3, 0), (18, 1)]   Punny 
-[(4, 14), (4, 19)]   props "
+[(3, 0), (18, 1)]   Punny  
+[(4, 14), (4, 19)]   props  "
 `;
 
 exports[`Parser.getSymbols es6 1`] = `
 "properties
-[(1, 23), (1, 30)]   PROMISE 
+[(1, 23), (1, 30)]   PROMISE  
 member expressions
 
 call expressions
-[(1, 0), (1, 8)]   dispatch 
+[(1, 0), (1, 8)]   dispatch  
 identifiers
-[(1, 0), (1, 8)]  dispatch dispatch 
-[(1, 14), (1, 20)]  action action 
-[(1, 23), (1, 30)]  PROMISE PROMISE 
-[(1, 33), (1, 40)]  promise promise 
+[(1, 0), (1, 8)]  dispatch dispatch  
+[(1, 14), (1, 20)]  action action  
+[(1, 23), (1, 30)]  PROMISE PROMISE  
+[(1, 33), (1, 40)]  promise promise  
 variables
-[(1, 22), (1, 40)]   PROMISE "
+[(1, 22), (1, 40)]   PROMISE  "
 `;
 
 exports[`Parser.getSymbols expression 1`] = `
 "properties
-[(1, 14), (1, 15)]  obj.a a 
-[(1, 19), (1, 20)]  obj.a.b b 
-[(5, 15), (5, 16)]  com[a] a 
-[(5, 21), (5, 22)]  com[a].b b 
-[(5, 30), (5, 31)]  com[a][d] d 
-[(5, 42), (5, 43)]  com[b] b 
-[(8, 2), (8, 8)]   render 
-[(12, 12), (12, 13)]  obj.foo.a a 
-[(12, 17), (12, 18)]  obj.foo.a.b b 
-[(12, 27), (12, 28)]  obj.foo.b b 
-[(13, 8), (13, 9)]  com.a a 
-[(13, 13), (13, 14)]  com.a.b b 
-[(13, 23), (13, 24)]  com.b b 
-[(16, 15), (16, 16)]  res[0].a a 
-[(16, 25), (16, 26)]  res[1].b b 
-[(17, 15), (17, 16)]  res2.a a 
-[(17, 21), (17, 22)]  res2.a[0].b b 
-[(18, 15), (18, 16)]  res3.a a 
-[(18, 21), (18, 22)]  res3.a[0].b b 
-[(18, 30), (18, 31)]  res3.b b 
-[(18, 36), (18, 37)]  res3.b[0].c c 
-[(19, 17), (19, 18)]  res4[0].a a 
-[(19, 29), (19, 30)]  res4[0].b b 
-[(22, 8), (22, 9)]  b b 
-[(22, 11), (22, 16)]  resty resty 
-[(25, 18), (25, 19)]  a a 
-[(25, 21), (25, 22)]  b b 
-[(26, 22), (26, 23)]  a a 
-[(26, 25), (26, 26)]  b b 
+[(1, 14), (1, 15)]  obj.a a  
+[(1, 19), (1, 20)]  obj.a.b b  
+[(5, 15), (5, 16)]  com[a] a  
+[(5, 21), (5, 22)]  com[a].b b  
+[(5, 30), (5, 31)]  com[a][d] d  
+[(5, 42), (5, 43)]  com[b] b  
+[(8, 2), (8, 8)]   render  
+[(12, 12), (12, 13)]  obj.foo.a a  
+[(12, 17), (12, 18)]  obj.foo.a.b b  
+[(12, 27), (12, 28)]  obj.foo.b b  
+[(13, 8), (13, 9)]  com.a a  
+[(13, 13), (13, 14)]  com.a.b b  
+[(13, 23), (13, 24)]  com.b b  
+[(16, 15), (16, 16)]  res[0].a a  
+[(16, 25), (16, 26)]  res[1].b b  
+[(17, 15), (17, 16)]  res2.a a  
+[(17, 21), (17, 22)]  res2.a[0].b b  
+[(18, 15), (18, 16)]  res3.a a  
+[(18, 21), (18, 22)]  res3.a[0].b b  
+[(18, 30), (18, 31)]  res3.b b  
+[(18, 36), (18, 37)]  res3.b[0].c c  
+[(19, 17), (19, 18)]  res4[0].a a  
+[(19, 29), (19, 30)]  res4[0].b b  
+[(22, 8), (22, 9)]  b b  
+[(22, 11), (22, 16)]  resty resty  
+[(25, 18), (25, 19)]  a a  
+[(25, 21), (25, 22)]  b b  
+[(26, 22), (26, 23)]  a a  
+[(26, 25), (26, 26)]  b b  
 member expressions
-[(2, 19), (2, 33)] [(2, 12), (2, 33)] obj2.c.secondProperty secondProperty 
-[(2, 17), (2, 18)] [(2, 12), (2, 18)] obj2.c c 
-[(7, 4), (7, 12)] [(7, 0), (7, 12)] app.TodoView TodoView 
-[(7, 24), (7, 30)] [(7, 15), (7, 30)] Backbone.extend extend 
-[(12, 4), (12, 7)] [(12, 0), (12, 7)] obj.foo foo 
-[(19, 40), (19, 41)] [(19, 32), (19, 41)] a.b.c.v.d d 
-[(19, 38), (19, 39)] [(19, 32), (19, 39)] a.b.c.v v 
-[(19, 36), (19, 37)] [(19, 32), (19, 37)] a.b.c c 
-[(19, 34), (19, 35)] [(19, 32), (19, 35)] a.b b 
-[(27, 29), (27, 43)] [(27, 13), (27, 43)]  secondProperty 
-[(27, 27), (27, 28)] [(27, 13), (27, 28)]  c 
-[(27, 18), (27, 24)] [(27, 13), (27, 24)] obj2.doEvil doEvil 
+[(2, 19), (2, 33)] [(2, 12), (2, 33)] obj2.c.secondProperty secondProperty  
+[(2, 17), (2, 18)] [(2, 12), (2, 18)] obj2.c c  
+[(7, 4), (7, 12)] [(7, 0), (7, 12)] app.TodoView TodoView  
+[(7, 24), (7, 30)] [(7, 15), (7, 30)] Backbone.extend extend  
+[(12, 4), (12, 7)] [(12, 0), (12, 7)] obj.foo foo  
+[(19, 40), (19, 41)] [(19, 32), (19, 41)] a.b.c.v.d d  
+[(19, 38), (19, 39)] [(19, 32), (19, 39)] a.b.c.v v  
+[(19, 36), (19, 37)] [(19, 32), (19, 37)] a.b.c c  
+[(19, 34), (19, 35)] [(19, 32), (19, 35)] a.b b  
+[(27, 29), (27, 43)] [(27, 13), (27, 43)]  secondProperty  
+[(27, 27), (27, 28)] [(27, 13), (27, 28)]  c  
+[(27, 18), (27, 24)] [(27, 13), (27, 24)] obj2.doEvil doEvil  
 call expressions
-[(22, 21), (22, 28)]   compute 
-[(23, 21), (23, 28)]   compute 
+[(22, 21), (22, 28)]   compute  
+[(23, 21), (23, 28)]   compute  
 identifiers
-[(1, 6), (1, 27)]  obj obj 
-[(1, 6), (1, 9)]  obj obj 
-[(1, 14), (1, 15)]  a a 
-[(1, 19), (1, 20)]  b b 
-[(2, 6), (2, 33)]  foo foo 
-[(2, 6), (2, 9)]  foo foo 
-[(2, 12), (2, 16)]  obj2 obj2 
-[(2, 17), (2, 18)]  c c 
-[(2, 19), (2, 33)]  secondProperty secondProperty 
-[(5, 6), (5, 49)]  com com 
-[(5, 6), (5, 9)]  com com 
-[(5, 15), (5, 16)]  a a 
-[(5, 21), (5, 22)]  b b 
-[(5, 30), (5, 31)]  d d 
-[(5, 42), (5, 43)]  b b 
-[(7, 0), (7, 3)]  app app 
-[(7, 4), (7, 12)]  TodoView TodoView 
-[(7, 15), (7, 23)]  Backbone Backbone 
-[(7, 24), (7, 30)]  extend extend 
-[(8, 2), (8, 8)]  render render 
-[(12, 0), (12, 3)]  obj obj 
-[(12, 4), (12, 7)]  foo foo 
-[(12, 12), (12, 13)]  a a 
-[(12, 17), (12, 18)]  b b 
-[(12, 27), (12, 28)]  b b 
-[(13, 0), (13, 3)]  com com 
-[(13, 8), (13, 9)]  a a 
-[(13, 13), (13, 14)]  b b 
-[(13, 23), (13, 24)]  b b 
-[(16, 6), (16, 32)]  res res 
-[(16, 6), (16, 9)]  res res 
-[(16, 15), (16, 16)]  a a 
-[(16, 25), (16, 26)]  b b 
-[(17, 6), (17, 30)]  res2 res2 
-[(17, 6), (17, 10)]  res2 res2 
-[(17, 15), (17, 16)]  a a 
-[(17, 21), (17, 22)]  b b 
-[(18, 6), (18, 45)]  res3 res3 
-[(18, 6), (18, 10)]  res3 res3 
-[(18, 15), (18, 16)]  a a 
-[(18, 21), (18, 22)]  b b 
-[(18, 30), (18, 31)]  b b 
-[(18, 36), (18, 37)]  c c 
-[(19, 6), (19, 45)]  res4 res4 
-[(19, 6), (19, 10)]  res4 res4 
-[(19, 17), (19, 18)]  a a 
-[(19, 29), (19, 30)]  b b 
-[(19, 32), (19, 33)]  a a 
-[(19, 34), (19, 35)]  b b 
-[(19, 36), (19, 37)]  c c 
-[(19, 38), (19, 39)]  v v 
-[(19, 40), (19, 41)]  d d 
-[(22, 6), (22, 35)]   undefined 
-[(22, 8), (22, 9)]  b b 
-[(22, 8), (22, 9)]  b b 
-[(22, 11), (22, 16)]  resty resty 
-[(22, 11), (22, 16)]  resty resty 
-[(22, 21), (22, 28)]  compute compute 
-[(22, 29), (22, 34)]  stuff stuff 
-[(23, 6), (23, 35)]   undefined 
-[(23, 7), (23, 8)]  a a 
-[(23, 13), (23, 17)]  rest rest 
-[(23, 21), (23, 28)]  compute compute 
-[(23, 29), (23, 34)]  stuff stuff 
-[(25, 9), (25, 15)]  params params 
-[(25, 18), (25, 19)]  a a 
-[(25, 18), (25, 19)]  a a 
-[(25, 21), (25, 22)]  b b 
-[(25, 21), (25, 22)]  b b 
-[(26, 4), (26, 32)]  pars pars 
-[(26, 4), (26, 8)]  pars pars 
-[(26, 22), (26, 23)]  a a 
-[(26, 22), (26, 23)]  a a 
-[(26, 25), (26, 26)]  b b 
-[(26, 25), (26, 26)]  b b 
-[(27, 6), (27, 43)]  evil evil 
-[(27, 6), (27, 10)]  evil evil 
-[(27, 13), (27, 17)]  obj2 obj2 
-[(27, 18), (27, 24)]  doEvil doEvil 
-[(27, 27), (27, 28)]  c c 
-[(27, 29), (27, 43)]  secondProperty secondProperty 
+[(1, 6), (1, 27)]  obj obj  
+[(1, 6), (1, 9)]  obj obj  
+[(1, 14), (1, 15)]  a a  
+[(1, 19), (1, 20)]  b b  
+[(2, 6), (2, 33)]  foo foo  
+[(2, 6), (2, 9)]  foo foo  
+[(2, 12), (2, 16)]  obj2 obj2  
+[(2, 17), (2, 18)]  c c  
+[(2, 19), (2, 33)]  secondProperty secondProperty  
+[(5, 6), (5, 49)]  com com  
+[(5, 6), (5, 9)]  com com  
+[(5, 15), (5, 16)]  a a  
+[(5, 21), (5, 22)]  b b  
+[(5, 30), (5, 31)]  d d  
+[(5, 42), (5, 43)]  b b  
+[(7, 0), (7, 3)]  app app  
+[(7, 4), (7, 12)]  TodoView TodoView  
+[(7, 15), (7, 23)]  Backbone Backbone  
+[(7, 24), (7, 30)]  extend extend  
+[(8, 2), (8, 8)]  render render  
+[(12, 0), (12, 3)]  obj obj  
+[(12, 4), (12, 7)]  foo foo  
+[(12, 12), (12, 13)]  a a  
+[(12, 17), (12, 18)]  b b  
+[(12, 27), (12, 28)]  b b  
+[(13, 0), (13, 3)]  com com  
+[(13, 8), (13, 9)]  a a  
+[(13, 13), (13, 14)]  b b  
+[(13, 23), (13, 24)]  b b  
+[(16, 6), (16, 32)]  res res  
+[(16, 6), (16, 9)]  res res  
+[(16, 15), (16, 16)]  a a  
+[(16, 25), (16, 26)]  b b  
+[(17, 6), (17, 30)]  res2 res2  
+[(17, 6), (17, 10)]  res2 res2  
+[(17, 15), (17, 16)]  a a  
+[(17, 21), (17, 22)]  b b  
+[(18, 6), (18, 45)]  res3 res3  
+[(18, 6), (18, 10)]  res3 res3  
+[(18, 15), (18, 16)]  a a  
+[(18, 21), (18, 22)]  b b  
+[(18, 30), (18, 31)]  b b  
+[(18, 36), (18, 37)]  c c  
+[(19, 6), (19, 45)]  res4 res4  
+[(19, 6), (19, 10)]  res4 res4  
+[(19, 17), (19, 18)]  a a  
+[(19, 29), (19, 30)]  b b  
+[(19, 32), (19, 33)]  a a  
+[(19, 34), (19, 35)]  b b  
+[(19, 36), (19, 37)]  c c  
+[(19, 38), (19, 39)]  v v  
+[(19, 40), (19, 41)]  d d  
+[(22, 6), (22, 35)]   undefined  
+[(22, 8), (22, 9)]  b b  
+[(22, 8), (22, 9)]  b b  
+[(22, 11), (22, 16)]  resty resty  
+[(22, 11), (22, 16)]  resty resty  
+[(22, 21), (22, 28)]  compute compute  
+[(22, 29), (22, 34)]  stuff stuff  
+[(23, 6), (23, 35)]   undefined  
+[(23, 7), (23, 8)]  a a  
+[(23, 13), (23, 17)]  rest rest  
+[(23, 21), (23, 28)]  compute compute  
+[(23, 29), (23, 34)]  stuff stuff  
+[(25, 9), (25, 15)]  params params  
+[(25, 18), (25, 19)]  a a  
+[(25, 18), (25, 19)]  a a  
+[(25, 21), (25, 22)]  b b  
+[(25, 21), (25, 22)]  b b  
+[(26, 4), (26, 32)]  pars pars  
+[(26, 4), (26, 8)]  pars pars  
+[(26, 22), (26, 23)]  a a  
+[(26, 22), (26, 23)]  a a  
+[(26, 25), (26, 26)]  b b  
+[(26, 25), (26, 26)]  b b  
+[(27, 6), (27, 43)]  evil evil  
+[(27, 6), (27, 10)]  evil evil  
+[(27, 13), (27, 17)]  obj2 obj2  
+[(27, 18), (27, 24)]  doEvil doEvil  
+[(27, 27), (27, 28)]  c c  
+[(27, 29), (27, 43)]  secondProperty secondProperty  
 variables
-[(1, 6), (1, 27)]   obj 
-[(1, 14), (1, 25)]   a 
-[(1, 19), (1, 23)]   b 
-[(2, 6), (2, 33)]   foo 
-[(5, 6), (5, 49)]   com 
-[(5, 14), (5, 39)]   a 
-[(5, 21), (5, 27)]   b 
-[(5, 29), (5, 37)]   d 
-[(5, 41), (5, 47)]   b 
-[(12, 12), (12, 25)]   a 
-[(12, 17), (12, 23)]   b 
-[(12, 27), (12, 31)]   b 
-[(13, 8), (13, 21)]   a 
-[(13, 13), (13, 19)]   b 
-[(13, 23), (13, 27)]   b 
-[(16, 6), (16, 32)]   res 
-[(16, 15), (16, 19)]   a 
-[(16, 25), (16, 29)]   b 
-[(17, 6), (17, 30)]   res2 
-[(17, 15), (17, 28)]   a 
-[(17, 21), (17, 25)]   b 
-[(18, 6), (18, 45)]   res3 
-[(18, 15), (18, 28)]   a 
-[(18, 21), (18, 25)]   b 
-[(18, 30), (18, 43)]   b 
-[(18, 36), (18, 40)]   c 
-[(19, 6), (19, 45)]   res4 
-[(19, 17), (19, 21)]   a 
-[(19, 29), (19, 41)]   b 
-[(22, 6), (22, 35)]   undefined 
-[(22, 8), (22, 9)]   b 
-[(22, 11), (22, 16)]   resty 
-[(23, 6), (23, 35)]   undefined 
-[(25, 16), (25, 24)]   undefined 
-[(25, 18), (25, 19)]   a 
-[(25, 21), (25, 22)]   b 
-[(26, 4), (26, 32)]   pars 
-[(26, 20), (26, 28)]   undefined 
-[(26, 22), (26, 23)]   a 
-[(26, 25), (26, 26)]   b 
-[(27, 6), (27, 43)]   evil "
+[(1, 6), (1, 27)]   obj  
+[(1, 14), (1, 25)]   a  
+[(1, 19), (1, 23)]   b  
+[(2, 6), (2, 33)]   foo  
+[(5, 6), (5, 49)]   com  
+[(5, 14), (5, 39)]   a  
+[(5, 21), (5, 27)]   b  
+[(5, 29), (5, 37)]   d  
+[(5, 41), (5, 47)]   b  
+[(12, 12), (12, 25)]   a  
+[(12, 17), (12, 23)]   b  
+[(12, 27), (12, 31)]   b  
+[(13, 8), (13, 21)]   a  
+[(13, 13), (13, 19)]   b  
+[(13, 23), (13, 27)]   b  
+[(16, 6), (16, 32)]   res  
+[(16, 15), (16, 19)]   a  
+[(16, 25), (16, 29)]   b  
+[(17, 6), (17, 30)]   res2  
+[(17, 15), (17, 28)]   a  
+[(17, 21), (17, 25)]   b  
+[(18, 6), (18, 45)]   res3  
+[(18, 15), (18, 28)]   a  
+[(18, 21), (18, 25)]   b  
+[(18, 30), (18, 43)]   b  
+[(18, 36), (18, 40)]   c  
+[(19, 6), (19, 45)]   res4  
+[(19, 17), (19, 21)]   a  
+[(19, 29), (19, 41)]   b  
+[(22, 6), (22, 35)]   undefined  
+[(22, 8), (22, 9)]   b  
+[(22, 11), (22, 16)]   resty  
+[(23, 6), (23, 35)]   undefined  
+[(25, 16), (25, 24)]   undefined  
+[(25, 18), (25, 19)]   a  
+[(25, 21), (25, 22)]   b  
+[(26, 4), (26, 32)]   pars  
+[(26, 20), (26, 28)]   undefined  
+[(26, 22), (26, 23)]   a  
+[(26, 25), (26, 26)]   b  
+[(27, 6), (27, 43)]   evil  "
 `;
 
 exports[`Parser.getSymbols finds symbols in an html file 1`] = `
 "properties
-[(5, 3), (5, 8)]  globalObject.first first 
-[(6, 3), (6, 7)]  globalObject.last last 
+[(5, 3), (5, 8)]  globalObject.first first  
+[(6, 3), (6, 7)]  globalObject.last last  
 member expressions
-[(23, 18), (23, 29)] [(23, 10), (23, 29)] name.undefined.toUpperCase toUpperCase 
-[(23, 15), (23, 16)] [(23, 10), (23, 17)] name. undefined 
-[(23, 39), (23, 48)] [(23, 34), (23, 48)] name.substring substring 
-[(28, 4), (28, 8)] [(25, 19), (28, 8)]  join 
-[(27, 4), (27, 7)] [(25, 19), (27, 7)]  map 
-[(26, 4), (26, 7)] [(25, 19), (26, 7)] map map 
-[(30, 15), (30, 24)] [(30, 2), (30, 24)] globalObject.greetings greetings 
-[(38, 11), (38, 14)] [(38, 3), (38, 14)] console.log log 
+[(23, 18), (23, 29)] [(23, 10), (23, 29)] name.undefined.toUpperCase toUpperCase  
+[(23, 15), (23, 16)] [(23, 10), (23, 17)] name. undefined  
+[(23, 39), (23, 48)] [(23, 34), (23, 48)] name.substring substring  
+[(28, 4), (28, 8)] [(25, 19), (28, 8)]  join  
+[(27, 4), (27, 7)] [(25, 19), (27, 7)]  map  
+[(26, 4), (26, 7)] [(25, 19), (26, 7)] map map  
+[(30, 15), (30, 24)] [(30, 2), (30, 24)] globalObject.greetings greetings  
+[(38, 11), (38, 14)] [(38, 3), (38, 14)] console.log log  
 call expressions
-[(36, 3), (39, 3)]   undefined 
-[(37, 20), (37, 28)]   sayHello 
+[(36, 3), (39, 3)]   undefined  
+[(37, 20), (37, 28)]   sayHello  
 identifiers
-[(4, 6), (7, 3)]  globalObject globalObject 
-[(4, 6), (4, 18)]  globalObject globalObject 
-[(5, 3), (5, 8)]  first first 
-[(6, 3), (6, 7)]  last last 
-[(8, 11), (8, 19)]  sayHello sayHello 
-[(8, 21), (8, 25)]  name name 
-[(9, 20), (9, 24)]  name name 
-[(22, 8), (24, 3)]  capitalize capitalize 
-[(22, 8), (22, 18)]  capitalize capitalize 
-[(22, 21), (22, 25)]  name name 
-[(23, 10), (23, 14)]  name name 
-[(23, 18), (23, 29)]  toUpperCase toUpperCase 
-[(23, 34), (23, 38)]  name name 
-[(23, 39), (23, 48)]  substring substring 
-[(25, 8), (28, 14)]  greetAll greetAll 
-[(25, 8), (25, 16)]  greetAll greetAll 
-[(26, 4), (26, 7)]  map map 
-[(26, 8), (26, 18)]  capitalize capitalize 
-[(27, 4), (27, 7)]  map map 
-[(27, 8), (27, 16)]  sayHello sayHello 
-[(28, 4), (28, 8)]  join join 
-[(30, 2), (30, 14)]  globalObject globalObject 
-[(30, 15), (30, 24)]  greetings greetings 
-[(30, 27), (30, 35)]  greetAll greetAll 
-[(36, 12), (36, 16)]  iife iife 
-[(37, 9), (37, 36)]  greeting greeting 
-[(37, 9), (37, 17)]  greeting greeting 
-[(37, 20), (37, 28)]  sayHello sayHello 
-[(38, 3), (38, 10)]  console console 
-[(38, 11), (38, 14)]  log log 
-[(38, 15), (38, 23)]  greeting greeting 
+[(4, 6), (7, 3)]  globalObject globalObject  
+[(4, 6), (4, 18)]  globalObject globalObject  
+[(5, 3), (5, 8)]  first first  
+[(6, 3), (6, 7)]  last last  
+[(8, 11), (8, 19)]  sayHello sayHello  
+[(8, 21), (8, 25)]  name name  
+[(9, 20), (9, 24)]  name name  
+[(22, 8), (24, 3)]  capitalize capitalize  
+[(22, 8), (22, 18)]  capitalize capitalize  
+[(22, 21), (22, 25)]  name name  
+[(23, 10), (23, 14)]  name name  
+[(23, 18), (23, 29)]  toUpperCase toUpperCase  
+[(23, 34), (23, 38)]  name name  
+[(23, 39), (23, 48)]  substring substring  
+[(25, 8), (28, 14)]  greetAll greetAll  
+[(25, 8), (25, 16)]  greetAll greetAll  
+[(26, 4), (26, 7)]  map map  
+[(26, 8), (26, 18)]  capitalize capitalize  
+[(27, 4), (27, 7)]  map map  
+[(27, 8), (27, 16)]  sayHello sayHello  
+[(28, 4), (28, 8)]  join join  
+[(30, 2), (30, 14)]  globalObject globalObject  
+[(30, 15), (30, 24)]  greetings greetings  
+[(30, 27), (30, 35)]  greetAll greetAll  
+[(36, 12), (36, 16)]  iife iife  
+[(37, 9), (37, 36)]  greeting greeting  
+[(37, 9), (37, 17)]  greeting greeting  
+[(37, 20), (37, 28)]  sayHello sayHello  
+[(38, 3), (38, 10)]  console console  
+[(38, 11), (38, 14)]  log log  
+[(38, 15), (38, 23)]  greeting greeting  
 variables
-[(4, 6), (7, 3)]   globalObject 
-[(5, 3), (5, 16)]   first 
-[(6, 3), (6, 16)]   last 
-[(8, 21), (8, 25)]   name 
-[(22, 8), (24, 3)]   capitalize 
-[(22, 21), (22, 25)]   name 
-[(25, 8), (28, 14)]   greetAll 
-[(37, 9), (37, 36)]   greeting "
+[(4, 6), (7, 3)]   globalObject  
+[(5, 3), (5, 16)]   first  
+[(6, 3), (6, 16)]   last  
+[(8, 21), (8, 25)]   name  
+[(22, 8), (24, 3)]   capitalize  
+[(22, 21), (22, 25)]   name  
+[(25, 8), (28, 14)]   greetAll  
+[(37, 9), (37, 36)]   greeting  "
 `;
 
 exports[`Parser.getSymbols func 1`] = `
 "properties
-[(24, 2), (24, 5)]  obj.foo foo 
+[(24, 2), (24, 5)]  obj.foo foo  
 member expressions
 
 call expressions
-[(19, 1), (21, 1)]   undefined 
+[(19, 1), (21, 1)]   undefined  
 identifiers
-[(1, 9), (1, 15)]  square square 
-[(1, 16), (1, 17)]  n n 
-[(2, 9), (2, 10)]  n n 
-[(2, 13), (2, 14)]  n n 
-[(5, 16), (5, 21)]  exFoo exFoo 
-[(9, 15), (9, 22)]  slowFoo slowFoo 
-[(13, 22), (13, 31)]  exSlowFoo exSlowFoo 
-[(17, 0), (17, 5)]  child child 
-[(23, 6), (31, 1)]  obj obj 
-[(23, 6), (23, 9)]  obj obj 
-[(24, 2), (24, 5)]  foo foo 
-[(24, 16), (24, 20)]  name name 
-[(28, 2), (28, 5)]  bar bar 
+[(1, 9), (1, 15)]  square square  
+[(1, 16), (1, 17)]  n n  
+[(2, 9), (2, 10)]  n n  
+[(2, 13), (2, 14)]  n n  
+[(5, 16), (5, 21)]  exFoo exFoo  
+[(9, 15), (9, 22)]  slowFoo slowFoo  
+[(13, 22), (13, 31)]  exSlowFoo exSlowFoo  
+[(17, 0), (17, 5)]  child child  
+[(23, 6), (31, 1)]  obj obj  
+[(23, 6), (23, 9)]  obj obj  
+[(24, 2), (24, 5)]  foo foo  
+[(24, 16), (24, 20)]  name name  
+[(28, 2), (28, 5)]  bar bar  
 variables
-[(1, 16), (1, 17)]   n 
-[(23, 6), (31, 1)]   obj "
+[(1, 16), (1, 17)]   n  
+[(23, 6), (31, 1)]   obj  "
 `;
 
 exports[`Parser.getSymbols math 1`] = `
@@ -424,70 +424,70 @@ exports[`Parser.getSymbols math 1`] = `
 member expressions
 
 call expressions
-[(5, 14), (5, 20)]   square 
-[(6, 15), (6, 22)]   squaare 
+[(5, 14), (5, 20)]   square  
+[(6, 15), (6, 22)]   squaare  
 identifiers
-[(1, 9), (1, 13)]  math math 
-[(1, 14), (1, 15)]  n n 
-[(2, 11), (2, 17)]  square square 
-[(2, 18), (2, 19)]  n n 
-[(3, 4), (3, 5)]  n n 
-[(3, 8), (3, 9)]  n n 
-[(5, 8), (5, 23)]  two two 
-[(5, 8), (5, 11)]  two two 
-[(5, 14), (5, 20)]  square square 
-[(6, 8), (6, 25)]  four four 
-[(6, 8), (6, 12)]  four four 
-[(6, 15), (6, 22)]  squaare squaare 
-[(7, 9), (7, 12)]  two two 
-[(7, 15), (7, 19)]  four four 
-[(10, 4), (10, 25)]  child child 
-[(10, 4), (10, 9)]  child child 
-[(11, 0), (11, 6)]  child2 child2 
+[(1, 9), (1, 13)]  math math  
+[(1, 14), (1, 15)]  n n  
+[(2, 11), (2, 17)]  square square  
+[(2, 18), (2, 19)]  n n  
+[(3, 4), (3, 5)]  n n  
+[(3, 8), (3, 9)]  n n  
+[(5, 8), (5, 23)]  two two  
+[(5, 8), (5, 11)]  two two  
+[(5, 14), (5, 20)]  square square  
+[(6, 8), (6, 25)]  four four  
+[(6, 8), (6, 12)]  four four  
+[(6, 15), (6, 22)]  squaare squaare  
+[(7, 9), (7, 12)]  two two  
+[(7, 15), (7, 19)]  four four  
+[(10, 4), (10, 25)]  child child  
+[(10, 4), (10, 9)]  child child  
+[(11, 0), (11, 6)]  child2 child2  
 variables
-[(1, 14), (1, 15)]   n 
-[(2, 18), (2, 19)]   n 
-[(5, 8), (5, 23)]   two 
-[(6, 8), (6, 25)]   four 
-[(10, 4), (10, 25)]   child "
+[(1, 14), (1, 15)]   n  
+[(2, 18), (2, 19)]   n  
+[(5, 8), (5, 23)]   two  
+[(6, 8), (6, 25)]   four  
+[(10, 4), (10, 25)]   child  "
 `;
 
 exports[`Parser.getSymbols proto 1`] = `
 "properties
-[(6, 2), (6, 9)]   tagName 
-[(7, 2), (7, 12)]   initialize 
-[(11, 2), (11, 8)]   render 
+[(6, 2), (6, 9)]   tagName  
+[(7, 2), (7, 12)]   initialize  
+[(11, 2), (11, 8)]   render  
 member expressions
-[(5, 31), (5, 37)] [(5, 17), (5, 37)] Backbone.View.extend extend 
-[(5, 26), (5, 30)] [(5, 17), (5, 30)] Backbone.View View 
-[(9, 12), (9, 15)] [(9, 4), (9, 15)] console.log log 
+[(5, 31), (5, 37)] [(5, 17), (5, 37)] Backbone.View.extend extend  
+[(5, 26), (5, 30)] [(5, 17), (5, 30)] Backbone.View View  
+[(9, 12), (9, 15)] [(9, 4), (9, 15)] console.log log  
 call expressions
 
 identifiers
-[(1, 6), (1, 25)]  foo foo 
-[(1, 6), (1, 9)]  foo foo 
-[(3, 6), (3, 20)]  bar bar 
-[(3, 6), (3, 9)]  bar bar 
-[(5, 6), (14, 2)]  TodoView TodoView 
-[(5, 6), (5, 14)]  TodoView TodoView 
-[(5, 17), (5, 25)]  Backbone Backbone 
-[(5, 26), (5, 30)]  View View 
-[(5, 31), (5, 37)]  extend extend 
-[(6, 2), (6, 9)]  tagName tagName 
-[(7, 2), (7, 12)]  initialize initialize 
-[(8, 2), (8, 9)]  doThing doThing 
-[(8, 10), (8, 11)]  b b 
-[(9, 4), (9, 11)]  console console 
-[(9, 12), (9, 15)]  log log 
-[(9, 22), (9, 23)]  b b 
-[(11, 2), (11, 8)]  render render 
-[(12, 11), (12, 15)] [(12, 11), (12, 15)] this this 
+[(1, 6), (1, 25)]  foo foo  
+[(1, 6), (1, 9)]  foo foo  
+[(3, 6), (3, 20)]  bar bar  
+[(3, 6), (3, 9)]  bar bar  
+[(5, 6), (14, 2)]  TodoView TodoView  
+[(5, 6), (5, 14)]  TodoView TodoView  
+[(5, 17), (5, 25)]  Backbone Backbone  
+[(5, 26), (5, 30)]  View View  
+[(5, 31), (5, 37)]  extend extend  
+[(6, 2), (6, 9)]  tagName tagName  
+[(7, 2), (7, 12)]  initialize initialize  
+[(8, 2), (8, 9)]  doThing doThing  
+[(8, 10), (8, 11)]  b b  
+[(9, 4), (9, 11)]  console console  
+[(9, 12), (9, 15)]  log log  
+[(9, 22), (9, 23)]  b b  
+[(11, 2), (11, 8)]  render render  
+[(12, 11), (12, 15)] [(12, 11), (12, 15)] this this  
 variables
-[(1, 6), (1, 25)]   foo 
-[(3, 6), (3, 20)]   bar 
-[(5, 6), (14, 2)]   TodoView 
-[(6, 2), (6, 15)]   tagName 
-[(8, 10), (8, 11)]   b "
+[(1, 6), (1, 25)]   foo  
+[(3, 6), (3, 20)]   bar  
+[(5, 6), (14, 2)]   TodoView  
+[(6, 2), (6, 15)]   tagName  
+[(8, 10), (8, 11)]   b  "
 `;
 
 exports[`Parser.getSymbols var 1`] = `
@@ -498,20 +498,20 @@ member expressions
 call expressions
 
 identifiers
-[(1, 4), (1, 11)]  foo foo 
-[(1, 4), (1, 7)]  foo foo 
-[(2, 4), (2, 11)]  bar bar 
-[(2, 4), (2, 7)]  bar bar 
-[(3, 6), (3, 13)]  baz baz 
-[(3, 6), (3, 9)]  baz baz 
-[(4, 6), (4, 11)]  a a 
-[(4, 6), (4, 7)]  a a 
-[(5, 2), (5, 7)]  b b 
-[(5, 2), (5, 3)]  b b 
+[(1, 4), (1, 11)]  foo foo  
+[(1, 4), (1, 7)]  foo foo  
+[(2, 4), (2, 11)]  bar bar  
+[(2, 4), (2, 7)]  bar bar  
+[(3, 6), (3, 13)]  baz baz  
+[(3, 6), (3, 9)]  baz baz  
+[(4, 6), (4, 11)]  a a  
+[(4, 6), (4, 7)]  a a  
+[(5, 2), (5, 7)]  b b  
+[(5, 2), (5, 3)]  b b  
 variables
-[(1, 4), (1, 11)]   foo 
-[(2, 4), (2, 11)]   bar 
-[(3, 6), (3, 13)]   baz 
-[(4, 6), (4, 11)]   a 
-[(5, 2), (5, 7)]   b "
+[(1, 4), (1, 11)]   foo  
+[(2, 4), (2, 11)]   bar  
+[(3, 6), (3, 13)]   baz  
+[(4, 6), (4, 11)]   a  
+[(5, 2), (5, 7)]   b  "
 `;

--- a/src/utils/parser/tests/__snapshots__/getSymbols.spec.js.snap
+++ b/src/utils/parser/tests/__snapshots__/getSymbols.spec.js.snap
@@ -1,19 +1,41 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Parser.getSymbols allSymbols 1`] = `
-"properties
-[(11, 2), (11, 5)]  Obj.foo foo  
-[(15, 2), (15, 14)]  Obj.doOtherThing doOtherThing  
-member expressions
-[(13, 12), (13, 15)] [(13, 4), (13, 15)] console.log log  
+Array [
+  "functions:
+ [(4, 0), (6, 1)]   incrementCounter counter 
+[(8, 12), (8, 27)]   sum a, b 
+[(12, 2), (14, 3)]   doThing  
+[(15, 16), (17, 3)]   doOtherThing  
+[(20, 15), (20, 23)]   property  
+[(24, 2), (26, 3)]   constructor  Ultra
+[(28, 2), (30, 3)]   beAwesome person Ultra",
+  "variables:
+ [(1, 6), (1, 15)]   TIME  
+[(2, 4), (2, 13)]   count  
+[(4, 26), (4, 33)]   counter  
+[(8, 6), (8, 27)]   sum  
+[(8, 13), (8, 14)]   a  
+[(8, 16), (8, 17)]   b  
+[(10, 6), (18, 1)]   Obj  
+[(11, 2), (11, 8)]   foo  
+[(23, 0), (31, 1)]   Ultra  
+[(28, 12), (28, 18)]   person  ",
+  "callExpressions:
+ ",
+  "memberExpressions:
+ [(13, 12), (13, 15)] [(13, 4), (13, 15)] console.log log  
 [(20, 4), (20, 12)] [(20, 0), (20, 12)] Obj.property property  
 [(21, 4), (21, 17)] [(21, 0), (21, 17)] Obj.otherProperty otherProperty  
 [(25, 9), (25, 16)] [(25, 4), (25, 16)] this.awesome awesome  
-[(29, 12), (29, 15)] [(29, 4), (29, 15)] console.log log  
-call expressions
-
-identifiers
-[(1, 6), (1, 15)]  TIME TIME  
+[(29, 12), (29, 15)] [(29, 4), (29, 15)] console.log log  ",
+  "objectProperties:
+ [(11, 2), (11, 5)]  Obj.foo foo  
+[(15, 2), (15, 14)]  Obj.doOtherThing doOtherThing  ",
+  "comments:
+ ",
+  "identifiers:
+ [(1, 6), (1, 15)]  TIME TIME  
 [(1, 6), (1, 10)]  TIME TIME  
 [(2, 4), (2, 13)]  count count  
 [(2, 4), (2, 9)]  count count  
@@ -45,52 +67,59 @@ identifiers
 [(28, 12), (28, 18)]  person person  
 [(29, 4), (29, 11)]  console console  
 [(29, 12), (29, 15)]  log log  
-[(29, 19), (29, 25)]  person person  
-variables
-[(1, 6), (1, 15)]   TIME  
-[(2, 4), (2, 13)]   count  
-[(4, 26), (4, 33)]   counter  
-[(8, 6), (8, 27)]   sum  
-[(8, 13), (8, 14)]   a  
-[(8, 16), (8, 17)]   b  
-[(10, 6), (18, 1)]   Obj  
-[(11, 2), (11, 8)]   foo  
-[(23, 0), (31, 1)]   Ultra  
-[(28, 12), (28, 18)]   person  "
+[(29, 19), (29, 25)]  person person  ",
+]
 `;
 
 exports[`Parser.getSymbols call sites 1`] = `
-"properties
-
-member expressions
-[(4, 3), (4, 7)] [(2, 0), (4, 7)]  ffff  
-[(3, 3), (3, 6)] [(2, 0), (3, 6)]  eee  
-call expressions
-[(1, 0), (1, 3)]   aaa  
+Array [
+  "functions:
+ ",
+  "variables:
+ ",
+  "callExpressions:
+ [(1, 0), (1, 3)]   aaa  
 [(1, 4), (1, 7)]   bbb  
 [(1, 11), (1, 14)]   ccc  
-[(2, 0), (2, 4)]   dddd  
-identifiers
-[(1, 0), (1, 3)]  aaa aaa  
+[(2, 0), (2, 4)]   dddd  ",
+  "memberExpressions:
+ [(4, 3), (4, 7)] [(2, 0), (4, 7)]  ffff  
+[(3, 3), (3, 6)] [(2, 0), (3, 6)]  eee  ",
+  "objectProperties:
+ ",
+  "comments:
+ ",
+  "identifiers:
+ [(1, 0), (1, 3)]  aaa aaa  
 [(1, 4), (1, 7)]  bbb bbb  
 [(1, 11), (1, 14)]  ccc ccc  
 [(2, 0), (2, 4)]  dddd dddd  
 [(3, 3), (3, 6)]  eee eee  
-[(4, 3), (4, 7)]  ffff ffff  
-variables
-"
+[(4, 3), (4, 7)]  ffff ffff  ",
+]
 `;
 
 exports[`Parser.getSymbols class 1`] = `
-"properties
-
-member expressions
-[(3, 9), (3, 12)] [(3, 4), (3, 12)] this.foo foo  
-[(7, 12), (7, 15)] [(7, 4), (7, 15)] console.log log  
-call expressions
-
-identifiers
-[(1, 6), (1, 10)]  Test Test  
+Array [
+  "functions:
+ [(2, 2), (4, 3)]   constructor  Test
+[(6, 2), (8, 3)]   bar a Test",
+  "variables:
+ [(1, 0), (9, 1)]   Test  
+[(6, 6), (6, 7)]   a  
+[(11, 0), (11, 14)]   Test2  
+[(13, 4), (13, 30)]   expressiveClass  ",
+  "callExpressions:
+ ",
+  "memberExpressions:
+ [(3, 9), (3, 12)] [(3, 4), (3, 12)] this.foo foo  
+[(7, 12), (7, 15)] [(7, 4), (7, 15)] console.log log  ",
+  "objectProperties:
+ ",
+  "comments:
+ ",
+  "identifiers:
+ [(1, 6), (1, 10)]  Test Test  
 [(2, 2), (2, 13)]  constructor constructor  
 [(3, 4), (3, 8)] [(3, 4), (3, 8)] this this  
 [(3, 9), (3, 12)]  foo foo  
@@ -101,26 +130,34 @@ identifiers
 [(7, 23), (7, 24)]  a a  
 [(11, 6), (11, 11)]  Test2 Test2  
 [(13, 4), (13, 30)]  expressiveClass expressiveClass  
-[(13, 4), (13, 19)]  expressiveClass expressiveClass  
-variables
-[(1, 0), (9, 1)]   Test  
-[(6, 6), (6, 7)]   a  
-[(11, 0), (11, 14)]   Test2  
-[(13, 4), (13, 30)]   expressiveClass  "
+[(13, 4), (13, 19)]  expressiveClass expressiveClass  ",
+]
 `;
 
 exports[`Parser.getSymbols component 1`] = `
-"properties
-
-member expressions
-[(6, 9), (6, 16)] [(6, 4), (6, 16)] this.onClick onClick  
+Array [
+  "functions:
+ [(4, 2), (7, 3)]   constructor props Punny
+[(9, 2), (9, 24)]   componentDidMount  Punny
+[(11, 2), (11, 14)]   onClick  Punny
+[(13, 2), (15, 3)]   renderMe  Punny
+[(17, 2), (17, 13)]   render  Punny",
+  "variables:
+ [(3, 0), (18, 1)]   Punny  
+[(4, 14), (4, 19)]   props  ",
+  "callExpressions:
+ [(5, 4), (5, 9)]   undefined  ",
+  "memberExpressions:
+ [(6, 9), (6, 16)] [(6, 4), (6, 16)] this.onClick onClick  
 [(6, 32), (6, 36)] [(6, 19), (6, 36)] this.onClick.bind bind  
 [(6, 24), (6, 31)] [(6, 19), (6, 31)] this.onClick onClick  
-[(14, 30), (14, 37)] [(14, 25), (14, 37)] this.onClick onClick  
-call expressions
-[(5, 4), (5, 9)]   undefined  
-identifiers
-[(1, 7), (1, 12)]  React React  
+[(14, 30), (14, 37)] [(14, 25), (14, 37)] this.onClick onClick  ",
+  "objectProperties:
+ ",
+  "comments:
+ ",
+  "identifiers:
+ [(1, 7), (1, 12)]  React React  
 [(1, 16), (1, 25)]  Component Component  
 [(1, 16), (1, 25)]  Component Component  
 [(3, 6), (3, 11)]  Punny Punny  
@@ -138,31 +175,98 @@ identifiers
 [(14, 25), (14, 29)] [(14, 25), (14, 29)] this this  
 [(14, 30), (14, 37)]  onClick onClick  
 [(17, 2), (17, 8)]  render render  
-[(3, 20), (3, 29)]  Component Component  
-variables
-[(3, 0), (18, 1)]   Punny  
-[(4, 14), (4, 19)]   props  "
+[(3, 20), (3, 29)]  Component Component  ",
+]
 `;
 
 exports[`Parser.getSymbols es6 1`] = `
-"properties
-[(1, 23), (1, 30)]   PROMISE  
-member expressions
-
-call expressions
-[(1, 0), (1, 8)]   dispatch  
-identifiers
-[(1, 0), (1, 8)]  dispatch dispatch  
+Array [
+  "functions:
+ ",
+  "variables:
+ [(1, 22), (1, 40)]   PROMISE  ",
+  "callExpressions:
+ [(1, 0), (1, 8)]   dispatch  ",
+  "memberExpressions:
+ ",
+  "objectProperties:
+ [(1, 23), (1, 30)]   PROMISE  ",
+  "comments:
+ ",
+  "identifiers:
+ [(1, 0), (1, 8)]  dispatch dispatch  
 [(1, 14), (1, 20)]  action action  
 [(1, 23), (1, 30)]  PROMISE PROMISE  
-[(1, 33), (1, 40)]  promise promise  
-variables
-[(1, 22), (1, 40)]   PROMISE  "
+[(1, 33), (1, 40)]  promise promise  ",
+]
 `;
 
 exports[`Parser.getSymbols expression 1`] = `
-"properties
-[(1, 14), (1, 15)]  obj.a a  
+Array [
+  "functions:
+ [(8, 10), (8, 23)]   render  
+[(25, 0), (25, 28)]   params  
+[(26, 11), (26, 32)]   pars  ",
+  "variables:
+ [(1, 6), (1, 27)]   obj  
+[(1, 14), (1, 25)]   a  
+[(1, 19), (1, 23)]   b  
+[(2, 6), (2, 33)]   foo  
+[(5, 6), (5, 49)]   com  
+[(5, 14), (5, 39)]   a  
+[(5, 21), (5, 27)]   b  
+[(5, 29), (5, 37)]   d  
+[(5, 41), (5, 47)]   b  
+[(12, 12), (12, 25)]   a  
+[(12, 17), (12, 23)]   b  
+[(12, 27), (12, 31)]   b  
+[(13, 8), (13, 21)]   a  
+[(13, 13), (13, 19)]   b  
+[(13, 23), (13, 27)]   b  
+[(16, 6), (16, 32)]   res  
+[(16, 15), (16, 19)]   a  
+[(16, 25), (16, 29)]   b  
+[(17, 6), (17, 30)]   res2  
+[(17, 15), (17, 28)]   a  
+[(17, 21), (17, 25)]   b  
+[(18, 6), (18, 45)]   res3  
+[(18, 15), (18, 28)]   a  
+[(18, 21), (18, 25)]   b  
+[(18, 30), (18, 43)]   b  
+[(18, 36), (18, 40)]   c  
+[(19, 6), (19, 45)]   res4  
+[(19, 17), (19, 21)]   a  
+[(19, 29), (19, 41)]   b  
+[(22, 6), (22, 35)]   undefined  
+[(22, 8), (22, 9)]   b  
+[(22, 11), (22, 16)]   resty  
+[(23, 6), (23, 35)]   undefined  
+[(25, 16), (25, 24)]   undefined  
+[(25, 18), (25, 19)]   a  
+[(25, 21), (25, 22)]   b  
+[(26, 4), (26, 32)]   pars  
+[(26, 20), (26, 28)]   undefined  
+[(26, 22), (26, 23)]   a  
+[(26, 25), (26, 26)]   b  
+[(27, 6), (27, 43)]   evil  ",
+  "callExpressions:
+ [(22, 21), (22, 28)]   compute  
+[(23, 21), (23, 28)]   compute  ",
+  "memberExpressions:
+ [(2, 19), (2, 33)] [(2, 12), (2, 33)] obj2.c.secondProperty secondProperty  
+[(2, 17), (2, 18)] [(2, 12), (2, 18)] obj2.c c  
+[(7, 4), (7, 12)] [(7, 0), (7, 12)] app.TodoView TodoView  
+[(7, 24), (7, 30)] [(7, 15), (7, 30)] Backbone.extend extend  
+[(12, 4), (12, 7)] [(12, 0), (12, 7)] obj.foo foo  
+[(19, 40), (19, 41)] [(19, 32), (19, 41)] a.b.c.v.d d  
+[(19, 38), (19, 39)] [(19, 32), (19, 39)] a.b.c.v v  
+[(19, 36), (19, 37)] [(19, 32), (19, 37)] a.b.c c  
+[(19, 34), (19, 35)] [(19, 32), (19, 35)] a.b b  
+[(27, 29), (27, 43)] [(27, 13), (27, 43)]  secondProperty  
+[(27, 27), (27, 28)] [(27, 13), (27, 28)]  c  
+[(27, 18), (27, 24)] [(27, 13), (27, 24)] obj2.doEvil doEvil  ",
+  "objectProperties:
+ [(1, 14), (1, 15)]  obj.a a  
 [(1, 19), (1, 20)]  obj.a.b b  
 [(5, 15), (5, 16)]  com[a] a  
 [(5, 21), (5, 22)]  com[a].b b  
@@ -190,25 +294,26 @@ exports[`Parser.getSymbols expression 1`] = `
 [(25, 18), (25, 19)]  a a  
 [(25, 21), (25, 22)]  b b  
 [(26, 22), (26, 23)]  a a  
-[(26, 25), (26, 26)]  b b  
-member expressions
-[(2, 19), (2, 33)] [(2, 12), (2, 33)] obj2.c.secondProperty secondProperty  
-[(2, 17), (2, 18)] [(2, 12), (2, 18)] obj2.c c  
-[(7, 4), (7, 12)] [(7, 0), (7, 12)] app.TodoView TodoView  
-[(7, 24), (7, 30)] [(7, 15), (7, 30)] Backbone.extend extend  
-[(12, 4), (12, 7)] [(12, 0), (12, 7)] obj.foo foo  
-[(19, 40), (19, 41)] [(19, 32), (19, 41)] a.b.c.v.d d  
-[(19, 38), (19, 39)] [(19, 32), (19, 39)] a.b.c.v v  
-[(19, 36), (19, 37)] [(19, 32), (19, 37)] a.b.c c  
-[(19, 34), (19, 35)] [(19, 32), (19, 35)] a.b b  
-[(27, 29), (27, 43)] [(27, 13), (27, 43)]  secondProperty  
-[(27, 27), (27, 28)] [(27, 13), (27, 28)]  c  
-[(27, 18), (27, 24)] [(27, 13), (27, 24)] obj2.doEvil doEvil  
-call expressions
-[(22, 21), (22, 28)]   compute  
-[(23, 21), (23, 28)]   compute  
-identifiers
-[(1, 6), (1, 27)]  obj obj  
+[(26, 25), (26, 26)]  b b  ",
+  "comments:
+ [(1, 29), (1, 44)]   undefined  
+[(2, 35), (2, 68)]   undefined  
+[(4, 0), (4, 22)]   undefined  
+[(5, 51), (5, 67)]   undefined  
+[(11, 0), (11, 14)]   undefined  
+[(12, 35), (12, 54)]   undefined  
+[(13, 31), (13, 46)]   undefined  
+[(15, 0), (15, 9)]   undefined  
+[(16, 34), (16, 50)]   undefined  
+[(17, 32), (17, 50)]   undefined  
+[(18, 47), (18, 65)]   undefined  
+[(19, 47), (19, 66)]   undefined  
+[(21, 0), (21, 16)]   undefined  
+[(22, 37), (22, 46)]   undefined  
+[(25, 29), (25, 38)]   undefined  
+[(27, 45), (27, 70)]   undefined  ",
+  "identifiers:
+ [(1, 6), (1, 27)]  obj obj  
 [(1, 6), (1, 9)]  obj obj  
 [(1, 14), (1, 15)]  a a  
 [(1, 19), (1, 20)]  b b  
@@ -288,69 +393,44 @@ identifiers
 [(27, 13), (27, 17)]  obj2 obj2  
 [(27, 18), (27, 24)]  doEvil doEvil  
 [(27, 27), (27, 28)]  c c  
-[(27, 29), (27, 43)]  secondProperty secondProperty  
-variables
-[(1, 6), (1, 27)]   obj  
-[(1, 14), (1, 25)]   a  
-[(1, 19), (1, 23)]   b  
-[(2, 6), (2, 33)]   foo  
-[(5, 6), (5, 49)]   com  
-[(5, 14), (5, 39)]   a  
-[(5, 21), (5, 27)]   b  
-[(5, 29), (5, 37)]   d  
-[(5, 41), (5, 47)]   b  
-[(12, 12), (12, 25)]   a  
-[(12, 17), (12, 23)]   b  
-[(12, 27), (12, 31)]   b  
-[(13, 8), (13, 21)]   a  
-[(13, 13), (13, 19)]   b  
-[(13, 23), (13, 27)]   b  
-[(16, 6), (16, 32)]   res  
-[(16, 15), (16, 19)]   a  
-[(16, 25), (16, 29)]   b  
-[(17, 6), (17, 30)]   res2  
-[(17, 15), (17, 28)]   a  
-[(17, 21), (17, 25)]   b  
-[(18, 6), (18, 45)]   res3  
-[(18, 15), (18, 28)]   a  
-[(18, 21), (18, 25)]   b  
-[(18, 30), (18, 43)]   b  
-[(18, 36), (18, 40)]   c  
-[(19, 6), (19, 45)]   res4  
-[(19, 17), (19, 21)]   a  
-[(19, 29), (19, 41)]   b  
-[(22, 6), (22, 35)]   undefined  
-[(22, 8), (22, 9)]   b  
-[(22, 11), (22, 16)]   resty  
-[(23, 6), (23, 35)]   undefined  
-[(25, 16), (25, 24)]   undefined  
-[(25, 18), (25, 19)]   a  
-[(25, 21), (25, 22)]   b  
-[(26, 4), (26, 32)]   pars  
-[(26, 20), (26, 28)]   undefined  
-[(26, 22), (26, 23)]   a  
-[(26, 25), (26, 26)]   b  
-[(27, 6), (27, 43)]   evil  "
+[(27, 29), (27, 43)]  secondProperty secondProperty  ",
+]
 `;
 
 exports[`Parser.getSymbols finds symbols in an html file 1`] = `
-"properties
-[(5, 3), (5, 8)]  globalObject.first first  
-[(6, 3), (6, 7)]  globalObject.last last  
-member expressions
-[(23, 18), (23, 29)] [(23, 10), (23, 29)] name.undefined.toUpperCase toUpperCase  
+Array [
+  "functions:
+ [(8, 2), (10, 3)]   sayHello name 
+[(22, 21), (24, 3)]   capitalize name 
+[(36, 3), (39, 3)]   iife  ",
+  "variables:
+ [(4, 6), (7, 3)]   globalObject  
+[(5, 3), (5, 16)]   first  
+[(6, 3), (6, 16)]   last  
+[(8, 21), (8, 25)]   name  
+[(22, 8), (24, 3)]   capitalize  
+[(22, 21), (22, 25)]   name  
+[(25, 8), (28, 14)]   greetAll  
+[(37, 9), (37, 36)]   greeting  ",
+  "callExpressions:
+ [(36, 3), (39, 3)]   undefined  
+[(37, 20), (37, 28)]   sayHello  ",
+  "memberExpressions:
+ [(23, 18), (23, 29)] [(23, 10), (23, 29)] name.undefined.toUpperCase toUpperCase  
 [(23, 15), (23, 16)] [(23, 10), (23, 17)] name. undefined  
 [(23, 39), (23, 48)] [(23, 34), (23, 48)] name.substring substring  
 [(28, 4), (28, 8)] [(25, 19), (28, 8)]  join  
 [(27, 4), (27, 7)] [(25, 19), (27, 7)]  map  
 [(26, 4), (26, 7)] [(25, 19), (26, 7)] map map  
 [(30, 15), (30, 24)] [(30, 2), (30, 24)] globalObject.greetings greetings  
-[(38, 11), (38, 14)] [(38, 3), (38, 14)] console.log log  
-call expressions
-[(36, 3), (39, 3)]   undefined  
-[(37, 20), (37, 28)]   sayHello  
-identifiers
-[(4, 6), (7, 3)]  globalObject globalObject  
+[(38, 11), (38, 14)] [(38, 3), (38, 14)] console.log log  ",
+  "objectProperties:
+ [(5, 3), (5, 8)]  globalObject.first first  
+[(6, 3), (6, 7)]  globalObject.last last  ",
+  "comments:
+ ",
+  "identifiers:
+ [(4, 6), (7, 3)]  globalObject globalObject  
 [(4, 6), (4, 18)]  globalObject globalObject  
 [(5, 3), (5, 8)]  first first  
 [(6, 3), (6, 7)]  last last  
@@ -380,27 +460,34 @@ identifiers
 [(37, 20), (37, 28)]  sayHello sayHello  
 [(38, 3), (38, 10)]  console console  
 [(38, 11), (38, 14)]  log log  
-[(38, 15), (38, 23)]  greeting greeting  
-variables
-[(4, 6), (7, 3)]   globalObject  
-[(5, 3), (5, 16)]   first  
-[(6, 3), (6, 16)]   last  
-[(8, 21), (8, 25)]   name  
-[(22, 8), (24, 3)]   capitalize  
-[(22, 21), (22, 25)]   name  
-[(25, 8), (28, 14)]   greetAll  
-[(37, 9), (37, 36)]   greeting  "
+[(38, 15), (38, 23)]  greeting greeting  ",
+]
 `;
 
 exports[`Parser.getSymbols func 1`] = `
-"properties
-[(24, 2), (24, 5)]  obj.foo foo  
-member expressions
-
-call expressions
-[(19, 1), (21, 1)]   undefined  
-identifiers
-[(1, 9), (1, 15)]  square square  
+Array [
+  "functions:
+ [(1, 0), (3, 1)]   square n 
+[(5, 7), (7, 1)]   exFoo  
+[(9, 0), (11, 1)]   slowFoo  
+[(13, 7), (15, 1)]   exSlowFoo  
+[(17, 8), (17, 21)]   child  
+[(19, 1), (21, 1)]   anonymous  
+[(24, 7), (26, 3)]   name  
+[(28, 2), (30, 3)]   bar  ",
+  "variables:
+ [(1, 16), (1, 17)]   n  
+[(23, 6), (31, 1)]   obj  ",
+  "callExpressions:
+ [(19, 1), (21, 1)]   undefined  ",
+  "memberExpressions:
+ ",
+  "objectProperties:
+ [(24, 2), (24, 5)]  obj.foo foo  ",
+  "comments:
+ ",
+  "identifiers:
+ [(1, 9), (1, 15)]  square square  
 [(1, 16), (1, 17)]  n n  
 [(2, 9), (2, 10)]  n n  
 [(2, 13), (2, 14)]  n n  
@@ -412,22 +499,34 @@ identifiers
 [(23, 6), (23, 9)]  obj obj  
 [(24, 2), (24, 5)]  foo foo  
 [(24, 16), (24, 20)]  name name  
-[(28, 2), (28, 5)]  bar bar  
-variables
-[(1, 16), (1, 17)]   n  
-[(23, 6), (31, 1)]   obj  "
+[(28, 2), (28, 5)]  bar bar  ",
+]
 `;
 
 exports[`Parser.getSymbols math 1`] = `
-"properties
-
-member expressions
-
-call expressions
-[(5, 14), (5, 20)]   square  
-[(6, 15), (6, 22)]   squaare  
-identifiers
-[(1, 9), (1, 13)]  math math  
+Array [
+  "functions:
+ [(1, 0), (8, 1)]   math n 
+[(2, 2), (4, 3)]   square n 
+[(10, 12), (10, 25)]   child  
+[(11, 9), (11, 22)]   child2  ",
+  "variables:
+ [(1, 14), (1, 15)]   n  
+[(2, 18), (2, 19)]   n  
+[(5, 8), (5, 23)]   two  
+[(6, 8), (6, 25)]   four  
+[(10, 4), (10, 25)]   child  ",
+  "callExpressions:
+ [(5, 14), (5, 20)]   square  
+[(6, 15), (6, 22)]   squaare  ",
+  "memberExpressions:
+ ",
+  "objectProperties:
+ ",
+  "comments:
+ ",
+  "identifiers:
+ [(1, 9), (1, 13)]  math math  
 [(1, 14), (1, 15)]  n n  
 [(2, 11), (2, 17)]  square square  
 [(2, 18), (2, 19)]  n n  
@@ -443,28 +542,38 @@ identifiers
 [(7, 15), (7, 19)]  four four  
 [(10, 4), (10, 25)]  child child  
 [(10, 4), (10, 9)]  child child  
-[(11, 0), (11, 6)]  child2 child2  
-variables
-[(1, 14), (1, 15)]   n  
-[(2, 18), (2, 19)]   n  
-[(5, 8), (5, 23)]   two  
-[(6, 8), (6, 25)]   four  
-[(10, 4), (10, 25)]   child  "
+[(11, 0), (11, 6)]  child2 child2  ",
+]
 `;
 
 exports[`Parser.getSymbols proto 1`] = `
-"properties
-[(6, 2), (6, 9)]   tagName  
-[(7, 2), (7, 12)]   initialize  
-[(11, 2), (11, 8)]   render  
-member expressions
-[(5, 31), (5, 37)] [(5, 17), (5, 37)] Backbone.View.extend extend  
+Array [
+  "functions:
+ [(1, 12), (1, 25)]   foo  
+[(3, 12), (3, 20)]   bar  
+[(7, 14), (7, 27)]   initialize  
+[(8, 2), (10, 3)]   doThing b 
+[(11, 10), (13, 3)]   render  ",
+  "variables:
+ [(1, 6), (1, 25)]   foo  
+[(3, 6), (3, 20)]   bar  
+[(5, 6), (14, 2)]   TodoView  
+[(6, 2), (6, 15)]   tagName  
+[(8, 10), (8, 11)]   b  ",
+  "callExpressions:
+ ",
+  "memberExpressions:
+ [(5, 31), (5, 37)] [(5, 17), (5, 37)] Backbone.View.extend extend  
 [(5, 26), (5, 30)] [(5, 17), (5, 30)] Backbone.View View  
-[(9, 12), (9, 15)] [(9, 4), (9, 15)] console.log log  
-call expressions
-
-identifiers
-[(1, 6), (1, 25)]  foo foo  
+[(9, 12), (9, 15)] [(9, 4), (9, 15)] console.log log  ",
+  "objectProperties:
+ [(6, 2), (6, 9)]   tagName  
+[(7, 2), (7, 12)]   initialize  
+[(11, 2), (11, 8)]   render  ",
+  "comments:
+ ",
+  "identifiers:
+ [(1, 6), (1, 25)]  foo foo  
 [(1, 6), (1, 9)]  foo foo  
 [(3, 6), (3, 20)]  bar bar  
 [(3, 6), (3, 9)]  bar bar  
@@ -481,24 +590,30 @@ identifiers
 [(9, 12), (9, 15)]  log log  
 [(9, 22), (9, 23)]  b b  
 [(11, 2), (11, 8)]  render render  
-[(12, 11), (12, 15)] [(12, 11), (12, 15)] this this  
-variables
-[(1, 6), (1, 25)]   foo  
-[(3, 6), (3, 20)]   bar  
-[(5, 6), (14, 2)]   TodoView  
-[(6, 2), (6, 15)]   tagName  
-[(8, 10), (8, 11)]   b  "
+[(12, 11), (12, 15)] [(12, 11), (12, 15)] this this  ",
+]
 `;
 
 exports[`Parser.getSymbols var 1`] = `
-"properties
-
-member expressions
-
-call expressions
-
-identifiers
-[(1, 4), (1, 11)]  foo foo  
+Array [
+  "functions:
+ ",
+  "variables:
+ [(1, 4), (1, 11)]   foo  
+[(2, 4), (2, 11)]   bar  
+[(3, 6), (3, 13)]   baz  
+[(4, 6), (4, 11)]   a  
+[(5, 2), (5, 7)]   b  ",
+  "callExpressions:
+ ",
+  "memberExpressions:
+ ",
+  "objectProperties:
+ ",
+  "comments:
+ ",
+  "identifiers:
+ [(1, 4), (1, 11)]  foo foo  
 [(1, 4), (1, 7)]  foo foo  
 [(2, 4), (2, 11)]  bar bar  
 [(2, 4), (2, 7)]  bar bar  
@@ -507,11 +622,6 @@ identifiers
 [(4, 6), (4, 11)]  a a  
 [(4, 6), (4, 7)]  a a  
 [(5, 2), (5, 7)]  b b  
-[(5, 2), (5, 3)]  b b  
-variables
-[(1, 4), (1, 11)]   foo  
-[(2, 4), (2, 11)]   bar  
-[(3, 6), (3, 13)]   baz  
-[(4, 6), (4, 11)]   a  
-[(5, 2), (5, 7)]   b  "
+[(5, 2), (5, 3)]  b b  ",
+]
 `;

--- a/src/utils/parser/tests/__snapshots__/getSymbols.spec.js.snap
+++ b/src/utils/parser/tests/__snapshots__/getSymbols.spec.js.snap
@@ -109,6 +109,41 @@ variables
 [(13, 4), (13, 30)]   expressiveClass "
 `;
 
+exports[`Parser.getSymbols component 1`] = `
+"properties
+
+member expressions
+[(6, 9), (6, 16)] [(6, 4), (6, 16)] this.onClick onClick 
+[(6, 32), (6, 36)] [(6, 19), (6, 36)] this.onClick.bind bind 
+[(6, 24), (6, 31)] [(6, 19), (6, 31)] this.onClick onClick 
+[(14, 30), (14, 37)] [(14, 25), (14, 37)] this.onClick onClick 
+call expressions
+[(5, 4), (5, 9)]   undefined 
+identifiers
+[(1, 7), (1, 12)]  React React 
+[(1, 16), (1, 25)]  Component Component 
+[(1, 16), (1, 25)]  Component Component 
+[(3, 6), (3, 11)]  Punny Punny 
+[(4, 2), (4, 13)]  constructor constructor 
+[(4, 14), (4, 19)]  props props 
+[(6, 4), (6, 8)] [(6, 4), (6, 8)] this this 
+[(6, 9), (6, 16)]  onClick onClick 
+[(6, 19), (6, 23)] [(6, 19), (6, 23)] this this 
+[(6, 24), (6, 31)]  onClick onClick 
+[(6, 32), (6, 36)]  bind bind 
+[(6, 37), (6, 41)] [(6, 37), (6, 41)] this this 
+[(9, 2), (9, 19)]  componentDidMount componentDidMount 
+[(11, 2), (11, 9)]  onClick onClick 
+[(13, 2), (13, 10)]  renderMe renderMe 
+[(14, 25), (14, 29)] [(14, 25), (14, 29)] this this 
+[(14, 30), (14, 37)]  onClick onClick 
+[(17, 2), (17, 8)]  render render 
+[(3, 20), (3, 29)]  Component Component 
+variables
+[(3, 0), (18, 1)]   Punny 
+[(4, 14), (4, 19)]   props "
+`;
+
 exports[`Parser.getSymbols es6 1`] = `
 "properties
 [(1, 23), (1, 30)]   PROMISE 

--- a/src/utils/parser/tests/fixtures/component.js
+++ b/src/utils/parser/tests/fixtures/component.js
@@ -1,0 +1,18 @@
+import React, { Component } from "react";
+
+class Punny extends Component {
+  constructor(props) {
+    super();
+    this.onClick = this.onClick.bind(this);
+  }
+
+  componentDidMount() {}
+
+  onClick() {}
+
+  renderMe() {
+    return <div onClick={this.onClick} />;
+  }
+
+  render() {}
+}

--- a/src/utils/parser/tests/getSymbols.spec.js
+++ b/src/utils/parser/tests/getSymbols.spec.js
@@ -53,4 +53,9 @@ describe("Parser.getSymbols", () => {
     const symbols = formatSymbols(getSource("parseScriptTags", "html"));
     expect(symbols).toMatchSnapshot();
   });
+
+  it("component", () => {
+    const symbols = formatSymbols(getSource("component"));
+    expect(symbols).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
Associated Issue: #4021

### Summary of Changes

- parsing function symbols now includes the name of the closest ancestor class, or `null` if there is no containing class
- can be used like this:

```diff
diff --git a/src/components/PrimaryPanes/Outline.js b/src/components/PrimaryPanes/Outline.js
index 5c0fac6..97359e6 100644
--- a/src/components/PrimaryPanes/Outline.js
+++ b/src/components/PrimaryPanes/Outline.js
@@ -45,7 +45,7 @@ export class Outline extends Component {
   }

   renderFunction(func: SymbolDeclaration) {
-    const { name, location, parameterNames } = func;
+    const { name, location, parameterNames, klass } = func;

     return (
       <li
@@ -54,6 +54,8 @@ export class Outline extends Component {
         onClick={() => this.selectItem(location)}
       >
         <PreviewFunction func={{ name, parameterNames }} />
+        {" - "}
+        {klass}
       </li>
     );
   }
```

<img width="835" alt="screen shot 2017-09-18 at 12 30 54 pm" src="https://user-images.githubusercontent.com/57372/30555556-70d2363e-9c6d-11e7-8881-2a4d216885f2.png">

### Test Plan

- added component test fixture (should I add more edge cases?)