### PR TITLE
Move "horizontal" state to Redux

### DIFF
--- a/src/actions/ui.js
+++ b/src/actions/ui.js
@@ -1,7 +1,11 @@
 // @flow
 import { getSource, getActiveSearch } from "../selectors";
 import type { ThunkArgs } from "./types";
-import type { ActiveSearchType, SymbolSearchType } from "../reducers/ui";
+import type {
+  ActiveSearchType,
+  SymbolSearchType,
+  OrientationType
+} from "../reducers/ui";
 import { clearSourceSearchQuery } from "./source-search";
 
 export function setContextMenu(type: string, event: any) {
@@ -124,4 +128,8 @@ export function setProjectDirectoryRoot(url: Object) {
     type: "SET_PROJECT_DIRECTORY_ROOT",
     url
   };
+}
+
+export function setOrientation(orientation: OrientationType) {
+  return { type: "SET_ORIENTATION", orientation };
 }

--- a/src/reducers/types.js
+++ b/src/reducers/types.js
@@ -32,5 +32,5 @@ export type PendingSelectedLocation = {
 };
 
 export type { SourceRecord, SourcesMap } from "./sources";
-
+export type { SymbolSearchType, ActiveSearchType, OrientationType } from "./ui";
 export type { BreakpointsMap } from "./breakpoints";

--- a/src/reducers/ui.js
+++ b/src/reducers/ui.js
@@ -22,6 +22,8 @@ export type ActiveSearchType =
   | "symbol"
   | "line";
 
+export type OrientationType = "horizontal" | "vertical";
+
 export type UIState = {
   activeSearch: ?ActiveSearchType,
   contextMenu: any,
@@ -31,6 +33,7 @@ export type UIState = {
   endPanelCollapsed: boolean,
   frameworkGroupingOn: boolean,
   projectDirectoryRoot: string,
+  orientation: OrientationType,
   highlightedLineRange?: {
     start?: number,
     end?: number,
@@ -50,7 +53,8 @@ export const State = makeRecord(
     endPanelCollapsed: prefs.endPanelCollapsed,
     frameworkGroupingOn: prefs.frameworkGroupingOn,
     highlightedLineRange: undefined,
-    conditionalPanelLine: null
+    conditionalPanelLine: null,
+    orientation: "horizontal"
   }: UIState)
 );
 
@@ -74,6 +78,10 @@ function update(
 
     case "SET_CONTEXT_MENU": {
       return state.set("contextMenu", action.contextMenu);
+    }
+
+    case "SET_ORIENTATION": {
+      return state.set("orientation", action.orientation);
     }
 
     case "SHOW_SOURCE": {
@@ -164,6 +172,10 @@ export function getConditionalPanelLine(state: OuterState): null | number {
 
 export function getProjectDirectoryRoot(state: OuterState): boolean {
   return state.ui.get("projectDirectoryRoot");
+}
+
+export function getOrientation(state: OuterState): boolean {
+  return state.ui.get("orientation");
 }
 
 export default update;

--- a/src/test/mochitest/head.js
+++ b/src/test/mochitest/head.js
@@ -362,7 +362,8 @@ function createDebuggerContext(toolbox) {
     store: store,
     client: client,
     toolbox: toolbox,
-    win: win
+    win: win,
+    panel: panel
   };
 }
 
@@ -504,7 +505,7 @@ function stepOut(dbg) {
 function resume(dbg) {
   info("Resuming");
   dbg.actions.resume();
-  return waitForState(dbg, (state) => !dbg.selectors.isPaused(state));
+  return waitForState(dbg, state => !dbg.selectors.isPaused(state));
 }
 
 function deleteExpression(dbg, input) {


### PR DESCRIPTION
### Summary of Changes

It would be nice to move the horizontal state to the UI reducer as an "orientation" field. The benefit is this:

1. persistence
2. other components can hook in fetch state/set it
3. tests are easier here