### PR TITLE
🎨: Update our symbol parsing code to extract additional function types

### DIFF
--- a/src/test/mochitest/browser_dbg-sourcemaps2.js
+++ b/src/test/mochitest/browser_dbg-sourcemaps2.js
@@ -1,7 +1,6 @@
 /* Any copyright is dedicated to the Public Domain.
  * http://creativecommons.org/publicdomain/zero/1.0/ */
 
-
 function assertBpInGutter(dbg, lineNumber) {
   const el = findElement(dbg, "breakpoint");
   const bpLineNumber = +el.querySelector(".CodeMirror-linenumber").innerText;

--- a/src/workers/parser/getSymbols.js
+++ b/src/workers/parser/getSymbols.js
@@ -36,7 +36,10 @@ export type SymbolDeclarations = {
 };
 
 function getFunctionParameterNames(path: NodePath): string[] {
-  return path.node.params.map(param => param.name);
+  if (path.node.params != null) {
+    return path.node.params.map(param => param.name);
+  }
+  return [];
 }
 
 function getVariableNames(path: NodePath): SymbolDeclaration[] {

--- a/src/workers/parser/tests/__snapshots__/getEmptyLines.spec.js.snap
+++ b/src/workers/parser/tests/__snapshots__/getEmptyLines.spec.js.snap
@@ -15,9 +15,10 @@ Array [
 exports[`getEmptyLines class 1`] = `
 Array [
   5,
-  10,
-  12,
+  9,
   14,
+  16,
+  18,
 ]
 `;
 

--- a/src/workers/parser/tests/__snapshots__/getSymbols.spec.js.snap
+++ b/src/workers/parser/tests/__snapshots__/getSymbols.spec.js.snap
@@ -122,10 +122,12 @@ exports[`Parser.getSymbols class 1`] = `
 "functions:
 [(2, 2), (4, 3)]   constructor() Test
 [(6, 2), (8, 3)]   bar(a) Test
+[(10, 8), (12, 3)]   baz(b) Test
 
 variables:
 [(6, 6), (6, 7)]   a
-[(13, 4), (13, 30)]   expressiveClass
+[(10, 8), (10, 9)]   b
+[(17, 4), (17, 30)]   expressiveClass
 
 callExpressions:
 
@@ -150,13 +152,16 @@ identifiers:
 [(7, 4), (7, 11)]  console console
 [(7, 12), (7, 15)]  log log
 [(7, 23), (7, 24)]  a a
-[(11, 6), (11, 11)]  Test2 Test2
-[(13, 4), (13, 30)]  expressiveClass expressiveClass
-[(13, 4), (13, 19)]  expressiveClass expressiveClass
+[(10, 2), (10, 5)]  baz baz
+[(10, 8), (10, 9)]  b b
+[(11, 11), (11, 12)]  b b
+[(15, 6), (15, 11)]  Test2 Test2
+[(17, 4), (17, 30)]  expressiveClass expressiveClass
+[(17, 4), (17, 19)]  expressiveClass expressiveClass
 
 classes:
-[(1, 0), (9, 1)]   Test
-[(11, 0), (11, 14)]   Test2
+[(1, 0), (13, 1)]   Test
+[(15, 0), (15, 14)]   Test2
 
 imports:
 "

--- a/src/workers/parser/tests/fixtures/class.js
+++ b/src/workers/parser/tests/fixtures/class.js
@@ -6,6 +6,10 @@ class Test {
   bar(a) {
     console.log("bar", a);
   }
+
+  baz = b => {
+    return b * 2;
+  };
 }
 
 class Test2 {}

--- a/src/workers/parser/utils/ast.js
+++ b/src/workers/parser/utils/ast.js
@@ -14,7 +14,19 @@ function _parse(code, opts) {
     code,
     Object.assign({}, opts, {
       sourceType: "module",
-      plugins: ["jsx", "flow", "objectRestSpread"]
+      plugins: [
+        "jsx",
+        "flow",
+        "doExpressions",
+        "objectRestSpread",
+        "classProperties",
+        "exportExtensions",
+        "asyncGenerators",
+        "functionBind",
+        "functionSent",
+        "dynamicImport",
+        "templateInvalidEscapes"
+      ]
     })
   );
 }

--- a/src/workers/parser/utils/getFunctionName.js
+++ b/src/workers/parser/utils/getFunctionName.js
@@ -1,9 +1,14 @@
 // @flow
+import * as t from "babel-types";
 import type { NodePath } from "babel-traverse";
 
 export default function getFunctionName(path: NodePath): string {
   if (path.node.id) {
     return path.node.id.name;
+  }
+
+  if (path.type === "MethodDefinition") {
+    return path.node.key.name;
   }
 
   const parent = path.parent;
@@ -25,6 +30,10 @@ export default function getFunctionName(path: NodePath): string {
     }
 
     return parent.left.name;
+  }
+
+  if (t.isClassProperty(parent) && t.isArrowFunctionExpression(path)) {
+    return parent.key.name;
   }
 
   return "anonymous";

--- a/src/workers/parser/utils/helpers.js
+++ b/src/workers/parser/utils/helpers.js
@@ -12,7 +12,9 @@ export function isFunction(path: NodePath) {
     t.isFunction(path) ||
     t.isArrowFunctionExpression(path) ||
     t.isObjectMethod(path) ||
-    t.isClassMethod(path)
+    t.isClassMethod(path) ||
+    path.type === "MethodDefinition" ||
+    (t.isClassProperty(path.parent) && t.isArrowFunctionExpression(path))
   );
 }
 
@@ -35,7 +37,7 @@ export function isYieldExpression(path: NodePath) {
 export function isVariable(path: NodePath) {
   return (
     t.isVariableDeclaration(path) ||
-    (isFunction(path) && path.node.params.length) ||
+    (isFunction(path) && path.node.params != null && path.node.params.length) ||
     (t.isObjectProperty(path) && !isFunction(path.node.value))
   );
 }


### PR DESCRIPTION
Associated Issue: #3239 

### Summary of Changes

* enable additional parser features
* parse out some additional function types

### Test Plan

Tell us a little a bit about how you tested your patch.

Example test plan:

- [x] Select a file that contains [class method arrow functions](https://github.com/devtools-html/debugger.html/compare/master...wldcordeiro:parse-more-babel?expand=1#diff-86a6158567e4b111270062b39add918eR10)
- [x] <kbd>cmd</kbd>+<kbd>shift</kbd>+<kbd>o</kbd> to open quick open modal to functions
- [x] See additional functions in list of results
