### PR TITLE
Don't persist pending breakpoints if hidden

### DIFF
--- a/src/actions/tests/pending-breakpoints.spec.js
+++ b/src/actions/tests/pending-breakpoints.spec.js
@@ -94,6 +94,19 @@ describe("when adding breakpoints", () => {
       expect(pendingBps.get(breakpointLocationId2)).toMatchSnapshot();
     });
 
+    it("hidden breakponts do not create pending bps", async () => {
+      const { dispatch, getState } = createStore(simpleMockThreadClient);
+
+      await dispatch(actions.newSource(makeSource("foo")));
+      await dispatch(
+        actions.addBreakpoint(breakpoint1.location, { hidden: true })
+      );
+      const pendingBps = selectors.getPendingBreakpoints(getState());
+
+      // should be null
+      expect(pendingBps.get(breakpointLocationId1)).toBe(null);
+    });
+
     it("remove a corresponding pending breakpoint when deleting", async () => {
       const { dispatch, getState } = createStore(simpleMockThreadClient);
       await dispatch(actions.newSource(makeSource("foo")));

--- a/src/reducers/pending-breakpoints.js
+++ b/src/reducers/pending-breakpoints.js
@@ -42,6 +42,9 @@ function update(
 ) {
   switch (action.type) {
     case "ADD_BREAKPOINT": {
+      if (action.breakpoint.hidden) {
+        return state;
+      }
       return addBreakpoint(state, action);
     }
 
@@ -62,6 +65,9 @@ function update(
     }
 
     case "REMOVE_BREAKPOINT": {
+      if (action.breakpoint.hidden) {
+        return state;
+      }
       return removeBreakpoint(state, action);
     }
   }


### PR DESCRIPTION
Associated Issue: #4055 

### Summary of Changes

* adopted pending_breakpoint reducer to not handle adding or removing hidden breakpoints
* added a test, but was not able to run it on my machine

### Test Plan
- [x] Open a website
- [x] make the debugger pause
- [x] choose "continue to here" at a location that won't get executed
- [x] refresh launchpad (before there was a regular breakpoint at the location of the hidden one)