### PR TITLE
Fix including non-JS scripts from HTML source

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "lodash": "^4.17.4",
     "lodash.kebabcase": "^4.1.1",
     "md5": "^2.2.1",
-    "parse-script-tags": "^0.1.1",
+    "parse-script-tags": "^0.1.4",
     "pretty-fast": "^0.2.2",
     "prop-types": "^15.6.0",
     "react": "^15.6.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -189,11 +189,7 @@
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/@types/inline-style-prefixer/-/inline-style-prefixer-3.0.1.tgz#8541e636b029124b747952e9a28848286d2b5bf6"
 
-"@types/node@*":
-  version "8.0.50"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.0.50.tgz#dc545448e128c88c4eec7cd64025fcc3b7604541"
-
-"@types/node@^7.0.12":
+"@types/node@*", "@types/node@^7.0.12":
   version "7.0.46"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-7.0.46.tgz#c3dedd25558c676b3d6303e51799abb9c3f8f314"
 
@@ -3188,16 +3184,9 @@ domhandler@^2.3.0:
   dependencies:
     domelementtype "1"
 
-domutils@1.5.1:
+domutils@1.5.1, domutils@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.5.1.tgz#dcd8488a26f563d61079e48c9f7b7e32373682cf"
-  dependencies:
-    dom-serializer "0"
-    domelementtype "1"
-
-domutils@^1.5.1:
-  version "1.6.2"
-  resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.6.2.tgz#1958cc0b4c9426e9ed367fb1c8e854891b0fa3ff"
   dependencies:
     dom-serializer "0"
     domelementtype "1"
@@ -7389,12 +7378,13 @@ parse-latin@^4.0.0:
     unist-util-modify-children "^1.0.0"
     unist-util-visit-children "^1.0.0"
 
-parse-script-tags@^0.1.1:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/parse-script-tags/-/parse-script-tags-0.1.3.tgz#abcc38665d4ff92bd5a2661b8f24c3e172db19d5"
+parse-script-tags@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/parse-script-tags/-/parse-script-tags-0.1.4.tgz#c14fe39bf487e045c84afeaaac82f8889d686c52"
   dependencies:
     babel-types "^6.24.1"
     babylon "^6.17.0"
+    parse5 "^3.0.3"
 
 parse-url@^1.3.0:
   version "1.3.11"
@@ -7407,7 +7397,7 @@ parse5@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-1.5.1.tgz#9b7f3b0de32be78dc2401b17573ccaf0f6f59d94"
 
-parse5@^3.0.0:
+parse5@^3.0.0, parse5@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-3.0.3.tgz#042f792ffdd36851551cf4e9e066b3874ab45b5c"
   dependencies:
@@ -9637,11 +9627,7 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-"statuses@>= 1.3.1 < 2":
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.4.0.tgz#bb73d446da2796106efcc1b601a253d6c46bd087"
-
-statuses@~1.3.1:
+"statuses@>= 1.3.1 < 2", statuses@~1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.3.1.tgz#faf51b9eb74aaef3b3acf4ad5f61abf24cb7b93e"
 


### PR DESCRIPTION
Associated Issue: #3307 

### Summary of Changes

Updates the dependency to `parse-script-tags` to version 0.1.4 which supports   omitting script tags that have non-JS types.

### Test Plan

* Added breakpoints on a Wordpress site (http://davidwalsh.name) with non-JS `<script>`s
* Created a simple sample with non-JS `<script>`:

```html
<html>
<script type="application/ld+json">
var notScript = true;
alert(notScript);
</script>
<script>
	console.log('from script');
</script>
<body>
Not Script
</body>
</html>
```
