### PR TITLE
Move the Editor font to Monospace

### DIFF
--- a/src/components/Editor/Editor.css
+++ b/src/components/Editor/Editor.css
@@ -119,7 +119,7 @@ html[dir="rtl"] .editor-mount {
   background-color: var(--theme-body-background);
 }
 
-.CodeMirror-linenumber {
+.CodeMirror-code {
   font-size: 12px;
   line-height: 15px;
   font-family: monospace;
@@ -138,10 +138,6 @@ html[dir="rtl"] .editor-mount {
 /* move the breakpoint below the other gutter elements */
 .new-breakpoint .CodeMirror-gutter-elt:nth-child(2) {
   z-index: 0;
-}
-
-.editor-wrapper .CodeMirror-line {
-  font-size: 11px;
 }
 
 .theme-dark .editor-wrapper .CodeMirror-line .cm-comment {


### PR DESCRIPTION
Monospace code is an industry standard for text editors and code displays.  Let's do it!

<img width="685" alt="monocode" src="https://user-images.githubusercontent.com/46655/31642646-9a7123ba-b2b1-11e7-83e8-907401ac6064.png">
