### PR TITLE
Removed tabs + button

### DIFF
--- a/assets/panel/debugger.properties
+++ b/assets/panel/debugger.properties
@@ -468,10 +468,6 @@ sourceFooter.codeCoverage=Code coverage
 # for close tab button in source tabs.
 sourceTabs.closeTabButtonTooltip=Close tab
 
-# LOCALIZATION NOTE (sourceTabs.newTabButtonTooltip): The tooltip that is displayed for
-# new tab button in source tabs.
-sourceTabs.newTabButtonTooltip=Search for sources (%S)
-
 # LOCALIZATION NOTE (scopes.header): Scopes right sidebar pane header.
 scopes.header=Scopes
 

--- a/src/components/Editor/Tabs.js
+++ b/src/components/Editor/Tabs.js
@@ -20,7 +20,6 @@ import CloseButton from "../shared/Button/Close";
 import Svg from "../shared/Svg";
 import { showMenu, buildMenu } from "devtools-launchpad";
 import { debounce } from "lodash";
-import { formatKeyShortcut } from "../../utils/text";
 import "./Tabs.css";
 
 import PaneToggleButton from "../shared/Button/PaneToggle";
@@ -91,7 +90,6 @@ class SourceTabs extends PureComponent {
   renderTab: Function;
   renderSourceTab: Function;
   renderSearchTab: Function;
-  renderNewButton: Function;
   renderDropDown: Function;
   renderStartPanelToggleButton: Function;
   renderEndPanelToggleButton: Function;
@@ -134,7 +132,6 @@ class SourceTabs extends PureComponent {
     this.renderTabs = this.renderTabs.bind(this);
     this.renderSourceTab = this.renderSourceTab.bind(this);
     this.renderSearchTab = this.renderSearchTab.bind(this);
-    this.renderNewButton = this.renderNewButton.bind(this);
     this.renderDropDown = this.renderDropdown.bind(this);
     this.renderStartPanelToggleButton = this.renderStartPanelToggleButton.bind(
       this
@@ -418,30 +415,6 @@ class SourceTabs extends PureComponent {
     );
   }
 
-  renderNewButton() {
-    const newTabTooltip = L10N.getFormatStr(
-      "sourceTabs.newTabButtonTooltip",
-      formatKeyShortcut(L10N.getStr("sources.search.key2"))
-    );
-
-    const onButtonClick = () => {
-      if (this.props.searchOn) {
-        return this.props.closeActiveSearch();
-      }
-      this.props.setActiveSearch("source");
-    };
-
-    return (
-      <div
-        className="new-tab-btn"
-        onClick={onButtonClick}
-        title={newTabTooltip}
-      >
-        <Svg name="plus" />
-      </div>
-    );
-  }
-
   renderDropdown() {
     const hiddenSourceTabs = this.state.hiddenSourceTabs;
     if (!hiddenSourceTabs || hiddenSourceTabs.size == 0) {
@@ -494,7 +467,6 @@ class SourceTabs extends PureComponent {
       <div className="source-header">
         {this.renderStartPanelToggleButton()}
         {this.renderTabs()}
-        {this.renderNewButton()}
         {this.renderDropdown()}
         {this.renderEndPanelToggleButton()}
       </div>


### PR DESCRIPTION
Associated Issue: #4312

### Summary of Changes

Removed:
* import of formatKeyShortcut
* onclick
* render newButton method
* property sourceTabs.newTabButtonTooltip

Kept:
* SVG plus icon

### Test Plan

Tell us a little a bit about how you tested your patch.

Example test plan:

Within Firefox debugger tab
- [x] Add several tabs from the source list
- [x] Remove tabs

Here's the Debugger's Testing doc
https://docs.google.com/document/d/1oBMRxV8A2ag2t22YsQOxTdEv0mXKzIg0tggJjRkU1S0/edit#.
Feel free to improve it!

### Screenshots/Videos (OPTIONAL)

![debugger](https://user-images.githubusercontent.com/579618/31523597-ee342a28-af60-11e7-8954-537c918b335f.PNG)
