### PR TITLE
Filter out all .css, .png and .svg files from showing up in Sources tree

### DIFF
--- a/src/utils/sources-tree/index.js
+++ b/src/utils/sources-tree/index.js
@@ -18,5 +18,5 @@ export {
   createNode,
   createParentMap,
   getRelativePath,
-  isCssPngSvg
+  isNotJavaScript
 } from "./utils";

--- a/src/utils/sources-tree/index.js
+++ b/src/utils/sources-tree/index.js
@@ -17,5 +17,6 @@ export {
   isDirectory,
   createNode,
   createParentMap,
-  getRelativePath
+  getRelativePath,
+  isCssPngSvg
 } from "./utils";

--- a/src/utils/sources-tree/tests/utils.spec.js
+++ b/src/utils/sources-tree/tests/utils.spec.js
@@ -10,7 +10,8 @@ import {
   addToTree,
   sortEntireTree,
   getURL,
-  getDirectories
+  getDirectories,
+  isCssPngSvg
 } from "../index";
 
 describe("sources tree", () => {
@@ -177,4 +178,43 @@ describe("sources tree", () => {
       expect(urlObject.filename).toBe("(index)");
     });
   });
+
+  describe("isCssPngSvg", () => {
+    it("js file", () => {
+      expect(
+        isCssPngSvg({
+          url: "http://example.com/foo.js",
+          contentType: "text/javascript"
+        })
+      ).toBe(false);
+    });
+
+    it("css file", () => {
+      expect(
+        isCssPngSvg({
+          url: "http://example.com/foo.css",
+          contentType: "text/javascript"
+        })
+      ).toBe(true);
+    });
+
+    it("svg file", () => {
+      expect(
+        isCssPngSvg({
+          url: "http://example.com/foo.svg",
+          contentType: "text/javascript"
+        })
+      ).toBe(true);
+    });
+
+    it("png file", () => {
+      expect(
+        isCssPngSvg({
+          url: "http://example.com/foo.png",
+          contentType: "text/javascript"
+        })
+      ).toBe(true);
+    });
+  });
+
 });

--- a/src/utils/sources-tree/tests/utils.spec.js
+++ b/src/utils/sources-tree/tests/utils.spec.js
@@ -11,7 +11,7 @@ import {
   sortEntireTree,
   getURL,
   getDirectories,
-  isCssPngSvg
+  isNotJavaScript
 } from "../index";
 
 describe("sources tree", () => {
@@ -179,39 +179,35 @@ describe("sources tree", () => {
     });
   });
 
-  describe("isCssPngSvg", () => {
+  describe("isNotJavaScript", () => {
     it("js file", () => {
       expect(
-        isCssPngSvg({
-          url: "http://example.com/foo.js",
-          contentType: "text/javascript"
+        isNotJavaScript({
+          url: "http://example.com/foo.js"
         })
       ).toBe(false);
     });
 
     it("css file", () => {
       expect(
-        isCssPngSvg({
-          url: "http://example.com/foo.css",
-          contentType: "text/javascript"
+        isNotJavaScript({
+          url: "http://example.com/foo.css"
         })
       ).toBe(true);
     });
 
     it("svg file", () => {
       expect(
-        isCssPngSvg({
-          url: "http://example.com/foo.svg",
-          contentType: "text/javascript"
+        isNotJavaScript({
+          url: "http://example.com/foo.svg"
         })
       ).toBe(true);
     });
 
     it("png file", () => {
       expect(
-        isCssPngSvg({
-          url: "http://example.com/foo.png",
-          contentType: "text/javascript"
+        isNotJavaScript({
+          url: "http://example.com/foo.png"
         })
       ).toBe(true);
     });

--- a/src/utils/sources-tree/utils.js
+++ b/src/utils/sources-tree/utils.js
@@ -30,7 +30,7 @@ export function isDirectory(url: Object) {
   );
 }
 
-export function isCssPngSvg(source: Object): boolean {
+export function isNotJavaScript(source: Object): boolean {
   const parsedExtension = parse(source.url).pathname.split('.').pop();
 
   return ["css", "svg", "png"].includes(parsedExtension)
@@ -43,7 +43,7 @@ export function isInvalidUrl(url: Object, source: Object) {
     source.get("loadedState") === "loading" ||
     !url.group ||
     isPretty(source.toJS()) ||
-    isCssPngSvg(source.toJS())
+    isNotJavaScript(source.toJS())
   );
 }
 

--- a/src/utils/sources-tree/utils.js
+++ b/src/utils/sources-tree/utils.js
@@ -32,6 +32,11 @@ export function isDirectory(url: Object) {
 
 export function isNotJavaScript(source: Object): boolean {
   const parsedUrl = parse(source.url).pathname
+
+  if !parsedUrl {
+    return false;
+  }
+
   const parsedExtension = parsedUrl.split('.').pop();
 
   return ["css", "svg", "png"].includes(parsedExtension)

--- a/src/utils/sources-tree/utils.js
+++ b/src/utils/sources-tree/utils.js
@@ -30,13 +30,20 @@ export function isDirectory(url: Object) {
   );
 }
 
+export function isCssPngSvg(source: Object): boolean {
+  const parsedExtension = parse(source.url).pathname.split('.').pop();
+
+  return ["css", "svg", "png"].includes(parsedExtension)
+}
+
 export function isInvalidUrl(url: Object, source: Object) {
   return (
     IGNORED_URLS.indexOf(url) != -1 ||
     !source.get("url") ||
     source.get("loadedState") === "loading" ||
     !url.group ||
-    isPretty(source.toJS())
+    isPretty(source.toJS()) ||
+    isCssPngSvg(source.toJS())
   );
 }
 

--- a/src/utils/sources-tree/utils.js
+++ b/src/utils/sources-tree/utils.js
@@ -31,7 +31,8 @@ export function isDirectory(url: Object) {
 }
 
 export function isNotJavaScript(source: Object): boolean {
-  const parsedExtension = parse(source.url).pathname.split('.').pop();
+  const parsedUrl = parse(source.url).pathname
+  const parsedExtension = parsedUrl.split('.').pop();
 
   return ["css", "svg", "png"].includes(parsedExtension)
 }

--- a/src/utils/sources-tree/utils.js
+++ b/src/utils/sources-tree/utils.js
@@ -32,11 +32,9 @@ export function isDirectory(url: Object) {
 
 export function isNotJavaScript(source: Object): boolean {
   const parsedUrl = parse(source.url).pathname
-
-  if !parsedUrl {
+  if (!parsedUrl) {
     return false;
   }
-
   const parsedExtension = parsedUrl.split('.').pop();
 
   return ["css", "svg", "png"].includes(parsedExtension)


### PR DESCRIPTION
Associated Issue: #4137

### Summary of Changes

* Files with extensions .css, .png and .svg are filtered out from the Sources file tree.
