### PR TITLE
fix #4471 - expand the right sidebar on pausing at breakpoint

### DIFF
--- a/src/actions/pause.js
+++ b/src/actions/pause.js
@@ -3,6 +3,7 @@
 import { selectSource, ensureParserHasSourceText } from "./sources";
 import { PROMISE } from "../utils/redux/middleware/promise";
 
+import { togglePaneCollapse } from "./ui";
 import {
   getPause,
   pausedInEval,
@@ -137,6 +138,8 @@ export function paused(pauseInfo: Pause) {
 
     const { line, column } = frame.location;
     dispatch(selectSource(frame.location.sourceId, { line, column }));
+
+    dispatch(togglePaneCollapse("end", false));
   };
 }
 


### PR DESCRIPTION
Associated Issue: #4471

### Summary of Changes

*  Expand the right sidebar on pausing at breakpoint

### Test Plan

Tell us a little a bit about how you tested your patch.

Example test plan:

- [x] Close the right sidebar.
- [x] Create new breakpoint.
- [x] Check if the right sidebar opens when the breakpoint pause.