### PR TITLE
Remove usage of create factory

### DIFF
--- a/src/components/Editor/tests/Breakpoints.spec.js
+++ b/src/components/Editor/tests/Breakpoints.spec.js
@@ -3,8 +3,6 @@ import { shallow } from "enzyme";
 import Breakpoints from "../Breakpoints";
 import * as I from "immutable";
 
-const BreakpointsComponent = React.createFactory(Breakpoints.WrappedComponent);
-
 function generateDefaults(overrides) {
   const sourceId = "server1.conn1.child1/source1";
   const matchingBreakpoints = { id1: { location: { sourceId } } };
@@ -23,7 +21,7 @@ function generateDefaults(overrides) {
 
 function render(overrides = {}) {
   const props = generateDefaults(overrides);
-  const component = shallow(new BreakpointsComponent(props));
+  const component = shallow(<Breakpoints.WrappedComponent {...props} />);
   return { component, props };
 }
 

--- a/src/components/Editor/tests/DebugLine.js
+++ b/src/components/Editor/tests/DebugLine.js
@@ -11,8 +11,6 @@ const mockGetDocument = {
 };
 getDocument.mockImplementation(() => mockGetDocument);
 
-const DebugLineComponent = React.createFactory(DebugLine);
-
 function generateDefaults(overrides) {
   return {
     editor: {
@@ -32,7 +30,7 @@ function generateDefaults(overrides) {
 
 function render(overrides = {}) {
   const props = generateDefaults(overrides);
-  const component = shallow(new DebugLineComponent(props));
+  const component = shallow(<DebugLine {...props} />);
   return { component, props };
 }
 

--- a/src/components/Editor/tests/Editor.spec.js
+++ b/src/components/Editor/tests/Editor.spec.js
@@ -3,8 +3,6 @@ import { shallow } from "enzyme";
 import Editor from "../index";
 import * as I from "immutable";
 
-const EditorComponent = React.createFactory(Editor.WrappedComponent);
-
 function generateDefaults(overrides) {
   return {
     breakpoints: I.Map(),
@@ -31,7 +29,7 @@ function generateDefaults(overrides) {
 
 function render(overrides = {}) {
   const props = generateDefaults(overrides);
-  const component = shallow(new EditorComponent(props));
+  const component = shallow(<Editor.WrappedComponent {...props} />);
   return { component, props };
 }
 

--- a/src/components/Editor/tests/SearchBar.spec.js
+++ b/src/components/Editor/tests/SearchBar.spec.js
@@ -1,4 +1,4 @@
-import { createFactory } from "react";
+import React from "react";
 import { shallow } from "enzyme";
 import SearchBar from "../SearchBar";
 import "../../../workers/search";
@@ -11,8 +11,6 @@ jest.mock("../../../workers/search", () => ({
 jest.mock("../../../utils/editor", () => ({
   find: () => ({ ch: "1", line: "1" })
 }));
-
-const SearchBarComponent = createFactory(SearchBar.WrappedComponent);
 
 function generateDefaults() {
   return {
@@ -39,7 +37,7 @@ function generateDefaults() {
 function render(overrides = {}) {
   const defaults = generateDefaults();
   const props = { ...defaults, ...overrides };
-  const component = shallow(new SearchBarComponent(props));
+  const component = shallow(<SearchBar.WrappedComponent {...props} />);
   return { component, props };
 }
 

--- a/src/components/ProjectSearch/tests/TextSearch.js
+++ b/src/components/ProjectSearch/tests/TextSearch.js
@@ -1,7 +1,6 @@
 import React from "react";
 import { shallow } from "enzyme";
-import TextSearchComponent from "../TextSearch.js";
-const TextSearch = React.createFactory(TextSearchComponent);
+import TextSearch from "../TextSearch.js";
 
 function render(overrides = {}) {
   const defaultProps = {
@@ -15,7 +14,7 @@ function render(overrides = {}) {
   };
   const props = Object.assign({}, defaultProps, overrides);
 
-  const component = shallow(new TextSearch(props));
+  const component = shallow(<TextSearch {...props} />);
   return component;
 }
 

--- a/src/components/SecondaryPanes/Frames/Group.js
+++ b/src/components/SecondaryPanes/Frames/Group.js
@@ -1,5 +1,5 @@
 // @flow
-import React, { Component, createFactory } from "react";
+import React, { Component } from "react";
 import classNames from "classnames";
 import Svg from "../../shared/Svg";
 import { formatDisplayName, getLibraryFromUrl } from "../../../utils/frame";
@@ -7,8 +7,7 @@ import FrameMenu from "./FrameMenu";
 
 import "./Group.css";
 
-import _FrameComponent from "./Frame";
-const FrameComponent = createFactory(_FrameComponent);
+import FrameComponent from "./Frame";
 
 import type { LocalFrame } from "./types";
 import type { Frame } from "debugger-html";
@@ -94,20 +93,20 @@ export default class Group extends Component {
 
     return (
       <div className="frames-list">
-        {group.map(frame =>
-          FrameComponent({
-            frame,
-            copyStackTrace,
-            toggleFrameworkGrouping,
-            frameworkGroupingOn,
-            selectFrame,
-            selectedFrame,
-            toggleBlackBox,
-            key: frame.id,
-            hideLocation: true,
-            shouldMapDisplayName: false
-          })
-        )}
+        {group.map(frame => (
+          <FrameComponent
+            copyStackTrace={copyStackTrace}
+            frame={frame}
+            frameworkGroupingOn={frameworkGroupingOn}
+            hideLocation={true}
+            key={frame.id}
+            selectedFrame={selectedFrame}
+            selectFrame={selectFrame}
+            shouldMapDisplayName={false}
+            toggleBlackBox={toggleBlackBox}
+            toggleFrameworkGrouping={toggleFrameworkGrouping}
+          />
+        ))}
       </div>
     );
   }

--- a/src/components/SecondaryPanes/Frames/index.js
+++ b/src/components/SecondaryPanes/Frames/index.js
@@ -1,7 +1,7 @@
 // @flow
 
 import PropTypes from "prop-types";
-import React, { Component, createFactory } from "react";
+import React, { Component } from "react";
 import { bindActionCreators } from "redux";
 import { connect } from "react-redux";
 import { createSelector } from "reselect";
@@ -10,11 +10,8 @@ import { get } from "lodash";
 import type { Frame } from "debugger-html";
 import type { SourcesMap } from "../../../reducers/sources";
 
-import _FrameComponent from "./Frame";
-const FrameComponent = createFactory(_FrameComponent);
-
-import _Group from "./Group";
-const Group = createFactory(_Group);
+import FrameComponent from "./Frame";
+import Group from "./Group";
 
 import renderWhyPaused from "./WhyPaused";
 
@@ -125,27 +122,29 @@ class Frames extends Component {
       <ul>
         {framesOrGroups.map(
           (frameOrGroup: FrameOrGroup) =>
-            frameOrGroup.id
-              ? FrameComponent({
-                  frame: frameOrGroup,
-                  toggleFrameworkGrouping: this.toggleFrameworkGrouping,
-                  copyStackTrace: this.copyStackTrace,
-                  frameworkGroupingOn,
-                  selectFrame,
-                  selectedFrame,
-                  toggleBlackBox,
-                  key: frameOrGroup.id
-                })
-              : Group({
-                  group: frameOrGroup,
-                  toggleFrameworkGrouping: this.toggleFrameworkGrouping,
-                  copyStackTrace: this.copyStackTrace,
-                  frameworkGroupingOn,
-                  selectFrame,
-                  selectedFrame,
-                  toggleBlackBox,
-                  key: frameOrGroup[0].id
-                })
+            frameOrGroup.id ? (
+              <FrameComponent
+                frame={frameOrGroup}
+                toggleFrameworkGrouping={this.toggleFrameworkGrouping}
+                copyStackTrace={this.copyStackTrace}
+                frameworkGroupingOn={frameworkGroupingOn}
+                selectFrame={selectFrame}
+                selectedFrame={selectedFrame}
+                toggleBlackBox={toggleBlackBox}
+                key={frameOrGroup.id}
+              />
+            ) : (
+              <Group
+                group={frameOrGroup}
+                toggleFrameworkGrouping={this.toggleFrameworkGrouping}
+                copyStackTrace={this.copyStackTrace}
+                frameworkGroupingOn={frameworkGroupingOn}
+                selectFrame={selectFrame}
+                selectedFrame={selectedFrame}
+                toggleBlackBox={toggleBlackBox}
+                key={frameOrGroup[0].id}
+              />
+            )
         )}
       </ul>
     );

--- a/src/components/SecondaryPanes/Frames/tests/Frame.js
+++ b/src/components/SecondaryPanes/Frames/tests/Frame.js
@@ -1,7 +1,6 @@
 import React from "react";
 import { shallow } from "enzyme";
-import FrameComponent from "../Frame.js";
-const Frame = React.createFactory(FrameComponent);
+import Frame from "../Frame.js";
 
 import FrameMenu from "../FrameMenu";
 jest.mock("../FrameMenu", () => jest.fn());
@@ -34,7 +33,7 @@ function render(frameToSelect = {}, overrides = {}) {
     selectFrame,
     toggleBlackBox
   };
-  const component = shallow(new Frame(props));
+  const component = shallow(<Frame {...props} />);
   return { component, props };
 }
 

--- a/src/components/SecondaryPanes/Frames/tests/Frames.js
+++ b/src/components/SecondaryPanes/Frames/tests/Frames.js
@@ -1,8 +1,7 @@
 import React from "react";
 import { shallow } from "enzyme";
 import { Map } from "immutable";
-import _Frames, { getAndProcessFrames } from "../index.js";
-const Frames = React.createFactory(_Frames.WrappedComponent);
+import Frames, { getAndProcessFrames } from "../index.js";
 
 function render(overrides = {}) {
   const defaultProps = {
@@ -16,7 +15,7 @@ function render(overrides = {}) {
   };
 
   const props = Object.assign({}, defaultProps, overrides);
-  const component = shallow(new Frames(props));
+  const component = shallow(<Frames.WrappedComponent {...props} />);
 
   return component;
 }

--- a/src/components/SecondaryPanes/Frames/tests/Group.js
+++ b/src/components/SecondaryPanes/Frames/tests/Group.js
@@ -1,7 +1,6 @@
 import React from "react";
 import { shallow } from "enzyme";
-import GroupComponent from "../Group.js";
-const Group = React.createFactory(GroupComponent);
+import Group from "../Group.js";
 
 import FrameMenu from "../FrameMenu";
 jest.mock("../FrameMenu", () => jest.fn());
@@ -18,7 +17,7 @@ function render(overrides = {}) {
   };
 
   const props = Object.assign({}, defaultProps, overrides);
-  const component = shallow(new Group(props));
+  const component = shallow(<Group {...props} />);
   return { component, props };
 }
 

--- a/src/components/SecondaryPanes/tests/Expressions.spec.js
+++ b/src/components/SecondaryPanes/tests/Expressions.spec.js
@@ -2,8 +2,6 @@ import React from "react";
 import { shallow } from "enzyme";
 import Expressions from "../Expressions";
 
-const ExpressionsComponent = React.createFactory(Expressions.WrappedComponent);
-
 function generateDefaults(overrides) {
   return {
     loadObjectProperties: jest.fn(),
@@ -33,7 +31,7 @@ function generateDefaults(overrides) {
 
 function render(overrides = {}) {
   const props = generateDefaults(overrides);
-  const component = shallow(new ExpressionsComponent(props));
+  const component = shallow(<Expressions.WrappedComponent {...props} />);
   return { component, props };
 }
 

--- a/src/components/tests/Outline.spec.js
+++ b/src/components/tests/Outline.spec.js
@@ -4,7 +4,6 @@ import Outline from "../../components/PrimaryPanes/Outline";
 import devtoolsConfig from "devtools-config";
 import { makeSymbolDeclaration } from "../../utils/test-head";
 
-const OutlineComponent = React.createFactory(Outline.WrappedComponent);
 const sourceId = "id";
 
 function generateDefaults(symbols) {
@@ -20,7 +19,7 @@ function generateDefaults(symbols) {
 
 function render(symbols = {}) {
   const props = generateDefaults(symbols);
-  const component = shallow(new OutlineComponent(props));
+  const component = shallow(<Outline.WrappedComponent {...props} />);
   return { component, props };
 }
 

--- a/src/components/tests/closeButton.spec.js
+++ b/src/components/tests/closeButton.spec.js
@@ -1,14 +1,11 @@
-import { createFactory } from "react";
+import React from "react";
 import { shallow } from "enzyme";
-
 import Close from "../../components/shared/Button/Close";
-
-const CloseButton = createFactory(Close);
 
 describe("CloseButton", () => {
   it("should call handleClick function", () => {
     const onClick = jest.genMockFunction();
-    const wrapper = shallow(new CloseButton({ handleClick: onClick }));
+    const wrapper = shallow(<Close handleClick={onClick} />);
 
     wrapper.simulate("click");
     expect(onClick).toBeCalled();
@@ -18,11 +15,11 @@ describe("CloseButton", () => {
     const onClick = jest.genMockFunction();
     const buttonClass = "class";
     const wrapper = shallow(
-      new CloseButton({
-        handleClick: onClick,
-        buttonClass: buttonClass,
-        tooltip: "Close button"
-      })
+      <Close
+        handleClick={onClick}
+        buttonClass={buttonClass}
+        tooltip={"Close button"}
+      />
     );
 
     expect(wrapper).toMatchSnapshot();

--- a/src/components/tests/resultList.spec.js
+++ b/src/components/tests/resultList.spec.js
@@ -1,8 +1,6 @@
-import { createFactory } from "react";
+import React from "react";
 import { shallow } from "enzyme";
-
-import ResultListComponent from "../shared/ResultList";
-const ResultList = createFactory(ResultListComponent);
+import ResultList from "../shared/ResultList";
 
 const selectItem = jest.genMockFunction();
 const selectedIndex = 1;
@@ -27,19 +25,19 @@ const payload = {
 
 describe("Result list", () => {
   it("should call onClick function", () => {
-    const wrapper = shallow(ResultList(payload));
+    const wrapper = shallow(<ResultList {...payload} />);
 
     wrapper.childAt(selectedIndex).simulate("click");
     expect(selectItem).toBeCalled();
   });
 
   it("should render the component", () => {
-    const wrapper = shallow(ResultList(payload));
+    const wrapper = shallow(<ResultList {...payload} />);
     expect(wrapper).toMatchSnapshot();
   });
 
   it("selected index should have 'selected class'", () => {
-    const wrapper = shallow(ResultList(payload));
+    const wrapper = shallow(<ResultList {...payload} />);
     const childHasClass = wrapper.childAt(selectedIndex).hasClass("selected");
 
     expect(childHasClass).toEqual(true);


### PR DESCRIPTION
Per [React's top-level API documentation](https://reactjs.org/docs/react-api.html#createfactory), using `createFactory` isn't really intended for a project to use if it's using JSX. Also, more developers will be familiar with using JSX.

For these reasons, this PR removes most instances of `createFactory` and replaces them with JSX.

Whereas before there would be something like:

```js
const Component = createFactory(_Component)
const rendered = new Component({some: "prop"});
```

Now there will be:

```jsx
const rendered = <Component some="prop" />
```

The `ManagedTree` component still uses `createFactory`. Changing that over revealed some prop-type failures, and will take some more digging to resolve.

Let me know if there's some good reasons for staying with `createFactory` instead of just using JSX. However, I can't really think of any, and being consistent with the community and with how we generally create React elements in this project probably makes sense.

### Test Plan

Ran the tests, which are green.
