### PR TITLE
Replace lodash find with native Array::find. Fixes #4343.

### DIFF
--- a/src/components/Editor/CallSites.js
+++ b/src/components/Editor/CallSites.js
@@ -3,7 +3,7 @@ import { connect } from "react-redux";
 import { bindActionCreators } from "redux";
 import { isEnabled } from "devtools-config";
 
-import { range, keyBy, find, isEqualWith } from "lodash";
+import { range, keyBy, isEqualWith } from "lodash";
 
 import CallSite from "./CallSite";
 
@@ -19,7 +19,7 @@ import { getTokenLocation, isWasm } from "../../utils/editor";
 import actions from "../../actions";
 
 function getCallSiteAtLocation(callSites, location) {
-  return find(callSites, callSite =>
+  return callSites.find(callSite =>
     isEqualWith(callSite.location, location, (cloc, loc) => {
       return (
         loc.line === cloc.start.line &&

--- a/src/components/PrimaryPanes/Outline.js
+++ b/src/components/PrimaryPanes/Outline.js
@@ -7,7 +7,7 @@ import actions from "../../actions";
 import { getSelectedSource, getSymbols } from "../../selectors";
 import "./Outline.css";
 import PreviewFunction from "../shared/PreviewFunction";
-import { uniq, find } from "lodash";
+import { uniq } from "lodash";
 import type {
   SymbolDeclarations,
   SymbolDeclaration
@@ -66,7 +66,7 @@ export class Outline extends Component {
     }
 
     const klass = classFunctions[0].klass;
-    const klassFunc = find(functions, func => func.name === klass);
+    const klassFunc = functions.find(func => func.name === klass);
 
     return (
       <div className="outline-list__class">


### PR DESCRIPTION
Associated Issue: #4343

Replaced all usage of lodash's `find` with `Array::find`.