### PR TITLE
Fixed Webpack Alignment

### DIFF
--- a/src/components/shared/Svg.css
+++ b/src/components/shared/Svg.css
@@ -76,7 +76,7 @@ html .arrow.expanded svg {
   width: 15px;
   height: 15px;
   margin-right: 5px;
-  vertical-align: bottom;
+  vertical-align: sub;
 }
 
 .theme-dark .webpack {


### PR DESCRIPTION
No associated issue.

### Changes

* Changed the vertical alignment on the webpack icon from `bottom` to `sub`.

### Testing

Tested on both Firefox and Chrome.

### Screenshots

![image](https://user-images.githubusercontent.com/9325039/31112504-b20dafe4-a7d9-11e7-9cff-28b24e12ba7d.png)

