### PR TITLE
Clicking a console link should navigate to the correct line

### DIFF
--- a/assets/panel/panel.js
+++ b/assets/panel/panel.js
@@ -99,7 +99,7 @@ DebuggerPanel.prototype = {
   },
 
   selectSource(sourceURL, sourceLine) {
-    this._actions.selectSourceURL(sourceURL, { line: sourceLine });
+    this._actions.selectSourceURL(sourceURL, { location: { line: sourceLine }});
   },
 
   getSource(sourceURL) {

--- a/src/test/mochitest/browser.ini
+++ b/src/test/mochitest/browser.ini
@@ -79,6 +79,7 @@ skip-if = !e10s # This test is only valid in e10s
 [browser_dbg-chrome-create.js]
 [browser_dbg-chrome-debugging.js]
 [browser_dbg-console.js]
+[browser_dbg-console-link.js]
 [browser_dbg-debugger-buttons.js]
 [browser_dbg-editor-gutter.js]
 [browser_dbg-editor-select.js]

--- a/src/test/mochitest/browser_dbg-console-link.js
+++ b/src/test/mochitest/browser_dbg-console-link.js
@@ -1,0 +1,26 @@
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+// Tests opening the console first, clicking a link
+// opens the editor at the correct location.
+
+async function waitForLink(toolbox) {
+  const { hud } = toolbox.getPanel("webconsole");
+
+  return waitFor(() =>
+    hud.ui.outputNode.querySelector(".frame-link-source")
+  );
+}
+
+add_task(async function() {
+  const toolbox = await initPane("doc-script-switching.html", "webconsole");
+  const node = await waitForLink(toolbox)
+  node.click();
+
+  await waitFor(() => toolbox.getPanel("jsdebugger"))
+  const dbg = createDebuggerContext(toolbox);
+  await waitForElement(dbg, ".CodeMirror-code > .highlight-line")
+  assertHighlightLocation(dbg, "script-switching-02", 14);
+});

--- a/src/test/mochitest/browser_dbg-pretty-print-console.js
+++ b/src/test/mochitest/browser_dbg-pretty-print-console.js
@@ -5,11 +5,6 @@
 
 // Tests that pretty-printing updates console messages.
 
-async function waitFor(condition) {
-  await BrowserTestUtils.waitForCondition(condition, "waitFor", 10, 500);
-  return condition();
-}
-
 add_task(async function() {
   const dbg = await initDebugger("doc-minified.html");
   invokeInTab("arithmetic");

--- a/src/test/mochitest/browser_dbg-toggling-tools.js
+++ b/src/test/mochitest/browser_dbg-toggling-tools.js
@@ -1,29 +1,9 @@
-// Return a promise with a reference to jsterm, opening the split
-// console if necessary.  This cleans up the split console pref so
-// it won't pollute other tests.
-function getSplitConsole(dbg) {
-  const { toolbox, win } = dbg;
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
 
-  registerCleanupFunction(() => {
-    Services.prefs.clearUserPref("devtools.toolbox.splitconsoleEnabled");
-  });
+"use strict";
 
-  if (!win) {
-    win = toolbox.win;
-  }
-
-  if (!toolbox.splitConsole) {
-    pressKey(dbg, "Escape");
-  }
-
-  return new Promise(resolve => {
-    toolbox.getPanelWhenReady("webconsole").then(() => {
-      ok(toolbox.splitConsole, "Split console is shown.");
-      let jsterm = toolbox.getPanel("webconsole").hud.jsterm;
-      resolve(jsterm);
-    });
-  });
-}
+// Tests that you can switch tools, without losing your editor position
 
 add_task(async function() {
   const dbg = await initDebugger("doc-scripts.html");

--- a/src/test/mochitest/examples/script-switching-02.js
+++ b/src/test/mochitest/examples/script-switching-02.js
@@ -11,3 +11,4 @@ function secondCall() {
 }
 
 var x = true;
+console.log("hi")

--- a/src/test/mochitest/head.js
+++ b/src/test/mochitest/head.js
@@ -64,6 +64,11 @@ function logThreadEvents(dbg, event) {
   });
 }
 
+async function waitFor(condition) {
+  await BrowserTestUtils.waitForCondition(condition, "waitFor", 10, 500);
+  return condition();
+}
+
 // Wait until an action of `type` is dispatched. This is different
 // then `_afterDispatchDone` because it doesn't wait for async actions
 // to be done/errored. Use this if you want to listen for the "start"
@@ -342,6 +347,7 @@ function assertHighlightLocation(dbg, source, line) {
   // Check the highlight line
   const lineEl = findElement(dbg, "highlightLine");
   ok(lineEl, "Line is highlighted");
+
   ok(isVisibleInEditor(dbg, lineEl), "Highlighted line is visible");
   ok(
     getCM(dbg)
@@ -491,12 +497,15 @@ function clearDebuggerPreferences() {
  * @return {Promise} dbg
  * @static
  */
-function initDebugger(url) {
-  return Task.spawn(function*() {
-    clearDebuggerPreferences();
-    const toolbox = yield openNewTabAndToolbox(EXAMPLE_URL + url, "jsdebugger");
-    return createDebuggerContext(toolbox);
-  });
+async function initDebugger(url) {
+  clearDebuggerPreferences();
+  const toolbox = await openNewTabAndToolbox(EXAMPLE_URL + url, "jsdebugger");
+  return createDebuggerContext(toolbox);
+}
+
+async function initPane(url, pane) {
+  clearDebuggerPreferences();
+  return openNewTabAndToolbox(EXAMPLE_URL + url, pane);
 }
 
 window.resumeTest = undefined;


### PR DESCRIPTION
Associated Issue: #3411

### Summary of Changes

When we switched to selectSource accepting a location we missed some call sites. This fixes that an adds a mochitest.
