### PR TITLE
Extract temp variables for wrapped components in their tests

### DIFF
--- a/src/components/Editor/tests/Breakpoints.spec.js
+++ b/src/components/Editor/tests/Breakpoints.spec.js
@@ -3,6 +3,8 @@ import { shallow } from "enzyme";
 import Breakpoints from "../Breakpoints";
 import * as I from "immutable";
 
+const BreakpointsComponent = Breakpoints.WrappedComponent;
+
 function generateDefaults(overrides) {
   const sourceId = "server1.conn1.child1/source1";
   const matchingBreakpoints = { id1: { location: { sourceId } } };
@@ -21,7 +23,7 @@ function generateDefaults(overrides) {
 
 function render(overrides = {}) {
   const props = generateDefaults(overrides);
-  const component = shallow(<Breakpoints.WrappedComponent {...props} />);
+  const component = shallow(<BreakpointsComponent {...props} />);
   return { component, props };
 }
 

--- a/src/components/Editor/tests/SearchBar.spec.js
+++ b/src/components/Editor/tests/SearchBar.spec.js
@@ -4,6 +4,8 @@ import SearchBar from "../SearchBar";
 import "../../../workers/search";
 import "../../../utils/editor";
 
+const SearchBarComponent = SearchBar.WrappedComponent;
+
 jest.mock("../../../workers/search", () => ({
   getMatches: () => Promise.resolve(["result"])
 }));
@@ -37,7 +39,7 @@ function generateDefaults() {
 function render(overrides = {}) {
   const defaults = generateDefaults();
   const props = { ...defaults, ...overrides };
-  const component = shallow(<SearchBar.WrappedComponent {...props} />);
+  const component = shallow(<SearchBarComponent {...props} />);
   return { component, props };
 }
 


### PR DESCRIPTION
Follow up to #4260. This PR extracts some temp variables in a couple of the tests.