### PR TITLE
Fix ESLint Dependencies from Fresh Install

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,16 +18,19 @@
     "start": "node bin/dev-server",
     "start-app": "TARGET=application node bin/dev-server",
     "flow": "flow",
-    "eslint-check": "eslint --print-config .eslintrc.js | eslint-config-prettier-check",
+    "eslint-check":
+      "eslint --print-config .eslintrc.js | eslint-config-prettier-check",
     "prettier": "node bin/prettier.js",
     "license-check": "devtools-license-check",
     "links": "ls -l node_modules/ | grep ^l || echo 'no linked packages'",
     "lint": "run-p lint-css lint-js lint-md",
     "lint-css": "stylelint \"src/components/**/*.css\"",
     "lint-js": "eslint *.js \"src/**/*.js\" --fix",
-    "lint-md": "remark -u devtools-linters/markdown/preset -qf *.md src configs docs",
+    "lint-md":
+      "remark -u devtools-linters/markdown/preset -qf *.md src configs docs",
     "lint-fix": "yarn lint-js -- --fix",
-    "mochi": "mochii --mc ./firefox --default-test-path devtools/client/debugger/new",
+    "mochi":
+      "mochii --mc ./firefox --default-test-path devtools/client/debugger/new",
     "mochid": "yarn mochi -- --jsdebugger --",
     "mochir": "yarn mochi -- --repeat 10 --",
     "mochih": "yarn mochi -- --setenv MOZ_HEADLESS=1 --",
@@ -35,14 +38,20 @@
     "test:watch": "jest --watch",
     "test-coverage": "yarn test -- --coverage",
     "test-all": "yarn test; yarn lint; yarn flow",
-    "firefox": "start-firefox --start --location https://devtools-html.github.io/debugger-examples/",
-    "chrome": "start-chrome --location https://devtools-html.github.io/debugger-examples/",
+    "firefox":
+      "start-firefox --start --location https://devtools-html.github.io/debugger-examples/",
+    "chrome":
+      "start-chrome --location https://devtools-html.github.io/debugger-examples/",
     "copy-assets": "node bin/copy-assets --symlink",
     "copy-assets-watch": "node bin/copy-assets --watch --symlink",
-    "build-docs": "documentation build --format html --sort-order alpha --shallow  --document-exported --output docs/reference/ src/types.js src/utils/ src/reducers/ src/actions/ src/test/mochitest/head.js",
-    "flow-coverage": "flow-coverage-report --threshold 50 -i 'src/actions/*.js' -i 'src/reducers/*.js' -i 'src/utils/*.js' -i 'src/components/*.js' -i 'src/components/**/*.js' -t html -t text",
-    "flow-utils": "flow-coverage-report -i 'src/utils/*.js' -i 'src/utils/**/*.js' -t text",
-    "flow-redux": "flow-coverage-report  -i 'src/reducers/*.js' -i 'src/actions/*.js'  -t text",
+    "build-docs":
+      "documentation build --format html --sort-order alpha --shallow  --document-exported --output docs/reference/ src/types.js src/utils/ src/reducers/ src/actions/ src/test/mochitest/head.js",
+    "flow-coverage":
+      "flow-coverage-report --threshold 50 -i 'src/actions/*.js' -i 'src/reducers/*.js' -i 'src/utils/*.js' -i 'src/components/*.js' -i 'src/components/**/*.js' -t html -t text",
+    "flow-utils":
+      "flow-coverage-report -i 'src/utils/*.js' -i 'src/utils/**/*.js' -t text",
+    "flow-redux":
+      "flow-coverage-report  -i 'src/reducers/*.js' -i 'src/actions/*.js'  -t text",
     "flow-react": "flow-coverage-report -i 'src/components/**/*.js' -t text",
     "storybook": "start-storybook -p 6006",
     "snapshot": "NODE_ENV='development' build-storybook && percy-storybook",
@@ -69,9 +78,6 @@
     "devtools-source-map": "^0.13.0",
     "devtools-splitter": "^0.0.3",
     "devtools-utils": "^0.0.9",
-    "eslint-plugin-babel": "^4.1.2",
-    "eslint-plugin-flowtype": "^2.36.0",
-    "eslint-plugin-mozilla": "^0.4.4",
     "fuzzaldrin-plus": "^0.4.1",
     "immutable": "^3.7.6",
     "lodash": "^4.17.4",
@@ -90,18 +96,9 @@
     "svg-inline-react": "^1.0.2",
     "wasmparser": "^0.4.10"
   },
-  "files": [
-    "src",
-    "assets"
-  ],
+  "files": ["src", "assets"],
   "greenkeeper": {
-    "ignore": [
-      "react",
-      "react-dom",
-      "react-redux",
-      "redux",
-      "codemirror"
-    ]
+    "ignore": ["react", "react-dom", "react-redux", "redux", "codemirror"]
   },
   "main": "src/main.js",
   "author": "Jason Laster <jlaster@mozilla.com>",
@@ -118,6 +115,9 @@
     "eslint-config-prettier": "^2.3.0",
     "eslint-plugin-prettier": "^2.2.0",
     "eslint-plugin-react": "^7.2.1",
+    "eslint-plugin-babel": "^4.1.2",
+    "eslint-plugin-flowtype": "^2.36.0",
+    "eslint-plugin-mozilla": "^0.4.4",
     "expect.js": "^0.3.1",
     "flow-bin": "^0.52.0",
     "glob": "^7.0.3",
@@ -157,47 +157,19 @@
     "workerjs": "github:jasonLaster/workerjs"
   },
   "lint-staged": {
-    "*.js": [
-      "prettier",
-      "git add"
-    ],
-    "src/*.js": [
-      "prettier",
-      "git add"
-    ],
-    "src/*/*.js": [
-      "prettier",
-      "git add"
-    ],
-    "src/*/!(mochitest)**/*.js": [
-      "prettier",
-      "git add"
-    ],
-    "src/*/!(mochitest)*/**/*.js": [
-      "prettier",
-      "git add"
-    ]
+    "*.js": ["prettier", "git add"],
+    "src/*.js": ["prettier", "git add"],
+    "src/*/*.js": ["prettier", "git add"],
+    "src/*/!(mochitest)**/*.js": ["prettier", "git add"],
+    "src/*/!(mochitest)*/**/*.js": ["prettier", "git add"]
   },
   "jest": {
     "rootDir": "src",
-    "testMatch": [
-      "**/tests/**/*.js"
-    ],
-    "testPathIgnorePatterns": [
-      "/node_modules/",
-      "/helpers/",
-      "/fixtures/"
-    ],
-    "transformIgnorePatterns": [
-      "node_modules/(?!devtools-)"
-    ],
-    "setupFiles": [
-      "<rootDir>/test/tests-setup.js",
-      "jest-localstorage-mock"
-    ],
-    "snapshotSerializers": [
-      "jest-serializer-babel-ast"
-    ],
+    "testMatch": ["**/tests/**/*.js"],
+    "testPathIgnorePatterns": ["/node_modules/", "/helpers/", "/fixtures/"],
+    "transformIgnorePatterns": ["node_modules/(?!devtools-)"],
+    "setupFiles": ["<rootDir>/test/tests-setup.js", "jest-localstorage-mock"],
+    "snapshotSerializers": ["jest-serializer-babel-ast"],
     "setupTestFrameworkScriptFile": "<rootDir>/test/tests-framework.js",
     "moduleNameMapper": {
       "\\.css$": "<rootDir>/test/__mocks__/styleMock.js",

--- a/package.json
+++ b/package.json
@@ -18,8 +18,7 @@
     "start": "node bin/dev-server",
     "start-app": "TARGET=application node bin/dev-server",
     "flow": "flow",
-    "eslint-check":
-      "eslint --print-config .eslintrc.js | eslint-config-prettier-check",
+    "eslint-check": "eslint --print-config .eslintrc.js | eslint-config-prettier-check",
     "prettier": "node bin/prettier.js",
     "license-check": "devtools-license-check",
     "links": "ls -l node_modules/ | grep ^l || echo 'no linked packages'",
@@ -28,8 +27,7 @@
     "lint-js": "eslint *.js \"src/**/*.js\" --fix",
     "lint-md": "remark -u devtools-linters/markdown/preset -qf *.md src configs docs",
     "lint-fix": "yarn lint-js -- --fix",
-    "mochi":
-      "mochii --mc ./firefox --default-test-path devtools/client/debugger/new",
+    "mochi": "mochii --mc ./firefox --default-test-path devtools/client/debugger/new",
     "mochid": "yarn mochi -- --jsdebugger --",
     "mochir": "yarn mochi -- --repeat 10 --",
     "mochih": "yarn mochi -- --setenv MOZ_HEADLESS=1 --",
@@ -37,20 +35,14 @@
     "test:watch": "jest --watch",
     "test-coverage": "yarn test -- --coverage",
     "test-all": "yarn test; yarn lint; yarn flow",
-    "firefox":
-      "start-firefox --start --location https://devtools-html.github.io/debugger-examples/",
-    "chrome":
-      "start-chrome --location https://devtools-html.github.io/debugger-examples/",
+    "firefox": "start-firefox --start --location https://devtools-html.github.io/debugger-examples/",
+    "chrome": "start-chrome --location https://devtools-html.github.io/debugger-examples/",
     "copy-assets": "node bin/copy-assets --symlink",
     "copy-assets-watch": "node bin/copy-assets --watch --symlink",
-    "build-docs":
-      "documentation build --format html --sort-order alpha --shallow  --document-exported --output docs/reference/ src/types.js src/utils/ src/reducers/ src/actions/ src/test/mochitest/head.js",
-    "flow-coverage":
-      "flow-coverage-report --threshold 50 -i 'src/actions/*.js' -i 'src/reducers/*.js' -i 'src/utils/*.js' -i 'src/components/*.js' -i 'src/components/**/*.js' -t html -t text",
-    "flow-utils":
-      "flow-coverage-report -i 'src/utils/*.js' -i 'src/utils/**/*.js' -t text",
-    "flow-redux":
-      "flow-coverage-report  -i 'src/reducers/*.js' -i 'src/actions/*.js'  -t text",
+    "build-docs": "documentation build --format html --sort-order alpha --shallow  --document-exported --output docs/reference/ src/types.js src/utils/ src/reducers/ src/actions/ src/test/mochitest/head.js",
+    "flow-coverage": "flow-coverage-report --threshold 50 -i 'src/actions/*.js' -i 'src/reducers/*.js' -i 'src/utils/*.js' -i 'src/components/*.js' -i 'src/components/**/*.js' -t html -t text",
+    "flow-utils": "flow-coverage-report -i 'src/utils/*.js' -i 'src/utils/**/*.js' -t text",
+    "flow-redux": "flow-coverage-report  -i 'src/reducers/*.js' -i 'src/actions/*.js'  -t text",
     "flow-react": "flow-coverage-report -i 'src/components/**/*.js' -t text",
     "storybook": "start-storybook -p 6006",
     "snapshot": "NODE_ENV='development' build-storybook && percy-storybook",
@@ -77,6 +69,9 @@
     "devtools-source-map": "^0.13.0",
     "devtools-splitter": "^0.0.3",
     "devtools-utils": "^0.0.9",
+    "eslint-plugin-babel": "^4.1.2",
+    "eslint-plugin-flowtype": "^2.36.0",
+    "eslint-plugin-mozilla": "^0.4.4",
     "fuzzaldrin-plus": "^0.4.1",
     "immutable": "^3.7.6",
     "lodash": "^4.17.4",
@@ -95,9 +90,18 @@
     "svg-inline-react": "^1.0.2",
     "wasmparser": "^0.4.10"
   },
-  "files": ["src", "assets"],
+  "files": [
+    "src",
+    "assets"
+  ],
   "greenkeeper": {
-    "ignore": ["react", "react-dom", "react-redux", "redux", "codemirror"]
+    "ignore": [
+      "react",
+      "react-dom",
+      "react-redux",
+      "redux",
+      "codemirror"
+    ]
   },
   "main": "src/main.js",
   "author": "Jason Laster <jlaster@mozilla.com>",
@@ -153,19 +157,47 @@
     "workerjs": "github:jasonLaster/workerjs"
   },
   "lint-staged": {
-    "*.js": ["prettier", "git add"],
-    "src/*.js": ["prettier", "git add"],
-    "src/*/*.js": ["prettier", "git add"],
-    "src/*/!(mochitest)**/*.js": ["prettier", "git add"],
-    "src/*/!(mochitest)*/**/*.js": ["prettier", "git add"]
+    "*.js": [
+      "prettier",
+      "git add"
+    ],
+    "src/*.js": [
+      "prettier",
+      "git add"
+    ],
+    "src/*/*.js": [
+      "prettier",
+      "git add"
+    ],
+    "src/*/!(mochitest)**/*.js": [
+      "prettier",
+      "git add"
+    ],
+    "src/*/!(mochitest)*/**/*.js": [
+      "prettier",
+      "git add"
+    ]
   },
   "jest": {
     "rootDir": "src",
-    "testMatch": ["**/tests/**/*.js"],
-    "testPathIgnorePatterns": ["/node_modules/", "/helpers/", "/fixtures/"],
-    "transformIgnorePatterns": ["node_modules/(?!devtools-)"],
-    "setupFiles": ["<rootDir>/test/tests-setup.js", "jest-localstorage-mock"],
-    "snapshotSerializers": ["jest-serializer-babel-ast"],
+    "testMatch": [
+      "**/tests/**/*.js"
+    ],
+    "testPathIgnorePatterns": [
+      "/node_modules/",
+      "/helpers/",
+      "/fixtures/"
+    ],
+    "transformIgnorePatterns": [
+      "node_modules/(?!devtools-)"
+    ],
+    "setupFiles": [
+      "<rootDir>/test/tests-setup.js",
+      "jest-localstorage-mock"
+    ],
+    "snapshotSerializers": [
+      "jest-serializer-babel-ast"
+    ],
     "setupTestFrameworkScriptFile": "<rootDir>/test/tests-framework.js",
     "moduleNameMapper": {
       "\\.css$": "<rootDir>/test/__mocks__/styleMock.js",

--- a/src/components/Editor/EditorMenu.js
+++ b/src/components/Editor/EditorMenu.js
@@ -53,7 +53,11 @@ function getMenuItems(
     left: event.clientX
   });
 
-  const sourceLocation = getSourceLocationFromMouseEvent(editor, selectedLocation, event)
+  const sourceLocation = getSourceLocationFromMouseEvent(
+    editor,
+    selectedLocation,
+    event
+  );
 
   const pairedType = isOriginalId(selectedLocation.sourceId)
     ? L10N.getStr("generated")

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -423,9 +423,13 @@ class Editor extends PureComponent {
     const { selectedLocation, jumpToMappedLocation } = this.props;
 
     if (e.metaKey && e.altKey) {
-      const sourceLocation = getSourceLocationFromMouseEvent(this.state.editor, selectedLocation, e);
+      const sourceLocation = getSourceLocationFromMouseEvent(
+        this.state.editor,
+        selectedLocation,
+        e
+      );
       jumpToMappedLocation(sourceLocation);
-   }
+    }
   }
 
   toggleConditionalPanel(line) {

--- a/src/utils/editor/index.js
+++ b/src/utils/editor/index.js
@@ -128,14 +128,14 @@ function lineAtHeight(editor, sourceId, event) {
 
 function getSourceLocationFromMouseEvent(editor, selectedLocation, e) {
   const { line, ch } = editor.codeMirror.coordsChar({
-     left: e.clientX,
-     top: e.clientY
+    left: e.clientX,
+    top: e.clientY
   });
 
   return {
-     sourceId: selectedLocation.sourceId,
-     line: line + 1,
-     column: ch + 1
+    sourceId: selectedLocation.sourceId,
+    line: line + 1,
+    column: ch + 1
   };
 }
 

--- a/src/utils/sources-tree/tests/utils.spec.js
+++ b/src/utils/sources-tree/tests/utils.spec.js
@@ -212,5 +212,4 @@ describe("sources tree", () => {
       ).toBe(true);
     });
   });
-
 });

--- a/src/utils/sources-tree/utils.js
+++ b/src/utils/sources-tree/utils.js
@@ -31,13 +31,13 @@ export function isDirectory(url: Object) {
 }
 
 export function isNotJavaScript(source: Object): boolean {
-  const parsedUrl = parse(source.url).pathname
+  const parsedUrl = parse(source.url).pathname;
   if (!parsedUrl) {
     return false;
   }
-  const parsedExtension = parsedUrl.split('.').pop();
+  const parsedExtension = parsedUrl.split(".").pop();
 
-  return ["css", "svg", "png"].includes(parsedExtension)
+  return ["css", "svg", "png"].includes(parsedExtension);
 }
 
 export function isInvalidUrl(url: Object, source: Object) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2979,7 +2979,7 @@ devtools-map-bindings@0.1.0:
     jest "^19.0.2"
     source-map "^0.5.6"
 
-devtools-map-bindings@0.2.0:
+devtools-map-bindings@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/devtools-map-bindings/-/devtools-map-bindings-0.2.0.tgz#0fe50f198d73b16a457430e41d5c673ee4047782"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -3469,7 +3469,11 @@ eslint-plugin-babel@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-babel/-/eslint-plugin-babel-3.3.0.tgz#2f494aedcf6f4aa4e75b9155980837bc1fbde193"
 
-eslint-plugin-flowtype@^2.20.0:
+eslint-plugin-babel@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-babel/-/eslint-plugin-babel-4.1.2.tgz#79202a0e35757dd92780919b2336f1fa2fe53c1e"
+
+eslint-plugin-flowtype@^2.20.0, eslint-plugin-flowtype@^2.36.0:
   version "2.36.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-flowtype/-/eslint-plugin-flowtype-2.36.0.tgz#ec21cf685dc270c2b24a99bdba1a57999c1040ec"
   dependencies:
@@ -3483,6 +3487,13 @@ eslint-plugin-mozilla@0.4.3:
     espree "3.4.3"
     estraverse "4.2.0"
     globals "9.18.0"
+    ini-parser "0.0.2"
+    sax "1.2.4"
+
+eslint-plugin-mozilla@^0.4.4:
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-mozilla/-/eslint-plugin-mozilla-0.4.4.tgz#8c65f73ba2c813a8e1942a7441aec44d0a0941bc"
+  dependencies:
     ini-parser "0.0.2"
     sax "1.2.4"
 


### PR DESCRIPTION
So I just got my 2 year Mozilla laptop refresh and I can't lint with debugger.html "out of the box" because I'm missing `eslint-plugin-mozilla`.

This PR could be totally wrong somehow, or we've all had moz-central, and we've taken advantage of having stuff installed already.