### PR TITLE
stop setting state in componentDidMount

### DIFF
--- a/src/components/shared/ManagedTree.js
+++ b/src/components/shared/ManagedTree.js
@@ -52,7 +52,7 @@ class ManagedTree extends Component {
     self.focusItem = this.focusItem.bind(this);
   }
 
-  componentDidMount() {
+  componentWillMount() {
     const { expanded } = this.props;
     if (expanded && expanded.size > 0) {
       this.setState({ expanded });


### PR DESCRIPTION
Associated Issue: #<issue number>

### Summary of Changes

* move the expanded state set up to `componentWillMount`
* Fix the react warning
