### PR TITLE
Throttle new sources

### DIFF
--- a/src/actions/sources.js
+++ b/src/actions/sources.js
@@ -101,8 +101,15 @@ export function newSources(sources: Source[]) {
       source => !getSource(getState(), source.id)
     );
 
+    dispatch({
+      type: "ADD_SOURCES",
+      sources
+    });
+
     for (const source of filteredSources) {
-      await dispatch(newSource(source));
+      await dispatch(loadSourceMap(source));
+      await checkSelectedSource(getState(), dispatch, source);
+      await checkPendingBreakpoints(getState(), dispatch, source.id);
     }
   };
 }
@@ -113,7 +120,11 @@ export function newSources(sources: Source[]) {
  */
 function loadSourceMap(generatedSource) {
   return async function({ dispatch, getState, sourceMaps }: ThunkArgs) {
-    const urls = await sourceMaps.getOriginalURLs(generatedSource);
+    let urls = null;
+    try {
+      urls = await sourceMaps.getOriginalURLs(generatedSource);
+    } catch (e) {}
+
     if (!urls) {
       // If this source doesn't have a sourcemap, do nothing.
       return;

--- a/src/actions/sources.js
+++ b/src/actions/sources.js
@@ -101,9 +101,13 @@ export function newSources(sources: Source[]) {
       source => !getSource(getState(), source.id)
     );
 
+    if (filteredSources.length == 0) {
+      return;
+    }
+
     dispatch({
       type: "ADD_SOURCES",
-      sources
+      sources: filteredSources
     });
 
     for (const source of filteredSources) {
@@ -120,10 +124,7 @@ export function newSources(sources: Source[]) {
  */
 function loadSourceMap(generatedSource) {
   return async function({ dispatch, getState, sourceMaps }: ThunkArgs) {
-    let urls = null;
-    try {
-      urls = await sourceMaps.getOriginalURLs(generatedSource);
-    } catch (e) {}
+    const urls = await sourceMaps.getOriginalURLs(generatedSource);
 
     if (!urls) {
       // If this source doesn't have a sourcemap, do nothing.

--- a/src/client/firefox/events.js
+++ b/src/client/firefox/events.js
@@ -12,6 +12,7 @@ import type {
   Actions
 } from "./types";
 
+import { throttle } from "lodash";
 import { createPause, createSource } from "./create";
 import { isEnabled } from "devtools-config";
 
@@ -61,8 +62,17 @@ function resumed(_: "resumed", packet: ResumedPacket) {
   actions.resumed(packet);
 }
 
+let pendingSources = [];
+const newSources = throttle(() => {
+  actions.newSources(
+    pendingSources.map(source => createSource(source, { supportsWasm }))
+  );
+  pendingSources = [];
+}, 100);
+
 function newSource(_: "newSource", { source }: SourcePacket) {
-  actions.newSource(createSource(source, { supportsWasm }));
+  pendingSources.push(source);
+  newSources();
 
   if (isEnabled("eventListeners")) {
     actions.fetchEventListeners();

--- a/src/client/firefox/events.js
+++ b/src/client/firefox/events.js
@@ -54,6 +54,7 @@ async function paused(_: "paused", packet: PausedPacket) {
 
   if (why.type != "alreadyPaused") {
     const pause = createPause(packet, response);
+    newSources.flush();
     actions.paused(pause);
   }
 }

--- a/src/client/firefox/types.js
+++ b/src/client/firefox/types.js
@@ -221,7 +221,7 @@ export type ListTabsResponse = {
 export type Actions = {
   paused: Pause => void,
   resumed: ResumedPacket => void,
-  newSource: Source => void,
+  newSources: (Source[]) => void,
   fetchEventListeners: () => void
 };
 

--- a/src/reducers/sources.js
+++ b/src/reducers/sources.js
@@ -55,16 +55,14 @@ function update(
 
   switch (action.type) {
     case "ADD_SOURCE": {
-      const source = action.source;
-      return updateSource(state, source);
+      return updateSource(state, action.source);
     }
 
     case "ADD_SOURCES": {
-      action.sources.forEach(source => {
-        state = state.mergeIn(["sources", source.id], source);
-      });
-
-      return state;
+      return action.sources.reduce(
+        (state, source) => updateSource(state, source),
+        state
+      );
     }
 
     case "SELECT_SOURCE":

--- a/src/reducers/sources.js
+++ b/src/reducers/sources.js
@@ -60,7 +60,7 @@ function update(
 
     case "ADD_SOURCES": {
       return action.sources.reduce(
-        (state, source) => updateSource(state, source),
+        (newState, source) => updateSource(newState, source),
         state
       );
     }

--- a/src/test/mochitest/browser_dbg-breaking.js
+++ b/src/test/mochitest/browser_dbg-breaking.js
@@ -13,7 +13,7 @@ add_task(async function() {
   reload(dbg);
   await waitForPaused(dbg);
 
-  await waitForLoadedSource(dbg, "doc-scripts.html");
+  await waitForSelectedSource(dbg, "doc-scripts.html");
   assertPausedLocation(dbg);
   await resume(dbg);
 


### PR DESCRIPTION
Associated Issue: #4705 

### Summary of Changes

This throttles the firefox newSource event so that we fire at most one newSources action every 50ms. 

* Not sure if we need a test
* Not sure if we want to debounce in the event or the actions. Events seem easier now

The performance savings is significant ⏲ 

#### No throttling, w/o the editor fix

~ 9 seconds. Lots of thrashing here :P

<img width="1269" alt="screen shot 2017-11-20 at 11 44 04 am" src="https://user-images.githubusercontent.com/254562/33030313-012c8098-cde9-11e7-8d0b-41027a0eaa7b.png">

#### Throttling w/o the editor fix

3 seconds. The editor update holds up the main thread so we also do more newSources calls :) vicious cycle

<img width="830" alt="screen shot 2017-11-20 at 11 47 12 am" src="https://user-images.githubusercontent.com/254562/33030451-55745ea0-cde9-11e7-9907-1a91bcb38e55.png">

#### Throttling w/ the editor fix

1.5 sec

<img width="1128" alt="screen shot 2017-11-20 at 11 48 40 am" src="https://user-images.githubusercontent.com/254562/33030462-5cff6908-cde9-11e7-81b4-5a4e345cdfb6.png">
