### PR TITLE
Scroll bar is not ignored in vertical mode calculations

### DIFF
--- a/src/components/SecondaryPanes/CommandBar.css
+++ b/src/components/SecondaryPanes/CommandBar.css
@@ -10,10 +10,6 @@
   background-color: var(--theme-toolbar-background);
 }
 
-.command-bar.vertical {
-  width: 100vw;
-}
-
 html[dir="rtl"] .command-bar {
   border-right: 1px solid var(--theme-splitter-color);
 }

--- a/src/components/SecondaryPanes/index.js
+++ b/src/components/SecondaryPanes/index.js
@@ -205,7 +205,6 @@ class SecondaryPanes extends Component {
   renderVerticalLayout() {
     return (
       <SplitBox
-        style={{ width: "100vw" }}
         initialSize="300px"
         minSize={10}
         maxSize="50%"


### PR DESCRIPTION
Associated Issue: #4032

### Summary of Changes

* Removed inline styles for Split-Box
* Removed `command-box.vertical` style

### Screenshots/Videos

Before:
![image](https://user-images.githubusercontent.com/9325039/30755282-a2d9c9e6-9f8b-11e7-89d4-d383a98bc23f.png)

After:
![image](https://user-images.githubusercontent.com/9325039/30755143-272fb314-9f8b-11e7-8572-dc806ade646c.png)

