### PR TITLE
Display 'Webpack' (project name) as Sources node

### DIFF
--- a/src/utils/sources-tree/getURL.js
+++ b/src/utils/sources-tree/getURL.js
@@ -30,6 +30,14 @@ export function getURL(sourceUrl: string): { path: string, group: string } {
       // Ignore `javascript:` URLs for now
       return def;
 
+    case "webpack:":
+      // A Webpack source is a special case
+      return merge(def, {
+        path: path,
+        group: "Webpack",
+        filename: filename
+      });
+
     case "about:":
       // An about page is a special case
       return merge(def, {


### PR DESCRIPTION
Associated Issue: #4138

* Display 'Webpack' (project name) as Sources node title, instead of the protocol

![image](https://user-images.githubusercontent.com/31376439/30783641-3ebad3a8-a114-11e7-9835-e24a34b4ba29.png)
