### PR TITLE
Accessible collapse pane buttons

### DIFF
--- a/src/components/App.css
+++ b/src/components/App.css
@@ -2,6 +2,16 @@
   box-sizing: border-box;
 }
 
+button {
+  background: transparent;
+  outline: none;
+  border: none;
+}
+
+button:hover,button:focus {
+  background-color: var(--theme-toolbar-background-hover);
+}
+
 .debugger {
   display: flex;
   flex: 1;

--- a/src/components/shared/Button/PaneToggle.css
+++ b/src/components/shared/Button/PaneToggle.css
@@ -1,13 +1,13 @@
 .toggle-button-start,
 .toggle-button-end {
-  transform: translate(0, 2px);
+  transform: translate(0, 0px);
   transition: transform 0.25s ease-in-out;
-  padding: 5px 2px;
+  padding: 5px 5px;
 }
 
 .toggle-button-start.vertical,
 .toggle-button-end.vertical {
-  padding: 4px 2px;
+  padding: 2.5px 2.5px;
 }
 
 .toggle-button-start svg,
@@ -22,12 +22,12 @@
 }
 
 .toggle-button-end {
-  margin-inline-end: 5px;
+  margin-inline-end: 0px;
   margin-inline-start: auto;
 }
 
 .toggle-button-start {
-  margin-inline-start: 5px;
+  margin-inline-start: 0px;
 }
 
 html:not([dir="rtl"]) .toggle-button-end svg,

--- a/src/components/shared/Button/PaneToggle.js
+++ b/src/components/shared/Button/PaneToggle.js
@@ -30,7 +30,7 @@ class PaneToggleButton extends Component {
       : L10N.getStr("collapsePanes");
 
     return (
-      <div
+      <button
         className={classnames(`toggle-button-${position}`, {
           collapsed,
           vertical: horizontal != null ? !horizontal : false
@@ -39,7 +39,7 @@ class PaneToggleButton extends Component {
         title={title}
       >
         <Svg name="togglePanes" />
-      </div>
+      </button>
     );
   }
 }


### PR DESCRIPTION
Associated Issue: #4073

### Summary of Changes

* Buttons were made reachable with the keyboard 
* hover/focus styling were added to buttons
* Buttons are made actionable with the keyboard - return/Space collapses/expands panes

### Test Plan

- [x] Open debugger
- [x] hover over buttons
- [x] click on source tree and tab to buttons
- [x] press space/return to collapse/expand panes]

### Video
![](http://g.recordit.co/YuEPJ6nvjk.gif)