### PR TITLE
Stop breakpoint label click from toggling breakpoint

### DIFF
--- a/src/components/SecondaryPanes/Breakpoints.css
+++ b/src/components/SecondaryPanes/Breakpoints.css
@@ -71,6 +71,7 @@ html .breakpoints-list .breakpoint.paused {
   overflow-x: hidden;
   text-overflow: ellipsis;
   padding: 1px 0;
+  vertical-align: bottom;
 }
 
 .breakpoints-list .pause-indicator {

--- a/src/components/SecondaryPanes/Breakpoints.js
+++ b/src/components/SecondaryPanes/Breakpoints.js
@@ -368,14 +368,14 @@ class Breakpoints extends PureComponent {
         onClick={() => this.selectBreakpoint(breakpoint)}
         onContextMenu={e => this.showContextMenu(e, breakpoint)}
       >
+        <input
+          type="checkbox"
+          className="breakpoint-checkbox"
+          checked={!isDisabled}
+          onChange={() => this.handleCheckbox(breakpoint)}
+          onClick={ev => ev.stopPropagation()}
+        />
         <label className="breakpoint-label" title={breakpoint.text}>
-          <input
-            type="checkbox"
-            className="breakpoint-checkbox"
-            checked={!isDisabled}
-            onChange={() => this.handleCheckbox(breakpoint)}
-            onClick={ev => ev.stopPropagation()}
-          />
           {renderSourceLocation(breakpoint.location.source, line, column)}
         </label>
         <div className="breakpoint-snippet">{snippet}</div>


### PR DESCRIPTION
Associated Issue: #4262

### Summary of Changes

* Stops the click on a breakpoint from toggling it as well
* Preserves the more semantic `<label>` and `<input>` tag pattern introduced [here](https://github.com/devtools-html/debugger.html/pull/4057), without breaking the click
* Centers the label text correctly (compare to bottom alignment [here](http://g.recordit.co/6gGbbS07dG.gif))

### Test Plan

Clicking in the debugger

### Screenshot

<img width="306" alt="screen shot 2017-10-03 at 8 22 07 pm" src="https://user-images.githubusercontent.com/1042288/31154948-b06aac06-a878-11e7-9a27-328d1ddcf222.png">

