### PR TITLE
Show the full url of a file in the source tab tooltip (#4203)

### DIFF
--- a/src/components/Editor/Tabs.js
+++ b/src/components/Editor/Tabs.js
@@ -13,7 +13,7 @@ import {
 } from "../../selectors";
 import { isVisible } from "../../utils/ui";
 
-import { getFilename, isPretty } from "../../utils/source";
+import { getFilename, getFileURL, isPretty } from "../../utils/source";
 import classnames from "classnames";
 import actions from "../../actions";
 import CloseButton from "../shared/Button/Close";
@@ -406,7 +406,7 @@ class SourceTabs extends PureComponent {
         key={source.get("id")}
         onClick={() => selectSource(source.get("id"))}
         onContextMenu={e => this.onTabContextMenu(e, source.get("id"))}
-        title={getFilename(source.toJS())}
+        title={getFileURL(source.toJS())}
       >
         {sourceAnnotation}
         <div className="filename">{filename}</div>

--- a/src/utils/source.js
+++ b/src/utils/source.js
@@ -101,10 +101,22 @@ function getRawSourceURL(url: string): string {
   return url.replace(/:formatted$/, "");
 }
 
-function getFilenameFromURL(url: string) {
+function resolveFileURL(
+  url: string,
+  transformUrl: string => string = initialUrl => initialUrl
+) {
   url = getRawSourceURL(url || "");
-  const name = basename(url) || "(index)";
+  const name = transformUrl(url) || "(index)";
   return endTruncateStr(name, 50);
+}
+
+function getFilenameFromURL(url: string) {
+  return resolveFileURL(url, initialUrl => basename(initialUrl));
+}
+
+function getFormattedSourceId(id: string) {
+  const sourceId = id.split("/")[1];
+  return `SOURCE${sourceId}`;
 }
 
 /**
@@ -117,11 +129,26 @@ function getFilenameFromURL(url: string) {
 function getFilename(source: Source) {
   const { url, id } = source;
   if (!url) {
-    const sourceId = id.split("/")[1];
-    return `SOURCE${sourceId}`;
+    return getFormattedSourceId(id);
   }
 
   return getFilenameFromURL(url);
+}
+
+/**
+ * Show a source url.
+ * If the source does not have a url, use the source id.
+ *
+ * @memberof utils/source
+ * @static
+ */
+function getFileURL(source: Source) {
+  const { url, id } = source;
+  if (!url) {
+    return getFormattedSourceId(id);
+  }
+
+  return resolveFileURL(url);
 }
 
 const contentTypeModeMap = {
@@ -226,6 +253,7 @@ export {
   getRawSourceURL,
   getFilename,
   getFilenameFromURL,
+  getFileURL,
   getSourcePath,
   getSourceLineCount,
   getMode,

--- a/src/utils/source.js
+++ b/src/utils/source.js
@@ -106,12 +106,12 @@ function resolveFileURL(
   transformUrl: string => string = initialUrl => initialUrl
 ) {
   url = getRawSourceURL(url || "");
-  const name = transformUrl(url) || "(index)";
+  const name = transformUrl(url);
   return endTruncateStr(name, 50);
 }
 
 function getFilenameFromURL(url: string) {
-  return resolveFileURL(url, initialUrl => basename(initialUrl));
+  return resolveFileURL(url, initialUrl => basename(initialUrl) || "(index)");
 }
 
 function getFormattedSourceId(id: string) {

--- a/src/utils/source.js
+++ b/src/utils/source.js
@@ -12,6 +12,8 @@ import { parse as parseURL } from "url";
 
 import type { Source } from "../types";
 
+type transformUrlCallback = string => string;
+
 /**
  * Trims the query part or reference identifier of a url string, if necessary.
  *
@@ -103,7 +105,7 @@ function getRawSourceURL(url: string): string {
 
 function resolveFileURL(
   url: string,
-  transformUrl: string => string = initialUrl => initialUrl
+  transformUrl: transformUrlCallback = initialUrl => initialUrl
 ) {
   url = getRawSourceURL(url || "");
   const name = transformUrl(url);

--- a/src/utils/tests/source.spec.js
+++ b/src/utils/tests/source.spec.js
@@ -1,5 +1,6 @@
 import {
   getFilename,
+  getFileURL,
   getMode,
   getSourceLineCount,
   isThirdParty,
@@ -20,6 +21,34 @@ describe("sources", () => {
           id: ""
         })
       ).toBe("hello.html");
+    });
+    it("should truncate the file name when it is more than 50 chars", () => {
+      expect(
+        getFileURL({
+          url:
+            "http://localhost/really-really-really-really-really-really-long-name.html",
+          id: ""
+        })
+      ).toBe("...-really-really-really-really-really-long-name.html");
+    });
+  });
+
+  describe("getFileURL", () => {
+    it("should give us the file url", () => {
+      expect(
+        getFileURL({
+          url: "http://localhost.com:7999/increment/hello.html",
+          id: ""
+        })
+      ).toBe("http://localhost.com:7999/increment/hello.html");
+    });
+    it("should truncate the file url when it is more than 50 chars", () => {
+      expect(
+        getFileURL({
+          url: "http://localhost-long.com:7999/increment/hello.html",
+          id: ""
+        })
+      ).toBe("...ttp://localhost-long.com:7999/increment/hello.html");
     });
   });
 


### PR DESCRIPTION
Associated Issue: #4203 

### Summary of Changes

The source tab tooltip now shows the full file url instead of just the file name.

### Test Plan

- Open the debugger panel
- Open an example source file
- Tab titles should be the file name
- Hover over the tab - the tooltip should be the file url