### PR TITLE
Watch Expressions Shouldn't Be Allowed with Syntax Errors

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,15 +1,8 @@
 [ignore]
-.*node_modules/cjson.*
-.*node_modules/fbjs.*
-.*node_modules/npm.*
-.*node_modules/stylelint.*
-.*node_modules/radium.*
-.*node_modules/config-chain.*
 .*node_modules/documentation.*
 .*node_modules/devtools-reps/src/object-inspector/index.js
 .*node_modules/devtools-mc-assets/.*
 .*node_modules/immutable/dist/immutable.js.flow
-.*node_modules/jest-in-case/index.js
 <PROJECT_ROOT>/firefox/.*
 .*mozilla-central/.*
 .*flow-coverage-report/.*

--- a/assets/panel/debugger.properties
+++ b/assets/panel/debugger.properties
@@ -441,7 +441,7 @@ original=original
 expressions.placeholder=Add watch expression
 # LOCALIZATION NOTE (expressions.errorMsg): Error text for expression
 # input element
-expressions.errorMsg=Invalid expression, try again…
+expressions.errorMsg=Invalid expression…
 expressions.label=Add watch expression
 expressions.accesskey=e
 

--- a/assets/panel/debugger.properties
+++ b/assets/panel/debugger.properties
@@ -439,6 +439,9 @@ original=original
 # LOCALIZATION NOTE (expressions.placeholder): Placeholder text for expression
 # input element
 expressions.placeholder=Add watch expression
+# LOCALIZATION NOTE (expressions.errorMsg): Error text for expression
+# input element
+expressions.errorMsg=Invalid expression, try again…
 expressions.label=Add watch expression
 expressions.accesskey=e
 

--- a/flow-typed/debugger-html.js
+++ b/flow-typed/debugger-html.js
@@ -210,7 +210,8 @@ declare module "debugger-html" {
   declare type Expression = {
     input: string,
     value: Object,
-    from: string
+    from: string,
+    updating: boolean
   };
 
   /**

--- a/flow-typed/npm/classnames_v2.x.x.js
+++ b/flow-typed/npm/classnames_v2.x.x.js
@@ -1,0 +1,23 @@
+// flow-typed signature: cf86673cc32d185bdab1d2ea90578d37
+// flow-typed version: 614bf49aa8/classnames_v2.x.x/flow_>=v0.25.x
+
+type $npm$classnames$Classes =
+  | string
+  | { [className: string]: * }
+  | false
+  | void
+  | null;
+
+declare module "classnames" {
+  declare module.exports: (
+    ...classes: Array<$npm$classnames$Classes | $npm$classnames$Classes[]>
+  ) => string;
+}
+
+declare module "classnames/bind" {
+  declare module.exports: $Exports<"classnames">;
+}
+
+declare module "classnames/dedupe" {
+  declare module.exports: $Exports<"classnames">;
+}

--- a/src/actions/expressions.js
+++ b/src/actions/expressions.js
@@ -34,7 +34,7 @@ export function addExpression(input: string) {
 
     const error = await parser.hasSyntaxError(input);
     if (error) {
-      return false;
+      return;
     }
 
     const expression = getExpression(getState(), input);
@@ -48,7 +48,7 @@ export function addExpression(input: string) {
     });
 
     const newExpression = getExpression(getState(), input);
-    dispatch(evaluateExpression(newExpression));
+    return dispatch(evaluateExpression(newExpression));
   };
 }
 

--- a/src/actions/expressions.js
+++ b/src/actions/expressions.js
@@ -34,8 +34,6 @@ export function addExpression(input: string) {
 
     const error = await parser.hasSyntaxError(input);
     if (error) {
-      // for debugging only
-      alert("'" + input + "' " + "has syntax error");
       return false;
     }
 

--- a/src/actions/expressions.js
+++ b/src/actions/expressions.js
@@ -35,7 +35,7 @@ export function addExpression(input: string) {
     const error = await parser.hasSyntaxError(input);
     if (error) {
       // for debugging only
-      console.log("has syntax error");
+      alert("'" + input + "' " + "has syntax error");
       return false;
     }
 

--- a/src/actions/expressions.js
+++ b/src/actions/expressions.js
@@ -28,7 +28,6 @@ import type { ThunkArgs } from "./types";
  */
 export function addExpression(input: string) {
   return async ({ dispatch, getState }: ThunkArgs) => {
-    const expressionError = await parser.hasSyntaxError(input);
     if (!input) {
       return;
     }
@@ -38,6 +37,7 @@ export function addExpression(input: string) {
       return dispatch(evaluateExpression(expression));
     }
 
+    const expressionError = await parser.hasSyntaxError(input);
     dispatch({ type: "ADD_EXPRESSION", input, expressionError });
 
     const newExpression = getExpression(getState(), input);
@@ -53,10 +53,11 @@ export function clearExpressionError() {
 
 export function updateExpression(input: string, expression: Expression) {
   return async ({ dispatch, getState }: ThunkArgs) => {
-    const expressionError = await parser.hasSyntaxError(input);
     if (!input || input == expression.input) {
       return;
     }
+
+    const expressionError = await parser.hasSyntaxError(input);
     dispatch({
       type: "UPDATE_EXPRESSION",
       expression,

--- a/src/actions/expressions.js
+++ b/src/actions/expressions.js
@@ -32,6 +32,13 @@ export function addExpression(input: string) {
       return;
     }
 
+    const error = await parser.hasSyntaxError(input);
+    if (error) {
+      // for debugging only
+      console.log("has syntax error");
+      return false;
+    }
+
     const expression = getExpression(getState(), input);
     if (expression) {
       return dispatch(evaluateExpression(expression));
@@ -102,15 +109,6 @@ function evaluateExpression(expression: Expression) {
     }
 
     let input = expression.input;
-    const error = await parser.hasSyntaxError(input);
-    if (error) {
-      return dispatch({
-        type: "EVALUATE_EXPRESSION",
-        input: expression.input,
-        value: { input: expression.input, result: error }
-      });
-    }
-
     const frame = getSelectedFrame(getState());
 
     if (frame) {

--- a/src/actions/tests/expressions.spec.js
+++ b/src/actions/tests/expressions.spec.js
@@ -15,10 +15,10 @@ const mockThreadClient = {
 };
 
 describe("expressions", () => {
-  it("should add an expression", () => {
+  it("should add an expression", async () => {
     const { dispatch, getState } = createStore(mockThreadClient);
 
-    dispatch(actions.addExpression("foo"));
+    await dispatch(actions.addExpression("foo"));
 
     expect(selectors.getExpressions(getState()).size).toBe(1);
   });
@@ -32,21 +32,21 @@ describe("expressions", () => {
     expect(selectors.getExpressions(getState()).size).toBe(0);
   });
 
-  it("should update an expression", () => {
+  it("should update an expression", async () => {
     const { dispatch, getState } = createStore(mockThreadClient);
 
-    dispatch(actions.addExpression("foo"));
+    await dispatch(actions.addExpression("foo"));
     const expression = selectors.getExpression(getState(), "foo");
     dispatch(actions.updateExpression("bar", expression));
 
     expect(selectors.getExpression(getState(), "bar").input).toBe("bar");
   });
 
-  it("should delete an expression", () => {
+  it("should delete an expression", async () => {
     const { dispatch, getState } = createStore(mockThreadClient);
 
-    dispatch(actions.addExpression("foo"));
-    dispatch(actions.addExpression("bar"));
+    await dispatch(actions.addExpression("foo"));
+    await dispatch(actions.addExpression("bar"));
 
     expect(selectors.getExpressions(getState()).size).toBe(2);
 
@@ -60,11 +60,12 @@ describe("expressions", () => {
   it("should evaluate expressions global scope", async () => {
     const { dispatch, getState } = createStore(mockThreadClient);
 
-    dispatch(actions.addExpression("foo"));
-    dispatch(actions.addExpression("bar"));
+    await dispatch(actions.addExpression("foo"));
+    await dispatch(actions.addExpression("bar"));
 
-    expect(selectors.getExpression(getState(), "foo").value).toBe(null);
-    expect(selectors.getExpression(getState(), "bar").value).toBe(null);
+    expect(selectors.getExpression(getState(), "foo").value).toBe("bla");
+    expect(selectors.getExpression(getState(), "bar").value).toBe("bla");
+
     await dispatch(actions.evaluateExpressions());
 
     expect(selectors.getExpression(getState(), "foo").value).toBe("bla");
@@ -75,13 +76,13 @@ describe("expressions", () => {
     const { dispatch, getState } = createStore(mockThreadClient);
     await createFrames(dispatch);
 
-    dispatch(actions.addExpression("foo"));
-    dispatch(actions.addExpression("bar"));
+    await dispatch(actions.addExpression("foo"));
+    await dispatch(actions.addExpression("bar"));
 
-    expect(selectors.getExpression(getState(), "foo").value).toBe(null);
-    expect(selectors.getExpression(getState(), "bar").value).toBe(null);
+    expect(selectors.getExpression(getState(), "foo").value).toBe("boo");
+    expect(selectors.getExpression(getState(), "bar").value).toBe("boo");
 
-    await dispatch(actions.evaluateExpressions("boo"));
+    await dispatch(actions.evaluateExpressions());
 
     expect(selectors.getExpression(getState(), "foo").value).toBe("boo");
     expect(selectors.getExpression(getState(), "bar").value).toBe("boo");

--- a/src/actions/tests/expressions.spec.js
+++ b/src/actions/tests/expressions.spec.js
@@ -32,6 +32,14 @@ describe("expressions", () => {
     expect(selectors.getExpressions(getState()).size).toBe(0);
   });
 
+  it("should not add invalid expressions", async () => {
+    const { dispatch, getState } = createStore(mockThreadClient);
+    await dispatch(actions.addExpression("foo#"));
+    const state = getState();
+    expect(selectors.getExpressions(state).size).toBe(0);
+    expect(selectors.getExpressionError(state)).toBe(true);
+  });
+
   it("should update an expression", async () => {
     const { dispatch, getState } = createStore(mockThreadClient);
 
@@ -40,6 +48,15 @@ describe("expressions", () => {
     await dispatch(actions.updateExpression("bar", expression));
 
     expect(selectors.getExpression(getState(), "bar").input).toBe("bar");
+  });
+
+  it("should not update an expression w/ invalid code", async () => {
+    const { dispatch, getState } = createStore(mockThreadClient);
+
+    await dispatch(actions.addExpression("foo"));
+    const expression = selectors.getExpression(getState(), "foo");
+    await dispatch(actions.updateExpression("#bar", expression));
+    expect(selectors.getExpression(getState(), "bar")).toBeUndefined();
   });
 
   it("should delete an expression", async () => {

--- a/src/actions/tests/expressions.spec.js
+++ b/src/actions/tests/expressions.spec.js
@@ -37,7 +37,7 @@ describe("expressions", () => {
 
     await dispatch(actions.addExpression("foo"));
     const expression = selectors.getExpression(getState(), "foo");
-    dispatch(actions.updateExpression("bar", expression));
+    await dispatch(actions.updateExpression("bar", expression));
 
     expect(selectors.getExpression(getState(), "bar").input).toBe("bar");
   });

--- a/src/actions/tests/pause.spec.js
+++ b/src/actions/tests/pause.spec.js
@@ -87,7 +87,7 @@ describe("pause", () => {
       const mockPauseInfo = createPauseInfo();
 
       await dispatch(actions.newSource(makeSource("foo1")));
-      await dispatch(actions.addExpression("foo"));
+      dispatch(actions.addExpression("foo"));
 
       mockThreadClient.evaluate = () => new Promise(r => r("YAY"));
       await dispatch(actions.paused(mockPauseInfo));

--- a/src/actions/types.js
+++ b/src/actions/types.js
@@ -253,6 +253,7 @@ type PauseAction =
       input: string,
       value: string
     }
+  | { type: "EXPRESSION_ERROR", value: boolean }
   | {
       type: "EVALUATE_EXPRESSION",
       input: string,

--- a/src/actions/types.js
+++ b/src/actions/types.js
@@ -251,9 +251,9 @@ type PauseAction =
       type: "ADD_EXPRESSION",
       id: number,
       input: string,
-      value: string
+      value: string,
+      expressionError: ?string
     }
-  | { type: "EXPRESSION_ERROR", value: boolean }
   | {
       type: "EVALUATE_EXPRESSION",
       input: string,
@@ -263,12 +263,14 @@ type PauseAction =
   | {
       type: "UPDATE_EXPRESSION",
       expression: Expression,
-      input: string
+      input: string,
+      expressionError: ?string
     }
   | {
       type: "DELETE_EXPRESSION",
       input: string
     }
+  | { type: "CLEAR_EXPRESSION_ERROR" }
   | {
       type: "MAP_SCOPES",
       frame: Frame,

--- a/src/components/SecondaryPanes/Expressions.css
+++ b/src/components/SecondaryPanes/Expressions.css
@@ -2,24 +2,38 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
+.expression-input-form {
+  width: 100%;
+}
+
 .input-expression {
   width: 100%;
-  margin: 0px;
+  margin: 0;
   border: 1px;
   background-color: var(--theme-sidebar-background);
   font-size: 12px;
-  padding: 0px 20px;
+  padding: 0.5em 2.16em;
   color: var(--theme-body-color);
 }
 
-.input-expression-error {
-  width: 100%;
-  margin: 0px;
-  border: 1px;
-  background-color: var(--theme-sidebar-background);
-  font-size: 12px;
-  padding: 0px 20px;
-  color: red;
+@keyframes shake {
+  0%,
+  100% {
+    transform: translateX(0);
+  }
+  20%,
+  60% {
+    transform: translateX(-10px);
+  }
+  40%,
+  80% {
+    transform: translateX(10px);
+  }
+}
+
+.input-expression.error {
+  border: 1px solid red;
+  animation: 150ms cubic-bezier(0.07, 0.95, 0, 1) shake;
 }
 
 .input-expression::placeholder {
@@ -40,7 +54,6 @@
   padding: 0;
 }
 .expression-input-container {
-  padding: 0.5em;
   display: flex;
 }
 

--- a/src/components/SecondaryPanes/Expressions.css
+++ b/src/components/SecondaryPanes/Expressions.css
@@ -12,6 +12,16 @@
   color: var(--theme-body-color);
 }
 
+.input-expression-error {
+  width: 100%;
+  margin: 0px;
+  border: 1px;
+  background-color: var(--theme-sidebar-background);
+  font-size: 12px;
+  padding: 0px 20px;
+  color: red;
+}
+
 .input-expression::placeholder {
   text-align: center;
   font-style: italic;

--- a/src/components/SecondaryPanes/Expressions.js
+++ b/src/components/SecondaryPanes/Expressions.js
@@ -70,7 +70,6 @@ class Expressions extends PureComponent<Props, State> {
     if (depth > 0) {
       return;
     }
-
     this.setState({ editing: expression.input });
   }
 
@@ -80,18 +79,31 @@ class Expressions extends PureComponent<Props, State> {
     deleteExpression(expression);
   }
 
-  inputKeyPress(e, expression) {
+  async inputKeyPress(e, expression) {
+    const target = e.target;
+    target.className = "input-expression";
+
     if (e.key !== "Enter") {
       return;
     }
 
-    const value = e.target.value;
+    const value = target.value;
+
     if (value == "") {
       return;
     }
 
+    const syntaxError = await hasSyntaxError(value);
+    this.setState({ error: syntaxError });
+
+    if (syntaxError) {
+      target.className = "input-expression-error";
+      return;
+    }
+
     this.setState({ editing: null });
-    e.target.value = "";
+    target.value = "";
+
     this.props.updateExpression(value, expression);
   }
 

--- a/src/components/SecondaryPanes/Expressions.js
+++ b/src/components/SecondaryPanes/Expressions.js
@@ -199,6 +199,7 @@ class Expressions extends PureComponent<Props, State> {
           className="input-expression"
           type="text"
           placeholder={L10N.getStr("expressions.placeholder")}
+          onBlur={e => (e.target.value = "")}
           onKeyPress={onKeyPress}
         />
       </li>

--- a/src/components/SecondaryPanes/Expressions.js
+++ b/src/components/SecondaryPanes/Expressions.js
@@ -5,47 +5,60 @@
 // @flow
 import React, { PureComponent } from "react";
 import { connect } from "react-redux";
-import { bindActionCreators } from "redux";
-import actions from "../../actions";
-import { getExpressions, getLoadedObjects } from "../../selectors";
-import { getValue } from "../../utils/expressions";
-import { hasSyntaxError } from "../../workers/parser";
-import CloseButton from "../shared/Button/Close";
+import classnames from "classnames";
 import { ObjectInspector } from "devtools-reps";
+
+import {
+  addExpression as _addExpression,
+  setExpressionError as _setExpressionError,
+  evaluateExpressions as _evaluateExpressions,
+  updateExpression as _updateExpression,
+  deleteExpression as _deleteExpression
+} from "../../actions/expressions";
+import { loadObjectProperties as loadObjectProps } from "../../actions/pause";
+import { openLink as _openLink } from "../../actions/toolbox";
+import {
+  getExpressions,
+  getExpressionError,
+  getLoadedObjects
+} from "../../selectors";
+import { getValue } from "../../utils/expressions";
+import CloseButton from "../shared/Button/Close";
+
+import type { List } from "immutable";
+import type { Expression } from "debugger-html";
 
 import "./Expressions.css";
 
-import type { List } from "immutable";
-import type { Expression } from "../../types";
-
 type State = {
-  editing: null | Node,
-  error: null
+  editing: boolean,
+  editIndex: number,
+  inputValue: string
 };
 
 type Props = {
   expressions: List<Expression>,
-  addExpression: (string, ?Object) => void,
-  evaluateExpressions: () => void,
-  updateExpression: (string, Expression) => void,
-  deleteExpression: Expression => void,
-  loadObjectProperties: () => void,
+  expressionError: boolean,
   loadedObjects: Map<string, any>,
+  addExpression: (input: string) => void,
+  setExpressionError: (value: boolean) => void,
+  evaluateExpressions: () => void,
+  updateExpression: (input: string, expression: Expression) => void,
+  deleteExpression: (expression: Expression) => void,
+  loadObjectProperties: () => void,
   openLink: (url: string) => void
 };
 
 class Expressions extends PureComponent<Props, State> {
-  _input: null | any;
-  renderExpression: Function;
+  _input: ?HTMLInputElement;
+  renderExpression: (
+    expression: Expression,
+    index: number
+  ) => React$Element<"li">;
 
-  constructor(...args) {
-    super(...args);
-
-    this.state = {
-      editing: null,
-      error: null
-    };
-
+  constructor(props: Props) {
+    super(props);
+    this.state = { editing: false, editIndex: -1, inputValue: "" };
     this.renderExpression = this.renderExpression.bind(this);
   }
 
@@ -56,78 +69,100 @@ class Expressions extends PureComponent<Props, State> {
     }
   }
 
+  clear = () => {
+    this.setState(() => {
+      this.props.setExpressionError(false);
+      return { editing: false, editIndex: -1, inputValue: "" };
+    });
+  };
+
+  componentWillReceiveProps(nextProps) {
+    if (this.state.editing && !nextProps.expressionError) {
+      this.clear();
+    }
+  }
+
   shouldComponentUpdate(nextProps, nextState) {
-    const { editing } = this.state;
-    const { expressions, loadedObjects } = this.props;
+    const { editing, inputValue } = this.state;
+    const { expressions, expressionError, loadedObjects } = this.props;
     return (
       expressions !== nextProps.expressions ||
+      expressionError !== nextProps.expressionError ||
       loadedObjects !== nextProps.loadedObjects ||
-      editing !== nextState.editing
+      editing !== nextState.editing ||
+      inputValue !== nextState.inputValue
     );
   }
 
-  editExpression(expression, { depth }) {
+  componentDidUpdate() {
+    if (this._input) {
+      const input = this._input;
+      input.setSelectionRange(input.value.length + 1, input.value.length + 1);
+      input.focus();
+    }
+  }
+
+  editExpression(
+    expression: Expression,
+    index: number,
+    { depth }: { depth: number }
+  ) {
     if (depth > 0) {
       return;
     }
-    this.setState({ editing: expression.input });
+    this.setState({
+      inputValue: expression.input,
+      editing: true,
+      editIndex: index
+    });
   }
 
-  deleteExpression(e, expression) {
+  deleteExpression(
+    e: SyntheticMouseEvent<HTMLDivElement>,
+    expression: Expression
+  ) {
     e.stopPropagation();
     const { deleteExpression } = this.props;
     deleteExpression(expression);
   }
 
-  async inputKeyPress(e, expression) {
-    const target = e.target;
-    target.className = "input-expression";
+  handleChange = (e: SyntheticInputEvent<HTMLInputElement>) => {
+    this.setState({ inputValue: e.target.value });
+  };
 
-    if (e.key !== "Enter") {
-      return;
+  handleKeyDown = (e: SyntheticKeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Escape") {
+      this.clear();
     }
+  };
 
-    const value = target.value;
+  handleExistingSubmit = async (
+    e: SyntheticEvent<HTMLFormElement>,
+    expression: Expression
+  ) => {
+    e.preventDefault();
+    e.stopPropagation();
+    this.props.updateExpression(this.state.inputValue, expression);
+  };
 
-    if (value == "") {
-      return;
-    }
+  handleNewSubmit = async (e: SyntheticEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+    this.props.addExpression(this.state.inputValue);
+    this.setState({ editing: false, editIndex: -1, inputValue: "" });
+  };
 
-    const syntaxError = await hasSyntaxError(value);
-    this.setState({ error: syntaxError });
-
-    if (syntaxError) {
-      target.className = "input-expression-error";
-      return;
-    }
-
-    this.setState({ editing: null });
-    target.value = "";
-
-    this.props.updateExpression(value, expression);
-  }
-
-  renderExpressionEditInput(expression) {
-    return (
-      <span className="expression-input-container" key={expression.input}>
-        <input
-          className="input-expression"
-          type="text"
-          onKeyPress={e => this.inputKeyPress(e, expression)}
-          onBlur={() => this.setState({ editing: null })}
-          defaultValue={expression.input}
-          ref={c => (this._input = c)}
-        />
-      </span>
-    );
-  }
-
-  renderExpression(expression) {
-    const { loadObjectProperties, loadedObjects, openLink } = this.props;
-    const { editing } = this.state;
+  renderExpression(expression: Expression, index: number) {
+    const {
+      expressionError,
+      loadObjectProperties,
+      loadedObjects,
+      openLink
+    } = this.props;
+    const { editing, editIndex } = this.state;
     const { input, updating } = expression;
-
-    if (editing == input) {
+    const isEditingExpr = editing && editIndex === index;
+    if (isEditingExpr || (isEditingExpr && expressionError)) {
       return this.renderExpressionEditInput(expression);
     }
 
@@ -152,7 +187,7 @@ class Expressions extends PureComponent<Props, State> {
             disableWrap={true}
             disabledFocus={true}
             onDoubleClick={(items, options) =>
-              this.editExpression(expression, options)
+              this.editExpression(expression, index, options)
             }
             openLink={openLink}
             getObjectProperties={id => loadedObjects[id]}
@@ -171,50 +206,55 @@ class Expressions extends PureComponent<Props, State> {
     );
   }
 
-  componentDidUpdate() {
-    if (this._input) {
-      this._input.focus();
-    }
-  }
-
   renderNewExpressionInput() {
-    const onKeyPress = async e => {
-      e.stopPropagation();
-
-      const target = e.target;
-      target.className = "input-expression";
-
-      if (e.key !== "Enter") {
-        return;
-      }
-
-      const value = target.value;
-      if (value == "") {
-        return;
-      }
-
-      const syntaxError = await hasSyntaxError(value);
-      this.setState({ error: syntaxError });
-
-      if (syntaxError) {
-        target.className = "input-expression-error";
-        return;
-      }
-
-      target.value = "";
-      this.props.addExpression(value);
-    };
-
+    const { expressionError } = this.props;
+    const { editing, inputValue } = this.state;
+    const error = editing === false && expressionError === true;
+    const placeholder: string = error
+      ? L10N.getStr("expressions.errorMsg")
+      : L10N.getStr("expressions.placeholder");
     return (
       <li className="expression-input-container">
-        <input
-          className="input-expression"
-          type="text"
-          placeholder={L10N.getStr("expressions.placeholder")}
-          onBlur={e => (e.target.value = "")}
-          onKeyPress={onKeyPress}
-        />
+        <form className="expression-input-form" onSubmit={this.handleNewSubmit}>
+          <input
+            className={classnames("input-expression", { error })}
+            type="text"
+            placeholder={placeholder}
+            onChange={this.handleChange}
+            onBlur={this.clear}
+            onKeyDown={this.handleKeyDown}
+            value={!editing ? inputValue : ""}
+          />
+          <input type="submit" style={{ display: "none" }} />
+        </form>
       </li>
+    );
+  }
+
+  renderExpressionEditInput(expression: Expression) {
+    const { expressionError } = this.props;
+    const { inputValue, editing } = this.state;
+    const error = editing === true && expressionError === true;
+    return (
+      <span className="expression-input-container" key={expression.input}>
+        <form
+          className="expression-input-form"
+          onSubmit={(e: SyntheticEvent<HTMLFormElement>) =>
+            this.handleExistingSubmit(e, expression)
+          }
+        >
+          <input
+            className={classnames("input-expression", { error })}
+            type="text"
+            onChange={this.handleChange}
+            onBlur={this.clear}
+            onKeyDown={this.handleKeyDown}
+            value={editing ? inputValue : expression.input}
+            ref={c => (this._input = c)}
+          />
+          <input type="submit" style={{ display: "none" }} />
+        </form>
+      </span>
     );
   }
 
@@ -232,7 +272,16 @@ class Expressions extends PureComponent<Props, State> {
 export default connect(
   state => ({
     expressions: getExpressions(state),
+    expressionError: getExpressionError(state),
     loadedObjects: getLoadedObjects(state)
   }),
-  dispatch => bindActionCreators(actions, dispatch)
+  {
+    addExpression: _addExpression,
+    setExpressionError: _setExpressionError,
+    evaluateExpressions: _evaluateExpressions,
+    updateExpression: _updateExpression,
+    deleteExpression: _deleteExpression,
+    loadObjectProperties: loadObjectProps,
+    openLink: _openLink
+  }
 )(Expressions);

--- a/src/components/SecondaryPanes/Expressions.js
+++ b/src/components/SecondaryPanes/Expressions.js
@@ -167,29 +167,29 @@ class Expressions extends PureComponent<Props, State> {
 
   renderNewExpressionInput() {
     const onKeyPress = async e => {
-      e.target.className = "input-expression";
+      e.stopPropagation();
+
+      const target = e.target;
+      target.className = "input-expression";
 
       if (e.key !== "Enter") {
         return;
       }
 
-      const value = e.target.value;
+      const value = target.value;
       if (value == "") {
         return;
       }
-
-      e.persist();
-      e.stopPropagation();
 
       const syntaxError = await hasSyntaxError(value);
       this.setState({ error: syntaxError });
 
       if (syntaxError) {
-        e.target.className = "input-expression-error";
+        target.className = "input-expression-error";
         return;
       }
 
-      e.target.value = "";
+      target.value = "";
       this.props.addExpression(value);
     };
 
@@ -199,6 +199,7 @@ class Expressions extends PureComponent<Props, State> {
           className="input-expression"
           type="text"
           placeholder={L10N.getStr("expressions.placeholder")}
+          onBlur={e => (e.target.value = "")}
           onKeyPress={onKeyPress}
         />
       </li>

--- a/src/components/SecondaryPanes/Expressions.js
+++ b/src/components/SecondaryPanes/Expressions.js
@@ -9,11 +9,10 @@ import { bindActionCreators } from "redux";
 import actions from "../../actions";
 import { getExpressions, getLoadedObjects } from "../../selectors";
 import { getValue } from "../../utils/expressions";
-import * as parser from "../../workers/parser";
+import { hasSyntaxError } from "../../workers/parser";
 import CloseButton from "../shared/Button/Close";
 import { ObjectInspector } from "devtools-reps";
 
-import classnames from "classnames";
 import "./Expressions.css";
 
 import type { List } from "immutable";
@@ -168,7 +167,8 @@ class Expressions extends PureComponent<Props, State> {
 
   renderNewExpressionInput() {
     const onKeyPress = async e => {
-      e.target.style.color = "black";
+      e.target.className = "input-expression";
+
       if (e.key !== "Enter") {
         return;
       }
@@ -181,25 +181,22 @@ class Expressions extends PureComponent<Props, State> {
       e.persist();
       e.stopPropagation();
 
-      const error = await parser.hasSyntaxError(value);
-      this.setState({ error });
+      const syntaxError = await hasSyntaxError(value);
+      this.setState({ error: syntaxError });
 
-      if (error) {
-        e.target.value = value;
-        e.target.style.color = "red";
-        alert("'" + value + "' " + " Cannot be added, has syntax error");
+      if (syntaxError) {
+        e.target.className = "input-expression-error";
         return;
-      } else {
-        e.target.value = "";
-        this.props.addExpression(value);
       }
+
+      e.target.value = "";
+      this.props.addExpression(value);
     };
 
-    const { error } = this.state;
     return (
       <li className="expression-input-container">
         <input
-          className={classnames("input-expression", { error })}
+          className="input-expression"
           type="text"
           placeholder={L10N.getStr("expressions.placeholder")}
           onKeyPress={onKeyPress}

--- a/src/components/SecondaryPanes/Expressions.js
+++ b/src/components/SecondaryPanes/Expressions.js
@@ -199,7 +199,6 @@ class Expressions extends PureComponent<Props, State> {
           className="input-expression"
           type="text"
           placeholder={L10N.getStr("expressions.placeholder")}
-          onBlur={e => (e.target.value = "")}
           onKeyPress={onKeyPress}
         />
       </li>

--- a/src/components/SecondaryPanes/Expressions.js
+++ b/src/components/SecondaryPanes/Expressions.js
@@ -8,15 +8,7 @@ import { connect } from "react-redux";
 import classnames from "classnames";
 import { ObjectInspector } from "devtools-reps";
 
-import {
-  addExpression as _addExpression,
-  setExpressionError as _setExpressionError,
-  evaluateExpressions as _evaluateExpressions,
-  updateExpression as _updateExpression,
-  deleteExpression as _deleteExpression
-} from "../../actions/expressions";
-import { loadObjectProperties as loadObjectProps } from "../../actions/pause";
-import { openLink as _openLink } from "../../actions/toolbox";
+import actions from "../../actions";
 import {
   getExpressions,
   getExpressionError,
@@ -41,7 +33,7 @@ type Props = {
   expressionError: boolean,
   loadedObjects: Map<string, any>,
   addExpression: (input: string) => void,
-  setExpressionError: (value: boolean) => void,
+  clearExpressionError: () => void,
   evaluateExpressions: () => void,
   updateExpression: (input: string, expression: Expression) => void,
   deleteExpression: (expression: Expression) => void,
@@ -71,7 +63,7 @@ class Expressions extends PureComponent<Props, State> {
 
   clear = () => {
     this.setState(() => {
-      this.props.setExpressionError(false);
+      this.props.clearExpressionError();
       return { editing: false, editIndex: -1, inputValue: "" };
     });
   };
@@ -275,13 +267,5 @@ export default connect(
     expressionError: getExpressionError(state),
     loadedObjects: getLoadedObjects(state)
   }),
-  {
-    addExpression: _addExpression,
-    setExpressionError: _setExpressionError,
-    evaluateExpressions: _evaluateExpressions,
-    updateExpression: _updateExpression,
-    deleteExpression: _deleteExpression,
-    loadObjectProperties: loadObjectProps,
-    openLink: _openLink
-  }
+  actions
 )(Expressions);

--- a/src/components/SecondaryPanes/Expressions.js
+++ b/src/components/SecondaryPanes/Expressions.js
@@ -168,6 +168,7 @@ class Expressions extends PureComponent<Props, State> {
 
   renderNewExpressionInput() {
     const onKeyPress = async e => {
+      e.target.style.color = "black";
       if (e.key !== "Enter") {
         return;
       }
@@ -177,30 +178,30 @@ class Expressions extends PureComponent<Props, State> {
         return;
       }
 
+      e.persist();
       e.stopPropagation();
-      e.target.value = "";
 
       const error = await parser.hasSyntaxError(value);
       this.setState({ error });
 
       if (error) {
-        // for debugging only
-        console.log("has syntax error");
+        e.target.value = value;
+        e.target.style.color = "red";
+        alert("'" + value + "' " + " Cannot be added, has syntax error");
         return;
+      } else {
+        e.target.value = "";
+        this.props.addExpression(value);
       }
-
-      this.props.addExpression(value);
     };
 
     const { error } = this.state;
     return (
       <li className="expression-input-container">
         <input
-          className="input-expression"
           className={classnames("input-expression", { error })}
           type="text"
           placeholder={L10N.getStr("expressions.placeholder")}
-          onBlur={e => (e.target.value = "")}
           onKeyPress={onKeyPress}
         />
       </li>

--- a/src/components/SecondaryPanes/tests/__snapshots__/Expressions.spec.js.snap
+++ b/src/components/SecondaryPanes/tests/__snapshots__/Expressions.spec.js.snap
@@ -87,13 +87,28 @@ exports[`Expressions should always have unique keys 1`] = `
   <li
     className="expression-input-container"
   >
-    <input
-      className="input-expression"
-      onBlur={[Function]}
-      onKeyPress={[Function]}
-      placeholder="Add watch expression"
-      type="text"
-    />
+    <form
+      className="expression-input-form"
+      onSubmit={[Function]}
+    >
+      <input
+        className="input-expression"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onKeyDown={[Function]}
+        placeholder="Add watch expression"
+        type="text"
+        value=""
+      />
+      <input
+        style={
+          Object {
+            "display": "none",
+          }
+        }
+        type="submit"
+      />
+    </form>
   </li>
 </ul>
 `;
@@ -185,13 +200,28 @@ exports[`Expressions should render 1`] = `
   <li
     className="expression-input-container"
   >
-    <input
-      className="input-expression"
-      onBlur={[Function]}
-      onKeyPress={[Function]}
-      placeholder="Add watch expression"
-      type="text"
-    />
+    <form
+      className="expression-input-form"
+      onSubmit={[Function]}
+    >
+      <input
+        className="input-expression"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onKeyDown={[Function]}
+        placeholder="Add watch expression"
+        type="text"
+        value=""
+      />
+      <input
+        style={
+          Object {
+            "display": "none",
+          }
+        }
+        type="submit"
+      />
+    </form>
   </li>
 </ul>
 `;

--- a/src/reducers/expressions.js
+++ b/src/reducers/expressions.js
@@ -37,23 +37,21 @@ function update(
 ): Record<ExpressionState> {
   switch (action.type) {
     case "ADD_EXPRESSION":
+      if (action.expressionError) {
+        return state.set("expressionError", !!action.expressionError);
+      }
       return appendToList(state, ["expressions"], {
         input: action.input,
         value: null,
         updating: true
       });
-    case "EXPRESSION_ERROR":
-      if (state.get("expressionError") === action.value) {
-        return state;
-      }
-      return state.set("expressionError", action.value);
     case "UPDATE_EXPRESSION":
       const key = action.expression.input;
       return updateItemInList(state, ["expressions"], key, {
         input: action.input,
         value: null,
         updating: true
-      });
+      }).set("expressionError", !!action.expressionError);
     case "EVALUATE_EXPRESSION":
       return updateItemInList(state, ["expressions"], action.input, {
         input: action.input,
@@ -62,6 +60,8 @@ function update(
       });
     case "DELETE_EXPRESSION":
       return deleteExpression(state, action.input);
+    case "CLEAR_EXPRESSION_ERROR":
+      return state.set("expressionError", false);
   }
 
   return state;

--- a/src/reducers/expressions.js
+++ b/src/reducers/expressions.js
@@ -20,12 +20,14 @@ import type { Action } from "../actions/types";
 import type { Record } from "../utils/makeRecord";
 
 type ExpressionState = {
-  expressions: List<Expression>
+  expressions: List<Expression>,
+  expressionError: boolean
 };
 
 export const State = makeRecord(
   ({
-    expressions: List(restoreExpressions())
+    expressions: List(restoreExpressions()),
+    expressionError: false
   }: ExpressionState)
 );
 
@@ -40,6 +42,11 @@ function update(
         value: null,
         updating: true
       });
+    case "EXPRESSION_ERROR":
+      if (state.get("expressionError") === action.value) {
+        return state;
+      }
+      return state.set("expressionError", action.value);
     case "UPDATE_EXPRESSION":
       const key = action.expression.input;
       return updateItemInList(state, ["expressions"], key, {
@@ -121,5 +128,10 @@ export const getExpressions = createSelector(
 export function getExpression(state: OuterState, input: string) {
   return getExpressions(state).find(exp => exp.input == input);
 }
+
+export const getExpressionError = createSelector(
+  getExpressionsWrapper,
+  expressions => expressions.get("expressionError")
+);
 
 export default update;

--- a/src/workers/parser/utils/formatSymbols.js
+++ b/src/workers/parser/utils/formatSymbols.js
@@ -32,9 +32,7 @@ function summarize(symbol) {
   const names = symbol.specifiers ? symbol.specifiers.join(", ") : "";
   const values = symbol.values ? symbol.values.join(", ") : "";
 
-  return `${loc} ${exprLoc} ${expression} ${name}${params} ${klass} ${names} ${
-    values
-  }`.trim(); // eslint-disable-line max-len
+  return `${loc} ${exprLoc} ${expression} ${name}${params} ${klass} ${names} ${values}`.trim(); // eslint-disable-line max-len
 }
 
 function formatKey(name, symbols) {


### PR DESCRIPTION
Associated Issue: #4524

Here's the Pull Request Doc
https://devtools-html.github.io/debugger.html/CONTRIBUTING.html#pull-requests

### Summary of Changes

* If a syntax error is detected for a watch expression, we don't allow its creation -- we instead highlight the input box red and notify the user that their expression is invalid.

### Test Plan

- [ ] Open a source file
- [x] Highlight an expression, right click it, click add watch expression:
         * if no syntax error. expression should be added to list
         * if syntax error. expression isn't added
- [x] Open watch expression panel, type in an expression to be watched:
         * if no syntax error. expression should be added to list
         * if syntax error, text is coloured red, delete text to go back to normal colour.


Here's the Debugger's Testing doc
https://docs.google.com/document/d/1oBMRxV8A2ag2t22YsQOxTdEv0mXKzIg0tggJjRkU1S0/edit#.
Feel free to improve it!

### Screenshot
<img width="301" alt="screen shot 2017-12-19 at 5 05 27 pm" src="https://user-images.githubusercontent.com/17691158/34181102-f4ecb322-e4de-11e7-8981-b1b131557fd8.png">
