### PR TITLE
Toggle Command Bar Buttons

### DIFF
--- a/assets/panel/prefs.js
+++ b/assets/panel/prefs.js
@@ -46,3 +46,4 @@ pref("devtools.debugger.features.root", false);
 pref("devtools.debugger.features.column-breakpoints", false);
 pref("devtools.debugger.features.map-scopes", true);
 pref("devtools.debugger.features.breakpoints-dropdown", false);
+pref("devtools.debugger.features.remove-command-bar-options", false);

--- a/src/components/SecondaryPanes/CommandBar.js
+++ b/src/components/SecondaryPanes/CommandBar.js
@@ -151,6 +151,10 @@ class CommandBar extends Component<Props> {
     const className = isPaused ? "active" : "disabled";
     const isDisabled = !this.props.pause;
 
+    if (!isPaused) {
+      return;
+    }
+
     return [
       debugBtn(
         this.props.stepOver,

--- a/src/components/SecondaryPanes/CommandBar.js
+++ b/src/components/SecondaryPanes/CommandBar.js
@@ -151,7 +151,7 @@ class CommandBar extends Component<Props> {
     const className = isPaused ? "active" : "disabled";
     const isDisabled = !this.props.pause;
 
-    if (!isPaused) {
+    if (!isPaused && features.removeCommandBarOptions) {
       return;
     }
 
@@ -190,6 +190,10 @@ class CommandBar extends Component<Props> {
         "active",
         L10N.getFormatStr("resumeButtonTooltip", formatKey("resume"))
       );
+    }
+
+    if (features.removeCommandBarOptions) {
+      return;
     }
 
     if (isWaitingOnBreak) {

--- a/src/utils/prefs.js
+++ b/src/utils/prefs.js
@@ -37,6 +37,7 @@ if (isDevelopment()) {
   pref("devtools.debugger.features.column-breakpoints", true);
   pref("devtools.debugger.features.map-scopes", true);
   pref("devtools.debugger.features.breakpoints-dropdown", true);
+  pref("devtools.debugger.features.remove-command-bar-options", true);
 }
 
 export const prefs = new PrefsHelper("devtools", {
@@ -67,7 +68,8 @@ export const features = new PrefsHelper("devtools.debugger.features", {
   root: ["Bool", "root", false],
   columnBreakpoints: ["Bool", "column-breakpoints", false],
   mapScopes: ["Bool", "map-scopes", true],
-  breakpointsDropdown: ["Bool", "breakpoints-dropdown", true]
+  breakpointsDropdown: ["Bool", "breakpoints-dropdown", true],
+  removeCommandBarOptions: ["Bool", "remove-command-bar-options", true]
 });
 
 if (prefs.debuggerPrefsSchemaVersion !== prefsSchemaVersion) {


### PR DESCRIPTION
### Summary of Changes

* Command bar buttons appear only when paused

### Test Plan

- [x] Selecting `Pause on Next Statement` pauses the debugger
- [x] When paused, command bar options are revealed
- [x] Selecting the "resume" command bar options resumes the debugger
- [x] When running, command bar options are hidden

### Screenshots/Videos
![command-bar-options](https://user-images.githubusercontent.com/22062107/32996510-a30822d4-cd51-11e7-88c7-f82be622a251.gif)


