### PR TITLE
[Refacoring] Make Redux Connect more explicit in Sources Tree

### DIFF
--- a/src/actions/types.js
+++ b/src/actions/types.js
@@ -261,8 +261,8 @@ export type ProjectTextSearchAction = {
   type: "ADD_SEARCH_RESULT",
   result: ProjectTextSearchResult
 } & {
-  type: "CLEAR_QUERY"
-};
+    type: "CLEAR_QUERY"
+  };
 
 export type FileTextSearchAction =
   | {

--- a/src/components/PrimaryPanes/SourcesTree.js
+++ b/src/components/PrimaryPanes/SourcesTree.js
@@ -9,7 +9,6 @@ import React, { Component } from "react";
 import classnames from "classnames";
 
 // Redux
-import { bindActionCreators } from "redux";
 import { connect } from "react-redux";
 import {
   getShownSource,
@@ -19,7 +18,9 @@ import {
   getProjectDirectoryRoot,
   getSources
 } from "../../selectors";
-import actions from "../../actions";
+
+import { setExpandedState } from "../../actions/source-tree";
+import { selectSource } from "../../actions/sources";
 
 // Types
 import type { SourcesMap } from "../../reducers/types";
@@ -47,13 +48,13 @@ import { features } from "../../utils/prefs";
 import { setProjectDirectoryRoot } from "../../actions/ui";
 
 type Props = {
-  sources: SourcesMap,
   selectSource: string => void,
+  setExpandedState: any => void,
+  sources: SourcesMap,
   shownSource?: string,
   selectedSource?: SourceRecord,
   debuggeeUrl: string,
   projectRoot: string,
-  setExpandedState: any => void,
   expanded?: any
 };
 
@@ -329,7 +330,7 @@ class SourcesTree extends Component<Props, State> {
   }
 
   render() {
-    const { setExpandedState, expanded } = this.props;
+    const expanded = this.props.expanded;
     const {
       focusedItem,
       sourceTree,
@@ -337,6 +338,14 @@ class SourcesTree extends Component<Props, State> {
       listItems,
       highlightItems
     } = this.state;
+
+    const onExpand = (item, expandedState) => {
+      this.props.setExpandedState(expandedState);
+    };
+
+    const onCollapse = (item, expandedState) => {
+      this.props.setExpandedState(expandedState);
+    };
 
     const isEmpty = sourceTree.contents.length === 0;
     const treeProps = {
@@ -352,8 +361,8 @@ class SourcesTree extends Component<Props, State> {
       listItems,
       highlightItems,
       expanded,
-      onExpand: (item, expandedState) => setExpandedState(expandedState),
-      onCollapse: (item, expandedState) => setExpandedState(expandedState),
+      onExpand,
+      onCollapse,
       renderItem: this.renderItem
     };
 
@@ -381,16 +390,20 @@ class SourcesTree extends Component<Props, State> {
   }
 }
 
-export default connect(
-  state => {
-    return {
-      shownSource: getShownSource(state),
-      selectedSource: getSelectedSource(state),
-      debuggeeUrl: getDebuggeeUrl(state),
-      expanded: getExpandedState(state),
-      projectRoot: getProjectDirectoryRoot(state),
-      sources: getSources(state)
-    };
-  },
-  dispatch => bindActionCreators(actions, dispatch)
-)(SourcesTree);
+const mapStateToProps = state => {
+  return {
+    shownSource: getShownSource(state),
+    selectedSource: getSelectedSource(state),
+    debuggeeUrl: getDebuggeeUrl(state),
+    expanded: getExpandedState(state),
+    projectRoot: getProjectDirectoryRoot(state),
+    sources: getSources(state)
+  };
+};
+
+const actionCreators = {
+  setExpandedState,
+  selectSource
+};
+
+export default connect(mapStateToProps, actionCreators)(SourcesTree);

--- a/src/test/mochitest/browser_dbg-debugger-buttons.js
+++ b/src/test/mochitest/browser_dbg-debugger-buttons.js
@@ -43,7 +43,7 @@ add_task(async function() {
   assertPausedLocation(dbg);
 
   // resume
-  await clickResume(dbg)
+  await clickResume(dbg);
   await waitForPaused(dbg);
   assertPausedLocation(dbg);
 

--- a/src/test/mochitest/browser_dbg-editor-select.js
+++ b/src/test/mochitest/browser_dbg-editor-select.js
@@ -47,5 +47,8 @@ add_task(async function() {
   await waitForLoadedSource(dbg, "long.js");
 
   assertPausedLocation(dbg);
-  ok(isVisibleInEditor(dbg, findElement(dbg, "breakpoint")), "Breakpoint is visible");
+  ok(
+    isVisibleInEditor(dbg, findElement(dbg, "breakpoint")),
+    "Breakpoint is visible"
+  );
 });

--- a/src/test/mochitest/browser_dbg-expressions-error.js
+++ b/src/test/mochitest/browser_dbg-expressions-error.js
@@ -47,7 +47,7 @@ async function editExpression(dbg, input) {
   info("updating the expression");
   dblClickElement(dbg, "expressionNode", 1);
   // Position cursor reliably at the end of the text.
-  const evaluation = waitForDispatch(dbg, "EVALUATE_EXPRESSION")
+  const evaluation = waitForDispatch(dbg, "EVALUATE_EXPRESSION");
   pressKey(dbg, "End");
   type(dbg, input);
   pressKey(dbg, "Enter");
@@ -59,7 +59,7 @@ async function editExpression(dbg, input) {
  * resume, and wait for the expression to finish being evaluated.
  */
 async function addBadExpression(dbg, input) {
-  const evaluation = waitForDispatch(dbg, "EVALUATE_EXPRESSION")
+  const evaluation = waitForDispatch(dbg, "EVALUATE_EXPRESSION");
 
   findElementWithSelector(dbg, expressionSelectors.input).focus();
   type(dbg, input);
@@ -70,7 +70,6 @@ async function addBadExpression(dbg, input) {
   ok(dbg.selectors.isEvaluatingExpression(dbg.getState()));
   await resume(dbg);
   await evaluation;
-
 }
 
 add_task(async function() {

--- a/src/test/mochitest/browser_dbg-sourcemaps2.js
+++ b/src/test/mochitest/browser_dbg-sourcemaps2.js
@@ -4,7 +4,11 @@
 function assertBpInGutter(dbg, lineNumber) {
   const el = findElement(dbg, "breakpoint");
   const bpLineNumber = +el.querySelector(".CodeMirror-linenumber").innerText;
-  is(bpLineNumber, lineNumber, "Breakpoint is on the correct line in the gutter");
+  is(
+    bpLineNumber,
+    lineNumber,
+    "Breakpoint is on the correct line in the gutter"
+  );
 }
 
 // Tests loading sourcemapped sources, setting breakpoints, and

--- a/src/test/mochitest/head.js
+++ b/src/test/mochitest/head.js
@@ -305,8 +305,9 @@ function assertDebugLine(dbg, line) {
     "Line is highlighted as paused"
   );
 
-  const debugLine = findElementWithSelector(dbg, ".new-debug-line")
-                    || findElementWithSelector(dbg, ".new-debug-line-error");
+  const debugLine =
+    findElementWithSelector(dbg, ".new-debug-line") ||
+    findElementWithSelector(dbg, ".new-debug-line-error");
 
   ok(isVisibleInEditor(dbg, debugLine), "debug line is visible");
 
@@ -553,8 +554,11 @@ function waitForLoadedSources(dbg) {
   return waitForState(
     dbg,
     state => {
-      const sources = dbg.selectors.getSources(state).valueSeq().toJS()
-      return !sources.some(source => source.loadedState == "loading")
+      const sources = dbg.selectors
+        .getSources(state)
+        .valueSeq()
+        .toJS();
+      return !sources.some(source => source.loadedState == "loading");
     },
     "loaded source"
   );
@@ -835,7 +839,6 @@ function type(dbg, string) {
   string.split("").forEach(char => EventUtils.synthesizeKey(char, {}, dbg.win));
 }
 
-
 /*
  * Checks to see if the inner element is visible inside the editor.
  *
@@ -874,12 +877,14 @@ function isVisible(outerEl, innerEl) {
   const outerRect = outerEl.getBoundingClientRect();
 
   const verticallyVisible =
-    (innerRect.top >= outerRect.top || innerRect.bottom <= outerRect.bottom)
-    || (innerRect.top < outerRect.top && innerRect.bottom > outerRect.bottom);
+    innerRect.top >= outerRect.top ||
+    innerRect.bottom <= outerRect.bottom ||
+    (innerRect.top < outerRect.top && innerRect.bottom > outerRect.bottom);
 
   const horizontallyVisible =
-    (innerRect.left >= outerRect.left || innerRect.right <= outerRect.right)
-    || (innerRect.left < outerRect.left && innerRect.right > outerRect.right);
+    innerRect.left >= outerRect.left ||
+    innerRect.right <= outerRect.right ||
+    (innerRect.left < outerRect.left && innerRect.right > outerRect.right);
 
   const visible = verticallyVisible && horizontallyVisible;
   return visible;


### PR DESCRIPTION
Hey folks, when working on SourcesTree.js I noticed that the redux usage can be made more readable using a more explicit approach.

### Summary of Changes

* explicit import of used actions
* ditch bindActionsCreators in favour of `() => dispatch(myImportedAction())`
* explicitly name and define connect props

I think this makes it more readable and more accessible for newbies who don't have to follow a trail of imports to see where props are coming from.


