### PR TITLE
firefox doesn't like fit-content

### DIFF
--- a/src/components/ShortcutsModal.css
+++ b/src/components/ShortcutsModal.css
@@ -41,7 +41,6 @@
 }
 
 .shortcuts-modal {
-  display: table;
   width: 45%;
 }
 

--- a/src/components/ShortcutsModal.css
+++ b/src/components/ShortcutsModal.css
@@ -41,7 +41,7 @@
 }
 
 .shortcuts-modal {
-  height: fit-content;
+  display: table;
   width: 45%;
 }
 

--- a/src/components/shared/Modal.css
+++ b/src/components/shared/Modal.css
@@ -1,7 +1,7 @@
 .modal-wrapper {
   position: fixed;
   display: flex;
-  justify-content: center;
+  align-items: center;
   width: 100%;
   height: 100%;
   top: 0;
@@ -12,7 +12,7 @@
 
 .modal {
   top: 0;
-  height: 230px;
+  margin: auto;
   width: 500px;
   background-color: var(--theme-toolbar-background);
   transform: translateY(-250px);
@@ -27,7 +27,7 @@
 
 .modal.entered,
 .modal.exiting {
-  transform: translateY(30px);
+  transform: translateY(0px);
 }
 
 @media (max-width: 520px) {


### PR DESCRIPTION
Associated Issue: #4122

### Summary of Changes

The shortcuts modal was super long in Firefox because of `height: fit-content` => use `display: table` instead

### Screenshots
In Firefox before:
![bad](https://user-images.githubusercontent.com/16711897/31039526-dfdce6e4-a543-11e7-9eb9-6363c24855cc.png)

In Firefox after:
![whatever](https://user-images.githubusercontent.com/16711897/31039482-92d3a464-a543-11e7-9a49-c1c1306b1f9c.png)

