### PR TITLE
flash function when it is copied - feature #4022

### DIFF
--- a/src/actions/ui.js
+++ b/src/actions/ui.js
@@ -99,6 +99,17 @@ export function highlightLineRange(location: {
   };
 }
 
+export function flashLineRange(location: {
+  start: number,
+  end: number,
+  sourceId: number
+}) {
+  return ({ dispatch }: ThunkArgs) => {
+    dispatch(highlightLineRange(location));
+    setTimeout(() => dispatch(clearHighlightLineRange()), 200);
+  };
+}
+
 /**
  * @memberof actions/sources
  * @static

--- a/src/components/Editor/EditorMenu.js
+++ b/src/components/Editor/EditorMenu.js
@@ -10,6 +10,7 @@ import { getSourceLocationFromMouseEvent } from "../../utils/editor";
 import { bindActionCreators } from "redux";
 import { connect } from "react-redux";
 import { findFunctionText } from "../../utils/function";
+import { findClosestScope } from "../../utils/breakpoint/astBreakpointLocation";
 import {
   getContextMenu,
   getSelectedLocation,
@@ -18,6 +19,7 @@ import {
 } from "../../selectors";
 
 import actions from "../../actions";
+
 type Props = {
   setContextMenu: Function
 };
@@ -33,7 +35,9 @@ function getMenuItems(
     jumpToMappedLocation,
     toggleBlackBox,
     addExpression,
-    getFunctionText
+    getFunctionText,
+    getFunctionLocation,
+    flashLineRange
   }
 ) {
   const copySourceLabel = L10N.getStr("copySource");
@@ -121,7 +125,15 @@ function getMenuItems(
     label: copyFunctionLabel,
     accesskey: copyFunctionKey,
     disabled: !functionText,
-    click: () => copyToTheClipboard(functionText)
+    click: () => {
+      const { location: { start, end } } = getFunctionLocation(line);
+      flashLineRange({
+        start: start.line,
+        end: end.line,
+        sourceId: selectedLocation.sourceId
+      });
+      return copyToTheClipboard(functionText);
+    }
   };
 
   const menuItems = [
@@ -181,7 +193,12 @@ export default connect(
           line,
           selectedSource.toJS(),
           getSymbols(state, selectedSource.toJS())
-        )
+        ),
+      getFunctionLocation: line =>
+        findClosestScope(getSymbols(state, selectedSource.toJS()).functions, {
+          line,
+          column: Infinity
+        })
     };
   },
   dispatch => bindActionCreators(actions, dispatch)


### PR DESCRIPTION
Associated Issue: feature #4022

Here's the Pull Request Doc
https://devtools-html.github.io/debugger.html/CONTRIBUTING.html#pull-requests

### Summary of Changes

* when selecting `copy Function` in the editor the function will be highlighted for 0.2 seconds
