### PR TITLE
Fix source tabs not lining up with file tabs

### DIFF
--- a/src/components/PrimaryPanes/Sources.css
+++ b/src/components/PrimaryPanes/Sources.css
@@ -77,7 +77,7 @@
   position: relative;
   transition: all 0.25s ease;
   overflow: hidden;
-  padding: 6.5px;
+  padding: 8px 8px 7px 8px;
   margin-bottom: 0px;
   margin-top: -1px;
   cursor: default;


### PR DESCRIPTION
Before:

<img width="467" alt="offbypixel" src="https://user-images.githubusercontent.com/46655/30774074-bcb7016e-a042-11e7-84c8-aaed001aa25e.png">

<img width="328" alt="before" src="https://user-images.githubusercontent.com/46655/30774068-ae3ff8d4-a042-11e7-80fc-d34052329619.png">


After:

<img width="529" alt="fixedline" src="https://user-images.githubusercontent.com/46655/30774069-b46e80ea-a042-11e7-90e9-0c3fff62e821.png">
<img width="429" alt="fixedline2" src="https://user-images.githubusercontent.com/46655/30774071-b98747ce-a042-11e7-92ba-e9032905cf20.png">

