### PR TITLE
Fix a typo for the difficulty level filter urls

### DIFF
--- a/docs/issues.md
+++ b/docs/issues.md
@@ -190,8 +190,8 @@ We focus on being community friendly for many reasons.
 [labels-available]:https://github.com/devtools-html/debugger.html/labels/available
 [labels-first-timers-only]:https://github.com/devtools-html/debugger.html/labels/first-timers-only
 [labels-difficulty-easy]:https://github.com/devtools-html/debugger.html/labels/difficulty%3A%20easy
-[labels-difficulty-medium]:https://github.com/devtools-html/debugger.html/labels/difficulty%3A%medium
-[labels-difficulty-hard]:https://github.com/devtools-html/debugger.html/labels/difficulty%3A%hard
+[labels-difficulty-medium]:https://github.com/devtools-html/debugger.html/labels/difficulty%3A%20medium
+[labels-difficulty-hard]:https://github.com/devtools-html/debugger.html/labels/difficulty%3A%20hard
 [labels-docs]:https://github.com/devtools-html/debugger.html/labels/docs
 [labels-design]:https://github.com/devtools-html/debugger.html/labels/design
 [labels-enhancement]:https://github.com/devtools-html/debugger.html/labels/enhancement


### PR DESCRIPTION
Associated Issue: None

### Summary of Changes

* Fix a typo in 2 urls that broke some links.

### Screenshots

#### Before
![image](https://user-images.githubusercontent.com/3439246/32952790-942dd8e8-cbae-11e7-8487-f4463274a450.png)

#### After
![image](https://user-images.githubusercontent.com/3439246/32952859-c4d37d40-cbae-11e7-8a1c-cc396e1570fc.png)
