### PR TITLE
Switch Close Button from PropType to Flow Props

### DIFF
--- a/src/components/shared/Button/Close.js
+++ b/src/components/shared/Button/Close.js
@@ -1,15 +1,15 @@
 // @flow
-import React, { PropTypes } from "react";
+import React from "react";
 import Svg from "../Svg";
 import "./Close.css";
 
-type CloseButtonType = {
-  handleClick: any,
+type Props = {
+  handleClick: Function,
   buttonClass?: string,
   tooltip?: string
 };
 
-function CloseButton({ handleClick, buttonClass, tooltip }: CloseButtonType) {
+function CloseButton({ handleClick, buttonClass, tooltip }: Props) {
   return (
     <div
       className={buttonClass ? `close-btn ${buttonClass}` : "close-btn"}
@@ -20,9 +20,5 @@ function CloseButton({ handleClick, buttonClass, tooltip }: CloseButtonType) {
     </div>
   );
 }
-
-CloseButton.propTypes = {
-  handleClick: PropTypes.func.isRequired
-};
 
 export default CloseButton;


### PR DESCRIPTION
Associated Issue: #2804

### Summary of Changes

* Change shared/Button/Close from PropTypes to Flow Props

### Test Plan

Example test plan:

- [x] yarn run test
- [x] yarn run flow
