### PR TITLE
Fix (mildly) incorrect scope identification

### DIFF
--- a/src/selectors/linesInScope.js
+++ b/src/selectors/linesInScope.js
@@ -14,7 +14,7 @@ function getOutOfScopeLines(outOfScopeLocations: AstLocation[]) {
 
   return uniq(
     flatMap(outOfScopeLocations, location =>
-      range(location.start.line, location.end.line)
+      range(location.start.line, location.end.line + 1)
     )
   );
 }


### PR DESCRIPTION
Associated Issue: #3705 

### Summary of Changes

* scope identification was not including last line of out-of-scope code as out of scope
* causes a number of side issues along the way

### Test Plan

Example test plan:

- Go to https://css-tricks.com/almanac/properties/s/shape-outside/
- Set a breakpoint in the (index) script at line 248 (if(autocomplete.autocomplete...)
- Scroll the page
=> Script execution will stop at that line.
- Console log the output of getOutOfScopeLines()
- Console log the output of getInScopeLines()

### Screenshots/Videos (OPTIONAL)

Example:

Lines 256-259 are out of scope with reference to line 248.
![lines_out_of_scope](https://user-images.githubusercontent.com/22062107/30784317-1c89541e-a121-11e7-808f-c369d5a773d1.PNG)

Lines 256-258 are caught, but not line 259
Lines out of scope (incorrect):
![lines_out_of_scope_console_array](https://user-images.githubusercontent.com/22062107/30784330-440e1402-a121-11e7-99aa-40fec9cae33e.PNG)
Lines in scope (incorrect)
![lines_in_scope_console](https://user-images.githubusercontent.com/22062107/30784333-50cf8ad6-a121-11e7-8724-10ccf7fc1ef8.PNG)

Side note, comments are also missed in out of scope lines:
![comments_missed_array](https://user-images.githubusercontent.com/22062107/30784341-7b4966ce-a121-11e7-9679-4048486b3a38.PNG)

With change,
Lines in scope scope (correct):
![lines_in_scope_console_correct](https://user-images.githubusercontent.com/22062107/30784346-9503fa98-a121-11e7-899f-84a9d4d9305e.PNG)
Lines out of scope (correct & catches comments):
![comments_included_array](https://user-images.githubusercontent.com/22062107/30784354-a9af12ac-a121-11e7-85a8-ec9df0f69183.PNG)




