### PR TITLE
Add syntax highlight for non-js languages

### DIFF
--- a/src/utils/source.js
+++ b/src/utils/source.js
@@ -280,6 +280,23 @@ function getMode(source: Source, sourceMetaData: SourceMetaDataType) {
     return "jsx";
   }
 
+  const languageMimeMap = [
+    { ext: ".c", mode: "text/x-csrc" },
+    { ext: ".kt", mode: "text/x-kotlin" },
+    { ext: ".cpp", mode: "text/x-c++src" },
+    { ext: ".m", mode: "text/x-objectivec" },
+    { ext: ".rs", mode: "text/x-rustsrc" }
+  ];
+
+  // check for C and other non JS languages
+  if (url) {
+    const result = languageMimeMap.find(({ ext }) => url.endsWith(ext));
+
+    if (result !== undefined) {
+      return result.mode;
+    }
+  }
+
   // if the url ends with .marko we set the name to Javascript so
   // syntax highlighting works for marko too
   if (url && url.match(/\.marko$/i)) {


### PR DESCRIPTION
Associated Issue: #3392

Here's the Pull Request Doc
https://devtools-html.github.io/debugger.html/CONTRIBUTING.html#pull-requests

### Summary of Changes

* Added modes for syntax highlighting some non-js languages for WASM (C, C++, Kotlin, Rust)

### Test Plan

First, this is dependent of https://github.com/devtools-html/devtools-core/pull/798
After the above is merged and new version of the source-editor is released, this would be tested:

test plan:

- [x] Open https://yurydelendik.github.io/sqlite-playground/src/playground.html
- [x] Open playground.c file in the debugger
- [x] Notice wonderful colors available to you now.
- 

Here's the Debugger's Testing doc
https://docs.google.com/document/d/1oBMRxV8A2ag2t22YsQOxTdEv0mXKzIg0tggJjRkU1S0/edit#.
Feel free to improve it!

### Screenshots/Videos (OPTIONAL)
![image](https://user-images.githubusercontent.com/69977/32892873-bf2fd2fe-cb2b-11e7-96e5-761d2bef139d.png)
![image](https://user-images.githubusercontent.com/69977/32893035-47da8338-cb2c-11e7-9042-2848050fd55e.png)

