### PR TITLE
Change port 9000 default to 8116 default

### DIFF
--- a/configs/development.json
+++ b/configs/development.json
@@ -82,7 +82,7 @@
   "firefox": {
     "webSocketConnection": false,
     "host": "localhost",
-    "webSocketPort": 9000,
+    "webSocketPort": 8116,
     "tcpPort": 6080,
     "mcPath": "./firefox"
   },


### PR DESCRIPTION
Associated Issue: N/A

### Summary of Changes

* Change port 9000 to 8112 to fix "Port in use" errors that sometimes occur

### Test Plan

* Changed port, everything proceeding to function properly

### Screenshots/Videos (OPTIONAL)
N/A