### PR TITLE
Undo string change to editor.addConditionalBreakpoint

### DIFF
--- a/assets/panel/debugger.properties
+++ b/assets/panel/debugger.properties
@@ -387,8 +387,8 @@ editor.removeBreakpoint=Remove breakpoint
 editor.editBreakpoint=Edit breakpoint
 
 # LOCALIZATION NOTE (editor.addConditionalBreakpoint): Editor gutter context
-# menu item for adding/editing a breakpoint condition on a line.
-editor.addConditionalBreakpoint=Add/Edit conditional breakpoint
+# menu item for adding a breakpoint condition on a line.
+editor.addConditionalBreakpoint=Add conditional breakpoint
 editor.addConditionalBreakpoint.accesskey=c
 
 # LOCALIZATION NOTE (editor.conditionalPanel.placeholder): Placeholder text for


### PR DESCRIPTION
Associated Issue: #4378

### Summary of Changes

* Reverts editor.addConditionalBreakpoint string changes