### PR TITLE
Revert "Use a monospace font for editor line numbers"

### DIFF
--- a/src/components/Editor/Editor.css
+++ b/src/components/Editor/Editor.css
@@ -120,9 +120,8 @@ html[dir="rtl"] .editor-mount {
 }
 
 .CodeMirror-linenumber {
-  font-size: 12px;
-  line-height: 15px;
-  font-family: monospace;
+  font-size: 11px;
+  line-height: 14px;
 }
 
 .folding-enabled .CodeMirror-linenumber {


### PR DESCRIPTION
So it turns out that this is simply a dev environment problem -- Nightly currently shows monospaced line numbers and code.  

We should, however, find a way to include the common.css file so that we see monospaced code in dev.