### PR TITLE
Search sources autocomplete functionality is accessible (#4071)

### DIFF
--- a/src/components/shared/ResultList.js
+++ b/src/components/shared/ResultList.js
@@ -16,14 +16,16 @@ type Props = {
     item: any,
     index: number
   ) => void,
-  size: string
+  size: string,
+  role: string
 };
 
 export default class ResultList extends Component<Props> {
   displayName: "ResultList";
 
   static defaultProps = {
-    size: "small"
+    size: "small",
+    role: "listbox"
   };
 
   constructor(props: Props) {
@@ -38,6 +40,7 @@ export default class ResultList extends Component<Props> {
       key: `${item.id}${item.value}${index}`,
       ref: String(index),
       title: item.value,
+      role: "option",
       className: classnames("result-item", {
         selected: index === selected
       })
@@ -52,10 +55,10 @@ export default class ResultList extends Component<Props> {
   }
 
   render() {
-    const { size, items } = this.props;
+    const { size, items, role } = this.props;
 
     return (
-      <ul className={classnames("result-list", size)}>
+      <ul className={classnames("result-list", size)} role={role}>
         {items.map(this.renderListItem)}
       </ul>
     );

--- a/src/components/shared/ResultList.js
+++ b/src/components/shared/ResultList.js
@@ -58,7 +58,15 @@ export default class ResultList extends Component<Props> {
     const { size, items, role } = this.props;
 
     return (
-      <ul className={classnames("result-list", size)} role={role}>
+      <ul
+        className={classnames("result-list", size)}
+        role={role}
+        aria-activedescendant={
+          typeof items !== undefined && items.length > 0
+            ? items[selected].id + "-title"
+            : null
+        }
+      >
         {items.map(this.renderListItem)}
       </ul>
     );

--- a/src/components/shared/ResultList.js
+++ b/src/components/shared/ResultList.js
@@ -40,6 +40,8 @@ export default class ResultList extends Component<Props> {
       key: `${item.id}${item.value}${index}`,
       ref: String(index),
       title: item.value,
+      "aria-labelledby": `${item.id}-title`,
+      "aria-describedby": `${item.id}-subtitle`,
       role: "option",
       className: classnames("result-item", {
         selected: index === selected
@@ -48,8 +50,12 @@ export default class ResultList extends Component<Props> {
 
     return (
       <li {...props}>
-        <div className="title">{item.title}</div>
-        <div className="subtitle">{item.subtitle}</div>
+        <div id={`${item.id}-title`} className="title">
+          {item.title}
+        </div>
+        <div id={`${item.id}-subtitle`} className="subtitle">
+          {item.subtitle}
+        </div>
       </li>
     );
   }

--- a/src/components/shared/ResultList.js
+++ b/src/components/shared/ResultList.js
@@ -61,7 +61,7 @@ export default class ResultList extends Component<Props> {
   }
 
   render() {
-    const { size, items, role } = this.props;
+    const { size, items, role, selected } = this.props;
 
     return (
       <ul

--- a/src/components/shared/ResultList.js
+++ b/src/components/shared/ResultList.js
@@ -72,6 +72,8 @@ export default class ResultList extends Component<Props> {
             ? items[selected].id + "-title"
             : null
         }
+        aria-expanded={typeof items !== undefined && items.length > 0}
+        aria-live="polite"
       >
         {items.map(this.renderListItem)}
       </ul>

--- a/src/components/shared/SearchInput.js
+++ b/src/components/shared/SearchInput.js
@@ -139,6 +139,8 @@ class SearchInput extends Component {
       onKeyUp,
       onFocus,
       onBlur,
+      "aria-autocomplete": "list",
+      "aria-controls": "result-list",
       placeholder,
       value: query,
       spellCheck: false,


### PR DESCRIPTION
Associated Issue: #4071

### Summary of Changes

- [x] aria-autocomplete="list" added in the search input field
- [x] aria-controls= ‘result-list’ added in the search input
- [x] aria-expanded added to show when the results are shown/hidden
- [x] aria-live="polite" added to result-list
- [x] result-list has a role of 'listbox' and each individual result has a role of 'option'.
- [x] aria-activedescendant points to the ID of the currently highlighted result item.
- [x]  aria-labelledby points to ".title" child and aria-describedby points to ".subttitle" using IDs.
 
### Test Plan

We used ChromeVox for Google Chrome as our screenreader. 

Example test plan:
1. Open TodoMVC example

From debugger:

2. Command-P opens the panel
3. type in ‘js’
4. you should here the first result’s filepath
5. you should be read the next items filepath as you scroll through the result list