### PR TITLE
Fix display of return value / thrown exception in scopes

### DIFF
--- a/flow-typed/debugger-html.js
+++ b/flow-typed/debugger-html.js
@@ -155,9 +155,13 @@ declare module "debugger-html" {
   declare type Why =
     | {|
         exception: string | Grip,
-        type: "exception"
+        type: "exception",
+        frameFinished?: Object
       |}
-    | { type: string };
+    | {
+        type: string,
+        frameFinished?: Object
+      };
 
   /**
  * Why is the Debugger Paused?
@@ -185,6 +189,7 @@ declare module "debugger-html" {
  * @static
  */
   declare type Pause = {
+    frame: Frame,
     frames: Frame[],
     why: Why,
     loadedObjects?: LoadedObject[]

--- a/src/test/mochitest/browser.ini
+++ b/src/test/mochitest/browser.ini
@@ -92,6 +92,7 @@ skip-if = os == "linux" # bug 1351952
 [browser_dbg-pretty-print-console.js]
 [browser_dbg-pretty-print-paused.js]
 [browser_dbg-preview.js]
+[browser_dbg-returnvalues.js]
 [browser_dbg-scopes-mutations.js]
 [browser_dbg-search-file.js]
 skip-if = os == "win" # Bug 1393121

--- a/src/test/mochitest/browser_dbg-returnvalues.js
+++ b/src/test/mochitest/browser_dbg-returnvalues.js
@@ -1,0 +1,69 @@
+function getLabel(dbg, index) {
+  return findElement(dbg, "scopeNode", index).innerText;
+}
+
+function getValue(dbg, index) {
+  return findElement(dbg, "scopeValue", index).innerText;
+}
+
+function toggleScopes(dbg) {
+  return findElement(dbg, "scopesHeader").click();
+}
+
+async function testReturnValue(dbg, val) {
+  invokeInTab("return_something", val);
+  await waitForPaused(dbg);
+
+  // "Step in" 3 times to get to the point where the debugger can
+  // see the return value.
+  await stepIn(dbg);
+  await stepIn(dbg);
+  await stepIn(dbg);
+
+  is(getLabel(dbg, 1), "return_something", "check for return_something");
+
+  // We don't show "undefined" but we do show other falsy values.
+  let label = getLabel(dbg, 2);
+  if (val === "undefined") {
+    ok(label !== "<return>", "do not show <return> for undefined");
+  } else {
+    is(label, "<return>", "check for <return>");
+    // The "uneval" call here gives us the way one would write `val` as
+    // a JavaScript expression, similar to the way the debugger
+    // displays values, so this test works when `val` is a string.
+    is(getValue(dbg, 2), uneval(val), `check value is ${uneval(val)}`);
+  }
+
+  await resume(dbg);
+  assertNotPaused(dbg);
+}
+
+async function testThrowValue(dbg, val) {
+  invokeInTab("throw_something", val);
+  await waitForPaused(dbg);
+
+  // "Step in" once to get to the point where the debugger can see the
+  // exception.
+  await stepIn(dbg);
+
+  is(getLabel(dbg, 1), "callee", "check for callee");
+  is(getLabel(dbg, 2), "<exception>", "check for <exception>");
+  // The "uneval" call here gives us the way one would write `val` as
+  // a JavaScript expression, similar to the way the debugger
+  // displays values, so this test works when `val` is a string.
+  is(getValue(dbg, 2), uneval(val), `check exception is ${uneval(val)}`);
+
+  await resume(dbg);
+  await waitForPaused(dbg);
+  await resume(dbg);
+  assertNotPaused(dbg);
+}
+
+add_task(async function() {
+  const dbg = await initDebugger("doc-return-values.html");
+  toggleScopes(dbg);
+  await togglePauseOnExceptions(dbg, true, false);
+
+  await testReturnValue(dbg, "to sender");
+  await testThrowValue(dbg, "a fit");
+});

--- a/src/test/mochitest/head.js
+++ b/src/test/mochitest/head.js
@@ -257,6 +257,15 @@ function waitForSelectedSource(dbg, url) {
 }
 
 /**
+ * Assert that the debugger is not currently paused.
+ * @memberof mochitest/asserts
+ * @static
+ */
+function assertNotPaused(dbg) {
+  ok(!isPaused(dbg), "client is not paused");
+}
+
+/**
  * Assert that the debugger is paused at the correct location.
  *
  * @memberof mochitest/asserts
@@ -726,14 +735,20 @@ function waitForActive(dbg) {
  * Invokes a global function in the debuggee tab.
  *
  * @memberof mochitest/helpers
- * @param {String} fnc
+ * @param {String} fnc The name of a global function on the content window to
+ *                     call. This is applied to structured clones of the
+ *                     remaining arguments to invokeInTab.
+ * @param {Any} ...args Remaining args to serialize and pass to fnc.
  * @return {Promise}
  * @static
  */
-function invokeInTab(fnc) {
-  info(`Invoking function ${fnc} in tab`);
-  return ContentTask.spawn(gBrowser.selectedBrowser, fnc, function*(fnc) {
-    content.wrappedJSObject[fnc](); // eslint-disable-line mozilla/no-cpows-in-tests, max-len
+function invokeInTab(fnc, ...args) {
+  info(`Invoking in tab: ${fnc}(${args.map(uneval).join(",")})`);
+  return ContentTask.spawn(gBrowser.selectedBrowser, { fnc, args }, function*({
+    fnc,
+    args
+  }) {
+    content.wrappedJSObject[fnc](...args); // eslint-disable-line mozilla/no-cpows-in-tests, max-len
   });
 }
 

--- a/src/utils/scopes.js
+++ b/src/utils/scopes.js
@@ -165,7 +165,7 @@ export function getScopes(
       // the return value or the exception being thrown as special variables.
       if (
         scope.actor === selectedScope.actor &&
-        selectedFrame.id == pauseInfo.frame.id
+        selectedFrame.id === pauseInfo.frame.id
       ) {
         vars = vars.concat(getFramePopVariables(pauseInfo, key));
       }

--- a/src/utils/scopes.js
+++ b/src/utils/scopes.js
@@ -5,7 +5,6 @@
 // @flow
 
 import { toPairs } from "lodash";
-import { get } from "lodash";
 import { simplifyDisplayName } from "./frame";
 import type { Frame, Pause, Scope, BindingContents } from "debugger-html";
 
@@ -75,28 +74,32 @@ function getSourceBindingVariables(
 }
 
 export function getSpecialVariables(pauseInfo: Pause, path: string) {
-  const thrown = get(pauseInfo, "why.frameFinished.throw", undefined);
-
-  const returned = get(pauseInfo, "why.frameFinished.return", undefined);
-
   const vars = [];
 
-  if (thrown !== undefined) {
-    vars.push({
-      name: "<exception>",
-      path: `${path}/<exception>`,
-      contents: { value: thrown }
-    });
-  }
+  if (pauseInfo.why && pauseInfo.why.frameFinished) {
+    const frameFinished = pauseInfo.why.frameFinished;
 
-  if (returned !== undefined) {
-    // Do not display a return value of "undefined",
-    if (!returned || !returned.type || returned.type !== "undefined") {
+    // Always display a `throw` property if present, even if it is falsy.
+    if (Object.prototype.hasOwnProperty.call(frameFinished, "throw")) {
       vars.push({
-        name: "<return>",
-        path: `${path}/<return>`,
-        contents: { value: returned }
+        name: "<exception>",
+        path: `${path}/<exception>`,
+        contents: { value: frameFinished.throw }
       });
+    }
+
+    if (Object.prototype.hasOwnProperty.call(frameFinished, "return")) {
+      const returned = frameFinished.return;
+
+      // Do not display undefined. Do display falsy values like 0 and false. The
+      // protocol grip for undefined is a JSON object: { type: "undefined" }.
+      if (typeof returned !== "object" || returned.type !== "undefined") {
+        vars.push({
+          name: "<return>",
+          path: `${path}/<return>`,
+          contents: { value: returned }
+        });
+      }
     }
   }
 
@@ -137,7 +140,6 @@ export function getScopes(
   const scopes = [];
 
   let scope = selectedScope;
-  const pausedScopeActor = get(pauseInfo, "frame.scope.actor");
   let scopeIndex = 1;
 
   do {
@@ -159,8 +161,12 @@ export function getScopes(
         ? getSourceBindingVariables(bindings, sourceBindings, key)
         : getBindingVariables(bindings, key);
 
-      // show exception, return, and this variables in innermost scope
-      if (scope.actor === pausedScopeActor) {
+      // On the innermost scope of a frame that is just about to be popped, show
+      // the return value or the exception being thrown as special variables.
+      if (
+        scope.actor === selectedScope.actor &&
+        selectedFrame.id == pauseInfo.frame.id
+      ) {
         vars = vars.concat(getSpecialVariables(pauseInfo, key));
       }
 

--- a/src/utils/scopes.js
+++ b/src/utils/scopes.js
@@ -73,7 +73,7 @@ function getSourceBindingVariables(
   return bound.concat(unused);
 }
 
-export function getSpecialVariables(pauseInfo: Pause, path: string) {
+export function getFramePopVariables(pauseInfo: Pause, path: string) {
   const vars = [];
 
   if (pauseInfo.why && pauseInfo.why.frameFinished) {
@@ -167,7 +167,7 @@ export function getScopes(
         scope.actor === selectedScope.actor &&
         selectedFrame.id == pauseInfo.frame.id
       ) {
-        vars = vars.concat(getSpecialVariables(pauseInfo, key));
+        vars = vars.concat(getFramePopVariables(pauseInfo, key));
       }
 
       if (scope.actor === selectedScope.actor) {

--- a/src/utils/tests/scopes.spec.js
+++ b/src/utils/tests/scopes.spec.js
@@ -1,4 +1,4 @@
-import { getSpecialVariables, getScopes } from "../scopes";
+import { getFramePopVariables, getScopes } from "../scopes";
 
 const errorGrip = {
   type: "object",
@@ -43,7 +43,7 @@ function throwWhy(grip) {
 }
 
 describe("scopes", () => {
-  describe("getSpecialVariables", () => {
+  describe("getFramePopVariables", () => {
     describe("falsey values", () => {
       // NOTE: null and undefined are treated like objects and given a type
       const falsey = { false: false, "0": 0, null: { type: "null" } };
@@ -51,7 +51,7 @@ describe("scopes", () => {
         const value = falsey[test];
         it(`shows ${test} returns`, () => {
           const pauseData = returnWhy(value);
-          const vars = getSpecialVariables(pauseData, "");
+          const vars = getFramePopVariables(pauseData, "");
           expect(vars[0].name).toEqual("<return>");
           expect(vars[0].name).toEqual("<return>");
           expect(vars[0].contents.value).toEqual(value);
@@ -59,7 +59,7 @@ describe("scopes", () => {
 
         it(`shows ${test} throws`, () => {
           const pauseData = throwWhy(value);
-          const vars = getSpecialVariables(pauseData, "");
+          const vars = getFramePopVariables(pauseData, "");
           expect(vars[0].name).toEqual("<exception>");
           expect(vars[0].name).toEqual("<exception>");
           expect(vars[0].contents.value).toEqual(value);
@@ -70,7 +70,7 @@ describe("scopes", () => {
     describe("Error / Objects", () => {
       it("shows Error returns", () => {
         const pauseData = returnWhy(errorGrip);
-        const vars = getSpecialVariables(pauseData, "");
+        const vars = getFramePopVariables(pauseData, "");
         expect(vars[0].name).toEqual("<return>");
         expect(vars[0].name).toEqual("<return>");
         expect(vars[0].contents.value.class).toEqual("Error");
@@ -78,7 +78,7 @@ describe("scopes", () => {
 
       it("shows error throws", () => {
         const pauseData = throwWhy(errorGrip);
-        const vars = getSpecialVariables(pauseData, "");
+        const vars = getFramePopVariables(pauseData, "");
         expect(vars[0].name).toEqual("<exception>");
         expect(vars[0].name).toEqual("<exception>");
         expect(vars[0].contents.value.class).toEqual("Error");
@@ -88,13 +88,13 @@ describe("scopes", () => {
     describe("undefined", () => {
       it("does not show undefined returns", () => {
         const pauseData = returnWhy({ type: "undefined" });
-        const vars = getSpecialVariables(pauseData, "");
+        const vars = getFramePopVariables(pauseData, "");
         expect(vars.length).toEqual(0);
       });
 
       it("shows undefined throws", () => {
         const pauseData = throwWhy({ type: "undefined" });
-        const vars = getSpecialVariables(pauseData, "");
+        const vars = getFramePopVariables(pauseData, "");
         expect(vars[0].name).toEqual("<exception>");
         expect(vars[0].name).toEqual("<exception>");
         expect(vars[0].contents.value).toEqual({ type: "undefined" });

--- a/src/utils/tests/scopes.spec.js
+++ b/src/utils/tests/scopes.spec.js
@@ -106,9 +106,6 @@ describe("scopes", () => {
     it("single scope", () => {
       const pauseData = {
         frame: {
-          scope: {
-            actor: "actor1"
-          },
           this: {}
         }
       };
@@ -138,9 +135,6 @@ describe("scopes", () => {
     it("second scope", () => {
       const pauseData = {
         frame: {
-          scope: {
-            actor: "actor1"
-          },
           this: {}
         }
       };

--- a/src/utils/tests/scopes.spec.js
+++ b/src/utils/tests/scopes.spec.js
@@ -169,5 +169,103 @@ describe("scopes", () => {
         contents: {}
       });
     });
+
+    it("returning scope", () => {
+      const pauseData = {
+        frame: {
+          this: {}
+        },
+        why: {
+          frameFinished: {
+            return: "to sender"
+          }
+        }
+      };
+
+      const selectedFrame = {
+        scope: {
+          actor: "actor1",
+          type: "block",
+          bindings: {
+            arguments: [],
+            variables: {}
+          },
+          parent: null
+        },
+        this: {}
+      };
+
+      const scopes = getScopes(pauseData, selectedFrame);
+      expect(scopes).toMatchObject([
+        {
+          path: "actor1-1",
+          contents: [
+            {
+              name: "<return>",
+              path: "actor1-1/<return>",
+              contents: {
+                value: "to sender"
+              }
+            },
+            {
+              name: "<this>",
+              path: "actor1-1/<this>",
+              contents: {
+                value: {}
+              }
+            }
+          ]
+        }
+      ]);
+    });
+
+    it("throwing scope", () => {
+      const pauseData = {
+        frame: {
+          this: {}
+        },
+        why: {
+          frameFinished: {
+            throw: "a party"
+          }
+        }
+      };
+
+      const selectedFrame = {
+        scope: {
+          actor: "actor1",
+          type: "block",
+          bindings: {
+            arguments: [],
+            variables: {}
+          },
+          parent: null
+        },
+        this: {}
+      };
+
+      const scopes = getScopes(pauseData, selectedFrame);
+      expect(scopes).toMatchObject([
+        {
+          path: "actor1-1",
+          contents: [
+            {
+              name: "<exception>",
+              path: "actor1-1/<exception>",
+              contents: {
+                value: "a party"
+              }
+            },
+            {
+              name: "<this>",
+              path: "actor1-1/<this>",
+              contents: {
+                value: {}
+              }
+            }
+          ]
+        }
+      ]);
+    });
   });
 });


### PR DESCRIPTION
Associated Issue: #3390

### Summary of Changes

* **[`scopes.spec.js`]: Don't supply scope in `pauseData`.**

    With [Bug 1370923], frames delivered to the new debugger no longer have `scope`
    properties. This commit changes the mock pause data to omit the scope property.
    However, since the tests don't actually check for `<return>` or `<throw>`
    pseudovars, nothing fails --- yet.

* **[`getScopes`]: Fix `<return>` and `<exception>` pseudo-vars.**

    As of [Bug 1370923], frames in "paused" packets from the server no longer include
    an environment form. This broke [`getScopes`], which assumed it could recognize the
    scope of the frame that is currently returning by comparing the scope's actor
    name with that given in the "paused" packet's frame.

    Since only one frame at a time will ever have a `frameFinished` property, it's
    good enough to simply watch for the top scope of the selected frame, and append
    the values whenever the frame has a `frameFinished` property.

    This commit adds tests to [`scopes.spec.js`].

* **Rename [`getSpecialVariables`] to `getFramePopVariables`.**

    This better reflects the function's actual purpose and behavior.

[Bug 1370923]: https://bugzilla.mozilla.org/show_bug.cgi?id=1370923
[`getScopes`]: https://github.com/devtools-html/debugger.html/blob/5bfe03c/src/utils/scopes.js#L158-L161
[`scopes.spec.js`]: https://github.com/devtools-html/debugger.html/blob/5bfe03c/src/utils/tests/scopes.spec.js
[`getSpecialVariables`]: https://github.com/devtools-html/debugger.html/blob/5bfe03c/src/utils/scopes.js#L73

### Test Plan

Each change includes changes or additions to [`scopes.spec.js`].
