### PR TITLE
Align empty message in Source Tab

### DIFF
--- a/src/components/PrimaryPanes/Sources.css
+++ b/src/components/PrimaryPanes/Sources.css
@@ -58,12 +58,12 @@
 }
 
 .no-sources-message {
+  width: 100%;
+  font-style: italic;
+  text-align: center;
+  padding: 0.5em;
   font-size: 12px;
-  color: var(--theme-comment-alt);
-  font-weight: lighter;
-  padding-top: 5px;
-  flex-grow: 1;
-  display: flex;
+  user-select: none;
   justify-content: center;
   align-items: center;
 }


### PR DESCRIPTION
Associated Issue: #4185 

### Summary of Changes

* Changed Empty message styling.
* As indicated by @gabrielluong I changed empty message of Sources tab as that of Outline tab.

### Screenshots

![screenshot-2017-10-10 debugger](https://user-images.githubusercontent.com/21259802/31400899-c6636cbe-ae0e-11e7-893d-f2021fa5cb8c.png)

![screenshot-2017-10-10 debugger 1](https://user-images.githubusercontent.com/21259802/31400904-ceb2b8e8-ae0e-11e7-9cb3-57f31545bd52.png)
