### PR TITLE
4609 - Hide scrollbar of Dropdown when no overflow

### DIFF
--- a/src/components/shared/Dropdown.css
+++ b/src/components/shared/Dropdown.css
@@ -13,7 +13,7 @@
   top: 23px;
   width: var(--width);
   z-index: 1000;
-  overflow: scroll;
+  overflow: auto;
 }
 
 html[dir="rtl"] .dropdown {


### PR DESCRIPTION
Associated Issue: #4609

### Summary of Changes
Use `overflow: auto` on the dropdown so the scroll bar will appear only when seeing overflow 
