### PR TITLE
Scroll bar overlap fix

### DIFF
--- a/src/components/SecondaryPanes/SecondaryPanes.css
+++ b/src/components/SecondaryPanes/SecondaryPanes.css
@@ -13,11 +13,13 @@
   Ref: https://github.com/devtools-html/debugger.html/issues/3426
 */
 .secondary-panes--sticky-commandbar {
-  overflow-y: scroll;
+  overflow-y: hidden;
 }
 
 .secondary-panes .accordion {
-  flex: 1 0 auto;
+  flex-grow: 1;
+  flex-basis: auto;
+  overflow-y: auto;
 }
 
 .pane {


### PR DESCRIPTION
Fixed the issue with the scroll bar invading the command bar's space.

### Summary of Changes

* Removed the flex-shrink attribute
* Changed `overflow-y: scroll` to `overflow-y: hidden` (will probably cause a conflict with my other PR 😢)

### Test Plan

* Tested that it shows when there is enough content to show the scroll bar
* Tested that it hides when there is not enough content to show the scroll bar

### Screenshots/Videos

![image](https://user-images.githubusercontent.com/9325039/30761187-fe552bfa-9fa2-11e7-8b06-10c04c914529.png)
