### PR TITLE
Exclude flow types from identifier locations

### DIFF
--- a/src/workers/parser/getSymbols.js
+++ b/src/workers/parser/getSymbols.js
@@ -165,7 +165,12 @@ function extractSymbols(source: Source) {
       }
 
       if (t.isIdentifier(path)) {
-        const { start, end } = path.node.loc;
+        let { start, end } = path.node.loc;
+
+        if (path.node.typeAnnotation) {
+          const column = path.node.typeAnnotation.loc.start.column;
+          end = { ...end, column };
+        }
 
         identifiers.push({
           name: path.node.name,

--- a/src/workers/parser/tests/__snapshots__/getSymbols.spec.js.snap
+++ b/src/workers/parser/tests/__snapshots__/getSymbols.spec.js.snap
@@ -643,6 +643,39 @@ imports:
 "
 `;
 
+exports[`Parser.getSymbols flow 1`] = `
+"functions:
+[(2, 2), (4, 3)]   renderHello(name) App
+
+variables:
+[(2, 14), (2, 26)]   name
+
+callExpressions:
+
+
+memberExpressions:
+
+
+objectProperties:
+
+
+comments:
+
+
+identifiers:
+[(1, 6), (1, 9)]  App App
+[(2, 2), (2, 13)]  renderHello renderHello
+[(2, 14), (2, 18)]  name name
+[(3, 20), (3, 24)]  name name
+[(1, 18), (1, 27)]  Component Component
+
+classes:
+[(1, 0), (5, 1)]   App
+
+imports:
+"
+`;
+
 exports[`Parser.getSymbols func 1`] = `
 "functions:
 [(1, 0), (3, 1)]   square(n)

--- a/src/workers/parser/tests/fixtures/flow.js
+++ b/src/workers/parser/tests/fixtures/flow.js
@@ -1,0 +1,5 @@
+class App extends Component {
+  renderHello(name: string) {
+    return `howdy ${name}`;
+  }
+}

--- a/src/workers/parser/tests/getSymbols.spec.js
+++ b/src/workers/parser/tests/getSymbols.spec.js
@@ -24,6 +24,7 @@ cases(
       type: "html"
     },
     { name: "component", file: "component" },
-    { name: "react component", file: "frameworks/component" }
+    { name: "react component", file: "frameworks/component" },
+    { name: "flow", file: "flow" }
   ]
 );


### PR DESCRIPTION
Fixes: #3462

### Summary of Changes

Previously we were using the full identifier location, which included the type annotation range: e.g `name: string`. We now update the identifiers end column to just include `name`.

### Test Plan

Unit test

### Screenshot

![screen shot 2017-11-04 at 7 58 50 pm](https://user-images.githubusercontent.com/254562/32410584-9eb57a0a-c19a-11e7-92a1-c250c6a92743.png)
