### PR TITLE
Converted Source Tree SVG's (including Blackbox) to images using CSS styles (#4350)

### DIFF
--- a/src/components/PrimaryPanes/Sources.css
+++ b/src/components/PrimaryPanes/Sources.css
@@ -131,18 +131,19 @@
   fill: var(--theme-body-color);
 }
 
-.sources-list .managed-tree .tree .node .blackBox svg {
+.sources-list .managed-tree .tree .node img.blackBox {
+  mask: url(/images/blackBox.svg) no-repeat;
+  mask-size: 100%;
+  background-color: var(--theme-highlight-blue);
   width: 13px;
-  position: relative;
-  top: 2px;
+  height: 13px;
+  display: inline-block;
   margin-inline-end: 5px;
-}
-.sources-list .managed-tree .tree .node .blackBox path {
-  fill: var(--theme-textbox-box-shadow);
+  margin-bottom: -2px;
 }
 
-.sources-list .managed-tree .tree .node.focused .blackBox path {
-  fill: white;
+.sources-list .managed-tree .tree .node.focused img.blackBox {
+  background-color: white;
 }
 
 .theme-dark
@@ -150,15 +151,14 @@
 .managed-tree
 .tree
 .node:not(.focused)
-.blackBox
-svg {
-  fill: var(--theme-content-color3);
+img.blackBox {
+  background-color: var(--theme-content-color3);
 }
 
-.theme-dark .sources-list .managed-tree .tree .node .blackBox circle {
-  fill: var(--theme-body-color);
+.theme-dark .sources-list .managed-tree .tree .node img.blackBox {
+  background-color: var(--theme-body-color);
 }
 
-.theme-dark .sources-list .managed-tree .tree .node.focused .blackBox circle {
-  fill: white;
+.theme-dark .sources-list .managed-tree .tree .node.focused img.blackBox {
+  background-color: white;
 }

--- a/src/components/PrimaryPanes/SourcesTree.js
+++ b/src/components/PrimaryPanes/SourcesTree.js
@@ -227,18 +227,18 @@ class SourcesTree extends Component<Props, State> {
     }
 
     if (depth === 0) {
-      return <Svg name="domain" />;
+      return <img className="domain" />;
     }
 
     if (!nodeHasChildren(item)) {
       const source = sources.get(item.contents.get("id"));
       if (source.get("isBlackBoxed")) {
-        return <Svg name="blackBox" />;
+        return <img className="blackBox" />;
       }
-      return <Svg name="file" />;
+      return <img className="file" />;
     }
 
-    return <Svg name="folder" />;
+    return <img className="folder" />;
   }
 
   onContextMenu(event, item) {

--- a/src/components/shared/Svg.css
+++ b/src/components/shared/Svg.css
@@ -1,12 +1,15 @@
 .arrow,
-.folder,
-.domain,
-.file,
 .worker,
 .refresh,
 .shortcut,
 .add-button {
   fill: var(--theme-splitter-color);
+}
+
+.file,
+.folder,
+.domain {
+  background-color: var(--theme-splitter-color);
 }
 
 .worker,
@@ -24,8 +27,6 @@
   top: 1px;
 }
 
-.domain svg,
-.folder svg,
 .worker svg,
 .refresh svg,
 .shortcut svg,
@@ -33,13 +34,34 @@
   width: 15px;
 }
 
-.file svg {
-  width: 13px;
+img.domain,
+img.folder {
+  width: 15px;
+  height: 15px;
 }
 
-.file svg,
-.domain svg,
-.folder svg,
+img.domain {
+  mask: url(/images/domain.svg) no-repeat;
+}
+
+img.folder {
+  mask: url(/images/folder.svg) no-repeat;
+}
+
+img.file {
+  mask: url(/images/file.svg) no-repeat;
+  width: 13px;
+  height: 13px;
+}
+
+img.domain,
+img.folder,
+img.file {
+    mask-size: 100%;
+    margin-inline-end: 5px;
+    display: inline-block;
+}
+
 .refresh svg,
 .shortcut svg,
 .worker svg {

--- a/src/components/shared/Svg.css
+++ b/src/components/shared/Svg.css
@@ -57,9 +57,9 @@ img.file {
 img.domain,
 img.folder,
 img.file {
-    mask-size: 100%;
-    margin-inline-end: 5px;
-    display: inline-block;
+  mask-size: 100%;
+  margin-inline-end: 5px;
+  display: inline-block;
 }
 
 .refresh svg,


### PR DESCRIPTION
Associated Issue: #4350 

Converted the Source Tree SVG's to images using CSS styles.  This also includes the newly added Blackbox SVG.

### Screenshots
#### Firefox
![firefox](https://user-images.githubusercontent.com/25250594/31919381-05a0d198-b830-11e7-9166-900c414882fa.PNG)

#### Chrome
![chrome](https://user-images.githubusercontent.com/25250594/31919384-0caa58ec-b830-11e7-8df5-513de67d9847.PNG)

