### PR TITLE
Fix weird position of 'X' close button

### DIFF
--- a/src/components/SecondaryPanes/Expressions.css
+++ b/src/components/SecondaryPanes/Expressions.css
@@ -63,10 +63,6 @@
   top: 0px;
 }
 
-.expression-container__close-btn .close-btn {
-  /* margin-top: 2px; */
-}
-
 .expression-content {
   position: relative;
 }

--- a/src/components/SecondaryPanes/Expressions.css
+++ b/src/components/SecondaryPanes/Expressions.css
@@ -64,7 +64,7 @@
 }
 
 .expression-container__close-btn .close-btn {
-  margin-top: 2px;
+  /* margin-top: 2px; */
 }
 
 .expression-content {


### PR DESCRIPTION
Associated Issue: #4688

### Summary of Changes

* remove `margin-top` from the container in order to fix vertical positioning. Fixed only positioning for the 'Watch Expression' panel.

Example test plan:

- [x] Verify that it is a unique class.
- [x] test the veiw and validate that the button is aligned.

#goodnessSquad
