### PR TITLE
Fixes secondary pane css classes being localized

### DIFF
--- a/src/components/SecondaryPanes/index.js
+++ b/src/components/SecondaryPanes/index.js
@@ -129,7 +129,7 @@ class SecondaryPanes extends Component<Props> {
 
     return {
       header: L10N.getStr("scopes.header"),
-      cssClass: "scopes-pane",
+      className: "scopes-pane",
       component: Scopes,
       opened: prefs.scopesVisible,
       onToggle: opened => {
@@ -142,7 +142,7 @@ class SecondaryPanes extends Component<Props> {
   getWatchItem() {
     return {
       header: L10N.getStr("watchExpressions.header"),
-      cssClass: "watch-expressions-pane",
+      className: "watch-expressions-pane",
       buttons: this.watchExpressionHeaderButtons(),
       component: Expressions,
       opened: true
@@ -158,14 +158,14 @@ class SecondaryPanes extends Component<Props> {
     const items: Array<SecondaryPanesItems> = [
       {
         header: L10N.getStr("breakpoints.header"),
-        cssClass: "breakpoints-pane",
+        className: "breakpoints-pane",
         buttons: this.renderBreakpointsToggle(),
         component: Breakpoints,
         opened: true
       },
       {
         header: L10N.getStr("callStack.header"),
-        cssClass: "call-stack-pane",
+        className: "call-stack-pane",
         component: Frames,
         opened: prefs.callStackVisible,
         onToggle: opened => {
@@ -179,7 +179,7 @@ class SecondaryPanes extends Component<Props> {
     if (isEnabled("eventListeners")) {
       items.push({
         header: L10N.getStr("eventListenersHeader"),
-        cssClass: "event-listeners-pane",
+        className: "event-listeners-pane",
         component: EventListeners
       });
     }
@@ -187,7 +187,7 @@ class SecondaryPanes extends Component<Props> {
     if (isEnabled("workers")) {
       items.push({
         header: L10N.getStr("workersHeader"),
-        cssClass: "workers-pane",
+        className: "workers-pane",
         component: Workers
       });
     }

--- a/src/components/SecondaryPanes/index.js
+++ b/src/components/SecondaryPanes/index.js
@@ -129,6 +129,7 @@ class SecondaryPanes extends Component<Props> {
 
     return {
       header: L10N.getStr("scopes.header"),
+      cssClass: "scopes-pane",
       component: Scopes,
       opened: prefs.scopesVisible,
       onToggle: opened => {
@@ -141,6 +142,7 @@ class SecondaryPanes extends Component<Props> {
   getWatchItem() {
     return {
       header: L10N.getStr("watchExpressions.header"),
+      cssClass: "watch-expressions-pane",
       buttons: this.watchExpressionHeaderButtons(),
       component: Expressions,
       opened: true
@@ -156,12 +158,14 @@ class SecondaryPanes extends Component<Props> {
     const items: Array<SecondaryPanesItems> = [
       {
         header: L10N.getStr("breakpoints.header"),
+        cssClass: "breakpoints-pane",
         buttons: this.renderBreakpointsToggle(),
         component: Breakpoints,
         opened: true
       },
       {
         header: L10N.getStr("callStack.header"),
+        cssClass: "call-stack-pane",
         component: Frames,
         opened: prefs.callStackVisible,
         onToggle: opened => {
@@ -175,6 +179,7 @@ class SecondaryPanes extends Component<Props> {
     if (isEnabled("eventListeners")) {
       items.push({
         header: L10N.getStr("eventListenersHeader"),
+        cssClass: "event-listeners-pane",
         component: EventListeners
       });
     }
@@ -182,6 +187,7 @@ class SecondaryPanes extends Component<Props> {
     if (isEnabled("workers")) {
       items.push({
         header: L10N.getStr("workersHeader"),
+        cssClass: "workers-pane",
         component: Workers
       });
     }

--- a/src/components/shared/Accordion.js
+++ b/src/components/shared/Accordion.js
@@ -9,7 +9,7 @@ type AccordionItem = {
   component(): any,
   componentProps: Object,
   header: string,
-  cssClass: string,
+  className: string,
   opened: boolean,
   onToggle?: () => void,
   shouldOpen?: () => void
@@ -65,7 +65,7 @@ class Accordion extends Component<Props, State> {
     const { opened, created } = this.state;
 
     return (
-      <div className={item.cssClass} key={i}>
+      <div className={item.className} key={i}>
         <div className="_header" onClick={() => this.handleHeaderClick(i)}>
           <Svg name="arrow" className={opened[i] ? "expanded" : ""} />
           {item.header}

--- a/src/components/shared/Accordion.js
+++ b/src/components/shared/Accordion.js
@@ -9,6 +9,7 @@ type AccordionItem = {
   component(): any,
   componentProps: Object,
   header: string,
+  cssClass: string,
   opened: boolean,
   onToggle?: () => void,
   shouldOpen?: () => void
@@ -62,12 +63,9 @@ class Accordion extends Component<Props, State> {
 
   renderContainer = (item: AccordionItem, i: number) => {
     const { opened, created } = this.state;
-    const containerClassName = `${item.header
-      .toLowerCase()
-      .replace(/\s/g, "-")}-pane`;
 
     return (
-      <div className={containerClassName} key={i}>
+      <div className={item.cssClass} key={i}>
         <div className="_header" onClick={() => this.handleHeaderClick(i)}>
           <Svg name="arrow" className={opened[i] ? "expanded" : ""} />
           {item.header}


### PR DESCRIPTION
Associated Issue: #4575

### Summary of Changes

* Added new property cssClass to getScopeItem, getWatchItem and getStartItems responsible for keeping the css class name of the item.
* added new property to typeCheck
* removed generation of class name based on header as it caused bugs now and might complicate things further in future.

### Test + Screenshot

End result:
![screenshot_7](https://user-images.githubusercontent.com/23530054/32481001-c4f81f62-c391-11e7-86f2-aa5ec83c39a4.png)

