### PR TITLE
Group the copy items in the edit context menu

### DIFF
--- a/src/components/Editor/EditorMenu.js
+++ b/src/components/Editor/EditorMenu.js
@@ -105,12 +105,12 @@ function getMenuItems(
   };
 
   const menuItems = [
+    copySource,
     copySourceUrl,
+    copyFunction,
     jumpLabel,
     showSourceMenuItem,
-    blackBoxMenuItem,
-    copySource,
-    copyFunction
+    blackBoxMenuItem
   ];
 
   if (textSelected) {

--- a/src/components/Editor/EditorMenu.js
+++ b/src/components/Editor/EditorMenu.js
@@ -108,6 +108,7 @@ function getMenuItems(
     copySource,
     copySourceUrl,
     copyFunction,
+    { type: "separator" },
     jumpLabel,
     showSourceMenuItem,
     blackBoxMenuItem


### PR DESCRIPTION
Looks odd having them apart.

<img width="425" alt="copy" src="https://user-images.githubusercontent.com/46655/30571288-589c8396-9cac-11e7-9052-ecb181f488fc.png">
