### PR TITLE
Changed vertical overflow to auto for command bar

### DIFF
--- a/src/components/SecondaryPanes/SecondaryPanes.css
+++ b/src/components/SecondaryPanes/SecondaryPanes.css
@@ -13,7 +13,7 @@
   Ref: https://github.com/devtools-html/debugger.html/issues/3426
 */
 .secondary-panes--sticky-commandbar {
-  overflow-y: scroll;
+  overflow-y: auto;
 }
 
 .secondary-panes .accordion {


### PR DESCRIPTION
Improves the view on the command bar on Chrome.

### Summary of Changes

* Change the style for command bar `overflow-y:scroll` to `overflow-y:auto`

### Test Plan

Tested on Chrome and Firefox and still works when the scrollbar is there.

### Screenshots/Videos

Chrome before fix:
![image](https://user-images.githubusercontent.com/9325039/30751202-42e25f38-9f7e-11e7-9e95-fb79f1c6199b.png)

Chrome after fix:
![image](https://user-images.githubusercontent.com/9325039/30751113-fcb4bc22-9f7d-11e7-84ab-a4d9d5ce2d86.png)