### PR TITLE
Remove createClass and PropTypes warning

### DIFF
--- a/src/components/shared/Modal.js
+++ b/src/components/shared/Modal.js
@@ -1,14 +1,15 @@
 // @flow
 
 import PropTypes from "prop-types";
-import * as React from "react";
+import React from "react";
+import type { Node as ReactNode } from "react";
 import classnames from "classnames";
 import Transition from "react-transition-group/Transition";
 import "./Modal.css";
 
 type ModalProps = {
   status: string,
-  children?: React.Node,
+  children?: ReactNode,
   additionalClass?: string,
   handleClose: () => any
 };
@@ -40,7 +41,7 @@ Modal.contextTypes = {
 
 type SlideProps = {
   in: boolean,
-  children?: React.Node,
+  children?: ReactNode,
   additionalClass?: string,
   handleClose: () => any
 };


### PR DESCRIPTION
Associated Issue: #4485 

### Summary of Changes

One set of createClass and PropTypes warnings were removed by avoiding use of `import * as React from "react";` facebook/react#10583

The remaining three sets of createClass and Proptypes warnings are from packages that are part of https://github.com/devtools-html/devtools-core