### PR TITLE
Fix 4074 - Align tabs to the bottom of the editor header

### DIFF
--- a/src/components/Editor/Editor.css
+++ b/src/components/Editor/Editor.css
@@ -40,7 +40,7 @@
   position: absolute;
   height: calc(100% - 31px);
   width: calc(100% - 1.5px);
-  top: 30px;
+  top: 29px;
   left: 0px;
   --editor-footer-height: 24px;
 }


### PR DESCRIPTION
Fixes the issue mentioned in #4074.

<img width="618" alt="crispheightlight" src="https://user-images.githubusercontent.com/46655/30562512-5435f580-9c84-11e7-96ef-5547eb853d42.png">

<img width="695" alt="crispheightdark" src="https://user-images.githubusercontent.com/46655/30562517-56b138f6-9c84-11e7-92bb-e3be1f866bbe.png">
