### PR TITLE
Disables updateScopeBindings for wasm source maps.

### DIFF
--- a/src/actions/pause.js
+++ b/src/actions/pause.js
@@ -7,6 +7,7 @@ import {
   getPause,
   pausedInEval,
   getLoadedObject,
+  getSource,
   isStepping,
   isPaused,
   getSelectedSource,
@@ -37,6 +38,11 @@ async function _getScopeBindings(
   scopes
 ) {
   const { sourceId } = generatedLocation;
+  const sourceRecord = getSource(getState(), sourceId);
+  if (sourceRecord.get("isWasm")) {
+    return scopes;
+  }
+
   await dispatch(ensureParserHasSourceText(sourceId));
 
   return await updateScopeBindings(scopes, generatedLocation, sourceMaps);

--- a/src/test/mochitest/browser.ini
+++ b/src/test/mochitest/browser.ini
@@ -103,4 +103,3 @@ skip-if = true # Bug 1393121, 1393299
 [browser_dbg-tabs.js]
 [browser_dbg-toggling-tools.js]
 [browser_dbg-wasm-sourcemaps.js]
-skip-if = true


### PR DESCRIPTION
Associated Issue: wasm source maps
See doc-wasm-sourcemaps.html mochitest