### PR TITLE
Fixing Shortcut Modal Dark Theme Legibility on Mac

### DIFF
--- a/src/components/ShortcutsModal.css
+++ b/src/components/ShortcutsModal.css
@@ -11,20 +11,6 @@
   color: var(--theme-content-color1);
 }
 
-.mac .keystroke {
-  border-style: solid;
-  border-width: 1px;
-  border-radius: 3px;
-  border-color: var(--theme-graphs-grey);
-  background-color: var(--theme-selection-color);
-  width: 21px;
-  height: 17px;
-  display: inline-block;
-  font-size: 10px;
-  text-align: center;
-  padding-top: 2px;
-}
-
 .shortcuts-section {
   display: inline-block;
   margin: 5px;


### PR DESCRIPTION
Associated Issue: #4432
### Summary of Changes

* removed Mac specific behavior for Shortcut Modal

### Screenshots
![screen shot 2017-10-26 at 2 16 00 pm](https://user-images.githubusercontent.com/32388517/32137601-0cc99ca6-bbf1-11e7-8d74-69a29f3f0081.png)
