### PR TITLE
[Editor] Show a link to a generated file - ultimate PR

### DIFF
--- a/assets/panel/debugger.properties
+++ b/assets/panel/debugger.properties
@@ -470,6 +470,11 @@ sourceFooter.unblackbox.accesskey=b
 # with a blackboxed source
 sourceFooter.blackboxed=Blackboxed source
 
+# LOCALIZATION NOTE (sourceFooter.mappedSource): Text associated
+# with a mapped source.
+# %S is replaced by the source map origin.
+sourceFooter.mappedSource=(Source mapped from %S)
+
 # LOCALIZATION NOTE (sourceFooter.codeCoverage): Text associated
 # with a code coverage button
 sourceFooter.codeCoverage=Code coverage

--- a/assets/panel/debugger.properties
+++ b/assets/panel/debugger.properties
@@ -471,12 +471,11 @@ sourceFooter.unblackbox.accesskey=b
 sourceFooter.blackboxed=Blackboxed source
 
 # LOCALIZATION NOTE (sourceFooter.mappedSource): Text associated
-# with a mapped source.
-# %S is replaced by the source map origin.
+# with a mapped source. %S is replaced by the source map origin.
 sourceFooter.mappedSource=(From %S)
 
 # LOCALIZATION NOTE (sourceFooter.mappedSourceTooltip): Tooltip text associated
-# with a mapped source
+# with a mapped source. %S is replaced by the source map origin.
 sourceFooter.mappedSourceTooltip=(Source mapped from %S)
 
 # LOCALIZATION NOTE (sourceFooter.codeCoverage): Text associated

--- a/assets/panel/debugger.properties
+++ b/assets/panel/debugger.properties
@@ -473,7 +473,11 @@ sourceFooter.blackboxed=Blackboxed source
 # LOCALIZATION NOTE (sourceFooter.mappedSource): Text associated
 # with a mapped source.
 # %S is replaced by the source map origin.
-sourceFooter.mappedSource=(Source mapped from %S)
+sourceFooter.mappedSource=(From %S)
+
+# LOCALIZATION NOTE (sourceFooter.mappedSourceTooltip): Tooltip text associated
+# with a mapped source
+sourceFooter.mappedSourceTooltip=(Source mapped from %S)
 
 # LOCALIZATION NOTE (sourceFooter.codeCoverage): Text associated
 # with a code coverage button

--- a/src/components/Editor/Footer.css
+++ b/src/components/Editor/Footer.css
@@ -88,3 +88,8 @@
 .source-footer .blackbox-summary {
   color: var(--theme-body-color);
 }
+
+.source-footer .mapped-source {
+  color: var(--theme-body-color);
+  padding: 2.5px;
+}

--- a/src/components/Editor/Footer.css
+++ b/src/components/Editor/Footer.css
@@ -91,5 +91,8 @@
 
 .source-footer .mapped-source {
   color: var(--theme-body-color);
-  padding: 2.5px;
+  padding: 2px;
+  font-size: 3;
+  align-items: right;
+  justify-content: right;
 }

--- a/src/components/Editor/Footer.css
+++ b/src/components/Editor/Footer.css
@@ -91,8 +91,5 @@
 
 .source-footer .mapped-source {
   color: var(--theme-body-color);
-  padding: 2px;
-  font-size: 3;
-  align-items: right;
-  justify-content: right;
+  padding: 2.5px;
 }

--- a/src/components/Editor/Footer.js
+++ b/src/components/Editor/Footer.js
@@ -193,8 +193,8 @@ class SourceFooter extends PureComponent<Props> {
     return (
       <div className="source-footer">
         {this.renderCommands()}
-        {this.renderToggleButton()}
         {this.renderSourceSummary()}
+        {this.renderToggleButton()}
       </div>
     );
   }

--- a/src/components/Editor/Footer.js
+++ b/src/components/Editor/Footer.js
@@ -15,7 +15,8 @@ import {
 
 import classnames from "classnames";
 import { isEnabled } from "devtools-config";
-import { isPretty, isLoaded } from "../../utils/source";
+import { isPretty, isLoaded, getFilename } from "../../utils/source";
+import { getGeneratedSource } from "../../reducers/sources";
 import { shouldShowFooter, shouldShowPrettyPrint } from "../../utils/editor";
 
 import PaneToggleButton from "../shared/Button/PaneToggle";
@@ -26,6 +27,7 @@ import "./Footer.css";
 
 type Props = {
   selectedSource: SourceRecord,
+  mappedSource: SourceRecord,
   selectSource: (string, ?Object) => void,
   editor: any,
   togglePrettyPrint: string => void,
@@ -152,6 +154,22 @@ class SourceFooter extends PureComponent<Props> {
     );
   }
 
+  renderSourceSummary() {
+    const { mappedSource } = this.props;
+    if (mappedSource) {
+      const bundleSource = mappedSource.toJS();
+      return (
+        <span className="mapped-source">
+          {L10N.getFormatStr(
+            "sourceFooter.mappedSource",
+            getFilename(bundleSource)
+          )}
+        </span>
+      );
+    }
+    return null;
+  }
+
   render() {
     const { selectedSource, horizontal } = this.props;
 
@@ -163,6 +181,7 @@ class SourceFooter extends PureComponent<Props> {
       <div className="source-footer">
         {this.renderCommands()}
         {this.renderToggleButton()}
+        {this.renderSourceSummary()}
       </div>
     );
   }
@@ -172,8 +191,10 @@ export default connect(
   state => {
     const selectedSource = getSelectedSource(state);
     const selectedId = selectedSource && selectedSource.get("id");
+    const source = selectedSource.toJS();
     return {
       selectedSource,
+      mappedSource: getGeneratedSource(state, source),
       prettySource: getPrettySource(state, selectedId),
       endPanelCollapsed: getPaneCollapse(state, "end")
     };

--- a/src/components/Editor/Footer.js
+++ b/src/components/Editor/Footer.js
@@ -156,7 +156,7 @@ class SourceFooter extends PureComponent<Props> {
   }
 
   renderSourceSummary() {
-    const { mappedSource, jumpToMappedLocation } = this.props;
+    const { mappedSource, jumpToMappedLocation, selectedSource } = this.props;
     if (mappedSource) {
       const bundleSource = mappedSource.toJS();
       const filename = getFilename(bundleSource);
@@ -166,7 +166,7 @@ class SourceFooter extends PureComponent<Props> {
       );
       const title = L10N.getFormatStr("sourceFooter.mappedSource", filename);
       const mappedSourceLocation = {
-        sourceId: bundleSource.id,
+        sourceId: selectedSource.get("id"),
         line: 1,
         column: 1
       };

--- a/src/components/Editor/Footer.js
+++ b/src/components/Editor/Footer.js
@@ -32,6 +32,7 @@ type Props = {
   editor: any,
   togglePrettyPrint: string => void,
   toggleBlackBox: Object => void,
+  jumpToMappedLocation: (SourceRecord: any) => void,
   recordCoverage: () => void,
   togglePaneCollapse: () => void,
   endPanelCollapsed: boolean,
@@ -155,16 +156,28 @@ class SourceFooter extends PureComponent<Props> {
   }
 
   renderSourceSummary() {
-    const { mappedSource } = this.props;
+    const { mappedSource, jumpToMappedLocation } = this.props;
     if (mappedSource) {
       const bundleSource = mappedSource.toJS();
+      const filename = getFilename(bundleSource);
+      const tooltip = L10N.getFormatStr(
+        "sourceFooter.mappedSourceTooltip",
+        filename
+      );
+      const title = L10N.getFormatStr("sourceFooter.mappedSource", filename);
+      const mappedSourceLocation = {
+        sourceId: bundleSource.id,
+        line: 1,
+        column: 1
+      };
       return (
-        <span className="mapped-source">
-          {L10N.getFormatStr(
-            "sourceFooter.mappedSource",
-            getFilename(bundleSource)
-          )}
-        </span>
+        <button
+          className="mapped-source"
+          onClick={() => jumpToMappedLocation(mappedSourceLocation)}
+          title={tooltip}
+        >
+          <span>{title}</span>
+        </button>
       );
     }
     return null;

--- a/src/reducers/sources.js
+++ b/src/reducers/sources.js
@@ -13,6 +13,7 @@ import * as I from "immutable";
 import { createSelector } from "reselect";
 import makeRecord from "../utils/makeRecord";
 import { getPrettySourceURL } from "../utils/source";
+import { originalToGeneratedId, isOriginalId } from "devtools-source-map";
 import { prefs } from "../utils/prefs";
 
 import type { Map, List } from "immutable";
@@ -297,6 +298,13 @@ export function getSource(state: OuterState, id: string) {
 
 export function getSourceByURL(state: OuterState, url: string): ?SourceRecord {
   return getSourceByUrlInSources(state.sources.sources, url);
+}
+
+export function getGeneratedSource(state: OuterState, source: any) {
+  if (!isOriginalId(source.id)) {
+    return null;
+  }
+  return getSource(state, originalToGeneratedId(source.id));
 }
 
 export function getPendingSelectedLocation(state: OuterState) {

--- a/src/test/mochitest/browser_dbg-pretty-print.js
+++ b/src/test/mochitest/browser_dbg-pretty-print.js
@@ -32,8 +32,8 @@ add_task(async function() {
 
   // The pretty-print button should go away in the pretty-printed
   // source.
-  ok(!findElement(dbg, "editorFooter"), "Footer is hidden");
+  ok(!findElement(dbg, "prettyPrintButton"), "Pretty Print Button is hidden");
 
   await selectSource(dbg, "math.min.js");
-  ok(findElement(dbg, "editorFooter"), "Footer is hidden");
+  ok(findElement(dbg, "prettyPrintButton"), "Pretty Print Button is visible");
 });

--- a/src/test/mochitest/browser_dbg-sourcemaps2.js
+++ b/src/test/mochitest/browser_dbg-sourcemaps2.js
@@ -4,7 +4,11 @@
 function assertBpInGutter(dbg, lineNumber) {
   const el = findElement(dbg, "breakpoint");
   const bpLineNumber = +el.querySelector(".CodeMirror-linenumber").innerText;
-  is(bpLineNumber, lineNumber, "Breakpoint is on the correct line in the gutter");
+  is(
+    bpLineNumber,
+    lineNumber,
+    "Breakpoint is on the correct line in the gutter"
+  );
 }
 
 // Tests loading sourcemapped sources, setting breakpoints, and
@@ -38,4 +42,12 @@ add_task(async function() {
 
   await waitForPaused(dbg);
   assertPausedLocation(dbg);
+
+  // Tests the existence of the sourcemap link in the original source.
+  ok(findElement(dbg, "sourceMapLink"), "Sourcemap link in original source");
+  await selectSource(dbg, "main.min.js");
+  ok(
+    !findElement(dbg, "sourceMapLink"),
+    "No Sourcemap link exists in generated source"
+  );
 });

--- a/src/test/mochitest/head.js
+++ b/src/test/mochitest/head.js
@@ -295,7 +295,9 @@ function assertDebugLine(dbg, line) {
     const url = source.get("url");
     ok(
       false,
-      `Looks like the source ${url} is still loading. Try adding waitForLoadedSource in the test.`
+      `Looks like the source ${
+        url
+      } is still loading. Try adding waitForLoadedSource in the test.`
     );
     return;
   }
@@ -305,8 +307,9 @@ function assertDebugLine(dbg, line) {
     "Line is highlighted as paused"
   );
 
-  const debugLine = findElementWithSelector(dbg, ".new-debug-line")
-                    || findElementWithSelector(dbg, ".new-debug-line-error");
+  const debugLine =
+    findElementWithSelector(dbg, ".new-debug-line") ||
+    findElementWithSelector(dbg, ".new-debug-line-error");
 
   ok(isVisibleInEditor(dbg, debugLine), "debug line is visible");
 
@@ -553,8 +556,11 @@ function waitForLoadedSources(dbg) {
   return waitForState(
     dbg,
     state => {
-      const sources = dbg.selectors.getSources(state).valueSeq().toJS()
-      return !sources.some(source => source.loadedState == "loading")
+      const sources = dbg.selectors
+        .getSources(state)
+        .valueSeq()
+        .toJS();
+      return !sources.some(source => source.loadedState == "loading");
     },
     "loaded source"
   );
@@ -835,7 +841,6 @@ function type(dbg, string) {
   string.split("").forEach(char => EventUtils.synthesizeKey(char, {}, dbg.win));
 }
 
-
 /*
  * Checks to see if the inner element is visible inside the editor.
  *
@@ -874,12 +879,14 @@ function isVisible(outerEl, innerEl) {
   const outerRect = outerEl.getBoundingClientRect();
 
   const verticallyVisible =
-    (innerRect.top >= outerRect.top || innerRect.bottom <= outerRect.bottom)
-    || (innerRect.top < outerRect.top && innerRect.bottom > outerRect.bottom);
+    innerRect.top >= outerRect.top ||
+    innerRect.bottom <= outerRect.bottom ||
+    (innerRect.top < outerRect.top && innerRect.bottom > outerRect.bottom);
 
   const horizontallyVisible =
-    (innerRect.left >= outerRect.left || innerRect.right <= outerRect.right)
-    || (innerRect.left < outerRect.left && innerRect.right > outerRect.right);
+    innerRect.left >= outerRect.left ||
+    innerRect.right <= outerRect.right ||
+    (innerRect.left < outerRect.left && innerRect.right > outerRect.right);
 
   const visible = verticallyVisible && horizontallyVisible;
   return visible;
@@ -891,7 +898,9 @@ const selectors = {
   expressionNode: i =>
     `.expressions-list .expression-container:nth-child(${i}) .object-label`,
   expressionValue: i =>
-    `.expressions-list .expression-container:nth-child(${i}) .object-delimiter + *`,
+    `.expressions-list .expression-container:nth-child(${
+      i
+    }) .object-delimiter + *`,
   expressionClose: i =>
     `.expressions-list .expression-container:nth-child(${i}) .close`,
   expressionNodes: ".expressions-list .tree-node",
@@ -914,7 +923,8 @@ const selectors = {
   stepOut: ".stepOut.active",
   stepIn: ".stepIn.active",
   toggleBreakpoints: ".breakpoints-toggle",
-  prettyPrintButton: ".prettyPrint",
+  prettyPrintButton: ".source-footer .prettyPrint",
+  sourceMapLink: ".source-footer .mapped-source",
   sourcesFooter: ".sources-panel .source-footer",
   editorFooter: ".editor-pane .source-footer",
   sourceNode: i => `.sources-list .tree-node:nth-child(${i})`,

--- a/src/utils/editor/index.js
+++ b/src/utils/editor/index.js
@@ -17,6 +17,7 @@ import { isWasm, lineToWasmOffset, wasmOffsetToLine } from "../wasm";
 import { resizeBreakpointGutter } from "../ui";
 
 import { SourceEditor, SourceEditorUtils } from "devtools-source-editor";
+import { isOriginalId } from "devtools-source-map";
 
 import type { AstPosition, AstLocation } from "../../workers/parser/types";
 import type { EditorPosition, EditorRange } from "../editor/types";
@@ -34,8 +35,13 @@ function shouldShowFooter(selectedSource, horizontal) {
   if (!horizontal) {
     return true;
   }
-
-  return shouldShowPrettyPrint(selectedSource);
+  if (!selectedSource) {
+    return false;
+  }
+  return (
+    shouldShowPrettyPrint(selectedSource) ||
+    isOriginalId(selectedSource.get("id"))
+  );
 }
 
 function traverseResults(e, ctx, query, dir, modifiers) {


### PR DESCRIPTION
Associated Issue: #4242

Here's the Pull Request Doc
https://devtools-html.github.io/debugger.html/CONTRIBUTING.html#pull-requests

### Summary of Changes

* Footer shows a short message in the bottom for generated with a link to the root original directory aka webpack "(From bundle.js)"
* Hover over message, tooltip comes up and shows full message "(source mapped from bundle.js)"
* Click on short message "(From bundle.js)" to jump to the start of the original file in the generated bundle

### Test Plan

- [x]  open http://firefox-dev.tools/debugger-examples/examples/increment/ in firefox
- [x]  navigate to webpack/math.js
- [x]  the Footer should show a message in the bottom for generated with a link to the root original directory aka webpack "(source mapped from bundle.js)"
- [x]  files without original sources will show nothing in footer or will footer wont appear if not necessary

Here's the Debugger's Testing doc
https://docs.google.com/document/d/1oBMRxV8A2ag2t22YsQOxTdEv0mXKzIg0tggJjRkU1S0/edit#.
Feel free to improve it!

### Screenshots/Videos
<img width="389" alt="screen shot 2017-11-15 at 1 31 57 pm" src="https://user-images.githubusercontent.com/17691158/32854891-0f00c3b6-ca0e-11e7-8d72-9bb57f235820.png">

<img width="1440" alt="screen shot 2017-11-15 at 1 32 06 pm" src="https://user-images.githubusercontent.com/17691158/32854895-12122194-ca0e-11e7-8a8b-498c4e420bd4.png">

<img width="606" alt="screen shot 2017-11-15 at 2 06 06 pm" src="https://user-images.githubusercontent.com/17691158/32854969-5a87b876-ca0e-11e7-905f-43f61565036e.png">
