### PR TITLE
Fix one case of different lodash import format

### DIFF
--- a/src/components/Editor/Preview/index.js
+++ b/src/components/Editor/Preview/index.js
@@ -1,7 +1,7 @@
 import React, { PureComponent } from "react";
 import { bindActionCreators } from "redux";
 import { connect } from "react-redux";
-import debounce from "lodash/debounce";
+import { debounce } from "lodash";
 
 import Popup from "./Popup";
 


### PR DESCRIPTION
I noticed this when searching for lodash usage.  Only one that's different.