### PR TITLE
Dont show Mochi output for passing tests

### DIFF
--- a/bin/ci/run-tests.sh
+++ b/bin/ci/run-tests.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 node ./bin/copy-assets.js --mc firefox
-./node_modules/.bin/mochii --mc ./firefox --default-test-path devtools/client/debugger/new
+./node_modules/.bin/mochii --ci true --mc ./firefox --default-test-path devtools/client/debugger/new
 exit $?

--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "jest-localstorage-mock": "^1.1.1",
     "jest-serializer-babel-ast": "^0.0.5",
     "lint-staged": "^4.0.1",
-    "mochii": "^0.0.12",
+    "mochii": "^0.0.13",
     "mock-require": "^2.0.2",
     "node-emoji": "^1.8.1",
     "npm-run-all": "^4.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6744,9 +6744,9 @@ mocha@^3.2.0:
     mkdirp "0.5.1"
     supports-color "3.1.2"
 
-mochii@^0.0.12:
-  version "0.0.12"
-  resolved "https://registry.yarnpkg.com/mochii/-/mochii-0.0.12.tgz#a2ab8ca455a7265c9026bce96e42ef408c3dd278"
+mochii@^0.0.13:
+  version "0.0.13"
+  resolved "https://registry.yarnpkg.com/mochii/-/mochii-0.0.13.tgz#fb3c1471721fdfbbf99dabf83426ed5d8d8bde76"
   dependencies:
     chalk "^2.1.0"
     eslint "^4.7.2"


### PR DESCRIPTION
One of the biggest pain points w/ mochitests is that it is hard to find the error in the test log. This will make it much easier by only showing the test logs for failing tests 🔥 

<img width="1404" alt="screen shot 2017-11-03 at 2 22 29 pm" src="https://user-images.githubusercontent.com/254562/32390235-f8ca0a30-c0a3-11e7-8cc5-9da60c8c83ec.png">
