### PR TITLE
fix bug where the line being 0 returns a falsy

### DIFF
--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -245,7 +245,7 @@ class Editor extends PureComponent<Props, State> {
     // Only update and jump around in real source texts. This will
     // keep the jump state around until the real source text is
     // loaded.
-    if (selectedSource && selectedSource.get("loadedState") === "loaded") {
+    if (selectedSource && isLoaded(selectedSource.toJS())) {
       this.highlightLine();
     }
   }

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -245,7 +245,7 @@ class Editor extends PureComponent<Props, State> {
     // Only update and jump around in real source texts. This will
     // keep the jump state around until the real source text is
     // loaded.
-    if (selectedSource && selectedSource.has("text")) {
+    if (selectedSource && selectedSource.get("loadedState") === "loaded") {
       this.highlightLine();
     }
   }
@@ -409,7 +409,7 @@ class Editor extends PureComponent<Props, State> {
     // cancel any existing animation, but it avoids it from
     // happening ever again (in case CodeMirror re-applies the
     // class, etc).
-    if (this.lastJumpLine) {
+    if (this.lastJumpLine !== null) {
       clearLineClass(this.state.editor.codeMirror, "highlight-line");
     }
 
@@ -423,8 +423,8 @@ class Editor extends PureComponent<Props, State> {
     // Also, if it the first time the debugger is being loaded, we don't want
     // to flash the previously saved selected line.
     if (
-      line &&
-      this.lastJumpLine &&
+      line !== null &&
+      this.lastJumpLine !== null &&
       (!selectedFrame || selectedFrame.location.line !== line)
     ) {
       this.state.editor.codeMirror.addLineClass(line, "line", "highlight-line");
@@ -437,7 +437,6 @@ class Editor extends PureComponent<Props, State> {
   scrollToPosition() {
     const { sourceId, line, column } = this.props.selectedLocation;
     const editorLine = toEditorLine(sourceId, line);
-
     scrollToColumn(this.state.editor.codeMirror, editorLine, column);
     return editorLine;
   }


### PR DESCRIPTION

Associated Issue: none

### Summary of Changes

* As a follow-up to #4143
* Fixes an issue where the `line` being `0` returns a falsy, causing the not to highlight for single line minifed files
* Use `loadedState` to check if the text has fully loaded

### Test Plan

Tell us a little a bit about how you tested your patch.

Example test plan:

- [x] Go to the `source mapped js.min files` example
- [x] Press `cmd + shift + f`
- [x] search for `log-message`
- [x] Click the match result for `example-websites/source-mapping/js/main.min.js`
- [x] The line should flash
