### PR TITLE
Make alt click expand/collapse all the nodes

### DIFF
--- a/src/components/PrimaryPanes/SourcesTree.js
+++ b/src/components/PrimaryPanes/SourcesTree.js
@@ -231,7 +231,7 @@ class SourcesTree extends Component {
         })}
         onClick={e => {
           e.stopPropagation();
-          setExpanded(item, !expanded);
+          setExpanded(item, !expanded, e.altKey);
         }}
       />
     ) : (
@@ -252,9 +252,9 @@ class SourcesTree extends Component {
         className={classnames("node", { focused })}
         style={{ [paddingDir]: `${depth * 15 + 5}px` }}
         key={item.path}
-        onClick={() => {
+        onClick={e => {
           this.selectItem(item);
-          setExpanded(item, !expanded);
+          setExpanded(item, !expanded, e.altKey);
         }}
         onContextMenu={e => this.onContextMenu(e, item)}
       >

--- a/src/components/shared/ManagedTree.js
+++ b/src/components/shared/ManagedTree.js
@@ -1,6 +1,5 @@
 // @flow
 import React, { createFactory, Component } from "react";
-import { nodeHasChildren } from "../../utils/sources-tree";
 import "./ManagedTree.css";
 
 import { Tree as _Tree } from "devtools-components";
@@ -69,31 +68,32 @@ class ManagedTree extends Component {
     }
   }
 
-  setExpanded = (item: Item, isExpanded: boolean, isRecursive: boolean) => {
+  setExpanded = (
+    item: Item,
+    isExpanded: boolean,
+    shouldIncludeChildren: boolean
+  ) => {
+    const expandItem = i => {
+      const path = this.props.getPath(i);
+      if (isExpanded) {
+        expanded.add(path);
+      } else {
+        expanded.delete(path);
+      }
+    };
     const expanded = this.state.expanded;
-    let itemPath = this.props.getPath(item);
-    if (isExpanded) {
-      expanded.add(itemPath);
-    } else {
-      expanded.delete(itemPath);
-    }
-    if (isRecursive) {
-      let children = null;
+    expandItem(item);
+
+    if (shouldIncludeChildren) {
       let parents = [item];
       while (parents.length) {
-        children = [];
+        const children = [];
         for (const parent of parents) {
-          if (!nodeHasChildren(parent)) {
-            continue;
-          }
-          for (const child of parent.contents) {
-            itemPath = this.props.getPath(child);
-            if (isExpanded) {
-              expanded.add(itemPath);
-            } else {
-              expanded.delete(itemPath);
+          if (parent.contents && parent.contents.length) {
+            for (const child of parent.contents) {
+              expandItem(child);
+              children.push(child);
             }
-            children.push(child);
           }
         }
         parents = children;


### PR DESCRIPTION
Associated Issue: #4061

### Summary of Changes
Expand/Collapse all nodes in the source tree when doing alt click on the tree item(folder)

### Screenshots
![4061-altkey-expand-collapse-all-nodes](https://user-images.githubusercontent.com/5627487/31287959-b2194326-aaf5-11e7-8353-b074c9d16b1a.gif)
