### PR TITLE
Removes unneeded SVG DOM elements for source tree arrows.

### DIFF
--- a/src/components/PrimaryPanes/Sources.css
+++ b/src/components/PrimaryPanes/Sources.css
@@ -51,6 +51,11 @@
   display: inline-block;
 }
 
+.sources-list .tree .node .no-arrow {
+  width: 10px;
+  display: inline-block;
+}
+
 .no-sources-message {
   font-size: 12px;
   color: var(--theme-comment-alt);

--- a/src/components/PrimaryPanes/SourcesTree.js
+++ b/src/components/PrimaryPanes/SourcesTree.js
@@ -208,18 +208,19 @@ class SourcesTree extends Component {
   }
 
   renderItem(item, depth, focused, _, expanded, { setExpanded }) {
-    const arrow = (
+    const arrow = nodeHasChildren(item) ? (
       <Svg
         name="arrow"
         className={classnames({
-          expanded: expanded,
-          hidden: !nodeHasChildren(item)
+          expanded: expanded
         })}
         onClick={e => {
           e.stopPropagation();
           setExpanded(item, !expanded);
         }}
       />
+    ) : (
+      <i className="no-arrow" />
     );
 
     const icon = this.getIcon(item, depth);


### PR DESCRIPTION
Associated Issue: #4168

I cannot properly measure, but for 3k files win is about 10%-20% (e.g. 2500ms->2000ms) during forceUpdate() of the SourceTree.