### PR TITLE
Display more wast text lines

### DIFF
--- a/src/utils/wasm.js
+++ b/src/utils/wasm.js
@@ -128,7 +128,7 @@ function renderWasmText(sourceId: string, { binary }: Object) {
     data[i] = binary.charCodeAt(i);
   }
   const { lines } = getWasmText(sourceId, data);
-  const MAX_LINES = 100000;
+  const MAX_LINES = 1000000;
   if (lines.length > MAX_LINES) {
     lines.splice(MAX_LINES, lines.length - MAX_LINES);
     lines.push(";; .... text is truncated due to the size");


### PR DESCRIPTION
Associated Issue: https://github.com/yurydelendik/sqlite-playground wast is truncated