### PR TITLE
Disallow uncaught exceptions

### DIFF
--- a/src/actions/tests/pause.spec.js
+++ b/src/actions/tests/pause.spec.js
@@ -2,7 +2,8 @@ import {
   actions,
   selectors,
   createStore,
-  getHistory
+  getHistory,
+  makeSource
 } from "../../utils/test-head";
 
 const { isStepping } = selectors;
@@ -43,6 +44,7 @@ describe("pause", () => {
       const { dispatch, getState } = createStore(mockThreadClient);
       const mockPauseInfo = createPauseInfo();
 
+      await dispatch(actions.newSource(makeSource("foo1")));
       await dispatch(actions.paused(mockPauseInfo));
       const stepped = dispatch(actions.stepIn());
       expect(isStepping(getState())).toBeTruthy();
@@ -66,6 +68,7 @@ describe("pause", () => {
       const { dispatch } = createStore(mockThreadClient);
       const mockPauseInfo = createPauseInfo();
 
+      await dispatch(actions.newSource(makeSource("foo1")));
       await dispatch(actions.paused(mockPauseInfo));
       await dispatch(actions.resumed());
 
@@ -74,6 +77,8 @@ describe("pause", () => {
 
     it("resuming when not paused", async () => {
       const { dispatch } = createStore(mockThreadClient);
+
+      await dispatch(actions.newSource(makeSource("foo1")));
       await dispatch(actions.resumed());
       expect(getHistory("RESUME").length).toEqual(0);
     });

--- a/src/client/firefox/tests/onconnect.spec.js
+++ b/src/client/firefox/tests/onconnect.spec.js
@@ -35,7 +35,7 @@ const debuggerClient = {
 const actions = {
   _sources: [],
   connect: () => {},
-
+  setWorkers: () => {},
   newSources: function(sources) {
     return new Promise(resolve => {
       setTimeout(() => {

--- a/src/test/tests-setup.js
+++ b/src/test/tests-setup.js
@@ -28,4 +28,5 @@ setConfig(config);
 
 process.on("unhandledRejection", (reason, p) => {
   console.log("Unhandled Rejection at:", p, "reason:", reason);
+  throw reason;
 });


### PR DESCRIPTION
We were allowing uncaught exceptions in our unit tests, which is a bad practice:

We now throw when we see it.

![screen shot 2017-11-04 at 11 56 07 am](https://user-images.githubusercontent.com/254562/32406949-60712a34-c157-11e7-8e2e-eb5d01bd3be6.png)
