### PR TITLE
Issue #3966: Show small values inside tooltip

### DIFF
--- a/src/components/Editor/Preview/Popup.js
+++ b/src/components/Editor/Preview/Popup.js
@@ -179,6 +179,8 @@ export class Popup extends Component {
   getPreviewType(value: any) {
     if (
       typeof value == "boolean" ||
+      (typeof value == "string" && value.length < 10) ||
+      (typeof value == "number" && value.toString().length < 10) ||
       value.type == "null" ||
       value.type == "undefined" ||
       value.class === "Function"

--- a/src/utils/editor/expression.js
+++ b/src/utils/editor/expression.js
@@ -38,14 +38,22 @@ export function updatePreview(
 
   const invalidToken =
     tokenText === "" || tokenText.match(/[(){}\|&%,.;=<>\+-/\*\s]/);
+
   const invalidTarget =
     (target.parentElement &&
       !target.parentElement.closest(".CodeMirror-line")) ||
     cursorPos.top == 0;
+
   const isUpdating = preview && preview.updating;
+
   const inScope = linesInScope && linesInScope.includes(location.line);
 
-  if (invalidTarget || !inScope || isUpdating || invalidToken) {
+  const invaildType =
+    target.className === "cm-string" ||
+    target.className === "cm-number" ||
+    target.className === "cm-atom";
+
+  if (invalidTarget || !inScope || isUpdating || invalidToken || invaildType) {
     return;
   }
 


### PR DESCRIPTION
Associated Issue: #3966 

### Summary of Changes

* Numbers and string < 10 letters moved to tooltip
* Removed mouseover events from value assignments in strings, numbers, and "atom" items (null)

![ovaikxwzuw](https://user-images.githubusercontent.com/12687394/31037420-ab8cf5be-a525-11e7-84b1-2473e1c66a10.gif)
