### PR TITLE
Make keyboard shortcuts button more specific and localized

### DIFF
--- a/assets/panel/debugger.properties
+++ b/assets/panel/debugger.properties
@@ -790,3 +790,7 @@ shortcuts.projectSearch=Full Project Search
 # LOCALIZATION NOTE (shortcuts.functionSearch): text describing
 # keyboard shortcut action for function search
 shortcuts.functionSearch=Function Search
+
+# LOCALIZATION NOTE (shortcuts.buttonName): text describing
+# keyboard shortcut button text
+shortcuts.buttonName=Keyboard shortcuts

--- a/src/components/SecondaryPanes/UtilsBar.js
+++ b/src/components/SecondaryPanes/UtilsBar.js
@@ -32,7 +32,7 @@ class UtilsBar extends Component {
         this.props.toggleShortcutsModal,
         "shortcut",
         "active",
-        "shortcuts",
+        L10N.getStr("shortcuts.buttonName"),
         false
       )
     ];


### PR DESCRIPTION
"shortcuts" doesn't mean much and doesn't follow the "Uppercase lower lower" pattern used elsewhere.