### PR TITLE
Migrate ManagedTree proptypes to flow

### DIFF
--- a/src/components/shared/ManagedTree.js
+++ b/src/components/shared/ManagedTree.js
@@ -147,6 +147,4 @@ class ManagedTree extends Component {
   }
 }
 
-ManagedTree.propTypes = Object.assign({}, Tree.propTypes);
-
 export default ManagedTree;


### PR DESCRIPTION
Removes dangling propTypes definition for the ManagedTree component, since it already uses Flow's props.