### PR TITLE
Fix webpack icon matching

### DIFF
--- a/src/components/PrimaryPanes/SourcesTree.js
+++ b/src/components/PrimaryPanes/SourcesTree.js
@@ -166,7 +166,7 @@ class SourcesTree extends Component {
   }
 
   getIcon(item, depth) {
-    if (item.path === "/webpack://") {
+    if (item.path === "/Webpack") {
       return <Svg name="webpack" />;
     }
 


### PR DESCRIPTION
looks like we lost this in the shuffle during the ucosp wknd