### PR TITLE
add shortcuts modal in vertical mode (#4288)

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -108,10 +108,7 @@ class App extends Component {
       this.toggleSymbolModal
     );
 
-    shortcuts.on(
-      L10N.getStr("gotoLineModal.key"),
-      this.toggleGoToLineModal
-    );
+    shortcuts.on(L10N.getStr("gotoLineModal.key"), this.toggleGoToLineModal);
 
     shortcuts.on("Escape", this.onEscape);
     shortcuts.on("Cmd+/", this.onCommandSlash);
@@ -290,7 +287,12 @@ class App extends Component {
             endPanel={this.renderEditorPane()}
           />
         }
-        endPanel={<SecondaryPanes horizontal={horizontal} />}
+        endPanel={
+          <SecondaryPanes
+            horizontal={horizontal}
+            toggleShortcutsModal={() => this.toggleShortcutsModal()}
+          />
+        }
         endPanelCollapsed={endPanelCollapsed}
       />
     );


### PR DESCRIPTION
Associated Issue: #4288 

Here's the Pull Request Doc
https://devtools-html.github.io/debugger.html/CONTRIBUTING.html#pull-requests

### Summary of Changes

* Added the shortcuts modal logic to the vertical mode component.

### Test Plan

Tell us a little a bit about how you tested your patch.

Example test plan:

- [x] Shrink down the debugging window render vertical mode
- [x] Clicking “K+” opens the shortcut modal
- [x] Clicking outside of the shortcuts modal closes the shortcuts modal

Here's the Debugger's Testing doc
https://docs.google.com/document/d/1oBMRxV8A2ag2t22YsQOxTdEv0mXKzIg0tggJjRkU1S0/edit#.
Feel free to improve it!

### Screenshots/Videos (OPTIONAL)
