### PR TITLE
[Outline] Use magenta for param color, fixes #4604

### DIFF
--- a/src/components/shared/PreviewFunction.css
+++ b/src/components/shared/PreviewFunction.css
@@ -11,7 +11,7 @@
 }
 
 .function-signature .param {
-  color: var(--string-color);
+  color: var(--theme-highlight-red);
 }
 
 .function-signature .paren {


### PR DESCRIPTION
Associated Issue: #4604 

### Summary of Changes

* As suggested in the associated issue #4604, the color of param in Outline is changed.

### Test Plan

- [x] Outline pane in debugger uses magenta color for function param as opposed to red.

### Screenshots

Before  | After
:--|:--
<img width="247" alt="screen shot 2017-11-16 at 8 42 40 pm" src="https://user-images.githubusercontent.com/6177621/32898656-bca45f40-cb0e-11e7-899b-be4925ddb0e4.png">| <img width="242" alt="screen shot 2017-11-16 at 8 42 47 pm" src="https://user-images.githubusercontent.com/6177621/32898658-bcfc59f2-cb0e-11e7-8517-9bf046795c76.png">

