### PR TITLE
Fix "3" expressions

### DIFF
--- a/src/utils/expressions.js
+++ b/src/utils/expressions.js
@@ -5,7 +5,7 @@ import type { Expression } from "debugger-html";
 
 // replace quotes and slashes that could interfere with the evaluation.
 export function sanitizeInput(input: string) {
-  return input.replace(/\\/g, "\\\\").replace(/"/g, "\\$&");
+  return input.replace(/\\/g, "\\\\").replace(/"/g, '"');
 }
 
 /*

--- a/src/utils/tests/__snapshots__/expressions.spec.js.snap
+++ b/src/utils/tests/__snapshots__/expressions.spec.js.snap
@@ -15,3 +15,11 @@ exports[`expressions wrap exxpression should wrap expression with a comment 1`] 
  e
 }"
 `;
+
+exports[`expressions wrap exxpression should wrap quotes 1`] = `
+"try {
+ \\"2\\"
+} catch (e) {
+ e
+}"
+`;

--- a/src/utils/tests/expressions.spec.js
+++ b/src/utils/tests/expressions.spec.js
@@ -15,11 +15,19 @@ describe("expressions", () => {
     it("should wrap expression with a comment", () => {
       expect(wrapExpression("foo // yo yo")).toMatchSnapshot();
     });
+
+    it("should wrap quotes", () => {
+      expect(wrapExpression('"2"')).toMatchSnapshot();
+    });
   });
 
   describe("sanitize input", () => {
     it("sanitizes quotes", () => {
-      expect(sanitizeInput('foo"')).toEqual('foo\\"');
+      expect(sanitizeInput('foo"')).toEqual('foo"');
+    });
+
+    it("sanitizes 2 quotes", () => {
+      expect(sanitizeInput('"3"')).toEqual('"3"');
     });
 
     it("sanitizes forward slashes", () => {


### PR DESCRIPTION
### Summary of Changes

@bomsy and i found that "3" watch expressions were showing a syntax error. The problem was how we escaped the watch expression: 

this is what we want:

```
"try {
 \\"2\\"
} catch (e) {
 e
}"
```

### Test Plan

unit tests

### before

<img width="448" alt="screen shot 2017-10-18 at 10 43 28 am" src="https://user-images.githubusercontent.com/254562/31724979-37ce2b86-b3f1-11e7-8a81-412bd5506d9d.png">


### after

<img width="439" alt="screen shot 2017-10-18 at 10 38 50 am" src="https://user-images.githubusercontent.com/254562/31724957-237c88bc-b3f1-11e7-9541-2db890ced335.png">
