### PR TITLE
Remove last vestige of devtools.debugger.client-source-maps-enabled

### DIFF
--- a/assets/panel/prefs.js
+++ b/assets/panel/prefs.js
@@ -12,10 +12,6 @@ pref("devtools.debugger.remote-timeout", 20000);
 pref("devtools.debugger.pause-on-exceptions", false);
 pref("devtools.debugger.ignore-caught-exceptions", false);
 pref("devtools.debugger.source-maps-enabled", true);
-// Temporarily leave this in place, even though it is unused, so the
-// options pane doesn't break.
-// https://bugzilla.mozilla.org/show_bug.cgi?id=1371849
-pref("devtools.debugger.client-source-maps-enabled", true);
 pref("devtools.debugger.pretty-print-enabled", true);
 pref("devtools.debugger.auto-pretty-print", false);
 pref("devtools.debugger.auto-black-box", true);


### PR DESCRIPTION
devtools.debugger.client-source-maps-enabled is no longer needed, and so
this removes the definition of it.
