### PR TITLE
Changes keyboard shortcut letter from O to S from to resolve conflict

### DIFF
--- a/assets/panel/debugger.properties
+++ b/assets/panel/debugger.properties
@@ -155,7 +155,7 @@ projectTextSearch.key=CmdOrCtrl+Shift+F
 
 # LOCALIZATION NOTE (functionSearch.key): A key shortcut to open the
 # modal for searching functions in a file.
-functionSearch.key=CmdOrCtrl+Shift+O
+functionSearch.key=CmdOrCtrl+Shift+S
 
 # LOCALIZATION NOTE (toggleBreakpoint.key): A key shortcut to toggle
 # breakpoints.
@@ -663,7 +663,7 @@ symbolSearch.search.variablesPlaceholder=Search variables…
 
 # LOCALIZATION NOTE(symbolSearch.search.key2): The Key Shortcut for
 # searching for a function or variable
-symbolSearch.search.key2=CmdOrCtrl+Shift+O
+symbolSearch.search.key2=CmdOrCtrl+Shift+S
 
 # LOCALIZATION NOTE(symbolSearch.searchModifier.modifiersLabel): A label
 # preceding the group of modifiers


### PR DESCRIPTION
Associated Issue: #3950

### Summary of Changes

* changes shortcut for search from CmdCtrl + Shift + O to CmdCtrl + Shift + S

