### PR TITLE
Show mapped names in watch expressions

### DIFF
--- a/src/actions/ast.js
+++ b/src/actions/ast.js
@@ -13,41 +13,17 @@ import { ensureParserHasSourceText } from "./sources";
 
 import { PROMISE } from "../utils/redux/middleware/promise";
 import {
-  getScopes,
   getSymbols,
   getEmptyLines,
   getOutOfScopeLocations
 } from "../utils/parser";
 
 import { isGeneratedId } from "devtools-source-map";
-import { replaceOriginalVariableName } from "devtools-map-bindings/src/utils";
 
 import type { SourceId } from "debugger-html";
 import type { ThunkArgs } from "./types";
 import type { AstLocation } from "../utils/parser";
-
-/**
- * Gets information about original variable names from the source map
- * and replaces all posible generated names.
- */
-async function getSourcemapedExpression(
-  { sourceMaps },
-  generatedLocation: Location,
-  expression: string
-): Promise<string> {
-  const astScopes = await getScopes(generatedLocation);
-
-  const generatedScopes = await sourceMaps.getLocationScopes(
-    generatedLocation,
-    astScopes
-  );
-
-  if (!generatedScopes) {
-    return expression;
-  }
-
-  return replaceOriginalVariableName(expression, generatedScopes);
-}
+import getSourceMappedExpression from "../utils/parser/getSourceMappedExpression";
 
 export function setSymbols(sourceId: SourceId) {
   return async ({ dispatch, getState }: ThunkArgs) => {
@@ -186,8 +162,8 @@ export function setPreview(
           const generatedSourceId = generatedLocation.sourceId;
           await dispatch(ensureParserHasSourceText(generatedSourceId));
 
-          expression = await getSourcemapedExpression(
-            { dispatch, sourceMaps },
+          expression = await getSourceMappedExpression(
+            { sourceMaps },
             generatedLocation,
             expression
           );

--- a/src/actions/ui.js
+++ b/src/actions/ui.js
@@ -121,6 +121,6 @@ export function clearHighlightLineRange() {
 export function toggleConditionalBreakpointPanel(line?: number) {
   return {
     type: "TOGGLE_CONDITIONAL_BREAKPOINT_PANEL",
-      line: line
+    line: line
   };
 }

--- a/src/components/PrimaryPanes/SourcesTree.js
+++ b/src/components/PrimaryPanes/SourcesTree.js
@@ -294,10 +294,7 @@ class SourcesTree extends Component {
     };
 
     return (
-      <div
-        className="sources-list"
-        onKeyDown={onKeyDown}
-      >
+      <div className="sources-list" onKeyDown={onKeyDown}>
         {tree}
       </div>
     );

--- a/src/components/PrimaryPanes/index.js
+++ b/src/components/PrimaryPanes/index.js
@@ -109,9 +109,7 @@ class PrimaryPanes extends Component {
     const { selectSource } = this.props;
 
     const outlineComp = isEnabled("outline") ? (
-      <Outline
-        selectSource={selectSource}
-      />
+      <Outline selectSource={selectSource} />
     ) : null;
 
     return outlineComp;
@@ -119,21 +117,18 @@ class PrimaryPanes extends Component {
 
   renderSources() {
     const { sources, selectSource } = this.props;
-    return (
-      <SourcesTree
-        sources={sources}
-        selectSource={selectSource}
-      />
-    );
+    return <SourcesTree sources={sources} selectSource={selectSource} />;
   }
 
   render() {
     const { selectedPane } = this.state;
-    
+
     return (
       <div className="sources-panel">
         {this.renderTabs()}
-        { selectedPane === "sources" ? this.renderSources() : this.renderOutline() }
+        {selectedPane === "sources"
+          ? this.renderSources()
+          : this.renderOutline()}
       </div>
     );
   }

--- a/src/components/SecondaryPanes/Breakpoints.js
+++ b/src/components/SecondaryPanes/Breakpoints.js
@@ -266,8 +266,8 @@ class Breakpoints extends PureComponent {
       label: addConditionLabel,
       accesskey: addConditionKey,
       click: () => {
-        this.selectBreakpoint(breakpoint)
-        toggleConditionalBreakpointPanel(breakpoint.location.line)
+        this.selectBreakpoint(breakpoint);
+        toggleConditionalBreakpointPanel(breakpoint.location.line);
       }
     };
 
@@ -276,8 +276,8 @@ class Breakpoints extends PureComponent {
       label: editConditionLabel,
       accesskey: editConditionKey,
       click: () => {
-        this.selectBreakpoint(breakpoint)
-        toggleConditionalBreakpointPanel(breakpoint.location.line)
+        this.selectBreakpoint(breakpoint);
+        toggleConditionalBreakpointPanel(breakpoint.location.line);
       }
     };
 

--- a/src/utils/parser/getSourceMappedExpression.js
+++ b/src/utils/parser/getSourceMappedExpression.js
@@ -1,0 +1,25 @@
+import { getScopes } from ".";
+import { replaceOriginalVariableName } from "devtools-map-bindings/src/utils";
+
+/**
+ * Gets information about original variable names from the source map
+ * and replaces all posible generated names.
+ */
+export default async function getSourceMappedExpression(
+  { sourceMaps },
+  generatedLocation: Location,
+  expression: string
+): Promise<string> {
+  const astScopes = await getScopes(generatedLocation);
+
+  const generatedScopes = await sourceMaps.getLocationScopes(
+    generatedLocation,
+    astScopes
+  );
+
+  if (!generatedScopes) {
+    return expression;
+  }
+
+  return replaceOriginalVariableName(expression, generatedScopes);
+}


### PR DESCRIPTION
Associated Issue: #4201

### Summary of Changes

* in `evaluateExpression` action, in case there's a frame (we're paused) and it's a generated source, get the mapped expression and evaluate it instead. But still show the original expression in the UI, of course.

* refactor `getSourceMappedExpression` out of `ast.js` (and also a slight name fix to the function name).

### Test Plan

getSourceMappedExpression should probably get tested. I need to be mentored on how to go about that.

### Screenshots
![screen shot 2017-09-29 at 4 45 24 am](https://user-images.githubusercontent.com/394320/30997531-246791c4-a4d1-11e7-9540-568bff5a2650.png)

