### PR TITLE
Fixed issue #4291

### DIFF
--- a/src/components/ShortcutsModal.css
+++ b/src/components/ShortcutsModal.css
@@ -52,3 +52,9 @@
   justify-content: space-between;
   border: 1px solid transparent;
 }
+
+@media (max-width: 640px) {
+  .shortcuts-section {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
Set media query @640px or smaller to respect the containers width.

Associated Issue: #4291

### Summary of Changes

* Made shortcuts section responsive to narrow widths

### Demo

![shorcuts_section](https://user-images.githubusercontent.com/579618/31410250-a3132208-adba-11e7-89f1-fdf44cb1dd60.PNG)

