### PR TITLE
Drop react-immutable-proptypes

### DIFF
--- a/src/components/SecondaryPanes/index.js
+++ b/src/components/SecondaryPanes/index.js
@@ -9,7 +9,6 @@ import React, { Component } from "react";
 import { connect } from "react-redux";
 import { bindActionCreators } from "redux";
 import { features } from "../../utils/prefs";
-import ImPropTypes from "react-immutable-proptypes";
 
 import actions from "../../actions";
 import {
@@ -271,7 +270,7 @@ SecondaryPanes.propTypes = {
   evaluateExpressions: PropTypes.func.isRequired,
   pauseData: PropTypes.object,
   horizontal: PropTypes.bool,
-  breakpoints: ImPropTypes.map.isRequired,
+  breakpoints: PropTypes.object,
   breakpointsDisabled: PropTypes.bool,
   breakpointsLoading: PropTypes.bool,
   toggleAllBreakpoints: PropTypes.func.isRequired,


### PR DESCRIPTION
Associated Issue: #4631 

Summary of Changes

Removed react-immutable-proptypes and replaced with proptypes

Test Plan

Secondary pane functionality should work as intended
