### PR TITLE
fix browser toolbox issues

### DIFF
--- a/src/client/firefox.js
+++ b/src/client/firefox.js
@@ -37,7 +37,12 @@ export async function onConnect(connection: any, actions: Object): Object {
 
   // NOTE: The Worker and Browser Content toolboxes do not have a parent
   // with a listWorkers function
-  if (threadClient._parent && threadClient._parent.listWorkers) {
+  // TODO: there is a listWorkers property, but it is not a function on the
+  // parent. Investigate what it is
+  if (
+    threadClient._parent &&
+    typeof threadClient._parent.listWorkers === "function"
+  ) {
     threadClient._parent
       .listWorkers()
       .then(workers => actions.setWorkers(workers));

--- a/src/utils/sources-tree/treeOrder.js
+++ b/src/utils/sources-tree/treeOrder.js
@@ -9,7 +9,11 @@ import type { Node } from "./types";
 /*
  * Gets domain from url (without www prefix)
  */
-export function getDomain(url: string): ?string {
+export function getDomain(url?: string): ?string {
+  // TODO: define how files should be ordered on the browser debugger
+  if (!url) {
+    return null;
+  }
   const { host } = parse(url);
   if (!host) {
     return null;


### PR DESCRIPTION
related issue: #4346 

There was an issue with debuggerUrl not being defined in the browser toolbox context and listWorkers being present but not a function on the threadClient._parent

both need more investigation, this is just to get the browser toolbox working again.