### PR TITLE
4532 - Part 1: Update the mapDispatchToProps calls for Breakpoints.js, Popup.js, Preview/index.js

### DIFF
--- a/src/components/Editor/Breakpoints.js
+++ b/src/components/Editor/Breakpoints.js
@@ -4,12 +4,10 @@
 
 // @flow
 import { connect } from "react-redux";
-import { bindActionCreators } from "redux";
 import React, { Component } from "react";
 
 import Breakpoint from "./Breakpoint";
 
-import actions from "../../actions";
 import { getSelectedSource } from "../../selectors";
 import getVisibleBreakpoints from "../../selectors/visibleBreakpoints";
 import { makeLocationId } from "../../utils/breakpoint";
@@ -64,5 +62,4 @@ export default connect(
     breakpoints: getVisibleBreakpoints(state),
     selectedSource: getSelectedSource(state)
   }),
-  dispatch => bindActionCreators(actions, dispatch)
 )(Breakpoints);

--- a/src/components/Editor/Preview/Popup.js
+++ b/src/components/Editor/Preview/Popup.js
@@ -6,7 +6,6 @@
 
 import React, { Component } from "react";
 import { connect } from "react-redux";
-import { bindActionCreators } from "redux";
 import { isEnabled } from "devtools-config";
 
 import Reps from "devtools-reps";
@@ -237,9 +236,23 @@ export class Popup extends Component<Props> {
   }
 }
 
+const {
+  addExpression,
+  selectSourceURL,
+  selectSource,
+  loadObjectProperties,
+  openLink
+} = actions;
+
 export default connect(
   state => ({
     loadedObjects: getLoadedObjects(state)
   }),
-  dispatch => bindActionCreators(actions, dispatch)
+  {
+    addExpression,
+    selectSourceURL,
+    selectSource,
+    loadObjectProperties,
+    openLink
+  }
 )(Popup);

--- a/src/components/Editor/Preview/index.js
+++ b/src/components/Editor/Preview/index.js
@@ -3,7 +3,6 @@
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
 import React, { PureComponent } from "react";
-import { bindActionCreators } from "redux";
 import { connect } from "react-redux";
 import { debounce } from "lodash";
 
@@ -124,6 +123,13 @@ class Preview extends PureComponent {
   }
 }
 
+const {
+  addExpression,
+  loadObjectProperties,
+  setPreview,
+  clearPreview
+} = actions;
+
 export default connect(
   state => ({
     preview: getPreview(state),
@@ -131,5 +137,10 @@ export default connect(
     linesInScope: getInScopeLines(state),
     selectedFrameVisible: isSelectedFrameVisible(state)
   }),
-  dispatch => bindActionCreators(actions, dispatch)
+  {
+    addExpression,
+    loadObjectProperties,
+    setPreview,
+    clearPreview
+  }
 )(Preview);


### PR DESCRIPTION
Associated Issue: #4532

### Summary of Changes

Update the mapDispatchToProps calls for 
- src/components/Editor/Breakpoints.js
- src/components/Editor/Preview/Popup.js
- src/components/Editor/Preview/index.js

