### PR TITLE
Protect Worker and Browser Content Toolboxes

### DIFF
--- a/src/client/firefox.js
+++ b/src/client/firefox.js
@@ -35,9 +35,13 @@ export async function onConnect(connection: any, actions: Object): Object {
     wasmBinarySource: supportsWasm
   });
 
-  threadClient._parent
-    .listWorkers()
-    .then(workers => actions.setWorkers(workers));
+  // NOTE: The Worker and Browser Content toolboxes do not have a parent
+  // with a listWorkers function
+  if (threadClient._parent && threadClient._parent.listWorkers) {
+    threadClient._parent
+      .listWorkers()
+      .then(workers => actions.setWorkers(workers));
+  }
 
   // In Firefox, we need to initially request all of the sources. This
   // usually fires off individual `newSource` notifications as the


### PR DESCRIPTION

### Summary of Changes

Add's a guard statement to protect against unsafe `listWorker` calls
