### PR TITLE
fix issue where minified files without js extns do get detected

### DIFF
--- a/src/components/Editor/Footer.js
+++ b/src/components/Editor/Footer.js
@@ -139,11 +139,6 @@ class SourceFooter extends PureComponent {
   }
 
   renderCommands() {
-    const { selectedSource } = this.props;
-    if (!shouldShowPrettyPrint(selectedSource)) {
-      return null;
-    }
-
     return (
       <div className="commands">
         {this.prettyPrintButton()}

--- a/src/utils/pretty-print/index.js
+++ b/src/utils/pretty-print/index.js
@@ -18,13 +18,9 @@ type PrettyPrintOpts = {
 };
 
 export async function prettyPrint({ source, url }: PrettyPrintOpts) {
-  const contentType = source.contentType;
   const indent = 2;
 
-  assert(
-    isJavaScript(source.url, contentType),
-    "Can't prettify non-javascript files."
-  );
+  assert(isJavaScript(source), "Can't prettify non-javascript files.");
 
   return await _prettyPrint({
     url,

--- a/src/utils/source.js
+++ b/src/utils/source.js
@@ -38,7 +38,7 @@ function shouldPrettyPrint(source: any) {
   }
 
   const _isPretty = isPretty(source);
-  const _isJavaScript = isJavaScript(source.url);
+  const _isJavaScript = isJavaScript(source);
   const isOriginal = isOriginalId(source.id);
   const hasSourceMap = source.sourceMapURL;
 
@@ -59,10 +59,10 @@ function shouldPrettyPrint(source: any) {
  * @memberof utils/source
  * @static
  */
-function isJavaScript(url: ?string, contentType: string = ""): boolean {
+function isJavaScript(source: Source): boolean {
   return (
-    (url && /\.(jsm|js)?$/.test(trimUrlQuery(url))) ||
-    contentType.includes("javascript")
+    (source.url && /\.(jsm|js)?$/.test(trimUrlQuery(source.url))) ||
+    !!(source.contentType && source.contentType.includes("javascript"))
   );
 }
 

--- a/src/utils/tests/source.spec.js
+++ b/src/utils/tests/source.spec.js
@@ -2,7 +2,8 @@ import {
   getFilename,
   getMode,
   getSourceLineCount,
-  isThirdParty
+  isThirdParty,
+  isJavaScript
 } from "../source.js";
 
 describe("sources", () => {
@@ -19,6 +20,22 @@ describe("sources", () => {
           id: ""
         })
       ).toBe("hello.html");
+    });
+  });
+
+  describe("isJavaScript", () => {
+    it("is not JavaScript", () => {
+      expect(isJavaScript({ url: "foo.html" })).toBe(false);
+      expect(isJavaScript({ contentType: "text/html" })).toBe(false);
+    });
+
+    it("is JavaScript", () => {
+      expect(isJavaScript({ url: "foo.js" })).toBe(true);
+      expect(isJavaScript({ url: "bar.jsm" })).toBe(true);
+      expect(isJavaScript({ contentType: "text/javascript" })).toBe(true);
+      expect(isJavaScript({ contentType: "application/javascript" })).toBe(
+        true
+      );
     });
   });
 


### PR DESCRIPTION
Associated Issue: #2782

### Summary of Changes

* pass source object to `isJavaScript` function instead 
* remove uneccessary shouldPrettyPrint check
* add tests

### Test Plan
- [x] go to https://www.google.com
- [x] In the Source tree select https://www.google.com/xjs/_/js/k=xjs.s.en_US._6_2EfjINk4.O/m=sx,c,sb,cdos,cr,elog,hsm,jsa,r,qsm,d,csi/am=wCJGjhccAPk_IRQStxAWyAImDiA/rt=j/d=1/t=zcms/rs=ACT90oFAvRO4FrdrO03G04l7APidtFKo3w or any of the minified files
- [x] Check for the pretty print button at the bottom

### Screenshots/Videos

#### Before
![](http://g.recordit.co/WCpd4BJCrB.gif)

#### After
![](http://g.recordit.co/Y06GNwz9T6.gif)
