### PR TITLE
Use a monospace font for editor line numbers

### DIFF
--- a/src/components/Editor/Editor.css
+++ b/src/components/Editor/Editor.css
@@ -120,8 +120,9 @@ html[dir="rtl"] .editor-mount {
 }
 
 .CodeMirror-linenumber {
-  font-size: 11px;
-  line-height: 14px;
+  font-size: 12px;
+  line-height: 15px;
+  font-family: monospace;
 }
 
 .folding-enabled .CodeMirror-linenumber {


### PR DESCRIPTION
IMO a monospaced font for the editor looks better:

Before:

<img width="32" alt="linenumbers" src="https://user-images.githubusercontent.com/46655/31641401-f482fea8-b2a9-11e7-823c-5fc0148e8174.png">

After:
<img width="115" alt="monospaced" src="https://user-images.githubusercontent.com/46655/31641396-ee021ba4-b2a9-11e7-9955-3196489a03a0.png">
