### PR TITLE
- unifies right click "Copy source URI" for tree view & tab view (#4325)

### DIFF
--- a/assets/panel/debugger.properties
+++ b/assets/panel/debugger.properties
@@ -441,11 +441,6 @@ sourceTabs.closeAllTabs.accesskey=a
 sourceTabs.revealInTree=Reveal in tree
 sourceTabs.revealInTree.accesskey=r
 
-# LOCALIZATION NOTE (sourceTabs.copyLink): Editor source tab context menu item
-# for copying a link address.
-sourceTabs.copyLink=Copy link address
-sourceTabs.copyLink.accesskey=l
-
 # LOCALIZATION NOTE (sourceTabs.prettyPrint): Editor source tab context menu item
 # for pretty printing the source.
 sourceTabs.prettyPrint=Pretty print source

--- a/src/components/Editor/Tabs.js
+++ b/src/components/Editor/Tabs.js
@@ -182,7 +182,7 @@ class SourceTabs extends PureComponent {
     const closeTabsToEndLabel = L10N.getStr("sourceTabs.closeTabsToEnd");
     const closeAllTabsLabel = L10N.getStr("sourceTabs.closeAllTabs");
     const revealInTreeLabel = L10N.getStr("sourceTabs.revealInTree");
-    const copyLinkLabel = L10N.getStr("sourceTabs.copyLink");
+    const copyLinkLabel = L10N.getStr("copySourceUri2");
     const prettyPrintLabel = L10N.getStr("sourceTabs.prettyPrint");
 
     const closeTabKey = L10N.getStr("sourceTabs.closeTab.accesskey");
@@ -194,7 +194,7 @@ class SourceTabs extends PureComponent {
     );
     const closeAllTabsKey = L10N.getStr("sourceTabs.closeAllTabs.accesskey");
     const revealInTreeKey = L10N.getStr("sourceTabs.revealInTree.accesskey");
-    const copyLinkKey = L10N.getStr("sourceTabs.copyLink.accesskey");
+    const copyLinkKey = L10N.getStr("copySourceUri2.accesskey");
     const prettyPrintKey = L10N.getStr("sourceTabs.prettyPrint.accesskey");
 
     const tabs = sourceTabs.map(t => t.get("id"));


### PR DESCRIPTION
Associated Issue: #4325 

### Summary of Changes

* removed sourceTabs.copyLink and all its occurrences
* substituted copySourceUri2 instead

### Test Plan

Launched yarn and compared the right-click response in both windows 

### Screenshots/Videos

http://g.recordit.co/KTpdMyLWck.gif
