### PR TITLE
(#4350) Converted Step Button SVG's to images using CSS Styles

### DIFF
--- a/src/components/SecondaryPanes/CommandBar.css
+++ b/src/components/SecondaryPanes/CommandBar.css
@@ -84,19 +84,16 @@ img.resume {
 }
 
 .command-bar > button.pause-exceptions.uncaught.enabled > img.pause-exceptions {
-  /*background-color: var(--theme-highlight-purple);*/
-  background-color: orange;
+  background-color: var(--theme-highlight-purple);
 }
 
 .command-bar > button.pause-exceptions.all > img.pause-exceptions {
-  /*background-color: var(--theme-highlight-blue) !important;*/
-  background-color: red !important;
+  background-color: var(--theme-highlight-blue) !important;
 }
 
 .command-bar > button.pause-exceptions.enabled > img.pause-exceptions {
-  /*background-color: var(--theme-body-color);*/
-  background-color: green;
-}
+  background-color: var(--theme-body-color);
+}  
 
 .command-bar > button > img.pause-exceptions {
   mask: url(/images/pause-exceptions.svg) no-repeat;

--- a/src/components/SecondaryPanes/CommandBar.css
+++ b/src/components/SecondaryPanes/CommandBar.css
@@ -83,23 +83,17 @@ img.resume {
   mask: url(/images/resume.svg) no-repeat;
 }
 
-.command-bar >
-button.pause-exceptions.uncaught.enabled >
-img.pause-exceptions {
+.command-bar > button.pause-exceptions.uncaught.enabled > img.pause-exceptions {
   /*background-color: var(--theme-highlight-purple);*/
   background-color: orange;
 }
 
-.command-bar >
-button.pause-exceptions.all >
-img.pause-exceptions {
+.command-bar > button.pause-exceptions.all > img.pause-exceptions {
   /*background-color: var(--theme-highlight-blue) !important;*/
   background-color: red !important;
 }
 
-.command-bar >
-button.pause-exceptions.enabled >
-img.pause-exceptions {
+.command-bar > button.pause-exceptions.enabled > img.pause-exceptions {
   /*background-color: var(--theme-body-color);*/
   background-color: green;
 }

--- a/src/components/SecondaryPanes/CommandBar.css
+++ b/src/components/SecondaryPanes/CommandBar.css
@@ -87,8 +87,8 @@ img.resume {
   background-color: var(--theme-highlight-purple);
 }
 
-.command-bar > button.pause-exceptions.all > img.pause-exceptions {
-  background-color: var(--theme-highlight-blue) !important;
+.command-bar > button.pause-exceptions.all.enabled > img.pause-exceptions {
+  background-color: var(--theme-highlight-blue);
 }
 
 .command-bar > button.pause-exceptions.enabled > img.pause-exceptions {

--- a/src/components/SecondaryPanes/CommandBar.css
+++ b/src/components/SecondaryPanes/CommandBar.css
@@ -37,7 +37,7 @@ html[dir="rtl"] .command-bar {
 }
 
 .command-bar > button {
-  margin-inline-end: 0.7em;
+  margin-inline-end: 0.3em;
 }
 
 .command-bar > button:focus {
@@ -49,31 +49,68 @@ html .command-bar > button:disabled {
   cursor: default;
 }
 
-.command-bar > button > i {
-  height: 100%;
-  width: 100%;
-  display: block;
+img.pause,
+img.stepOver,
+img.stepIn,
+img.stepOut,
+img.resume {
+  background-color: var(--theme-body-color);
 }
 
-.command-bar > button > i > svg {
+.command-bar > button > img {
   width: 16px;
   height: 16px;
+  display: inline-block;
 }
 
-.command-bar button.pause-exceptions {
-  margin-inline-start: 0.5em;
+.command-bar > button > img.pause {
+  mask: url(/images/pause.svg) no-repeat;
+}
+
+.command-bar > button > img.stepOver {
+  mask: url(/images/stepOver.svg) no-repeat;
+}
+
+.command-bar > button > img.stepIn {
+  mask: url(/images/stepIn.svg) no-repeat;
+}
+
+.command-bar > button > img.stepOut {
+  mask: url(/images/stepOut.svg) no-repeat;
+}
+
+.command-bar > button > img.resume {
+  mask: url(/images/resume.svg) no-repeat;
+}
+
+.command-bar >
+button.pause-exceptions.uncaught.enabled >
+img.pause-exceptions {
+  /*background-color: var(--theme-highlight-purple);*/
+  background-color: orange;
+}
+
+.command-bar >
+button.pause-exceptions.all >
+img.pause-exceptions {
+  /*background-color: var(--theme-highlight-blue) !important;*/
+  background-color: red !important;
+}
+
+.command-bar >
+button.pause-exceptions.enabled >
+img.pause-exceptions {
+  /*background-color: var(--theme-body-color);*/
+  background-color: green;
+}
+
+.command-bar > button > img.pause-exceptions {
+  mask: url(/images/pause-exceptions.svg) no-repeat;
+  margin-inline-start: 0.2em;
 }
 
 .command-bar .subSettings {
   float: right;
-}
-
-.command-bar button.pause-exceptions.uncaught {
-  color: var(--theme-highlight-purple);
-}
-
-.command-bar button.pause-exceptions.all {
-  color: var(--theme-highlight-blue);
 }
 
 .bottom {

--- a/src/components/SecondaryPanes/CommandBar.css
+++ b/src/components/SecondaryPanes/CommandBar.css
@@ -93,7 +93,7 @@ img.resume {
 
 .command-bar > button.pause-exceptions.enabled > img.pause-exceptions {
   background-color: var(--theme-body-color);
-}  
+}
 
 .command-bar > button > img.pause-exceptions {
   mask: url(/images/pause-exceptions.svg) no-repeat;

--- a/src/components/SecondaryPanes/CommandBar.js
+++ b/src/components/SecondaryPanes/CommandBar.js
@@ -10,7 +10,6 @@ import {
   getShouldPauseOnExceptions,
   getShouldIgnoreCaughtExceptions
 } from "../../selectors";
-import Svg from "../shared/Svg";
 import { formatKeyShortcut } from "../../utils/text";
 import actions from "../../actions";
 import "./CommandBar.css";

--- a/src/components/SecondaryPanes/CommandBar.js
+++ b/src/components/SecondaryPanes/CommandBar.js
@@ -80,7 +80,7 @@ function debugBtn(onClick, type, className, tooltip, disabled = false) {
 
   return (
     <button className={classnames(type, className)} {...props}>
-      <Svg name={type} />
+      <img className={type} />
     </button>
   );
 }


### PR DESCRIPTION
Associated Issue: #4350 

## Summary of Changes
Converted the Step Button SVG's to images using CSS styles in the Command Bar.  Functionality remains the same, however I made a change that I think reflects pausing during exceptions in a very logical manner.  I used traffic lights as my inspiration for this and therefore used colors **Green**, **Orange**, and **Red** .  

When ignoring them, the User would not experience any halts and therefore Green was used to signify that.  When clicking on the `pause-exceptions` button to change it to pausing during uncaught exceptions, the image would be Orange as we are pausing only some of the time.  Finally, when clicking on the `pause-exceptions` button once again to change it to pausing on all exceptions, the image would be Red where the User is coming to a halt for all exceptions, caught or uncaught.

Would really appreciate feedback from the DevTools team on this.  I can always change them to their original state should this not work out or be feasible for the project. 

## Screenshots  
### Firefox
#### Ignore Exceptions
![ignoreexceptions](https://user-images.githubusercontent.com/25250594/32081771-559b5d1a-ba85-11e7-8ecf-421756b6b210.PNG)  
#### Pause on Uncaught Exceptions
![pauseuncaughtexceptions](https://user-images.githubusercontent.com/25250594/32081776-58949838-ba85-11e7-82ad-2b999ad0096c.PNG)
#### Pause on All Exceptions
![pauseallexceptions](https://user-images.githubusercontent.com/25250594/32081783-5af6d212-ba85-11e7-859b-f8a348f5443c.PNG)
#### Pause Button Active
![pauseactive](https://user-images.githubusercontent.com/25250594/32081817-93435762-ba85-11e7-9eda-95b8094d0672.PNG)
#### Resume Button Active
![resumeactive](https://user-images.githubusercontent.com/25250594/32081824-9ba6d26c-ba85-11e7-87c9-d485972828d5.PNG)

### Chrome
#### Ignore Exceptions
![ignoreexceptions](https://user-images.githubusercontent.com/25250594/32081833-a79d1040-ba85-11e7-8de4-4a8f0cf3c0b7.PNG)
#### Pause on Uncaught Exceptions
![pauseuncaughtexceptions](https://user-images.githubusercontent.com/25250594/32081842-b570c630-ba85-11e7-9d10-756083d4ec2b.PNG)
#### Pause on All Exceptions
![pauseallexceptions](https://user-images.githubusercontent.com/25250594/32081849-bc94b110-ba85-11e7-8826-b560931c9d02.PNG)
#### Pause Button Active
![pauseactive](https://user-images.githubusercontent.com/25250594/32081851-c41ea4e0-ba85-11e7-8b18-56a5b17c3392.PNG)
#### Resume Button Active
![resumeactive](https://user-images.githubusercontent.com/25250594/32081857-ca583bd2-ba85-11e7-92fd-749b6164364d.PNG)