### PR TITLE
Added step over functionality for yield (#4232)

### DIFF
--- a/src/workers/parser/steps.js
+++ b/src/workers/parser/steps.js
@@ -1,11 +1,11 @@
 import { Source } from "../../../flow-typed/debugger-html";
 import { AstPosition } from "./types";
 import { getClosestPath } from "./utils/closest";
-import { isAwaitExpression } from "./utils/helpers";
+import { isAwaitExpression, isYieldExpression } from "./utils/helpers";
 import type { NodePath } from "babel-traverse";
 
 export function getNextStep(source: Source, pausedPosition: AstPosition) {
-  const awaitExpression = getAwaitExpression(source, pausedPosition);
+  const awaitExpression = getAsyncExpression(source, pausedPosition);
   if (!awaitExpression) {
     return null;
   }
@@ -13,18 +13,18 @@ export function getNextStep(source: Source, pausedPosition: AstPosition) {
   return getLocationAfterAwaitExpression(awaitStatement, pausedPosition);
 }
 
-function getAwaitExpression(source: Source, pausedPosition: AstPosition) {
+function getAsyncExpression(source: Source, pausedPosition: AstPosition) {
   const closestPath = getClosestPath(source, pausedPosition);
 
   if (!closestPath) {
     return null;
   }
 
-  if (isAwaitExpression(closestPath)) {
+  if (isAwaitExpression(closestPath) || isYieldExpression(closestPath)) {
     return closestPath;
   }
 
-  return closestPath.find(p => p.isAwaitExpression());
+  return closestPath.find(p => p.isAwaitExpression() || p.isYieldExpression());
 }
 
 function getLocationAfterAwaitExpression(

--- a/src/workers/parser/steps.js
+++ b/src/workers/parser/steps.js
@@ -5,15 +5,15 @@ import { isAwaitExpression, isYieldExpression } from "./utils/helpers";
 import type { NodePath } from "babel-traverse";
 
 export function getNextStep(source: Source, pausedPosition: AstPosition) {
-  const awaitExpression = getAsyncExpression(source, pausedPosition);
-  if (!awaitExpression) {
+  const currentExpression = getSteppableExpression(source, pausedPosition);
+  if (!currentExpression) {
     return null;
   }
-  const awaitStatement = awaitExpression.getStatementParent();
-  return getLocationAfterAwaitExpression(awaitStatement, pausedPosition);
+  const currentStatement = currentExpression.getStatementParent();
+  return _getNextStep(currentStatement, pausedPosition);
 }
 
-function getAsyncExpression(source: Source, pausedPosition: AstPosition) {
+function getSteppableExpression(source: Source, pausedPosition: AstPosition) {
   const closestPath = getClosestPath(source, pausedPosition);
 
   if (!closestPath) {
@@ -27,10 +27,7 @@ function getAsyncExpression(source: Source, pausedPosition: AstPosition) {
   return closestPath.find(p => p.isAwaitExpression() || p.isYieldExpression());
 }
 
-function getLocationAfterAwaitExpression(
-  statement: NodePath,
-  position: AstPosition
-) {
+function _getNextStep(statement: NodePath, position: AstPosition) {
   const nextStatement = statement.getSibling(statement.key + 1);
   if (nextStatement.node) {
     return {

--- a/src/workers/parser/tests/fixtures/async.js
+++ b/src/workers/parser/tests/fixtures/async.js
@@ -8,8 +8,3 @@ async function stuff() {
   await foo(1);
   await foo(2);
 }
-
-function* bar() {
-  yield 1;
-  yield 2;
-}

--- a/src/workers/parser/tests/fixtures/async.js
+++ b/src/workers/parser/tests/fixtures/async.js
@@ -8,3 +8,8 @@ async function stuff() {
   await foo(1);
   await foo(2);
 }
+
+function* bar() {
+  yield 1;
+  yield 2;
+}

--- a/src/workers/parser/tests/fixtures/generators.js
+++ b/src/workers/parser/tests/fixtures/generators.js
@@ -1,0 +1,4 @@
+function* foo() {
+  yield 1;
+  yield 2;
+}

--- a/src/workers/parser/tests/steps.spec.js
+++ b/src/workers/parser/tests/steps.spec.js
@@ -37,17 +37,17 @@ describe("getNextStep", () => {
 
   describe("yield", () => {
     it("first yield call", () => {
-      const source = getSource("async");
-      const pausePosition = { line: 13, column: 2, sourceId: "async" };
+      const source = getSource("generators");
+      const pausePosition = { line: 2, column: 2, sourceId: "generators" };
       expect(getNextStep(source, pausePosition)).toEqual({
         ...pausePosition,
-        line: 14
+        line: 3
       });
     });
 
     it("second yield call", () => {
-      const source = getSource("async");
-      const pausePosition = { line: 14, column: 2, sourceId: "async" };
+      const source = getSource("generators");
+      const pausePosition = { line: 3, column: 2, sourceId: "generators" };
       expect(getNextStep(source, pausePosition)).toEqual(null);
     });
   });

--- a/src/workers/parser/tests/steps.spec.js
+++ b/src/workers/parser/tests/steps.spec.js
@@ -2,34 +2,53 @@ import { getNextStep } from "../steps";
 import { getSource } from "./helpers";
 
 describe("getNextStep", () => {
-  it("first await call", () => {
-    const source = getSource("async");
-    const pausePosition = { line: 8, column: 2, sourceId: "async" };
-    expect(getNextStep(source, pausePosition)).toEqual({
-      ...pausePosition,
-      line: 9
+  describe("await", () => {
+    it("first await call", () => {
+      const source = getSource("async");
+      const pausePosition = { line: 8, column: 2, sourceId: "async" };
+      expect(getNextStep(source, pausePosition)).toEqual({
+        ...pausePosition,
+        line: 9
+      });
+    });
+
+    it("first await call expression", () => {
+      const source = getSource("async");
+      const pausePosition = { line: 8, column: 9, sourceId: "async" };
+      expect(getNextStep(source, pausePosition)).toEqual({
+        ...pausePosition,
+        line: 9,
+        column: 2
+      });
+    });
+
+    it("second await call", () => {
+      const source = getSource("async");
+      const pausePosition = { line: 9, column: 2, sourceId: "async" };
+      expect(getNextStep(source, pausePosition)).toEqual(null);
+    });
+
+    it("second call expression", () => {
+      const source = getSource("async");
+      const pausePosition = { line: 9, column: 9, sourceId: "async" };
+      expect(getNextStep(source, pausePosition)).toEqual(null);
     });
   });
 
-  it("first await call expression", () => {
-    const source = getSource("async");
-    const pausePosition = { line: 8, column: 9, sourceId: "async" };
-    expect(getNextStep(source, pausePosition)).toEqual({
-      ...pausePosition,
-      line: 9,
-      column: 2
+  describe("yield", () => {
+    it("first yield call", () => {
+      const source = getSource("async");
+      const pausePosition = { line: 13, column: 2, sourceId: "async" };
+      expect(getNextStep(source, pausePosition)).toEqual({
+        ...pausePosition,
+        line: 14
+      });
     });
-  });
 
-  it("second await call", () => {
-    const source = getSource("async");
-    const pausePosition = { line: 9, column: 2, sourceId: "async" };
-    expect(getNextStep(source, pausePosition)).toEqual(null);
-  });
-
-  it("second call expression", () => {
-    const source = getSource("async");
-    const pausePosition = { line: 9, column: 9, sourceId: "async" };
-    expect(getNextStep(source, pausePosition)).toEqual(null);
+    it("second yield call", () => {
+      const source = getSource("async");
+      const pausePosition = { line: 14, column: 2, sourceId: "async" };
+      expect(getNextStep(source, pausePosition)).toEqual(null);
+    });
   });
 });

--- a/src/workers/parser/utils/helpers.js
+++ b/src/workers/parser/utils/helpers.js
@@ -24,6 +24,14 @@ export function isAwaitExpression(path: NodePath) {
   );
 }
 
+export function isYieldExpression(path: NodePath) {
+  return (
+    t.isYieldExpression(path) ||
+    t.isYieldExpression(path.container.init) ||
+    t.isYieldExpression(path.parentPath)
+  );
+}
+
 export function isVariable(path: NodePath) {
   return (
     t.isVariableDeclaration(path) ||


### PR DESCRIPTION
Associated Issue: #4232

### Summary of Changes

* Added step over functionality for `yield`

### Test Plan

Tell us a little a bit about how you tested your patch.

Example test plan:

- [x] Wrote local HTML to try out step over functionality for `await` and `yield`
- [x] Wrote unit tests to cover `yield` step over scenarios.

Opened with @longitude @mjfrancoeur.