### PR TITLE
Fix link issues in docs 

### DIFF
--- a/docs/debugging-the-debugger.md
+++ b/docs/debugging-the-debugger.md
@@ -6,15 +6,14 @@ Debugging the Debugger is one of the highest levels of inception. Before you beg
 
 Setup the Debugger so that your environment looks like this [gif][debugger-intro-gif].
 
-If you have any questions, go back to the [getting setup][getting-setup]
-instructions.
+If you have any questions, go back to the [getting setup][getting-setup] instructions.
 
 
 ### Design a new theme :snowflake:
 
 Lets design a new theme for the debugger, it's not too hard! Our goal here is to style the source tree, editor, and other UI components.
 
-Share your a screenshot of your theme [here][getting-started-issue]! Here's an example camo [theme][camo-theme] that I designed the other day.
+Share your a screenshot of your theme [here](./getting-setup.md) ! Here's an example camo [theme][camo-theme] that I designed the other day.
 
 
 ### Make breakpoints dance :dancers:
@@ -95,9 +94,8 @@ Now that you've internalized the debugger philosophy, it's time to start putting
 
 - here are @amitzur's [slides][amit-slides] from his [talk][amit-tweet]
 
-**Contribute back** take a look at how you can [contributing][contributing]. We would love the help!
-
-
+**Contribute back** take a look at how you can start [contributing][contributing]. We would love the help!
+---
 
 [contributing]: ../CONTRIBUTING.md
 [getting-setup]: ./getting-setup.md

--- a/docs/getting-setup.md
+++ b/docs/getting-setup.md
@@ -193,8 +193,7 @@ If you want to hack the debugger even with being offline, you might want to get 
 [yarn-install]:https://yarnpkg.com/en/docs/install
 [dev-server]:https://github.com/devtools-html/devtools-core/blob/master/packages/devtools-launchpad/README.md#dev-server
 [first-activity]: ./debugging-the-debugger.md
+[common-issues]: ./most-common-issues.md
 [slack]:https://devtools-html-slack.herokuapp.com/
-
 [launchpad-screenshot]:https://cloud.githubusercontent.com/assets/2134/22162697/913777b2-df04-11e6-9150-f6ad676c31ef.png
 [nvm]:https://github.com/creationix/nvm
-[common-issues]:./most-common-issues.md


### PR DESCRIPTION
Associated Issue: #4455 

### Summary of Changes

* Fixed Link issues in [getting setup](http://firefox-dev.tools/debugger.html/docs/getting-setup.html) page. Corrected Link [here](http://pradeepgangwar.tech/debugger.html/docs/getting-setup.html)
* Fixed Link issues in [debugging the debugger](http://firefox-dev.tools/debugger.html/docs/debugging-the-debugger.html) page. Corrected Link [here](http://pradeepgangwar.tech/debugger.html/docs/debugging-the-debugger.html)
