### PR TITLE
Breakpoint contextmenu: add "Add/Edit breakpoint condition"

### DIFF
--- a/assets/panel/debugger.properties
+++ b/assets/panel/debugger.properties
@@ -247,8 +247,10 @@ breakpointMenuItem.deleteAll=Remove all breakpoints
 breakpointMenuItem.deleteAll.accesskey=a
 breakpointMenuItem.removeCondition.label=Remove breakpoint condition
 breakpointMenuItem.removeCondition.accesskey=c
-breakpointMenuItem.addOrEditCondition.label=Add/Edit breakpoint condition
-breakpointMenuItem.addOrEditCondition.accesskey=n
+breakpointMenuItem.addCondition.label=Add breakpoint condition
+breakpointMenuItem.addCondition.accesskey=A
+breakpointMenuItem.editCondition.label=Edit breakpoint condition
+breakpointMenuItem.editCondition.accesskey=n
 
 # LOCALIZATION NOTE (breakpoints.header): Breakpoints right sidebar pane header.
 breakpoints.header=Breakpoints

--- a/assets/panel/debugger.properties
+++ b/assets/panel/debugger.properties
@@ -247,8 +247,8 @@ breakpointMenuItem.deleteAll=Remove all breakpoints
 breakpointMenuItem.deleteAll.accesskey=a
 breakpointMenuItem.removeCondition.label=Remove breakpoint condition
 breakpointMenuItem.removeCondition.accesskey=c
-breakpointMenuItem.editCondition.label=Edit breakpoint condition
-breakpointMenuItem.editCondition.accesskey=n
+breakpointMenuItem.addOrEditCondition.label=Add/Edit breakpoint condition
+breakpointMenuItem.addOrEditCondition.accesskey=n
 
 # LOCALIZATION NOTE (breakpoints.header): Breakpoints right sidebar pane header.
 breakpoints.header=Breakpoints

--- a/src/actions/ui.js
+++ b/src/actions/ui.js
@@ -1,8 +1,9 @@
 // @flow
-import { getSource, getActiveSearch } from "../selectors";
+import { getSource, getActiveSearch, getSelectedSource } from "../selectors";
 import type { ThunkArgs } from "./types";
 import type { ActiveSearchType, SymbolSearchType } from "../reducers/ui";
 import { clearSourceSearchQuery } from "./source-search";
+import { selectSource } from "./sources";
 
 export function closeActiveSearch() {
   return ({ getState, dispatch }: ThunkArgs) => {
@@ -119,8 +120,14 @@ export function clearHighlightLineRange() {
 }
 
 export function toggleConditionalBreakpointPanel(line: null | number) {
-  return {
-    type: "TOGGLE_CONDITIONAL_BREAKPOINT_PANEL",
-    line
+  return ({ dispatch, getState }: ThunkArgs) => {
+    const selectedSource = getSelectedSource(getState());
+    const sourceId = selectedSource.get("id");
+    dispatch(selectSource(sourceId, { line }));
+
+    dispatch({
+      type: "TOGGLE_CONDITIONAL_BREAKPOINT_PANEL",
+      line
+    });
   };
 }

--- a/src/components/SecondaryPanes/Breakpoints.js
+++ b/src/components/SecondaryPanes/Breakpoints.js
@@ -125,8 +125,8 @@ class Breakpoints extends PureComponent {
     const removeConditionLabel = L10N.getStr(
       "breakpointMenuItem.removeCondition.label"
     );
-    const editConditionLabel = L10N.getStr(
-      "breakpointMenuItem.editCondition.label"
+    const addOrEditConditionLabel = L10N.getStr(
+      "breakpointMenuItem.addOrEditCondition.label"
     );
 
     const deleteSelfKey = L10N.getStr(
@@ -155,8 +155,8 @@ class Breakpoints extends PureComponent {
     const removeConditionKey = L10N.getStr(
       "breakpointMenuItem.removeCondition.accesskey"
     );
-    const editConditionKey = L10N.getStr(
-      "breakpointMenuItem.editCondition.accesskey"
+    const addOrEditConditionKey = L10N.getStr(
+      "breakpointMenuItem.addOrEditCondition.accesskey"
     );
 
     const otherBreakpoints = breakpoints.filter(b => b !== breakpoint);
@@ -248,11 +248,16 @@ class Breakpoints extends PureComponent {
       click: () => setBreakpointCondition(breakpoint.location)
     };
 
-    const editCondition = {
+    const addOrEditCondition = {
       id: "node-menu-edit-condition",
-      label: editConditionLabel,
-      accesskey: editConditionKey,
-      click: () => toggleConditionalBreakpointPanel(breakpoint.location.line)
+      label: addOrEditConditionLabel,
+      accesskey: addOrEditConditionKey,
+      click: () => {
+        const sourceId = breakpoint.location.sourceId;
+        const line = breakpoint.location.line;
+        this.props.selectSource(sourceId, { line });
+        toggleConditionalBreakpointPanel(breakpoint.location.line);
+      }
     };
 
     const items = [
@@ -278,11 +283,10 @@ class Breakpoints extends PureComponent {
         hidden: () => otherEnabledBreakpoints.size === 0
       },
       {
-        item: removeCondition,
-        hidden: () => !breakpoint.condition
+        item: addOrEditCondition
       },
       {
-        item: editCondition,
+        item: removeCondition,
         hidden: () => !breakpoint.condition
       }
     ];

--- a/src/components/SecondaryPanes/Breakpoints.js
+++ b/src/components/SecondaryPanes/Breakpoints.js
@@ -125,8 +125,11 @@ class Breakpoints extends PureComponent {
     const removeConditionLabel = L10N.getStr(
       "breakpointMenuItem.removeCondition.label"
     );
-    const addOrEditConditionLabel = L10N.getStr(
-      "breakpointMenuItem.addOrEditCondition.label"
+    const addConditionLabel = L10N.getStr(
+      "breakpointMenuItem.addCondition.label"
+    );
+    const editConditionLabel = L10N.getStr(
+      "breakpointMenuItem.editCondition.label"
     );
 
     const deleteSelfKey = L10N.getStr(
@@ -155,8 +158,11 @@ class Breakpoints extends PureComponent {
     const removeConditionKey = L10N.getStr(
       "breakpointMenuItem.removeCondition.accesskey"
     );
-    const addOrEditConditionKey = L10N.getStr(
-      "breakpointMenuItem.addOrEditCondition.accesskey"
+    const addConditionKey = L10N.getStr(
+      "breakpointMenuItem.addCondition.accesskey"
+    );
+    const editConditionKey = L10N.getStr(
+      "breakpointMenuItem.editCondition.accesskey"
     );
 
     const otherBreakpoints = breakpoints.filter(b => b !== breakpoint);
@@ -248,10 +254,17 @@ class Breakpoints extends PureComponent {
       click: () => setBreakpointCondition(breakpoint.location)
     };
 
-    const addOrEditCondition = {
+    const editCondition = {
       id: "node-menu-edit-condition",
-      label: addOrEditConditionLabel,
-      accesskey: addOrEditConditionKey,
+      label: editConditionLabel,
+      accesskey: editConditionKey,
+      click: () => toggleConditionalBreakpointPanel(breakpoint.location.line)
+    };
+
+    const addCondition = {
+      id: "node-menu-add-condition",
+      label: addConditionLabel,
+      accesskey: addConditionKey,
       click: () => {
         const sourceId = breakpoint.location.sourceId;
         const line = breakpoint.location.line;
@@ -283,7 +296,12 @@ class Breakpoints extends PureComponent {
         hidden: () => otherEnabledBreakpoints.size === 0
       },
       {
-        item: addOrEditCondition
+        item: addCondition,
+        hidden: () => breakpoint.condition
+      },
+      {
+        item: editCondition,
+        hidden: () => !breakpoint.condition
       },
       {
         item: removeCondition,

--- a/src/components/SecondaryPanes/Breakpoints.js
+++ b/src/components/SecondaryPanes/Breakpoints.js
@@ -265,12 +265,7 @@ class Breakpoints extends PureComponent {
       id: "node-menu-add-condition",
       label: addConditionLabel,
       accesskey: addConditionKey,
-      click: () => {
-        const sourceId = breakpoint.location.sourceId;
-        const line = breakpoint.location.line;
-        this.props.selectSource(sourceId, { line });
-        toggleConditionalBreakpointPanel(breakpoint.location.line);
-      }
+      click: () => toggleConditionalBreakpointPanel(breakpoint.location.line)
     };
 
     const items = [


### PR DESCRIPTION
Associated Issue: NONE

@jasonLaster suggested this feature on slack

### Summary of Changes

* renamed contextmenu entry 
* jump to breakpoint location

![conditional](https://user-images.githubusercontent.com/2511026/30609627-38d49366-9d7c-11e7-8ba4-06fbcf6ecaa1.gif)
