### PR TITLE
Memoize loading

### DIFF
--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -47,6 +47,7 @@ import EmptyLines from "./EmptyLines";
 import {
   showSourceText,
   updateDocument,
+  showLoading,
   shouldShowFooter,
   clearLineClass,
   createEditor,
@@ -539,7 +540,7 @@ class Editor extends PureComponent {
     }
 
     if (!isLoaded(nextProps.selectedSource.toJS())) {
-      return this.showMessage(L10N.getStr("loadingText"));
+      return showLoading(this.state.editor);
     }
 
     if (nextProps.selectedSource.get("error")) {
@@ -556,9 +557,6 @@ class Editor extends PureComponent {
       return;
     }
 
-    this.state.editor.replaceDocument(this.state.editor.createDocument());
-    this.state.editor.setText(msg);
-    this.state.editor.setMode({ name: "text" });
     resetLineNumberFormat(this.state.editor);
   }
 

--- a/src/utils/editor/source-documents.js
+++ b/src/utils/editor/source-documents.js
@@ -45,10 +45,23 @@ function updateDocument(editor: Object, sourceId: string) {
   if (!sourceId) {
     return;
   }
+
   const doc = getDocument(sourceId) || editor.createDocument();
   editor.replaceDocument(doc);
 
   updateLineNumberFormat(editor, sourceId);
+}
+
+function showLoading(editor: Object) {
+  if (!!getDocument("loading")) {
+    return;
+  }
+
+  const doc = editor.createDocument();
+  setDocument("loading", doc);
+  editor.replaceDocument(doc);
+  editor.setText(L10N.getStr("loadingText"));
+  editor.setMode({ name: "text" });
 }
 
 function setEditorText(editor: Object, source: Source) {
@@ -100,5 +113,6 @@ export {
   resetLineNumberFormat,
   updateLineNumberFormat,
   updateDocument,
-  showSourceText
+  showSourceText,
+  showLoading
 };


### PR DESCRIPTION
Associated Issue: #3988

### Summary of Changes

This fixes a big problem of codemirror touches by memoizing loading:

* [before](https://perfht.ml/2k9wYBf)
* [after](https://perfht.ml/2k9dD3h)

Here is the time spent in `setText`, before the change it was about 22s after the fix it was about 1s.

### Before

![screen shot 2017-09-29 at 4 25 04 pm](https://user-images.githubusercontent.com/254562/31034666-029911a0-a533-11e7-9147-23093a85a896.png)

### After

![screen shot 2017-09-29 at 4 26 01 pm](https://user-images.githubusercontent.com/254562/31034670-067601ac-a533-11e7-99e1-418eb50c75a5.png)
