### PR TITLE
Fix some react test warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "npm-run-all": "^4.0.2",
     "prettier": "^1.6.1",
     "react-addons-perf": "^15.4.2",
-    "react-addons-test-utils": "^15.6.2",
+    "react-test-renderer": "15.6.2",
     "remark-cli": "^4.0.0",
     "remark-lint": "^6.0.1",
     "remark-lint-list-item-bullet-indent": "^1.0.1",

--- a/src/components/Editor/tests/__snapshots__/Breakpoints.spec.js.snap
+++ b/src/components/Editor/tests/__snapshots__/Breakpoints.spec.js.snap
@@ -133,7 +133,7 @@ ShallowWrapper {
           "validateCallback": [Function],
         },
       },
-      "_mountOrder": 5,
+      "_mountOrder": 2,
       "_pendingCallbacks": null,
       "_pendingElement": null,
       "_pendingForceUpdate": false,

--- a/src/components/Editor/tests/__snapshots__/Editor.spec.js.snap
+++ b/src/components/Editor/tests/__snapshots__/Editor.spec.js.snap
@@ -122,7 +122,7 @@ ShallowWrapper {
           "validateCallback": [Function],
         },
       },
-      "_mountOrder": 4,
+      "_mountOrder": 1,
       "_pendingCallbacks": null,
       "_pendingElement": null,
       "_pendingForceUpdate": false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -7957,10 +7957,6 @@ react-addons-perf@^15.4.2:
     fbjs "^0.8.4"
     object-assign "^4.1.0"
 
-react-addons-test-utils@^15.6.2:
-  version "15.6.2"
-  resolved "https://registry.yarnpkg.com/react-addons-test-utils/-/react-addons-test-utils-15.6.2.tgz#c12b6efdc2247c10da7b8770d185080a7b047156"
-
 react-docgen@^2.15.0:
   version "2.18.0"
   resolved "https://registry.yarnpkg.com/react-docgen/-/react-docgen-2.18.0.tgz#fe6c57bd10fe2f3ecb32ab800a2db0fb43a93a35"
@@ -8106,6 +8102,13 @@ react-style-proptype@^3.0.0:
   resolved "https://registry.yarnpkg.com/react-style-proptype/-/react-style-proptype-3.0.0.tgz#89e0b646f266c656abb0f0dd8202dbd5036c31e6"
   dependencies:
     prop-types "^15.5.4"
+
+react-test-renderer@15.6.2:
+  version "15.6.2"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-15.6.2.tgz#d0333434fc2c438092696ca770da5ed48037efa8"
+  dependencies:
+    fbjs "^0.8.9"
+    object-assign "^4.1.0"
 
 react-transition-group@^1.1.2:
   version "1.2.0"


### PR DESCRIPTION
Resolves many of the console warnings when running tests.

Per Enzyme's documentation for v15.5 and up, react-test-renderer should be included instead of the old test utils. See https://github.com/airbnb/enzyme/pull/876.

There are still some warnings about using `React.PropTypes` that I haven't tracked down yet, and they may be coming from dependencies. Additionally, there are some for using `React.createClass` that will take some more code changes to fix.

Associated Issue: #4221 

### Summary of Changes

* Removed `react-addons-test-utils`
* Added `react-test-renderer`

### Test Plan

Ran the tests, all of which are green.
