### PR TITLE
Open link

### DIFF
--- a/assets/panel/panel.js
+++ b/assets/panel/panel.js
@@ -32,24 +32,10 @@ DebuggerPanel.prototype = {
       debuggerClient: this.toolbox.target.client,
       sourceMaps: this.toolbox.sourceMapService,
       // Open a link in a new browser tab.
-      openLink: url => {
-        const parentDoc = this.toolbox.doc;
-        if (!parentDoc) {
-          return;
-        }
-
-        const win = parentDoc.querySelector("window");
-        if (!win) {
-          return;
-        }
-
-        const top = win.ownerDocument.defaultView.top;
-        if (!top || typeof top.openUILinkIn !== "function") {
-          return;
-        }
-        top.openUILinkIn(url, "tab");
+      toolboxActions: {
+        openLink: this.openLink.bind(this)
       }
-    });
+    })
 
     this._actions = actions;
     this._store = store;
@@ -70,6 +56,25 @@ DebuggerPanel.prototype = {
 
   _getState: function() {
     return this._store.getState();
+  },
+
+  openLink: function(url) {
+    const parentDoc = this.toolbox.doc;
+    if (!parentDoc) {
+      return;
+    }
+
+    const win = parentDoc.querySelector("window");
+    if (!win) {
+      return;
+    }
+
+    const top = win.ownerDocument.defaultView.top;
+    if (!top || typeof top.openUILinkIn !== "function") {
+      return;
+    }
+
+    top.openUILinkIn(url, "tab");
   },
 
   getFrames: function() {

--- a/assets/panel/panel.js
+++ b/assets/panel/panel.js
@@ -31,8 +31,8 @@ DebuggerPanel.prototype = {
       tabTarget: this.toolbox.target,
       debuggerClient: this.toolbox.target.client,
       sourceMaps: this.toolbox.sourceMapService,
-      // Open a link in a new browser tab.
       toolboxActions: {
+        // Open a link in a new browser tab.
         openLink: this.openLink.bind(this)
       }
     })

--- a/assets/panel/panel.js
+++ b/assets/panel/panel.js
@@ -30,7 +30,25 @@ DebuggerPanel.prototype = {
       threadClient: this.toolbox.threadClient,
       tabTarget: this.toolbox.target,
       debuggerClient: this.toolbox.target.client,
-      sourceMaps: this.toolbox.sourceMapService
+      sourceMaps: this.toolbox.sourceMapService,
+      // Open a link in a new browser tab.
+      openLink: url => {
+        const parentDoc = this.toolbox.doc;
+        if (!parentDoc) {
+          return;
+        }
+
+        const win = parentDoc.querySelector("window");
+        if (!win) {
+          return;
+        }
+
+        const top = win.ownerDocument.defaultView.top;
+        if (!top || typeof top.openUILinkIn !== "function") {
+          return;
+        }
+        top.openUILinkIn(url, "tab");
+      }
     });
 
     this._actions = actions;

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -14,6 +14,7 @@ import * as sourceSearch from "./source-search";
 import * as sourceTree from "./source-tree";
 import * as loadSourceText from "./sources/loadSourceText";
 import * as debuggee from "./debuggee";
+import * as toolbox from "./toolbox";
 
 export default Object.assign(
   {},
@@ -30,5 +31,6 @@ export default Object.assign(
   sourceSearch,
   sourceTree,
   loadSourceText,
-  debuggee
+  debuggee,
+  toolbox
 );

--- a/src/actions/toolbox.js
+++ b/src/actions/toolbox.js
@@ -3,15 +3,21 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+const { isDevelopment } = require("devtools-config");
 
 import type { ThunkArgs } from "./types";
 
 /**
- * @memberof actions/sources
+ * @memberof actions/toolbox
  * @static
  */
 export function openLink(url: string) {
-  return async function({ openLink }: ThunkArgs) {
-    openLink(url);
+  return async function({ openLink: openLinkCommand }: ThunkArgs) {
+    if (isDevelopment()) {
+      const win = window.open(url, "_blank");
+      win.focus();
+    } else {
+      openLinkCommand(url);
+    }
   };
 }

--- a/src/actions/toolbox.js
+++ b/src/actions/toolbox.js
@@ -1,0 +1,17 @@
+// @flow
+
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import type { ThunkArgs } from "./types";
+
+/**
+ * @memberof actions/sources
+ * @static
+ */
+export function openLink(url: string) {
+  return async function({ openLink }: ThunkArgs) {
+    openLink(url);
+  };
+}

--- a/src/actions/types.js
+++ b/src/actions/types.js
@@ -32,7 +32,8 @@ export type ThunkArgs = {
   dispatch: (action: any) => Promise<any>,
   getState: () => State,
   client: any,
-  sourceMaps: any
+  sourceMaps: any,
+  openLink: (url: string) => void
 };
 
 export type Thunk = ThunkArgs => any;

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -23,7 +23,10 @@ function getClient(connection: any) {
   return clientType == "firefox" ? firefox : chrome;
 }
 
-async function onConnect(connection: Object, services: Object) {
+async function onConnect(
+  connection: Object,
+  { services, toolboxActions }: Object
+) {
   // NOTE: the landing page does not connect to a JS process
   if (!connection) {
     return;
@@ -31,7 +34,10 @@ async function onConnect(connection: Object, services: Object) {
 
   const client = getClient(connection);
   const commands = client.clientCommands;
-  const { store, actions, selectors } = bootstrapStore(commands, services);
+  const { store, actions, selectors } = bootstrapStore(commands, {
+    services,
+    toolboxActions
+  });
 
   bootstrapWorkers();
   const { bpClients } = await client.onConnect(connection, actions);

--- a/src/components/Editor/Preview/Popup.js
+++ b/src/components/Editor/Preview/Popup.js
@@ -30,7 +30,8 @@ type Props = {
   onClose: () => void,
   range: EditorRange,
   editor: any,
-  selectSourceURL: (string, Object) => void
+  selectSourceURL: (string, Object) => void,
+  openLink: string => void
 };
 
 export class Popup extends Component {
@@ -101,20 +102,20 @@ export class Popup extends Component {
   }
 
   renderSimplePreview(value: Object) {
+    const { openLink } = this.props;
     return (
       <div className="preview-popup">
         {Rep({
           object: value,
           mode: MODE.LONG,
-          // TODO: Add proper logic here.
-          openLink: () => {}
+          openLink
         })}
       </div>
     );
   }
 
   renderObjectInspector(root: Object) {
-    const { loadObjectProperties, loadedObjects } = this.props;
+    const { loadObjectProperties, loadedObjects, openLink } = this.props;
 
     const getObjectProperties = id => loadedObjects[id];
     const roots = this.getChildren(root, getObjectProperties);
@@ -135,7 +136,7 @@ export class Popup extends Component {
         getObjectEntries={actor => {}}
         loadObjectEntries={grip => {}}
         // TODO: Add proper logic here.
-        openLink={() => {}}
+        openLink={openLink}
       />
     );
   }

--- a/src/components/Editor/Preview/Popup.js
+++ b/src/components/Editor/Preview/Popup.js
@@ -130,13 +130,12 @@ export class Popup extends Component {
         autoExpandDepth={0}
         disableWrap={true}
         disabledFocus={true}
+        openLink={openLink}
         getObjectProperties={getObjectProperties}
         loadObjectProperties={loadObjectProperties}
         // TODO: See https://github.com/devtools-html/debugger.html/issues/3555.
         getObjectEntries={actor => {}}
         loadObjectEntries={grip => {}}
-        // TODO: Add proper logic here.
-        openLink={openLink}
       />
     );
   }

--- a/src/components/Editor/Preview/Popup.js
+++ b/src/components/Editor/Preview/Popup.js
@@ -103,7 +103,12 @@ export class Popup extends Component {
   renderSimplePreview(value: Object) {
     return (
       <div className="preview-popup">
-        {Rep({ object: value, mode: MODE.LONG })}
+        {Rep({
+          object: value,
+          mode: MODE.LONG,
+          // TODO: Add proper logic here.
+          openLink: () => {}
+        })}
       </div>
     );
   }
@@ -129,6 +134,8 @@ export class Popup extends Component {
         // TODO: See https://github.com/devtools-html/debugger.html/issues/3555.
         getObjectEntries={actor => {}}
         loadObjectEntries={grip => {}}
+        // TODO: Add proper logic here.
+        openLink={() => {}}
       />
     );
   }

--- a/src/components/SecondaryPanes/Expressions.js
+++ b/src/components/SecondaryPanes/Expressions.js
@@ -179,6 +179,8 @@ class Expressions extends PureComponent {
             // TODO: See https://github.com/devtools-html/debugger.html/issues/3555.
             getObjectEntries={actor => {}}
             loadObjectEntries={grip => {}}
+            // TODO: Add proper logic here.
+            openLink={() => {}}
           />
           <div className="expression-container__close-btn">
             <CloseButton

--- a/src/components/SecondaryPanes/Expressions.js
+++ b/src/components/SecondaryPanes/Expressions.js
@@ -175,13 +175,12 @@ class Expressions extends PureComponent {
             disabledFocus={true}
             onDoubleClick={(items, options) =>
               this.editExpression(expression, options)}
+            openLink={openLink}
             getObjectProperties={id => loadedObjects[id]}
             loadObjectProperties={loadObjectProperties}
             // TODO: See https://github.com/devtools-html/debugger.html/issues/3555.
             getObjectEntries={actor => {}}
             loadObjectEntries={grip => {}}
-            // TODO: Add proper logic here.
-            openLink={openLink}
           />
           <div className="expression-container__close-btn">
             <CloseButton

--- a/src/components/SecondaryPanes/Expressions.js
+++ b/src/components/SecondaryPanes/Expressions.js
@@ -65,7 +65,8 @@ class Expressions extends PureComponent {
     updateExpression: (string, Expression) => void,
     deleteExpression: Expression => void,
     loadObjectProperties: () => void,
-    loadedObjects: Map<string, any>
+    loadedObjects: Map<string, any>,
+    openLink: (url: string) => void
   };
 
   constructor(...args) {
@@ -140,7 +141,7 @@ class Expressions extends PureComponent {
   }
 
   renderExpression(expression) {
-    const { loadObjectProperties, loadedObjects } = this.props;
+    const { loadObjectProperties, loadedObjects, openLink } = this.props;
     const { editing } = this.state;
     const { input, updating } = expression;
 
@@ -180,7 +181,7 @@ class Expressions extends PureComponent {
             getObjectEntries={actor => {}}
             loadObjectEntries={grip => {}}
             // TODO: Add proper logic here.
-            openLink={() => {}}
+            openLink={openLink}
           />
           <div className="expression-container__close-btn">
             <CloseButton

--- a/src/components/SecondaryPanes/Scopes.js
+++ b/src/components/SecondaryPanes/Scopes.js
@@ -1,5 +1,5 @@
 // @flow
-import React, { PropTypes, PureComponent } from "react";
+import React, { PureComponent } from "react";
 import { bindActionCreators } from "redux";
 import { connect } from "react-redux";
 import actions from "../../actions";
@@ -9,13 +9,26 @@ import {
   getFrameScopes,
   getPause
 } from "../../selectors";
-import { getScopes } from "../../utils/scopes";
 
+import { getScopes } from "../../utils/scopes";
 import { ObjectInspector } from "devtools-reps";
 
 import "./Scopes.css";
 
+import type { Pause, LoadedObject, Frame } from "debugger-html";
+
+type Props = {
+  pauseInfo: Pause,
+  loadedObjects: LoadedObject[],
+  loadObjectProperties: Object => void,
+  selectedFrame: Frame,
+  frameScopes: ?any,
+  openLink: string => void
+};
+
 class Scopes extends PureComponent {
+  props: Props;
+
   state: {
     scopes: any
   };
@@ -47,7 +60,12 @@ class Scopes extends PureComponent {
   }
 
   render() {
-    const { pauseInfo, loadObjectProperties, loadedObjects } = this.props;
+    const {
+      pauseInfo,
+      loadObjectProperties,
+      loadedObjects,
+      openLink
+    } = this.props;
     const { scopes } = this.state;
 
     if (scopes) {
@@ -64,8 +82,7 @@ class Scopes extends PureComponent {
             // TODO: See https://github.com/devtools-html/debugger.html/issues/3555.
             getObjectEntries={actor => {}}
             loadObjectEntries={grip => {}}
-            // TODO: Add proper logic here.
-            openLink={() => {}}
+            openLink={openLink}
           />
         </div>
       );
@@ -81,14 +98,6 @@ class Scopes extends PureComponent {
     );
   }
 }
-
-Scopes.propTypes = {
-  pauseInfo: PropTypes.object,
-  loadedObjects: PropTypes.object,
-  loadObjectProperties: PropTypes.func,
-  selectedFrame: PropTypes.object,
-  frameScopes: PropTypes.object
-};
 
 Scopes.displayName = "Scopes";
 

--- a/src/components/SecondaryPanes/Scopes.js
+++ b/src/components/SecondaryPanes/Scopes.js
@@ -64,6 +64,8 @@ class Scopes extends PureComponent {
             // TODO: See https://github.com/devtools-html/debugger.html/issues/3555.
             getObjectEntries={actor => {}}
             loadObjectEntries={grip => {}}
+            // TODO: Add proper logic here.
+            openLink={() => {}}
           />
         </div>
       );

--- a/src/components/SecondaryPanes/tests/__snapshots__/Expressions.spec.js.snap
+++ b/src/components/SecondaryPanes/tests/__snapshots__/Expressions.spec.js.snap
@@ -26,6 +26,7 @@ ShallowWrapper {
                 loadObjectEntries={[Function]}
                 loadObjectProperties={[Function]}
                 onDoubleClick={[Function]}
+                openLink={undefined}
                 roots={
                     Array [
                         Object {
@@ -65,6 +66,7 @@ ShallowWrapper {
                 loadObjectEntries={[Function]}
                 loadObjectProperties={[Function]}
                 onDoubleClick={[Function]}
+                openLink={undefined}
                 roots={
                     Array [
                         Object {
@@ -120,6 +122,7 @@ ShallowWrapper {
                         loadObjectEntries={[Function]}
                         loadObjectProperties={[Function]}
                         onDoubleClick={[Function]}
+                        openLink={undefined}
                         roots={
                               Array [
                                     Object {
@@ -159,6 +162,7 @@ ShallowWrapper {
                         loadObjectEntries={[Function]}
                         loadObjectProperties={[Function]}
                         onDoubleClick={[Function]}
+                        openLink={undefined}
                         roots={
                               Array [
                                     Object {
@@ -297,6 +301,7 @@ ShallowWrapper {
                                         loadObjectEntries={[Function]}
                                         loadObjectProperties={[Function]}
                                         onDoubleClick={[Function]}
+                                        openLink={undefined}
                                         roots={
                                                   Array [
                                                             Object {
@@ -336,6 +341,7 @@ ShallowWrapper {
                                         loadObjectEntries={[Function]}
                                         loadObjectProperties={[Function]}
                                         onDoubleClick={[Function]}
+                                        openLink={undefined}
                                         roots={
                                                   Array [
                                                             Object {
@@ -391,6 +397,7 @@ ShallowWrapper {
                                         loadObjectEntries={[Function]}
                                         loadObjectProperties={[Function]}
                                         onDoubleClick={[Function]}
+                                        openLink={undefined}
                                         roots={
                                                   Array [
                                                             Object {
@@ -430,6 +437,7 @@ ShallowWrapper {
                                         loadObjectEntries={[Function]}
                                         loadObjectProperties={[Function]}
                                         onDoubleClick={[Function]}
+                                        openLink={undefined}
                                         roots={
                                                   Array [
                                                             Object {
@@ -531,6 +539,7 @@ ShallowWrapper {
                 loadObjectEntries={[Function]}
                 loadObjectProperties={[Function]}
                 onDoubleClick={[Function]}
+                openLink={undefined}
                 roots={
                     Array [
                         Object {
@@ -570,6 +579,7 @@ ShallowWrapper {
                 loadObjectEntries={[Function]}
                 loadObjectProperties={[Function]}
                 onDoubleClick={[Function]}
+                openLink={undefined}
                 roots={
                     Array [
                         Object {
@@ -625,6 +635,7 @@ ShallowWrapper {
                         loadObjectEntries={[Function]}
                         loadObjectProperties={[Function]}
                         onDoubleClick={[Function]}
+                        openLink={undefined}
                         roots={
                               Array [
                                     Object {
@@ -664,6 +675,7 @@ ShallowWrapper {
                         loadObjectEntries={[Function]}
                         loadObjectProperties={[Function]}
                         onDoubleClick={[Function]}
+                        openLink={undefined}
                         roots={
                               Array [
                                     Object {
@@ -802,6 +814,7 @@ ShallowWrapper {
                                         loadObjectEntries={[Function]}
                                         loadObjectProperties={[Function]}
                                         onDoubleClick={[Function]}
+                                        openLink={undefined}
                                         roots={
                                                   Array [
                                                             Object {
@@ -841,6 +854,7 @@ ShallowWrapper {
                                         loadObjectEntries={[Function]}
                                         loadObjectProperties={[Function]}
                                         onDoubleClick={[Function]}
+                                        openLink={undefined}
                                         roots={
                                                   Array [
                                                             Object {
@@ -896,6 +910,7 @@ ShallowWrapper {
                                         loadObjectEntries={[Function]}
                                         loadObjectProperties={[Function]}
                                         onDoubleClick={[Function]}
+                                        openLink={undefined}
                                         roots={
                                                   Array [
                                                             Object {
@@ -935,6 +950,7 @@ ShallowWrapper {
                                         loadObjectEntries={[Function]}
                                         loadObjectProperties={[Function]}
                                         onDoubleClick={[Function]}
+                                        openLink={undefined}
                                         roots={
                                                   Array [
                                                             Object {

--- a/src/main.js
+++ b/src/main.js
@@ -21,7 +21,8 @@ if (isFirefoxPanel()) {
       threadClient,
       tabTarget,
       debuggerClient,
-      sourceMaps
+      sourceMaps,
+      openLink
     }: any) => {
       return onConnect(
         {
@@ -33,7 +34,8 @@ if (isFirefoxPanel()) {
           }
         },
         {
-          sourceMaps
+          sourceMaps,
+          openLink
         }
       );
     },
@@ -49,7 +51,11 @@ if (isFirefoxPanel()) {
 
   bootstrap(React, ReactDOM).then(connection => {
     onConnect(connection, {
-      sourceMaps: require("devtools-source-map")
+      sourceMaps: require("devtools-source-map"),
+      openLink: url => {
+        var win = window.open(url, "_blank");
+        win.focus();
+      }
     });
   });
 }

--- a/src/main.js
+++ b/src/main.js
@@ -22,7 +22,7 @@ if (isFirefoxPanel()) {
       tabTarget,
       debuggerClient,
       sourceMaps,
-      openLink
+      toolboxActions
     }: any) => {
       return onConnect(
         {
@@ -34,8 +34,8 @@ if (isFirefoxPanel()) {
           }
         },
         {
-          sourceMaps,
-          openLink
+          services: { sourceMaps },
+          toolboxActions
         }
       );
     },
@@ -51,11 +51,8 @@ if (isFirefoxPanel()) {
 
   bootstrap(React, ReactDOM).then(connection => {
     onConnect(connection, {
-      sourceMaps: require("devtools-source-map"),
-      openLink: url => {
-        var win = window.open(url, "_blank");
-        win.focus();
-      }
+      services: { sourceMaps: require("devtools-source-map") },
+      toolboxActions: {}
     });
   });
 }

--- a/src/utils/bootstrap.js
+++ b/src/utils/bootstrap.js
@@ -17,12 +17,12 @@ import selectors from "../selectors";
 import App from "../components/App";
 import { prefs } from "./prefs";
 
-export function bootstrapStore(client, services) {
+export function bootstrapStore(client, { services, toolboxActions }) {
   const createStore = configureStore({
     log: getValue("logging.actions"),
     timing: getValue("performance.actions"),
     makeThunkArgs: (args, state) => {
-      return Object.assign({}, args, { client }, services);
+      return Object.assign({}, args, { client }, services, toolboxActions);
     }
   });
 


### PR DESCRIPTION
Associated Issue: #4049

Here's the Pull Request Doc
https://devtools-html.github.io/debugger.html/CONTRIBUTING.html#pull-requests

### Summary of Changes

* Add an `openLink` function in assets/panel.js that open a link in a new tab (as well as a version for the launchpad).
* Create an action that call this openLink function
* Call the action in components that declare `ObjectInspector` or `Reps` component

### Test Plan

- [x] Add `"http://mozilla.org"` as a watch expression, click on the resulting link

---

This is working in launchpad and in toolbox. I am not sure that this should be in an action though, but I didn't want to change too much things to pass it as a prop to the App components and pipe it down.  One thing to have in mind is that we will also need the toolbox integration for the open-in-inspector button on DomElement reps. So maybe all the toolbox integration can be done in the actions/toolbox.js file.  I plan to add a mochitest to make sure we don't regress on this in the different components.

Do tell me if it's not appropriate to have an action that does not dispatch anything (I feel weird about it) and if we should do this in another way.


By the way if we are in a hurry, the first commit of this PR fixes the bug (but does not open the link, which I think is fine since it's a new feature).



