### PR TITLE
Converted tab, breakpoint, watch expression, and search bar Close Button SVG's to Images

### DIFF
--- a/src/components/Editor/SearchBar.css
+++ b/src/components/Editor/SearchBar.css
@@ -14,12 +14,6 @@
 
 .search-field .close-btn {
   margin-top: 7px;
-  display: inline-flex;
-}
-
-.search-field .close-btn img.close {
-  margin-top: 3px;
-  margin-left: -1.5px;
 }
 
 .search-bottom-bar * {

--- a/src/components/Editor/SearchBar.css
+++ b/src/components/Editor/SearchBar.css
@@ -12,8 +12,14 @@
   height: var(--editor-searchbar-height);
 }
 
-.search-bar .close-btn {
-  padding: 6px;
+.search-field .close-btn {
+  margin-top: 7px;
+  display: inline-flex;
+}
+
+.search-field .close-btn img.close {
+  margin-top: 3px;
+  margin-left: -1.5px;
 }
 
 .search-bottom-bar * {

--- a/src/components/Editor/Tabs.css
+++ b/src/components/Editor/Tabs.css
@@ -123,6 +123,11 @@
   line-height: 0;
 }
 
+.source-tab .close-btn img.close {
+  margin-top: 3px;
+  margin-left: -2px;
+}
+
 .source-tab.active .close-btn {
   visibility: visible;
 }

--- a/src/components/Editor/Tabs.css
+++ b/src/components/Editor/Tabs.css
@@ -43,7 +43,7 @@
   border-top-left-radius: 2px;
   border-top-right-radius: 2px;
   display: inline-flex;
-  align-items: flex-end;
+  align-items: center;
   position: relative;
   transition: all 0.15s ease;
   min-width: 40px;
@@ -121,11 +121,6 @@
 .source-tab .close-btn {
   visibility: hidden;
   line-height: 0;
-}
-
-.source-tab .close-btn img.close {
-  margin-top: 3px;
-  margin-left: -2px;
 }
 
 .source-tab.active .close-btn {

--- a/src/components/ProjectSearch/TextSearch.css
+++ b/src/components/ProjectSearch/TextSearch.css
@@ -83,12 +83,7 @@
 }
 
 .project-text-search .search-field .close-btn.big {
-  margin-top: 10px;
-}
-
-.project-text-search .search-field .close-btn.big img.close {
-  margin-top: 0px;
-  margin-left: 0px;
+  margin-top: 12px;
 }
 
 .project-text-search .managed-tree {

--- a/src/components/ProjectSearch/TextSearch.css
+++ b/src/components/ProjectSearch/TextSearch.css
@@ -82,6 +82,15 @@
   flex-grow: 1;
 }
 
+.project-text-search .search-field .close-btn.big {
+  margin-top: 10px;
+}
+
+.project-text-search .search-field .close-btn.big img.close {
+  margin-top: 0px;
+  margin-left: 0px;
+}
+
 .project-text-search .managed-tree {
   overflow-y: auto;
   height: calc(100% - 81px);

--- a/src/components/SecondaryPanes/Breakpoints.css
+++ b/src/components/SecondaryPanes/Breakpoints.css
@@ -107,6 +107,11 @@ html .breakpoints-list .breakpoint.paused {
   top: 9px;
 }
 
+.breakpoint .close-btn img.close {
+  padding-top: 8px;
+  margin-left: -2px;
+}
+
 .breakpoint .close {
   visibility: hidden;
 }

--- a/src/components/SecondaryPanes/Breakpoints.css
+++ b/src/components/SecondaryPanes/Breakpoints.css
@@ -107,11 +107,6 @@ html .breakpoints-list .breakpoint.paused {
   top: 9px;
 }
 
-.breakpoint .close-btn img.close {
-  padding-top: 8px;
-  margin-left: -2px;
-}
-
 .breakpoint .close {
   visibility: hidden;
 }

--- a/src/components/SecondaryPanes/Expressions.css
+++ b/src/components/SecondaryPanes/Expressions.css
@@ -64,13 +64,7 @@
 }
 
 .expression-container__close-btn .close-btn {
-  padding-left: 3px;
   margin-top: 2px;
-}
-
-.expression-container__close-btn .close-btn img.close {
-  padding-top: 11px;
-  margin-left: -0.5px;
 }
 
 .expression-content {
@@ -84,10 +78,6 @@
 
 .expression-content .tree-node {
   overflow-x: hidden;
-}
-
-.expression-container:hover .close-btn {
-  display: inline-block;
 }
 
 .expression-input {

--- a/src/components/SecondaryPanes/Expressions.css
+++ b/src/components/SecondaryPanes/Expressions.css
@@ -60,7 +60,17 @@
 .expression-container__close-btn {
   position: absolute;
   offset-inline-end: 0px;
-  top: 4px;
+  top: 0px;
+}
+
+.expression-container__close-btn .close-btn {
+  padding-left: 3px;
+  margin-top: 2px;
+}
+
+.expression-container__close-btn .close-btn img.close {
+  padding-top: 11px;
+  margin-left: -0.5px;
 }
 
 .expression-content {
@@ -77,7 +87,7 @@
 }
 
 .expression-container:hover .close-btn {
-  display: block;
+  display: inline-block;
 }
 
 .expression-input {

--- a/src/components/shared/Button/Close.css
+++ b/src/components/shared/Button/Close.css
@@ -7,7 +7,10 @@
   height: 14px;
   border: 1px solid transparent;
   border-radius: 2px;
-  padding-left: 4px;
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
 }
 
 .close-btn .close {
@@ -19,8 +22,6 @@
   transition: all 0.15s ease-in-out;
   padding: 0;
   margin-top: 0;
-  display: inline-flex;
-  justify-content: center;
 }
 
 .close-btn:hover img.close {
@@ -28,21 +29,15 @@
 }
 
 .close-btn:hover {
-  display: block;
   background-color: var(--theme-selection-background);
 }
 
 .close-btn.big {
-  padding: 3px;
-  width: 20px;
-  height: 20px;
-}
-
-.close-btn.big .close {
   width: 16px;
   height: 16px;
 }
 
-.close-btn.big img.close {
-  width: 12px;
+.close-btn.big .close {
+  width: 9px;
+  height: 9px;
 }

--- a/src/components/shared/Button/Close.css
+++ b/src/components/shared/Button/Close.css
@@ -2,43 +2,40 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
-.close-btn path {
-  fill: var(--theme-comment-alt);
+.close-btn {
+  width: 14px;
+  height: 14px;
+  border: 1px solid transparent;
+  border-radius: 2px;
+  padding-left: 4px;
 }
 
 .close-btn .close {
-  width: 14px;
-  height: 14px;
+  mask: url(/images/close.svg) no-repeat;
+  mask-size: 100%;
+  background-color: var(--theme-comment-alt);
+  width: 8px;
+  height: 8px;
   transition: all 0.15s ease-in-out;
-  border: 1px solid transparent;
-  border-radius: 2px;
   padding: 0;
   margin-top: 0;
   display: inline-flex;
   justify-content: center;
 }
 
-.close-btn .close svg {
-  width: 8px;
+.close-btn:hover img.close {
+  background-color: white;
 }
 
 .close-btn:hover {
   display: block;
-}
-
-.close-btn:hover .close {
-  background: var(--theme-selection-background);
-}
-
-.close-btn:hover .close path {
-  fill: white;
+  background-color: var(--theme-selection-background);
 }
 
 .close-btn.big {
-  padding: 11px;
-  margin-right: 7px;
-  width: 27px;
-  height: 40px;
+  padding: 3px;
+  width: 20px;
+  height: 20px;
 }
 
 .close-btn.big .close {
@@ -46,6 +43,6 @@
   height: 16px;
 }
 
-.close-btn.big .close svg {
-  width: 9px;
+.close-btn.big img.close {
+  width: 12px;
 }

--- a/src/components/shared/Button/Close.js
+++ b/src/components/shared/Button/Close.js
@@ -4,7 +4,6 @@
 
 // @flow
 import React from "react";
-import Svg from "../Svg";
 import "./Close.css";
 
 type Props = {
@@ -20,7 +19,7 @@ function CloseButton({ handleClick, buttonClass, tooltip }: Props) {
       onClick={handleClick}
       title={tooltip}
     >
-      <Svg name="close" />
+      <img className="close" />
     </div>
   );
 }

--- a/src/components/shared/Modal.css
+++ b/src/components/shared/Modal.css
@@ -29,10 +29,6 @@
   justify-content: center;
 }
 
-.modal .close-btn {
-  padding: 6px;
-}
-
 .modal .result-list {
   height: calc(100% - 28px);
   overflow-y: auto;

--- a/src/components/tests/__snapshots__/QuickOpenModal.spec.js.snap
+++ b/src/components/tests/__snapshots__/QuickOpenModal.spec.js.snap
@@ -107,26 +107,9 @@ exports[`QuickOpenModal Basic render with mount & searchType = functions 1`] = `
                       className="close-btn"
                       onClick={[Function]}
                     >
-                      <Svg
-                        name="close"
-                      >
-                        <InlineSVG
-                          className="close "
-                          element="i"
-                          raw={false}
-                          src="<svg></svg>"
-                        >
-                          <i
-                            className="close "
-                            dangerouslySetInnerHTML={
-                              Object {
-                                "__html": "<svg></svg>",
-                              }
-                            }
-                            src={null}
-                          />
-                        </InlineSVG>
-                      </Svg>
+                      <img
+                        className="close"
+                      />
                     </div>
                   </CloseButton>
                 </div>
@@ -258,26 +241,9 @@ exports[`QuickOpenModal Basic render with mount & searchType = variables 1`] = `
                       className="close-btn"
                       onClick={[Function]}
                     >
-                      <Svg
-                        name="close"
-                      >
-                        <InlineSVG
-                          className="close "
-                          element="i"
-                          raw={false}
-                          src="<svg></svg>"
-                        >
-                          <i
-                            className="close "
-                            dangerouslySetInnerHTML={
-                              Object {
-                                "__html": "<svg></svg>",
-                              }
-                            }
-                            src={null}
-                          />
-                        </InlineSVG>
-                      </Svg>
+                      <img
+                        className="close"
+                      />
                     </div>
                   </CloseButton>
                 </div>
@@ -403,26 +369,9 @@ exports[`QuickOpenModal Basic render with mount 1`] = `
                       className="close-btn"
                       onClick={[Function]}
                     >
-                      <Svg
-                        name="close"
-                      >
-                        <InlineSVG
-                          className="close "
-                          element="i"
-                          raw={false}
-                          src="<svg></svg>"
-                        >
-                          <i
-                            className="close "
-                            dangerouslySetInnerHTML={
-                              Object {
-                                "__html": "<svg></svg>",
-                              }
-                            }
-                            src={null}
-                          />
-                        </InlineSVG>
-                      </Svg>
+                      <img
+                        className="close"
+                      />
                     </div>
                   </CloseButton>
                 </div>
@@ -563,26 +512,9 @@ exports[`QuickOpenModal closeModal 1`] = `
                       className="close-btn"
                       onClick={[Function]}
                     >
-                      <Svg
-                        name="close"
-                      >
-                        <InlineSVG
-                          className="close "
-                          element="i"
-                          raw={false}
-                          src="<svg></svg>"
-                        >
-                          <i
-                            className="close "
-                            dangerouslySetInnerHTML={
-                              Object {
-                                "__html": "<svg></svg>",
-                              }
-                            }
-                            src={null}
-                          />
-                        </InlineSVG>
-                      </Svg>
+                      <img
+                        className="close"
+                      />
                     </div>
                   </CloseButton>
                 </div>
@@ -710,26 +642,9 @@ exports[`QuickOpenModal updateResults on enable 2`] = `
                       className="close-btn"
                       onClick={[Function]}
                     >
-                      <Svg
-                        name="close"
-                      >
-                        <InlineSVG
-                          className="close "
-                          element="i"
-                          raw={false}
-                          src="<svg></svg>"
-                        >
-                          <i
-                            className="close "
-                            dangerouslySetInnerHTML={
-                              Object {
-                                "__html": "<svg></svg>",
-                              }
-                            }
-                            src={null}
-                          />
-                        </InlineSVG>
-                      </Svg>
+                      <img
+                        className="close"
+                      />
                     </div>
                   </CloseButton>
                 </div>

--- a/src/components/tests/__snapshots__/closeButton.spec.js.snap
+++ b/src/components/tests/__snapshots__/closeButton.spec.js.snap
@@ -6,8 +6,8 @@ exports[`CloseButton should render a button 1`] = `
   onClick={[Function]}
   title="Close button"
 >
-  <Svg
-    name="close"
+  <img
+    className="close"
   />
 </div>
 `;


### PR DESCRIPTION
Associated Issue: #4350 

### Summary of Changes
* Converted Close Button SVG's in tab, breakpoint, watch expression, and the search bar.

I used the close button styling from the Atom text editor.  Their close button change in color when they are hovered over.  A GIF follows for representation:

![atomsourcetabs](https://user-images.githubusercontent.com/25250594/32453188-9c45cdd8-c2e9-11e7-85f7-09a2f3889b8a.gif)

### Screenshots/GIF's
##### Source Tabs
![sourcetabs](https://user-images.githubusercontent.com/25250594/32451836-e7cb856c-c2e5-11e7-9216-73610d00fac7.gif)

##### Watch Expressions/Breakpoints
![watchexpressionandbreakpoints](https://user-images.githubusercontent.com/25250594/32451871-01274eec-c2e6-11e7-8199-1a5643aae9f4.gif)

##### Find In Files
![findinfiles](https://user-images.githubusercontent.com/25250594/32451879-081a1298-c2e6-11e7-8ca3-b9f63e492d9c.gif)

##### Source File Search
![sourcefilesearch](https://user-images.githubusercontent.com/25250594/32451920-213b721c-c2e6-11e7-8ecc-6ad8308c926a.gif)



