### PR TITLE
Converted source tree SVG's to images using CSS styles

### DIFF
--- a/src/components/PrimaryPanes/SourcesTree.js
+++ b/src/components/PrimaryPanes/SourcesTree.js
@@ -214,14 +214,14 @@ class SourcesTree extends Component<Props, State> {
     }
 
     if (depth === 0) {
-      return <Svg name="domain" />;
+      return <img className="domain" />;
     }
 
     if (!nodeHasChildren(item)) {
-      return <Svg name="file" />;
+      return <img className="file" />;
     }
 
-    return <Svg name="folder" />;
+    return <img className="folder" />;
   }
 
   onContextMenu(event, item) {

--- a/src/components/shared/Svg.css
+++ b/src/components/shared/Svg.css
@@ -1,12 +1,15 @@
 .arrow,
-.folder,
-.domain,
-.file,
 .worker,
 .refresh,
 .shortcut,
 .add-button {
   fill: var(--theme-splitter-color);
+}
+
+.file,
+.folder,
+.domain {
+  background-color: var(--theme-splitter-color);
 }
 
 .worker,
@@ -24,8 +27,6 @@
   top: 1px;
 }
 
-.domain svg,
-.folder svg,
 .worker svg,
 .refresh svg,
 .shortcut svg,
@@ -33,13 +34,34 @@
   width: 15px;
 }
 
-.file svg {
-  width: 13px;
+img.domain,
+img.folder {
+  width: 15px;
+  height: 15px;
 }
 
-.file svg,
-.domain svg,
-.folder svg,
+img.domain {
+  mask: url(/images/domain.svg) no-repeat;
+}
+
+img.folder {
+  mask: url(/images/folder.svg) no-repeat;
+}
+
+img.file {
+  mask: url(/images/file.svg) no-repeat;
+  width: 13px;
+  height: 13px;
+}
+
+img.domain,
+img.folder,
+img.file {
+  mask-size: 100%;
+  margin-inline-end: 5px;
+  display: inline-block;
+}
+
 .refresh svg,
 .shortcut svg,
 .worker svg {


### PR DESCRIPTION
Associated Issue: #4350 
#### Description
Converted the Source Tree SVG's to Images using CSS styles.  This should have a significant performance improvement for the project as rendering of SVG's is no longer required. Can perhaps also close Issue #4168 should the improvement be significant enough.

In regards to the Webpack SVG, with so many different paths being filled different colours, converting to an image would likely not reflect the same image that is portrayed currently as it will all be one colour if changed. 

#### Screenshots
##### Webpack SVG
![webpacksvg](https://user-images.githubusercontent.com/25250594/31852817-bdbd0e1c-b64c-11e7-8a40-a3c8f7fd3087.PNG)
##### Fill Paths
![fillpaths](https://user-images.githubusercontent.com/25250594/31852818-bf64087e-b64c-11e7-960d-42ac96be4b19.PNG)


