### PR TITLE
Fix breakpoint jumping

### DIFF
--- a/src/client/firefox/commands.js
+++ b/src/client/firefox/commands.js
@@ -132,7 +132,7 @@ function removeBreakpoint(generatedLocation: Location) {
     const bpClient = bpClients[id];
     if (!bpClient) {
       console.warn("No breakpoint to delete on server");
-      return;
+      return Promise.resolve();
     }
     delete bpClients[id];
     return bpClient.remove();


### PR DESCRIPTION
Associated Issue: #3715

### Summary of Changes

the jumping comes from trying to remove a breakpoint when the client does not have it registered yet.

### Test Plan

held cmd+b down for 3 minutes. Created literally thousands of breakpoints at the same line
