### PR TITLE
[Search] Clear results while closing project search

### DIFF
--- a/src/actions/project-text-search.js
+++ b/src/actions/project-text-search.js
@@ -39,6 +39,10 @@ export function updateSearchStatus(status: string) {
   return { type: "UPDATE_STATUS", status };
 }
 
+export function closeProjectSearch() {
+  return { type: "CLOSE_PROJECT_SEARCH" };
+}
+
 export function searchSources(query: string) {
   return async ({ dispatch, getState }: ThunkArgs) => {
     await dispatch(clearSearchResults());

--- a/src/actions/tests/__snapshots__/project-text-search.spec.js.snap
+++ b/src/actions/tests/__snapshots__/project-text-search.spec.js.snap
@@ -70,6 +70,76 @@ Immutable.List [
 ]
 `;
 
+exports[`project text search should close project search 1`] = `
+Immutable.List [
+  Object {
+    "filepath": "http://localhost:8000/examples/foo1",
+    "matches": Array [
+      Object {
+        "column": 9,
+        "line": 1,
+        "match": "foo",
+        "sourceId": "foo1",
+        "text": "function foo1() {",
+        "value": "function foo1() {",
+      },
+      Object {
+        "column": 8,
+        "line": 2,
+        "match": "foo",
+        "sourceId": "foo1",
+        "text": "  const foo = 5; return foo;",
+        "value": "  const foo = 5; return foo;",
+      },
+      Object {
+        "column": 24,
+        "line": 2,
+        "match": "foo",
+        "sourceId": "foo1",
+        "text": "  const foo = 5; return foo;",
+        "value": "  const foo = 5; return foo;",
+      },
+    ],
+    "sourceId": "foo1",
+  },
+  Object {
+    "filepath": "http://localhost:8000/examples/foo1",
+    "matches": Array [
+      Object {
+        "column": 9,
+        "line": 1,
+        "match": "foo",
+        "sourceId": "foo1",
+        "text": "function foo1() {",
+        "value": "function foo1() {",
+      },
+      Object {
+        "column": 8,
+        "line": 2,
+        "match": "foo",
+        "sourceId": "foo1",
+        "text": "  const foo = 5; return foo;",
+        "value": "  const foo = 5; return foo;",
+      },
+      Object {
+        "column": 24,
+        "line": 2,
+        "match": "foo",
+        "sourceId": "foo1",
+        "text": "  const foo = 5; return foo;",
+        "value": "  const foo = 5; return foo;",
+      },
+    ],
+    "sourceId": "foo1",
+  },
+]
+`;
+
+exports[`project text search should close project search 2`] = `
+Immutable.List [
+]
+`;
+
 exports[`project text search should search a specific source 1`] = `
 Immutable.List [
   Object {

--- a/src/actions/tests/project-text-search.spec.js
+++ b/src/actions/tests/project-text-search.spec.js
@@ -113,4 +113,23 @@ describe("project text search", () => {
     dispatch(actions.updateSearchStatus(mockStatus));
     expect(getTextSearchStatus(getState())).toEqual(mockStatus);
   });
+
+  it("should close project search", async () => {
+    const { dispatch, getState } = createStore(threadClient);
+    const mockQuery = "foo";
+
+    await dispatch(actions.newSource(makeSource("foo1")));
+    await dispatch(actions.searchSources(mockQuery));
+
+    expect(getTextSearchResults(getState())).toMatchSnapshot();
+
+    dispatch(actions.closeProjectSearch());
+
+    expect(getTextSearchQuery(getState())).toEqual("");
+
+    const results = getTextSearchResults(getState());
+
+    expect(results).toMatchSnapshot();
+    expect(results.size).toEqual(0);
+  });
 });

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -63,6 +63,7 @@ type Props = {
   quickOpenEnabled: boolean,
   setActiveSearch: string => void,
   closeActiveSearch: () => void,
+  closeProjectSearch: () => void,
   openQuickOpen: (query?: string) => void,
   closeQuickOpen: () => void,
   setOrientation: OrientationType => void

--- a/src/components/ProjectSearch/TextSearch.js
+++ b/src/components/ProjectSearch/TextSearch.js
@@ -196,7 +196,7 @@ export default class TextSearch extends Component {
         onFocus={() => (this.inputFocused = true)}
         onBlur={() => (this.inputFocused = false)}
         onKeyDown={e => this.onKeyDown(e)}
-        handleClose={this.props.closeActiveSearch}
+        handleClose={this.props.closeProjectSearch}
         ref="searchInput"
       />
     );
@@ -221,7 +221,7 @@ TextSearch.propTypes = {
   results: PropTypes.array,
   status: PropTypes.string,
   query: PropTypes.string,
-  closeActiveSearch: PropTypes.func,
+  closeProjectSearch: PropTypes.func,
   searchSources: PropTypes.func,
   selectSource: PropTypes.func,
   searchBottomBar: PropTypes.object

--- a/src/components/ProjectSearch/index.js
+++ b/src/components/ProjectSearch/index.js
@@ -28,6 +28,7 @@ type Props = {
   textSearchQuery: string,
   setActiveSearch: Function,
   closeActiveSearch: Function,
+  closeProjectSearch: Function,
   searchSources: Function,
   activeSearch: string,
   selectSource: Function,
@@ -83,7 +84,7 @@ class ProjectSearch extends Component<Props> {
       results,
       status,
       searchSources,
-      closeActiveSearch,
+      closeProjectSearch,
       selectSource,
       textSearchQuery
     } = this.props;
@@ -94,7 +95,7 @@ class ProjectSearch extends Component<Props> {
         results={results.toJS()}
         status={status}
         searchSources={searchSources}
-        closeActiveSearch={closeActiveSearch}
+        closeProjectSearch={closeProjectSearch}
         selectSource={selectSource}
         query={textSearchQuery}
       />
@@ -116,6 +117,7 @@ ProjectSearch.propTypes = {
   textSearchQuery: PropTypes.string,
   setActiveSearch: PropTypes.func.isRequired,
   closeActiveSearch: PropTypes.func.isRequired,
+  closeProjectSearch: PropTypes.func.isRequired,
   searchSources: PropTypes.func,
   activeSearch: PropTypes.string,
   selectSource: PropTypes.func.isRequired

--- a/src/components/ProjectSearch/tests/TextSearch.js
+++ b/src/components/ProjectSearch/tests/TextSearch.js
@@ -7,7 +7,7 @@ function render(overrides = {}) {
     sources: {},
     results: [],
     query: "foo",
-    closeActiveSearch: jest.fn(),
+    closeProjectSearch: jest.fn(),
     searchSources: jest.fn(),
     selectSource: jest.fn()
   };

--- a/src/reducers/project-text-search.js
+++ b/src/reducers/project-text-search.js
@@ -70,6 +70,12 @@ function update(
       return state.merge({
         results: state.get("results").clear()
       });
+
+    case "CLOSE_PROJECT_SEARCH":
+      return state.merge({
+        query: "",
+        results: state.get("results").clear()
+      });
   }
   return state;
 }

--- a/src/reducers/ui.js
+++ b/src/reducers/ui.js
@@ -118,6 +118,13 @@ function update(
     case "SET_PRIMARY_PANE_TAB":
       return state.set("selectedPrimaryPaneTab", action.tabName);
 
+    case "CLOSE_PROJECT_SEARCH": {
+      if (state.get("activeSearch") === "project") {
+        return state.set("activeSearch", null);
+      }
+      return state;
+    }
+
     default: {
       return state;
     }


### PR DESCRIPTION
Associated Issue: #4526 

### Steps

- Press ⌘ + ⇧ + F
- Enter a search term
- Press 'x'
- Press ⌘ + ⇧ + F
- The older search results are now cleared

### Before

![Before](http://g.recordit.co/KBECPvJa2L.gif)

### After

![After](http://g.recordit.co/5a05dxCASf.gif)
