### PR TITLE
Attempt to address "Debugger.Frame is not live".

### DIFF
--- a/src/test/mochitest/browser.ini
+++ b/src/test/mochitest/browser.ini
@@ -107,5 +107,4 @@ skip-if = true # Bug 1393121, 1393299
 [browser_dbg-tabs.js]
 [browser_dbg-toggling-tools.js]
 [browser_dbg-wasm-sourcemaps.js]
-skip-if = true 
 [browser_dbg-reload.js]

--- a/src/test/mochitest/browser_dbg-wasm-sourcemaps.js
+++ b/src/test/mochitest/browser_dbg-wasm-sourcemaps.js
@@ -7,6 +7,10 @@
 add_task(async function() {
   const dbg = await initDebugger("doc-wasm-sourcemaps.html");
 
+  // NOTE: wait for page load -- attempt to fight the intermittent failure:
+  // "A promise chain failed to handle a rejection: Debugger.Frame is not live"
+  await waitForSource(dbg, "doc-wasm-sourcemaps");
+
   await reload(dbg);
   await waitForPaused(dbg);
   assertPausedLocation(dbg);


### PR DESCRIPTION
Associated Issue: Failure at https://bugzilla.mozilla.org/show_bug.cgi?id=1406551#c5