### PR TITLE
Relax findSource

### DIFF
--- a/src/test/mochitest/head.js
+++ b/src/test/mochitest/head.js
@@ -244,7 +244,7 @@ function waitForSelectedSource(dbg, url) {
         return true;
       }
 
-      const newSource = findSource(dbg, url);
+      const newSource = findSource(dbg, url, { silent: true });
       if (newSource.id != source.get("id")) {
         return false;
       }
@@ -519,7 +519,7 @@ function pauseTest() {
  * @return {Object} source
  * @static
  */
-function findSource(dbg, url) {
+function findSource(dbg, url, { silent } = { silent: false }) {
   if (typeof url !== "string") {
     // Support passing in a source object itelf all APIs that use this
     // function support both styles
@@ -531,6 +531,10 @@ function findSource(dbg, url) {
   const source = sources.find(s => (s.get("url") || "").includes(url));
 
   if (!source) {
+    if (silent) {
+      return false;
+    }
+
     throw new Error(`Unable to find source: ${url}`);
   }
 
@@ -540,7 +544,7 @@ function findSource(dbg, url) {
 function waitForLoadedSource(dbg, url) {
   return waitForState(
     dbg,
-    state => findSource(dbg, url).loadedState == "loaded",
+    state => findSource(dbg, url, { silent: true }).loadedState == "loaded",
     "loaded source"
   );
 }


### PR DESCRIPTION
Associated Issue: #4642 

### Summary of Changes

The recent release was pulled out twice due to `browser_dbg-wasm-sourcemaps`. It looks like it was pulled out this time because we call: `waitForLoadedSource` before `doc-wasm-sourcemaps` has been loaded... This should be fine because we don't assume it here... The problem is that `findSource` was designed as a util for invoking actions like `selectSource(dbg, findSource(dbg, "simple1"))` where if the source didn't exist we wanted a clear error. 

This fix adds a `silent` mode, which allows findSource to return quietly if the source does not exist.

```
16:13:14     INFO - Buffered messages finished
16:13:14     INFO - TEST-UNEXPECTED-FAIL | devtools/client/debugger/new/test/mochitest/browser_dbg-wasm-sourcemaps.js | Uncaught exception - at chrome://mochitests/content/browser/devtools/client/debugger/new/test/mochitest/head.js:534 - Error: Unable to find source: doc-wasm-sourcemaps
16:13:14     INFO - Stack trace:
16:13:14     INFO -     findSource@chrome://mochitests/content/browser/devtools/client/debugger/new/test/mochitest/head.js:534:11
16:13:14     INFO -     waitForLoadedSource/<@chrome://mochitests/content/browser/devtools/client/debugger/new/test/mochitest/head.js:543:14
16:13:14     INFO -     waitForState/<@chrome://mochitests/content/browser/devtools/client/debugger/new/test/mochitest/head.js:167:9
16:13:14     INFO -     waitForState@chrome://mochitests/content/browser/devtools/client/debugger/new/test/mochitest/head.js:165:10
16:13:14     INFO -     waitForLoadedSource@chrome://mochitests/content/browser/devtools/client/debugger/new/test/mochitest/head.js:541:10
16:13:14     INFO -     @chrome://mochitests/content/browser/devtools/client/debugger/new/test/mochitest/browser_dbg-wasm-sourcemaps.js:18:9
16:13:14     INFO -     Async*Tester_execTest/<@chrome://mochikit/content/browser-test.js:1060:21
16:13:14     INFO -     Tester_execTest@chrome://mochikit/content/browser-test.js:1051:9
16:13:14     INFO -     Tester.prototype.nextTest</<@chrome://mochikit/content/browser-test.js:951:9
16:13:14     INFO -     SimpleTest.waitForFocus/waitForFocusInner/focusedOrLoaded/<@chrome://mochikit/content/tests/SimpleTest/SimpleTest.js:795:59
16:13:14     INFO - Leaving test bound 
```