### PR TITLE
Mochi intermittent script

### DIFF
--- a/bin/mochi-intermittents.js
+++ b/bin/mochi-intermittents.js
@@ -1,0 +1,52 @@
+const shell = require("shelljs");
+const _ = require("lodash");
+const fs = require("fs");
+
+/*
+Mochi Intermittents is a small script for running the full mochitest
+suite several times to look for intermittent failures.
+
+There are two commands:
+* run - runs the full suite N times
+* uniqErrors - scans the logs for uniq test errors and their count
+
+It is easy to pick up on trends by running `less logs`
+and looking for `TEST-START <test-name>`
+*/
+
+
+function run(count) {
+  fs.writeFileSync("logs", "");
+  const headlessParam = headless ? '': `-- --setenv MOZ_HEADLESS=1`
+  const cmd = `mochii --ci true --mc ./firefox --default-test-path devtools/client/debugger/new`;
+  _.times(count).forEach(i => {
+    console.log(`### RUN ${i}`);
+    fs.appendFileSync("logs", `### RUN ${i}`);
+
+    const out = shell.exec(cmd);
+    fs.appendFileSync("logs", out.stdout);
+    fs.appendFileSync("logs", out.stderr);
+  });
+}
+
+
+function uniqErrors() {
+  const text = fs.readFileSync("logs", "utf8")
+  const errors = text.split("\n")
+    .filter(line => line.includes("TEST-START"))
+    .map(line => line.match(/TEST-START (.*)/)[1])
+
+  const uniq_errors = _.uniq(errors)
+
+  errorCounts = uniq_errors.map(error => ({
+    error,
+    count: errors.filter(e => e == error).length
+  }))
+
+  console.log(errors.length)
+}
+
+(() => {
+  // run(50);
+  // uniqErrors();
+})()


### PR DESCRIPTION
Mochi Intermittents is a small script for running the full mochitest
suite several times to look for intermittent failures.

There are two commands:
* run - runs the full suite N times
* uniqErrors - scans the logs for uniq test errors and their count

It is easy to pick up on trends by running `less logs`
and looking for `TEST-START <test-name>`

![screen shot 2017-11-04 at 4 24 03 pm](https://user-images.githubusercontent.com/254562/32409151-a51090b0-c17c-11e7-8874-aa7e56265ce9.png)
