### PR TITLE
[Previews] Fix computation of out of scope locations

### DIFF
--- a/src/components/Editor/Preview/index.js
+++ b/src/components/Editor/Preview/index.js
@@ -9,7 +9,8 @@ import {
   getPreview,
   getSelectedSource,
   getInScopeLines,
-  isSelectedFrameVisible
+  isSelectedFrameVisible,
+  getOutOfScopeLocations
 } from "../../../selectors";
 import actions from "../../../actions";
 import { updatePreview, toEditorRange } from "../../../utils/editor";
@@ -112,6 +113,7 @@ export default connect(
     preview: getPreview(state),
     selectedSource: getSelectedSource(state),
     linesInScope: getInScopeLines(state),
+    outOfScopeLocations: getOutOfScopeLocations(state),
     selectedFrameVisible: isSelectedFrameVisible(state)
   }),
   dispatch => bindActionCreators(actions, dispatch)

--- a/src/utils/editor/expression.js
+++ b/src/utils/editor/expression.js
@@ -18,7 +18,7 @@ export function getTokenLocation(codeMirror: any, tokenEl: HTMLElement) {
 export function updatePreview(
   target: HTMLElement,
   editor: any,
-  { linesInScope, preview, setPreview, clearPreview }: any
+  { linesInScope, preview, setPreview, clearPreview, outOfScopeLocations }: any
 ) {
   const location = getTokenLocation(editor.codeMirror, target);
   const tokenText = target.innerText ? target.innerText.trim() : "";
@@ -46,7 +46,25 @@ export function updatePreview(
 
   const isUpdating = preview && preview.updating;
 
-  const inScope = linesInScope && linesInScope.includes(location.line);
+  let inScope;
+  const isLineInScope = linesInScope && linesInScope.includes(location.line);
+  if (isLineInScope) {
+    inScope = true;
+  } else {
+    const startLineLocation = outOfScopeLocations.find(
+      loc => loc.start.line === location.line
+    );
+    if (startLineLocation) {
+      inScope = startLineLocation.start.column > location.column;
+    } else if (!inScope) {
+      const endLineLocation = outOfScopeLocations.find(
+        loc => loc.end.line === location.line
+      );
+      if (endLineLocation) {
+        inScope = endLineLocation.end.column < location.column;
+      }
+    }
+  }
 
   const invaildType =
     target.className === "cm-string" ||


### PR DESCRIPTION
Associated Issue: #4369 

### Summary of Changes

Thanks @liorpr for working on this together!

The reason for the bug was that it was ignoring column data. If the token is at the same line where an out of scope range begins, but earlier, then the token was considered out of scope. We added consideration of the column position.

* Add outOfScopeLocations to props of preview
* Use column data to accurately compute out of scope

NOTE: the code is dirty, maybe a bit of refactoring is in place. We did it in #goodnessSquad and wanted to create a PR. It works, but it's complicated and can probably be simplified.

### Test Plan

`updatePreview` probably needs testing, but we didn't add it.
