### PR TITLE
4651-call-stack-should-not-open-automatically

### DIFF
--- a/src/components/SecondaryPanes/index.js
+++ b/src/components/SecondaryPanes/index.js
@@ -158,8 +158,6 @@ class SecondaryPanes extends Component<Props> {
     const scopesContent: any = this.props.horizontal
       ? this.getScopeItem()
       : null;
-    const isPaused = () => !!this.props.pauseData;
-
     const items: Array<SecondaryPanesItems> = [
       {
         header: L10N.getStr("breakpoints.header"),
@@ -175,8 +173,7 @@ class SecondaryPanes extends Component<Props> {
         opened: prefs.callStackVisible,
         onToggle: opened => {
           prefs.callStackVisible = opened;
-        },
-        shouldOpen: isPaused
+        }
       },
       scopesContent
     ];

--- a/src/test/mochitest/browser_dbg-wasm-sourcemaps.js
+++ b/src/test/mochitest/browser_dbg-wasm-sourcemaps.js
@@ -25,6 +25,7 @@ add_task(async function() {
   await waitForPaused(dbg);
   await waitForLoadedSource(dbg, "average.c");
   assertPausedLocation(dbg);
+  toggleCallStack(dbg);
 
   const frames = findAllElements(dbg, "frames");
   const firstFrameTitle = frames[0].querySelector(".title").textContent;


### PR DESCRIPTION
Associated Issue: #4651

### Summary of Changes
Make the call stack not open automatically on pause
