### PR TITLE
Add Jest Cases

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -7,6 +7,7 @@
 .*node_modules/config-chain.*
 .*node_modules/documentation.*
 .*node_modules/devtools-reps/src/object-inspector/index.js
+.*node_modules/jest-in-case/index.js
 <PROJECT_ROOT>/firefox/.*
 .*mozilla-central/.*
 .*flow-coverage-report/.*

--- a/package.json
+++ b/package.json
@@ -130,6 +130,7 @@
     "husky": "^0.14.2",
     "jest": "^20.0.4",
     "jest-cli": "^20.0.4",
+    "jest-in-case": "^1.0.2",
     "jest-junit-reporter": "^1.0.1",
     "jest-localstorage-mock": "^1.1.1",
     "jest-serializer-babel-ast": "^0.0.5",

--- a/src/workers/parser/tests/getSymbols.spec.js
+++ b/src/workers/parser/tests/getSymbols.spec.js
@@ -2,65 +2,28 @@
 
 import { formatSymbols } from "../utils/formatSymbols";
 import { getSource } from "./helpers";
+import cases from "jest-in-case";
 
-describe("Parser.getSymbols", () => {
-  it("es6", () => {
-    const symbols = formatSymbols(getSource("es6"));
-    expect(symbols).toMatchSnapshot();
-  });
-
-  it("func", () => {
-    const symbols = formatSymbols(getSource("func"));
-    expect(symbols).toMatchSnapshot();
-  });
-
-  it("math", () => {
-    const symbols = formatSymbols(getSource("math"));
-    expect(symbols).toMatchSnapshot();
-  });
-
-  it("proto", () => {
-    const symbols = formatSymbols(getSource("proto"));
-    expect(symbols).toMatchSnapshot();
-  });
-
-  it("class", () => {
-    const symbols = formatSymbols(getSource("class"));
-    expect(symbols).toMatchSnapshot();
-  });
-
-  it("var", () => {
-    const symbols = formatSymbols(getSource("var"));
-    expect(symbols).toMatchSnapshot();
-  });
-
-  it("expression", () => {
-    const symbols = formatSymbols(getSource("expression"));
-    expect(symbols).toMatchSnapshot();
-  });
-
-  it("allSymbols", () => {
-    const symbols = formatSymbols(getSource("allSymbols"));
-    expect(symbols).toMatchSnapshot();
-  });
-
-  it("call sites", () => {
-    const symbols = formatSymbols(getSource("call-sites"));
-    expect(symbols).toMatchSnapshot();
-  });
-
-  it("finds symbols in an html file", () => {
-    const symbols = formatSymbols(getSource("parseScriptTags", "html"));
-    expect(symbols).toMatchSnapshot();
-  });
-
-  it("component", () => {
-    const symbols = formatSymbols(getSource("component"));
-    expect(symbols).toMatchSnapshot();
-  });
-
-  it("react component", () => {
-    const symbols = formatSymbols(getSource("frameworks/component"));
-    expect(symbols).toMatchSnapshot();
-  });
-});
+cases(
+  "Parser.getSymbols",
+  ({ name, file, type }) =>
+    expect(formatSymbols(getSource(file, type))).toMatchSnapshot(),
+  [
+    { name: "es6", file: "es6" },
+    { name: "func", file: "func" },
+    { name: "math", file: "math" },
+    { name: "proto", file: "proto" },
+    { name: "class", file: "class" },
+    { name: "var", file: "var" },
+    { name: "expression", file: "expression" },
+    { name: "allSymbols", file: "allSymbols" },
+    { name: "call sites", file: "call-sites" },
+    {
+      name: "finds symbols in an html file",
+      file: "parseScriptTags",
+      type: "html"
+    },
+    { name: "component", file: "component" },
+    { name: "react component", file: "frameworks/component" }
+  ]
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -5460,6 +5460,10 @@ jest-haste-map@^20.0.4:
     sane "~1.6.0"
     worker-farm "^1.3.1"
 
+jest-in-case@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/jest-in-case/-/jest-in-case-1.0.2.tgz#56744b5af33222bd0abab70cf919f1d170ab75cc"
+
 jest-jasmine2@^19.0.2:
   version "19.0.2"
   resolved "https://registry.yarnpkg.com/jest-jasmine2/-/jest-jasmine2-19.0.2.tgz#167991ac825981fb1a800af126e83afcca832c73"


### PR DESCRIPTION
### Summary of Changes

Adds support for cases aka data providers, via the `jest-in-case` package. Note our tests don't change at all