### PR TITLE
Style line numbers in search results

### DIFF
--- a/src/test/mochitest/browser_dbg-quick-open.js
+++ b/src/test/mochitest/browser_dbg-quick-open.js
@@ -99,7 +99,7 @@ add_task(async function() {
   quickOpen(dbg, "#");
   is(resultCount(dbg), 1, "one variable result");
   const results = findAllElements(dbg, "resultItems");
-  results.forEach(result => is(result.textContent, "x:13"));
+  results.forEach(result => is(result.textContent, "x13"));
   await waitToClose(dbg);
 
   info("Testing goto line:column");

--- a/src/utils/quick-open.js
+++ b/src/utils/quick-open.js
@@ -71,7 +71,7 @@ export function formatSymbol(
   return {
     id: `${symbol.name}:${symbol.location.start.line}`,
     title: symbol.name,
-    subtitle: `:${symbol.location.start.line}`,
+    subtitle: `${symbol.location.start.line}`,
     value: symbol.name,
     location: symbol.location
   };


### PR DESCRIPTION
Associated Issue: #4488 

### Summary of Changes

* `:` is removed from the line numbers in search results

### Before

![screen shot 2017-10-31 at 13 28 09](https://user-images.githubusercontent.com/8022693/32213023-81cb7a4c-be3f-11e7-9efd-1e93a7d5e703.png)

### After

![screen shot 2017-10-31 at 13 25 56](https://user-images.githubusercontent.com/8022693/32213030-8a8717e0-be3f-11e7-9c03-09052dc47f54.png)


