### PR TITLE
Don't show "No sources" hint if sources panel is hidden

### DIFF
--- a/src/components/PrimaryPanes/Outline.js
+++ b/src/components/PrimaryPanes/Outline.js
@@ -3,7 +3,6 @@
 import React, { Component } from "react";
 import { bindActionCreators } from "redux";
 import { connect } from "react-redux";
-import classnames from "classnames";
 import actions from "../../actions";
 import { getSelectedSource, getSymbols } from "../../selectors";
 import "./Outline.css";

--- a/src/components/PrimaryPanes/Outline.js
+++ b/src/components/PrimaryPanes/Outline.js
@@ -20,7 +20,6 @@ export class Outline extends Component {
   state: any;
 
   props: {
-    isHidden: boolean,
     symbols: SymbolDeclarations,
     selectSource: (string, { line: number }) => void,
     selectedSource: ?SourceRecord
@@ -67,14 +66,14 @@ export class Outline extends Component {
   }
 
   render() {
-    const { isHidden, symbols } = this.props;
+    const { symbols } = this.props;
 
     const symbolsToDisplay = symbols.functions.filter(
       func => func.name != "anonymous"
     );
 
     return (
-      <div className={classnames("outline", { hidden: isHidden })}>
+      <div className="outline">
         {symbolsToDisplay.length > 0
           ? this.renderFunctions(symbolsToDisplay)
           : this.renderPlaceholder()}

--- a/src/components/PrimaryPanes/Sources.css
+++ b/src/components/PrimaryPanes/Sources.css
@@ -67,14 +67,6 @@
   flex: 1;
 }
 
-.sources-panel .outline.hidden {
-  display: none;
-}
-
-.hidden {
-  display: none;
-}
-
 .source-outline-tabs {
   width: 100%;
   background: var(--theme-body-background);

--- a/src/components/PrimaryPanes/SourcesTree.js
+++ b/src/components/PrimaryPanes/SourcesTree.js
@@ -281,7 +281,7 @@ class SourcesTree extends Component {
 
     if (isEmpty) {
       return (
-        <div className="no-sources-message">
+        <div className={classnames("no-sources-message", { hidden: isHidden })}>
           {L10N.getStr("sources.noSourcesAvailable")}
         </div>
       );

--- a/src/components/PrimaryPanes/SourcesTree.js
+++ b/src/components/PrimaryPanes/SourcesTree.js
@@ -249,7 +249,7 @@ class SourcesTree extends Component {
   }
 
   render() {
-    const { isHidden, setExpandedState, expanded } = this.props;
+    const { setExpandedState, expanded } = this.props;
     const {
       focusedItem,
       sourceTree,
@@ -281,7 +281,7 @@ class SourcesTree extends Component {
 
     if (isEmpty) {
       return (
-        <div className={classnames("no-sources-message", { hidden: isHidden })}>
+        <div className="no-sources-message">
           {L10N.getStr("sources.noSourcesAvailable")}
         </div>
       );
@@ -295,7 +295,7 @@ class SourcesTree extends Component {
 
     return (
       <div
-        className={classnames("sources-list", { hidden: isHidden })}
+        className="sources-list"
         onKeyDown={onKeyDown}
       >
         {tree}
@@ -305,7 +305,6 @@ class SourcesTree extends Component {
 }
 
 SourcesTree.propTypes = {
-  isHidden: PropTypes.bool,
   sources: ImPropTypes.map.isRequired,
   selectSource: PropTypes.func.isRequired,
   shownSource: PropTypes.string,

--- a/src/components/PrimaryPanes/index.js
+++ b/src/components/PrimaryPanes/index.js
@@ -129,7 +129,6 @@ class PrimaryPanes extends Component {
 
   render() {
     const { selectedPane } = this.state;
-    const { sources, selectSource } = this.props;
     
     return (
       <div className="sources-panel">

--- a/src/components/PrimaryPanes/index.js
+++ b/src/components/PrimaryPanes/index.js
@@ -105,26 +105,36 @@ class PrimaryPanes extends Component {
     }
   }
 
-  render() {
-    const { selectedPane } = this.state;
-    const { sources, selectSource } = this.props;
+  renderOutline() {
+    const { selectSource } = this.props;
 
     const outlineComp = isEnabled("outline") ? (
       <Outline
         selectSource={selectSource}
-        isHidden={selectedPane === "sources"}
       />
     ) : null;
 
+    return outlineComp;
+  }
+
+  renderSources() {
+    const { sources, selectSource } = this.props;
+    return (
+      <SourcesTree
+        sources={sources}
+        selectSource={selectSource}
+      />
+    );
+  }
+
+  render() {
+    const { selectedPane } = this.state;
+    const { sources, selectSource } = this.props;
+    
     return (
       <div className="sources-panel">
         {this.renderTabs()}
-        <SourcesTree
-          sources={sources}
-          selectSource={selectSource}
-          isHidden={selectedPane === "outline"}
-        />
-        {outlineComp}
+        { selectedPane === "sources" ? this.renderSources() : this.renderOutline() }
       </div>
     );
   }


### PR DESCRIPTION
Associated Issue: NONE

While fiddling around I found that the "No sources" hint gets displayed even when the sources panel is hidden.

STR:

- Open debuggee with "about:blank"
- Switch from sources panel to outline

Before:
![sources_before](https://user-images.githubusercontent.com/2511026/30896001-41d7defa-a34e-11e7-85f7-ce2f20fa11e6.gif)

After:
![sources_after](https://user-images.githubusercontent.com/2511026/30896011-5089fcee-a34e-11e7-9b82-51bce46cba50.gif)

