### PR TITLE
Fixes 3846 Source Tabs and Gutter Column Don't Line Up

### DIFF
--- a/src/components/Editor/Tabs.css
+++ b/src/components/Editor/Tabs.css
@@ -50,6 +50,10 @@
   cursor: default;
 }
 
+.source-tab:first-child {
+  margin-inline-start: 0;
+}
+
 .source-tab:hover {
   background-color: var(--theme-toolbar-background-alt);
   border-color: var(--theme-splitter-color);

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -46,6 +46,7 @@ import {
   createEditor,
   getCursorLine,
   resizeBreakpointGutter,
+  resizeToggleButton,
   traverseResults,
   toSourceLine,
   toEditorLine,
@@ -87,6 +88,7 @@ class Editor extends PureComponent {
     }
 
     resizeBreakpointGutter(this.state.editor.codeMirror);
+    resizeToggleButton(this.state.editor.codeMirror);
   }
 
   setupEditor() {
@@ -105,6 +107,8 @@ class Editor extends PureComponent {
     const codeMirrorWrapper = codeMirror.getWrapperElement();
 
     resizeBreakpointGutter(codeMirror);
+    resizeToggleButton(codeMirror);
+
     debugGlobal("cm", codeMirror);
 
     codeMirror.on("gutterClick", this.onGutterClick);

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -45,14 +45,14 @@ import {
   clearLineClass,
   createEditor,
   getCursorLine,
-  resizeBreakpointGutter,
-  resizeToggleButton,
   traverseResults,
   toSourceLine,
   toEditorLine,
   resetLineNumberFormat,
   getSourceLocationFromMouseEvent
 } from "../../utils/editor";
+
+import { resizeBreakpointGutter, resizeToggleButton } from "../../utils/ui";
 
 import "./Editor.css";
 import "./Highlight.css";

--- a/src/components/shared/Button/PaneToggle.css
+++ b/src/components/shared/Button/PaneToggle.css
@@ -2,7 +2,7 @@
 .toggle-button-end {
   transform: translate(0, 0px);
   transition: transform 0.25s ease-in-out;
-  padding: 5px 5px;
+  padding: 5px 7px 5px 6px;
 }
 
 .toggle-button-start.vertical,

--- a/src/components/shared/Button/PaneToggle.css
+++ b/src/components/shared/Button/PaneToggle.css
@@ -2,7 +2,7 @@
 .toggle-button-end {
   transform: translate(0, 0px);
   transition: transform 0.25s ease-in-out;
-  padding: 5px 7px 5px 6px;
+  padding: 5px;
 }
 
 .toggle-button-start.vertical,

--- a/src/utils/editor/source-documents.js
+++ b/src/utils/editor/source-documents.js
@@ -110,12 +110,18 @@ function showSourceText(editor: Object, source: Source) {
 function resizeBreakpointGutter(editor: Object) {
   const gutters = editor.display.gutters;
   const breakpoints = gutters.querySelector(".breakpoints");
-  breakpoints.style.width = `${getLineNumberWidth(editor)}px`;
+  if (breakpoints) {
+    breakpoints.style.width = `${getLineNumberWidth(editor)}px`;
+  }
 }
 
 function resizeToggleButton(editor: Object) {
-  const toggleButton = document.querySelector(".toggle-button-start");
-  toggleButton.style.width = `${getLineNumberWidth(editor)}px`;
+  const toggleButton = document.querySelector(
+    ".source-header .toggle-button-start"
+  );
+  if (toggleButton) {
+    toggleButton.style.width = `${getLineNumberWidth(editor)}px`;
+  }
 }
 
 export {

--- a/src/utils/editor/source-documents.js
+++ b/src/utils/editor/source-documents.js
@@ -5,7 +5,7 @@ import { getMode } from "../source";
 import type { Source } from "debugger-html";
 import { isWasm, getWasmLineNumberFormatter, renderWasmText } from "../wasm";
 import { SourceEditorUtils } from "devtools-source-editor";
-const { resizeBreakpointGutter } = SourceEditorUtils;
+const { getLineNumberWidth } = SourceEditorUtils;
 
 let sourceDocs = {};
 
@@ -29,6 +29,7 @@ function resetLineNumberFormat(editor: Object) {
   const cm = editor.codeMirror;
   cm.setOption("lineNumberFormatter", number => number);
   resizeBreakpointGutter(cm);
+  resizeToggleButton(cm);
 }
 
 function updateLineNumberFormat(editor: Object, sourceId: string) {
@@ -39,6 +40,7 @@ function updateLineNumberFormat(editor: Object, sourceId: string) {
   const lineNumberFormatter = getWasmLineNumberFormatter(sourceId);
   cm.setOption("lineNumberFormatter", lineNumberFormatter);
   resizeBreakpointGutter(cm);
+  resizeToggleButton(cm);
 }
 
 function updateDocument(editor: Object, sourceId: string) {
@@ -105,6 +107,17 @@ function showSourceText(editor: Object, source: Source) {
   updateLineNumberFormat(editor, source.id);
 }
 
+function resizeBreakpointGutter(editor: Object) {
+  const gutters = editor.display.gutters;
+  const breakpoints = gutters.querySelector(".breakpoints");
+  breakpoints.style.width = `${getLineNumberWidth(editor)}px`;
+}
+
+function resizeToggleButton(editor: Object) {
+  const toggleButton = document.querySelector(".toggle-button-start");
+  toggleButton.style.width = `${getLineNumberWidth(editor)}px`;
+}
+
 export {
   getDocument,
   setDocument,
@@ -114,5 +127,7 @@ export {
   updateLineNumberFormat,
   updateDocument,
   showSourceText,
-  showLoading
+  showLoading,
+  resizeBreakpointGutter,
+  resizeToggleButton
 };

--- a/src/utils/editor/source-documents.js
+++ b/src/utils/editor/source-documents.js
@@ -4,8 +4,7 @@ import { getMode } from "../source";
 
 import type { Source } from "debugger-html";
 import { isWasm, getWasmLineNumberFormatter, renderWasmText } from "../wasm";
-import { SourceEditorUtils } from "devtools-source-editor";
-const { getLineNumberWidth } = SourceEditorUtils;
+import { resizeBreakpointGutter, resizeToggleButton } from "../ui";
 
 let sourceDocs = {};
 
@@ -107,23 +106,6 @@ function showSourceText(editor: Object, source: Source) {
   updateLineNumberFormat(editor, source.id);
 }
 
-function resizeBreakpointGutter(editor: Object) {
-  const gutters = editor.display.gutters;
-  const breakpoints = gutters.querySelector(".breakpoints");
-  if (breakpoints) {
-    breakpoints.style.width = `${getLineNumberWidth(editor)}px`;
-  }
-}
-
-function resizeToggleButton(editor: Object) {
-  const toggleButton = document.querySelector(
-    ".source-header .toggle-button-start"
-  );
-  if (toggleButton) {
-    toggleButton.style.width = `${getLineNumberWidth(editor)}px`;
-  }
-}
-
 export {
   getDocument,
   setDocument,
@@ -133,7 +115,5 @@ export {
   updateLineNumberFormat,
   updateDocument,
   showSourceText,
-  showLoading,
-  resizeBreakpointGutter,
-  resizeToggleButton
+  showLoading
 };

--- a/src/utils/ui.js
+++ b/src/utils/ui.js
@@ -3,14 +3,14 @@
  * because it is more reliable than either checking a focus state or
  * the visibleState or hidden property.
  */
-function isVisible() {
+export function isVisible() {
   const el = document.querySelector("#mount");
   return el && el.getBoundingClientRect().width;
 }
 
 /* Gets the line numbers width in the code editor
  */
-function getLineNumberWidth(editor) {
+export function getLineNumberWidth(editor) {
   const gutters = editor.display.gutters;
   const lineNumbers = gutters.querySelector(".CodeMirror-linenumbers");
   return lineNumbers && lineNumbers.clientWidth;
@@ -22,7 +22,7 @@ function getLineNumberWidth(editor) {
  * beneath the line numbers. This makes it easy to be flexible with
  * how we overlay breakpoints.
  */
-function resizeBreakpointGutter(editor: Object) {
+export function resizeBreakpointGutter(editor: Object) {
   const gutters = editor.display.gutters;
   const breakpoints = gutters.querySelector(".breakpoints");
   if (breakpoints) {
@@ -34,7 +34,7 @@ function resizeBreakpointGutter(editor: Object) {
  * Forces the left toggle button in source header to be the same size
  * as the line numbers gutter.
  */
-function resizeToggleButton(editor: Object) {
+export function resizeToggleButton(editor: Object) {
   const toggleButton = document.querySelector(
     ".source-header .toggle-button-start"
   );
@@ -42,5 +42,3 @@ function resizeToggleButton(editor: Object) {
     toggleButton.style.width = `${getLineNumberWidth(editor)}px`;
   }
 }
-
-export { isVisible, resizeBreakpointGutter, resizeToggleButton };

--- a/src/utils/ui.js
+++ b/src/utils/ui.js
@@ -3,7 +3,44 @@
  * because it is more reliable than either checking a focus state or
  * the visibleState or hidden property.
  */
-export function isVisible() {
+function isVisible() {
   const el = document.querySelector("#mount");
   return el && el.getBoundingClientRect().width;
 }
+
+/* Gets the line numbers width in the code editor
+ */
+function getLineNumberWidth(editor) {
+  const gutters = editor.display.gutters;
+  const lineNumbers = gutters.querySelector(".CodeMirror-linenumbers");
+  return lineNumbers && lineNumbers.clientWidth;
+}
+
+/**
+ * Forces the breakpoint gutter to be the same size as the line
+ * numbers gutter. Editor CSS will absolutely position the gutter
+ * beneath the line numbers. This makes it easy to be flexible with
+ * how we overlay breakpoints.
+ */
+function resizeBreakpointGutter(editor: Object) {
+  const gutters = editor.display.gutters;
+  const breakpoints = gutters.querySelector(".breakpoints");
+  if (breakpoints) {
+    breakpoints.style.width = `${getLineNumberWidth(editor)}px`;
+  }
+}
+
+/**
+ * Forces the left toggle button in source header to be the same size
+ * as the line numbers gutter.
+ */
+function resizeToggleButton(editor: Object) {
+  const toggleButton = document.querySelector(
+    ".source-header .toggle-button-start"
+  );
+  if (toggleButton) {
+    toggleButton.style.width = `${getLineNumberWidth(editor)}px`;
+  }
+}
+
+export { isVisible, resizeBreakpointGutter, resizeToggleButton };


### PR DESCRIPTION
Associated Issue: #3846 

### Summary of Changes

* Pane toggle button padding changed to make it wider
* Margin left removed from first tab

### Test Plan

- [x] Open the debugger and check the view

### Screenshots/Videos (OPTIONAL)
<img width="739" alt="screen shot 2017-10-18 at 11 12 15 pm" src="https://user-images.githubusercontent.com/8366397/31733681-07bf433a-b45a-11e7-91b1-57c546563282.png">
