### PR TITLE
Remove tab header search shortcut

### DIFF
--- a/src/components/PrimaryPanes/Sources.css
+++ b/src/components/PrimaryPanes/Sources.css
@@ -12,38 +12,6 @@
   user-select: none;
 }
 
-.sources-header {
-  height: 29px;
-  background-color: var(--theme-toolbar-background);
-  border-bottom: 1px solid var(--theme-splitter-color);
-  padding-top: 0px;
-  padding-bottom: 0px;
-  line-height: 30px;
-  font-size: 1.2em;
-  display: flex;
-  align-items: baseline;
-  -moz-user-select: none;
-  user-select: none;
-  justify-content: flex-end;
-}
-
-.theme-dark .sources-header {
-  background-color: var(--theme-tab-toolbar-background);
-}
-
-.sources-header {
-  padding-inline-start: 10px;
-}
-
-.sources-header-info {
-  font-size: 12px;
-  color: var(--theme-comment-alt);
-  font-weight: lighter;
-  white-space: nowrap;
-  padding-inline-end: 10px;
-  cursor: default;
-}
-
 .sources-list {
   flex: 1;
   display: flex;
@@ -109,7 +77,7 @@
   position: relative;
   transition: all 0.25s ease;
   overflow: hidden;
-  padding: 5px;
+  padding:6.5px;
   margin-bottom: 0px;
   margin-top: -1px;
   cursor: default;

--- a/src/components/PrimaryPanes/Sources.css
+++ b/src/components/PrimaryPanes/Sources.css
@@ -77,7 +77,7 @@
   position: relative;
   transition: all 0.25s ease;
   overflow: hidden;
-  padding:6.5px;
+  padding: 6.5px;
   margin-bottom: 0px;
   margin-top: -1px;
   cursor: default;

--- a/src/components/PrimaryPanes/index.js
+++ b/src/components/PrimaryPanes/index.js
@@ -105,10 +105,6 @@ class PrimaryPanes extends Component {
     }
   }
 
-  renderHeader() {
-    return <div className="sources-header" />;
-  }
-
   render() {
     const { selectedPane } = this.state;
     const { sources, selectSource } = this.props;

--- a/src/components/PrimaryPanes/index.js
+++ b/src/components/PrimaryPanes/index.js
@@ -134,7 +134,6 @@ class PrimaryPanes extends Component {
   }
 }
 
-PrimaryPanes.displayName = "PrimaryPanes";
 
 export default connect(
   state => ({

--- a/src/components/PrimaryPanes/index.js
+++ b/src/components/PrimaryPanes/index.js
@@ -106,7 +106,7 @@ class PrimaryPanes extends Component {
   }
 
   renderHeader() {
-    return <div className="sources-header">{this.renderShortcut()}</div>;
+    return <div className="sources-header" />;
   }
 
   render() {
@@ -122,7 +122,6 @@ class PrimaryPanes extends Component {
 
     return (
       <div className="sources-panel">
-        {this.renderHeader()}
         {this.renderTabs()}
         <SourcesTree
           sources={sources}
@@ -134,6 +133,8 @@ class PrimaryPanes extends Component {
     );
   }
 }
+
+PrimaryPanes.displayName = "PrimaryPanes";
 
 export default connect(
   state => ({


### PR DESCRIPTION
Associated Issue: #4110

### Summary of Changes

* Remove the tab header search shortcut

![image](https://user-images.githubusercontent.com/31376439/30763890-6ed375fe-9fb6-11e7-95b8-918392d65992.png)
