### PR TITLE
Fix #4031 - Move source and outline tabs to the top of the left pane

### DIFF
--- a/src/components/PrimaryPanes/Sources.css
+++ b/src/components/PrimaryPanes/Sources.css
@@ -101,7 +101,8 @@
 .source-footer .tab {
   flex: 1;
   justify-content: center;
-  border: 1px solid transparent;
+  border-bottom: 1px solid transparent;
+  border-left: 1px solid transparent;
   border-bottom-left-radius: 2px;
   border-bottom-right-radius: 2px;
   display: inline-flex;
@@ -114,15 +115,24 @@
   cursor: default;
 }
 
+.source-footer .tab:first-child {
+  border-left: 0;
+}
+
 .source-footer .tab:hover {
   background-color: var(--theme-toolbar-background-alt);
   border-color: var(--theme-splitter-color);
 }
 
-.source-footer .tab.active {
+.source-footer .tab {
   color: var(--theme-body-color);
   background-color: var(--theme-toolbar-background);
   border-color: var(--theme-splitter-color);
+}
+
+.source-footer .tab.active {
+  background-color: var(--theme-body-background);
+  border-bottom-color: transparent;
 }
 
 .source-footer .tab.active path,

--- a/src/components/PrimaryPanes/Sources.css
+++ b/src/components/PrimaryPanes/Sources.css
@@ -105,8 +105,6 @@
   justify-content: center;
   border-bottom: 1px solid transparent;
   border-left: 1px solid transparent;
-  border-bottom-left-radius: 2px;
-  border-bottom-right-radius: 2px;
   display: inline-flex;
   position: relative;
   transition: all 0.25s ease;

--- a/src/components/PrimaryPanes/Sources.css
+++ b/src/components/PrimaryPanes/Sources.css
@@ -77,10 +77,6 @@
   align-items: center;
 }
 
-.sources-panel .source-footer {
-  position: relative;
-}
-
 .sources-panel .outline {
   display: flex;
   flex: 1;
@@ -94,11 +90,17 @@
   display: none;
 }
 
-.source-footer {
+.source-outline-tabs {
   width: 100%;
+  background: var(--theme-body-background);
+  border-top: 1px solid var(--theme-splitter-color);
+  display: flex;
+  -moz-user-select: none;
+  user-select: none;
+  box-sizing: border-box;
 }
 
-.source-footer .tab {
+.source-outline-tabs .tab {
   flex: 1;
   justify-content: center;
   border-bottom: 1px solid transparent;
@@ -115,27 +117,27 @@
   cursor: default;
 }
 
-.source-footer .tab:first-child {
+.source-outline-tabs .tab:first-child {
   border-left: 0;
 }
 
-.source-footer .tab:hover {
+.source-outline-tabs .tab:hover {
   background-color: var(--theme-toolbar-background-alt);
   border-color: var(--theme-splitter-color);
 }
 
-.source-footer .tab {
+.source-outline-tabs .tab {
   color: var(--theme-body-color);
   background-color: var(--theme-toolbar-background);
   border-color: var(--theme-splitter-color);
 }
 
-.source-footer .tab.active {
+.source-outline-tabs .tab.active {
   background-color: var(--theme-body-background);
   border-bottom-color: transparent;
 }
 
-.source-footer .tab.active path,
-.source-footer .tab:hover path {
+.source-outline-tabs .tab.active path,
+.source-outline-tabs .tab:hover path {
   fill: var(--theme-body-color);
 }

--- a/src/components/PrimaryPanes/index.js
+++ b/src/components/PrimaryPanes/index.js
@@ -31,7 +31,7 @@ class PrimaryPanes extends Component {
   renderShortcut: Function;
   selectedPane: String;
   showPane: Function;
-  renderFooter: Function;
+  renderTabs: Function;
   renderChildren: Function;
   state: SourcesState;
   props: Props;
@@ -42,7 +42,7 @@ class PrimaryPanes extends Component {
 
     this.renderShortcut = this.renderShortcut.bind(this);
     this.showPane = this.showPane.bind(this);
-    this.renderFooter = this.renderFooter.bind(this);
+    this.renderTabs = this.renderTabs.bind(this);
   }
 
   showPane(selectedPane: string) {
@@ -80,7 +80,7 @@ class PrimaryPanes extends Component {
     ];
   }
 
-  renderFooter() {
+  renderTabs() {
     return <div className="source-footer">{this.renderOutlineTabs()}</div>;
   }
 
@@ -121,13 +121,13 @@ class PrimaryPanes extends Component {
     return (
       <div className="sources-panel">
         {this.renderHeader()}
+        {this.renderTabs()}
         <SourcesTree
           sources={sources}
           selectSource={selectSource}
           isHidden={selectedPane === "outline"}
         />
         {outlineComp}
-        {this.renderFooter()}
       </div>
     );
   }

--- a/src/components/PrimaryPanes/index.js
+++ b/src/components/PrimaryPanes/index.js
@@ -81,7 +81,9 @@ class PrimaryPanes extends Component {
   }
 
   renderTabs() {
-    return <div className="source-footer">{this.renderOutlineTabs()}</div>;
+    return (
+      <div className="source-outline-tabs">{this.renderOutlineTabs()}</div>
+    );
   }
 
   renderShortcut() {


### PR DESCRIPTION
Putting this in quick to see how people like it.

<img width="921" alt="after" src="https://user-images.githubusercontent.com/46655/30557641-9d3ab352-9c74-11e7-86a0-f255a21d1825.png">
