### PR TITLE
Make watch expressions safe

### DIFF
--- a/src/actions/expressions.js
+++ b/src/actions/expressions.js
@@ -2,7 +2,7 @@
 
 import { PROMISE } from "../utils/redux/middleware/promise";
 import { getExpression, getExpressions, getSelectedFrame } from "../selectors";
-
+import { wrapExpression } from "../utils/expressions";
 import type { Expression } from "../types";
 import type { ThunkArgs } from "./types";
 
@@ -103,10 +103,11 @@ function evaluateExpression(expression: Expression, frameId: frameIdType) {
       return;
     }
 
+    const input = wrapExpression(expression.input);
     return dispatch({
       type: "EVALUATE_EXPRESSION",
       input: expression.input,
-      [PROMISE]: client.evaluate(expression.input, { frameId })
+      [PROMISE]: client.evaluate(input, { frameId })
     });
   };
 }

--- a/src/utils/expressions.js
+++ b/src/utils/expressions.js
@@ -1,0 +1,22 @@
+// @flow
+
+// replace quotes and slashes that could interfere with the evaluation.
+export function sanitizeInput(input: string) {
+  return input.replace(/\\/g, "\\\\").replace(/"/g, "\\$&");
+}
+
+/*
+ * wrap the expression input in a try/catch so that it can be safely
+ * evaluated.
+ *
+ * NOTE: we add line after the expression to protect against comments.
+*/
+export function wrapExpression(input: string) {
+  return `eval(\`
+    try {
+      ${sanitizeInput(input)}
+    } catch (e) {
+      e
+    }
+  \`)`.trim();
+}

--- a/src/utils/tests/__snapshots__/expressions.spec.js.snap
+++ b/src/utils/tests/__snapshots__/expressions.spec.js.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`expressions wrap expression 1`] = `
+"eval(\`
+    try {
+      foo
+    } catch (e) {
+      e
+    }
+  \`)"
+`;
+
+exports[`expressions wrap expression with a comment 1`] = `
+"eval(\`
+    try {
+      foo // yo yo
+    } catch (e) {
+      e
+    }
+  \`)"
+`;

--- a/src/utils/tests/expressions.spec.js
+++ b/src/utils/tests/expressions.spec.js
@@ -1,0 +1,19 @@
+import { wrapExpression, sanitizeInput } from "../expressions";
+
+describe("expressions", () => {
+  it("wrap expression", () => {
+    expect(wrapExpression("foo")).toMatchSnapshot();
+  });
+
+  it("wrap expression with a comment", () => {
+    expect(wrapExpression("foo // yo yo")).toMatchSnapshot();
+  });
+
+  it("sanitizes quotes", () => {
+    expect(sanitizeInput('foo"')).toEqual('foo\\"');
+  });
+
+  it("sanitizes forward slashes", () => {
+    expect(sanitizeInput("foo\\\\")).toEqual("foo\\\\\\\\");
+  });
+});


### PR DESCRIPTION
Associated Issue: #4106

### Summary of Changes

* wraps expressions in a try/catch

### Test Plan

unit tests