### PR TITLE
FIX - cmd+shift+b is no longer bound

### DIFF
--- a/src/actions/ui.js
+++ b/src/actions/ui.js
@@ -104,10 +104,14 @@ export function clearHighlightLineRange() {
   };
 }
 
-export function openConditionalPanel(line?: number) {
+export function openConditionalPanel(line: ?number) {
+  if (!line) {
+    return;
+  }
+
   return {
     type: "OPEN_CONDITIONAL_PANEL",
-    line: line
+    line
   };
 }
 

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -185,10 +185,7 @@ class Editor extends PureComponent<Props, State> {
     );
 
     shortcuts.on(L10N.getStr("toggleBreakpoint.key"), this.onToggleBreakpoint);
-    shortcuts.on(
-      L10N.getStr("toggleCondPanel.key"),
-      this.toggleConditionalPanel
-    );
+    shortcuts.on(L10N.getStr("toggleCondPanel.key"), this.toggleCondPanelKey);
     shortcuts.on("Esc", this.onEscape);
     shortcuts.on(searchAgainPrevKey, this.onSearchAgain);
     shortcuts.on(searchAgainKey, this.onSearchAgain);
@@ -265,6 +262,14 @@ class Editor extends PureComponent<Props, State> {
     } else {
       this.props.toggleBreakpoint(sourceLine);
     }
+  };
+
+  toggleCondPanelKey = () => {
+    const { codeMirror } = this.state.editor;
+    const { selectedSource } = this.props;
+    const line = getCursorLine(codeMirror);
+    const sourceLine = toSourceLine(selectedSource.get("id"), line);
+    this.toggleConditionalPanel(sourceLine);
   };
 
   onKeyDown(e) {

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -185,7 +185,10 @@ class Editor extends PureComponent<Props, State> {
     );
 
     shortcuts.on(L10N.getStr("toggleBreakpoint.key"), this.onToggleBreakpoint);
-    shortcuts.on(L10N.getStr("toggleCondPanel.key"), this.toggleCondPanelKey);
+    shortcuts.on(
+      L10N.getStr("toggleCondPanel.key"),
+      this.toggleConditionalPanel
+    );
     shortcuts.on("Esc", this.onEscape);
     shortcuts.on(searchAgainPrevKey, this.onSearchAgain);
     shortcuts.on(searchAgainKey, this.onSearchAgain);
@@ -245,31 +248,29 @@ class Editor extends PureComponent<Props, State> {
     }
   }
 
-  onToggleBreakpoint = (key, e) => {
-    e.preventDefault();
+  getCurrentLine() {
     const { codeMirror } = this.state.editor;
     const { selectedSource } = this.props;
     const line = getCursorLine(codeMirror);
+
+    return toSourceLine(selectedSource.get("id"), line);
+  }
+
+  onToggleBreakpoint = (key, e) => {
+    e.preventDefault();
+    const { selectedSource } = this.props;
 
     if (!selectedSource) {
       return;
     }
 
-    const sourceLine = toSourceLine(selectedSource.get("id"), line);
+    const line = this.getCurrentLine();
 
     if (e.shiftKey) {
-      this.toggleConditionalPanel(sourceLine);
+      this.toggleConditionalPanel(line);
     } else {
-      this.props.toggleBreakpoint(sourceLine);
+      this.props.toggleBreakpoint(line);
     }
-  };
-
-  toggleCondPanelKey = () => {
-    const { codeMirror } = this.state.editor;
-    const { selectedSource } = this.props;
-    const line = getCursorLine(codeMirror);
-    const sourceLine = toSourceLine(selectedSource.get("id"), line);
-    this.toggleConditionalPanel(sourceLine);
   };
 
   onKeyDown(e) {
@@ -388,6 +389,10 @@ class Editor extends PureComponent<Props, State> {
       closeConditionalPanel,
       openConditionalPanel
     } = this.props;
+
+    if (!line || isNaN(line)) {
+      line = this.getCurrentLine();
+    }
 
     if (conditionalPanelLine) {
       return closeConditionalPanel();


### PR DESCRIPTION
Associated Issue: #4517 

Summary of Changes

The line number parameter is passed to the toggle function

Test Plan

Move the cursor to the desired line and press cmd+shift+b
The conditional breakpoint pane is toggled
