### PR TITLE
Unselects highlight on search window close

### DIFF
--- a/src/components/QuickOpenModal.js
+++ b/src/components/QuickOpenModal.js
@@ -43,7 +43,6 @@ type Props = {
   selectSource: (id: string, ?SelectSourceOptions) => void,
   setQuickOpenQuery: (query: string) => void,
   highlightLineRange: ({ start: number, end: number }) => void,
-  clearHighlightLineRange: () => void,
   closeQuickOpen: () => void
 };
 
@@ -79,7 +78,6 @@ export class QuickOpenModal extends Component<Props, State> {
 
   closeModal = () => {
     this.props.closeQuickOpen();
-    this.props.clearHighlightLineRange();
   };
 
   searchSources = (query: string) => {

--- a/src/components/tests/QuickOpenModal.spec.js
+++ b/src/components/tests/QuickOpenModal.spec.js
@@ -76,7 +76,6 @@ describe("QuickOpenModal", () => {
     expect(wrapper).toMatchSnapshot();
     wrapper.find("CloseButton").simulate("click");
     expect(props.closeQuickOpen).toHaveBeenCalled();
-    expect(props.clearHighlightLineRange).toHaveBeenCalled();
   });
 
   test("updateResults on enable", () => {

--- a/src/reducers/ui.js
+++ b/src/reducers/ui.js
@@ -96,6 +96,7 @@ function update(
 
       return state.set("highlightedLineRange", lineRange);
 
+    case "CLOSE_QUICK_OPEN":
     case "CLEAR_HIGHLIGHT_LINES":
       return state.set("highlightedLineRange", {});
 


### PR DESCRIPTION
Associated Issue: #4490 

### Summary of Changes

* removed reference to CLEAR_HIGHLIGHT_LINES
* hooked clearing highlightedLineRange directly to window close

### Test Plan

Performed searches


### Screenshots/Videos (OPTIONAL)
http://g.recordit.co/cy8JFnonNG.gif
