### PR TITLE
Simplify scope display names

### DIFF
--- a/assets/panel/debugger.properties
+++ b/assets/panel/debugger.properties
@@ -698,3 +698,7 @@ whyPaused.other=Debugger paused
 # LOCALIZATION NOTE (ctrl): The text that is used for documenting
 # keyboard shortcuts that use the control key
 ctrl=Ctrl
+
+# LOCALIZATION NOTE (anonymous): The text that is displayed when the
+# display name is null.
+anonymous=(anonymous)

--- a/src/client/firefox/create.js
+++ b/src/client/firefox/create.js
@@ -13,7 +13,8 @@ export function createFrame(frame: FramePacket): Frame {
   let title;
   if (frame.type == "call") {
     const c = frame.callee;
-    title = c.name || c.userDisplayName || c.displayName || "(anonymous)";
+    title =
+      c.name || c.userDisplayName || c.displayName || L10N.getStr("anonymous");
   } else {
     title = `(${frame.type})`;
   }

--- a/src/utils/scopes.js
+++ b/src/utils/scopes.js
@@ -2,6 +2,7 @@
 
 import { toPairs } from "lodash";
 import { get } from "lodash";
+import { simplifyDisplayName } from "./frame";
 import type { Frame, Pause, Scope } from "debugger-html";
 
 type ScopeData = {
@@ -96,7 +97,9 @@ export function getScopes(
       const bindings = scope.bindings;
       let title;
       if (type === "function") {
-        title = scope.function.displayName || "(anonymous)";
+        title = scope.function.displayName
+          ? simplifyDisplayName(scope.function.displayName)
+          : L10N.getStr("anonymous");
       } else {
         title = L10N.getStr("scopes.block");
       }


### PR DESCRIPTION
Associated Issue: #3974 

### Summary of Changes

* Simplify the display name
* Added Localization for `(anonymous)`

### Test Plan

I used Jason's test example https://cray-scopes.glitch.me/

### Screenshots/Videos

In this example `stuff/Foo<` has been changed to `Foo`.
![image](https://user-images.githubusercontent.com/9325039/30752971-8ef2fd38-9f83-11e7-83d5-5573626d846c.png)
