### PR TITLE
Fix quick open mochi

### DIFF
--- a/docs/mochitests.md
+++ b/docs/mochitests.md
@@ -139,9 +139,17 @@ add_task(function* () {
 
 The Debugger Mochitest API Documentation can be found [here](https://devtools-html.github.io/debugger.html/reference#mochitest).
 
+## Debugging Tips
+
+* Run your mochitest with `yarn mochid <filename>` and add a `debugger` statement to your test before or after a failure.
+* Go back to the development server and watch the Redux logs (either with the Redux Devtools or by setting action logging on in your [local config][local-config].) as you perform your mochitest step by step. Watch the actions that fire. Sometimes all you need is a `waitForDispatch("THE_ACTION")` to ensure enough time has passed for your assertion to be true.
+* Write simple helpers that describe the actions you take so that your mochitest reads more like you would describe the workflow, this will help with clarity and maintainability.
+
+
 [head]: https://github.com/devtools-html/debugger.html/blob/master/src/test/mochitest/head.js
 [mochitests]: https://developer.mozilla.org/en-US/docs/Mozilla/Projects/Mochitest
 
 [waiting]: https://github.com/devtools-html/debugger.html/commit/7b4762d9333108b15d81bc41e12182370c81e81c
 [server-oops]: https://github.com/devtools-html/debugger.html/commit/7e54e6b46181b747a828ab2dc1db96c88313db95#diff-4fb7729ef51f162ae50b7c3bc020a1e3
 [pretty-printing]: https://github.com/devtools-html/debugger.html/commit/6a66ce54faf8239fb358462c53c022a75615aae6#diff-a81153d2e92178917a135261f4245c39R12
+[local-config]: https://github.com/devtools-html/debugger.html/blob/master/docs/local-development.md#logging

--- a/docs/mochitests.md
+++ b/docs/mochitests.md
@@ -67,6 +67,35 @@ ContentTask.spawn(gBrowser.selectedBrowser, null, function* () {
 
 The above calls the function `foo` that exists in the page itself. You can also access the DOM this way: `content.document.querySelector`, if you want to click a button or do other things. You can even you use assertions inside this callback to check DOM state.
 
+### Debugging Tips
+
+The first step for debugging an integration test is establishing a clear sequence of events: where did the test break and what were the events that preceded it.
+
+The mochitest logs provide some context:
+
+1. The actions that fired
+2. Assertion Passes/Failures
+3. Events that the test waited for: dispatches, state changes
+
+> NOTE: it might be nice to run the tests in headless mode: `yarn mochih browser_dbg-editor-highlight`
+
+![](https://shipusercontent.com/90d3d0484aedcdbe9e2bc1aa291a6eb8/Screen%20Shot%202017-10-26%20at%205.42.41%20PM.png)
+
+The next step is to add additional logging in the test and debugger code with `info` calls.
+We recommend prefixing your logs and formatting them so they are easy to scan e.g.:
+
+* `info(\`>> Add breakpoint ${line} -> ${condition}\n\`)`
+* `info(\`>> Current breakpoints ${breakpoints.map(bp => bp.location.line).join(", ")}\n\`)`
+* `info(\`>> Symbols for source ${source.url} ${JSON.stringify(symbols)}\n\`)`
+
+At some point, it can be nice to pause the test and debug it. We are working on a debugger after all :)
+Mochitest, makes it easy to pause the test at `debugger` statements  with the `--jsdebugger` flag.
+You can run the test like this `yarn mochid browser_dbg-editor-highlight`.
+
+![](https://shipusercontent.com/e8441c77ab9ff6e84e5561b05bc25da2/Screen%20Shot%202017-10-26%20at%205.45.05%20PM.png)
+![](https://shipusercontent.com/57e41ae7227a46b2b6ae8b66956729ea/Screen%20Shot%202017-10-26%20at%205.44.54%20PM.png)
+
+
 #### Debugging Intermittents
 
 Intermittents are when a test succeeds most the time (95%) of the time, but not all the time.
@@ -138,13 +167,6 @@ add_task(function* () {
 ```
 
 The Debugger Mochitest API Documentation can be found [here](https://devtools-html.github.io/debugger.html/reference#mochitest).
-
-## Debugging Tips
-
-* Run your mochitest with `yarn mochid <filename>` and add a `debugger` statement to your test before or after a failure.
-* Go back to the development server and watch the Redux logs (either with the Redux Devtools or by setting action logging on in your [local config][local-config].) as you perform your mochitest step by step. Watch the actions that fire. Sometimes all you need is a `waitForDispatch("THE_ACTION")` to ensure enough time has passed for your assertion to be true.
-* Write simple helpers that describe the actions you take so that your mochitest reads more like you would describe the workflow, this will help with clarity and maintainability.
-
 
 [head]: https://github.com/devtools-html/debugger.html/blob/master/src/test/mochitest/head.js
 [mochitests]: https://developer.mozilla.org/en-US/docs/Mozilla/Projects/Mochitest

--- a/src/components/PrimaryPanes/Sources.css
+++ b/src/components/PrimaryPanes/Sources.css
@@ -146,12 +146,7 @@
   background-color: white;
 }
 
-.theme-dark
-.sources-list
-.managed-tree
-.tree
-.node:not(.focused)
-img.blackBox {
+.theme-dark .sources-list .managed-tree .tree .node:not(.focused) img.blackBox {
   background-color: var(--theme-content-color3);
 }
 

--- a/src/components/QuickOpenModal.js
+++ b/src/components/QuickOpenModal.js
@@ -88,6 +88,7 @@ export class QuickOpenModal extends Component<Props, State> {
       this.setState({ results });
       return;
     }
+
     const { searchType } = this.props;
 
     if (searchType === "gotoSource") {

--- a/src/test/mochitest/browser_dbg-breaking.js
+++ b/src/test/mochitest/browser_dbg-breaking.js
@@ -12,7 +12,7 @@ add_task(async function() {
   await addBreakpoint(dbg, "scripts.html", 18);
   reload(dbg);
   await waitForPaused(dbg);
-  await waitForLoadedSource(dbg, "doc-scripts.html")
+  await waitForLoadedSource(dbg, "doc-scripts.html");
   assertPausedLocation(dbg);
   await resume(dbg);
 

--- a/src/test/mochitest/browser_dbg-debugger-buttons.js
+++ b/src/test/mochitest/browser_dbg-debugger-buttons.js
@@ -29,7 +29,7 @@ add_task(async function() {
 
   await reload(dbg);
   await waitForPaused(dbg);
-  await waitForLoadedSource(dbg, "debugger-statements.html")
+  await waitForLoadedSource(dbg, "debugger-statements.html");
   assertPausedLocation(dbg);
 
   // resume

--- a/src/test/mochitest/browser_dbg-editor-select.js
+++ b/src/test/mochitest/browser_dbg-editor-select.js
@@ -29,13 +29,13 @@ add_task(async function() {
   // Call the function that we set a breakpoint in.
   invokeInTab("main");
   await waitForPaused(dbg);
-  await waitForLoadedSource(dbg, "simple1")
+  await waitForLoadedSource(dbg, "simple1");
   assertPausedLocation(dbg);
 
   // Step through to another file and make sure it's paused in the
   // right place.
   await stepIn(dbg);
-  await waitForLoadedSource(dbg, "simple2")
+  await waitForLoadedSource(dbg, "simple2");
   assertPausedLocation(dbg);
 
   // Step back out to the initial file.
@@ -51,7 +51,7 @@ add_task(async function() {
 
   invokeInTab("testModel");
   await waitForPaused(dbg);
-  await waitForLoadedSource(dbg, "long.js")
+  await waitForLoadedSource(dbg, "long.js");
 
   assertPausedLocation(dbg);
   ok(isElementVisible(dbg, "breakpoint"), "Breakpoint is visible");

--- a/src/test/mochitest/browser_dbg-iframes.js
+++ b/src/test/mochitest/browser_dbg-iframes.js
@@ -12,13 +12,13 @@ add_task(async function() {
   // test pausing in the main thread
   await reload(dbg);
   await waitForPaused(dbg);
-  await waitForLoadedSource(dbg, "doc-iframes.html")
+  await waitForLoadedSource(dbg, "doc-iframes.html");
   assertPausedLocation(dbg);
 
   // test pausing in the iframe
   await resume(dbg);
   await waitForPaused(dbg);
-  await waitForLoadedSource(dbg, "doc-debugger-statements.html")
+  await waitForLoadedSource(dbg, "doc-debugger-statements.html");
   assertPausedLocation(dbg);
 
   // test pausing in the iframe

--- a/src/test/mochitest/browser_dbg-navigation.js
+++ b/src/test/mochitest/browser_dbg-navigation.js
@@ -21,7 +21,7 @@ add_task(async function() {
   await addBreakpoint(dbg, "simple1.js", 4);
   invokeInTab("main");
   await waitForPaused(dbg);
-  await waitForLoadedSource(dbg, "simple1")
+  await waitForLoadedSource(dbg, "simple1");
 
   assertPausedLocation(dbg);
   is(countSources(dbg), 4, "4 sources are loaded.");

--- a/src/test/mochitest/browser_dbg-quick-open.js
+++ b/src/test/mochitest/browser_dbg-quick-open.js
@@ -50,7 +50,7 @@ function resultCount(dbg) {
 function quickOpen(dbg, query, shortcut = "quickOpen") {
   pressKey(dbg, shortcut);
   assertEnabled(dbg);
-  type(dbg, query);
+  query !== "" && type(dbg, query);
 }
 
 // Testing quick open
@@ -67,27 +67,27 @@ add_task(async function() {
 
   let source = dbg.selectors.getSelectedSource(dbg.getState());
   ok(source.get("url").match(/switching-01/), "first source is selected");
+  await waitForSelectedSource(dbg, "switching-01");
 
   info("Arrow keys and check to see if source is selected");
   quickOpen(dbg, "sw");
-  is(resultCount(dbg), 2);
+  is(resultCount(dbg), 2, "two file results");
   pressKey(dbg, "Down");
   pressKey(dbg, "Enter");
-  await waitForDispatch(dbg, "SELECT_SOURCE");
-  await waitForSymbols(dbg, "switching-02");
 
   source = dbg.selectors.getSelectedSource(dbg.getState());
   ok(source.get("url").match(/switching-02/), "second source is selected");
+  await waitForSelectedSource(dbg, "switching-02");
   quickOpen(dbg, "sw");
   pressKey(dbg, "Tab");
   assertDisabled(dbg);
 
   info("Testing function search");
   quickOpen(dbg, "", "quickOpenFunc");
-  is(resultCount(dbg), 2);
+  is(resultCount(dbg), 2, "two function results");
 
   type(dbg, "x");
-  is(resultCount(dbg), 0);
+  is(resultCount(dbg), 0, "no functions with 'x' in name");
 
   pressKey(dbg, "Escape");
   assertDisabled(dbg);
@@ -95,10 +95,9 @@ add_task(async function() {
   info("Testing variable search");
   quickOpen(dbg, "sw2");
   pressKey(dbg, "Enter");
-  await waitForDispatch(dbg, "SELECT_SOURCE");
-  await waitForSymbols(dbg, "switching-02");
+
   quickOpen(dbg, "#");
-  is(resultCount(dbg), 1);
+  is(resultCount(dbg), 1, "one variable result");
   const results = findAllElements(dbg, "resultItems");
   results.forEach(result => is(result.textContent, "x:13"));
   await waitToClose(dbg);

--- a/src/test/mochitest/browser_dbg-quick-open.js
+++ b/src/test/mochitest/browser_dbg-quick-open.js
@@ -74,7 +74,7 @@ add_task(async function() {
   pressKey(dbg, "Down");
   pressKey(dbg, "Enter");
   await waitForDispatch(dbg, "SELECT_SOURCE");
-  await waitForSymbols(dbg, "switching-01");
+  await waitForSymbols(dbg, "switching-02");
 
   source = dbg.selectors.getSelectedSource(dbg.getState());
   ok(source.get("url").match(/switching-02/), "second source is selected");

--- a/src/test/mochitest/browser_dbg-scopes.js
+++ b/src/test/mochitest/browser_dbg-scopes.js
@@ -16,7 +16,7 @@ add_task(async function() {
 
   invokeInTab("firstCall");
   await waitForPaused(dbg);
-  await waitForLoadedSource(dbg, "switching-02")
+  await waitForLoadedSource(dbg, "switching-02");
 
   is(getLabel(dbg, 1), "secondCall");
   is(getLabel(dbg, 2), "<this>");

--- a/src/test/mochitest/browser_dbg-wasm-sourcemaps.js
+++ b/src/test/mochitest/browser_dbg-wasm-sourcemaps.js
@@ -14,7 +14,7 @@ add_task(async function() {
   await reload(dbg);
   await waitForPaused(dbg);
 
-  await waitForLoadedSource(dbg, "doc-wasm-sourcemaps")
+  await waitForLoadedSource(dbg, "doc-wasm-sourcemaps");
   assertPausedLocation(dbg);
 
   await waitForSource(dbg, "wasm-sourcemaps/average.c");
@@ -23,7 +23,7 @@ add_task(async function() {
   clickElement(dbg, "resume");
 
   await waitForPaused(dbg);
-  await waitForLoadedSource(dbg, "average.c")
+  await waitForLoadedSource(dbg, "average.c");
   assertPausedLocation(dbg);
 
   const frames = findAllElements(dbg, "frames");

--- a/src/test/mochitest/browser_dbg_keyboard-shortcuts.js
+++ b/src/test/mochitest/browser_dbg_keyboard-shortcuts.js
@@ -30,7 +30,7 @@ add_task(async function() {
 
   await reload(dbg);
   await waitForPaused(dbg);
-  await waitForLoadedSource(dbg, "doc-debugger-statements.html")
+  await waitForLoadedSource(dbg, "doc-debugger-statements.html");
   assertPausedLocation(dbg, "doc-debugger-statements");
 
   await pressResume(dbg);

--- a/src/test/mochitest/head.js
+++ b/src/test/mochitest/head.js
@@ -158,7 +158,7 @@ function waitForState(dbg, predicate, msg) {
 
     const unsubscribe = dbg.store.subscribe(() => {
       if (predicate(dbg.store.getState())) {
-        info(`Finished waiting for state change: ${msg || ""}`)
+        info(`Finished waiting for state change: ${msg || ""}`);
         unsubscribe();
         resolve();
       }
@@ -219,16 +219,20 @@ async function waitForElement(dbg, selector) {
 }
 
 function waitForSelectedSource(dbg, sourceId) {
-  return waitForState(dbg, state => {
-    const source = dbg.selectors.getSelectedSource(state);
-    const isLoaded =
-      source && source.has("loadedState") && sourceUtils.isLoaded(source);
-    if (sourceId) {
-      return isLoaded && sourceId == source.get("id");
-    }
+  return waitForState(
+    dbg,
+    state => {
+      const source = dbg.selectors.getSelectedSource(state);
+      const isLoaded =
+        source && source.has("loadedState") && sourceUtils.isLoaded(source);
+      if (sourceId) {
+        return isLoaded && sourceId == source.get("id");
+      }
 
-    return isLoaded;
-  }, "selected source");
+      return isLoaded;
+    },
+    "selected source"
+  );
 }
 
 /**
@@ -254,10 +258,13 @@ function assertPausedLocation(dbg) {
 function assertDebugLine(dbg, line) {
   // Check the debug line
   const lineInfo = getCM(dbg).lineInfo(line - 1);
-  const source = dbg.selectors.getSelectedSource(dbg.getState())
+  const source = dbg.selectors.getSelectedSource(dbg.getState());
   if (source && source.get("loadedState") == "loading") {
-    const url = source.get("url")
-    ok(false, `Looks like the source ${url} is still loading. Try adding waitForLoadedSource in the test.`)
+    const url = source.get("url");
+    ok(
+      false,
+      `Looks like the source ${url} is still loading. Try adding waitForLoadedSource in the test.`
+    );
     return;
   }
 
@@ -344,10 +351,14 @@ async function waitForPaused(dbg) {
  * @static
  */
 async function waitForMappedScopes(dbg) {
-  await waitForState(dbg, state => {
-    const scopes = dbg.selectors.getScopes(state);
-    return scopes && scopes.sourceBindings;
-  }, "mapped scopes");
+  await waitForState(
+    dbg,
+    state => {
+      const scopes = dbg.selectors.getScopes(state);
+      return scopes && scopes.sourceBindings;
+    },
+    "mapped scopes"
+  );
 }
 
 function isTopFrameSelected(dbg, state) {
@@ -462,8 +473,11 @@ function findSource(dbg, url) {
 }
 
 function waitForLoadedSource(dbg, url) {
-  return waitForState(dbg, state => findSource(dbg, url).loadedState == "loaded",
-`loaded source`)
+  return waitForState(
+    dbg,
+    state => findSource(dbg, url).loadedState == "loaded",
+    `loaded source`
+  );
 }
 
 /**
@@ -541,8 +555,7 @@ function stepOut(dbg) {
 function resume(dbg) {
   info("Resuming");
   dbg.actions.resume();
-  return waitForState(dbg, state => !dbg.selectors.isPaused(state),
-"resumed");
+  return waitForState(dbg, state => !dbg.selectors.isPaused(state), "resumed");
 }
 
 function deleteExpression(dbg, input) {
@@ -560,7 +573,9 @@ function deleteExpression(dbg, input) {
  * @static
  */
 function reload(dbg, ...sources) {
-  return dbg.client.reload().then(() => waitForSources(dbg, ...sources), "reloaded");
+  return dbg.client
+    .reload()
+    .then(() => waitForSources(dbg, ...sources), "reloaded");
 }
 
 /**


### PR DESCRIPTION
Associated Issue: N/A

### Summary of Changes

* Fix up the quick open mochitest that had a failure. Not 100% certain if it was just racy before or if this was to adjust to changes from @jasonLaster's recent work. 🙁 
* Doc some tips based on what I did here.
* Prettier did its thing here.

### Test Plan

Example test plan:

- [x] `yarn mochi browser_dbg-quick-open.js`
