### PR TITLE
Prevent unecessary renders

### DIFF
--- a/src/reducers/ast.js
+++ b/src/reducers/ast.js
@@ -183,8 +183,9 @@ export function getPreview(state: OuterState) {
   return state.ast.get("preview");
 }
 
+const emptySourceMetaData = {};
 export function getSourceMetaData(state: OuterState, sourceId: string) {
-  return state.ast.getIn(["sourceMetaData", sourceId]) || {};
+  return state.ast.getIn(["sourceMetaData", sourceId]) || emptySourceMetaData;
 }
 
 export default update;


### PR DESCRIPTION
Fixes #4692

### Summary of Changes

- the JSX patch introduced sourceMetaData, which when not set would be a new empty object every time, this fixes that by sharing the same object.
- i think it can be a bit cleaner

### Testing

I'd like to add a unit test that adds a source and checks to make sure the editor did not render.