### PR TITLE
#4756 Remove stray line

### DIFF
--- a/src/components/Editor/Editor.css
+++ b/src/components/Editor/Editor.css
@@ -9,7 +9,7 @@
   --editor-second-searchbar-height: 27px;
   --debug-line-error-border: rgb(255, 0, 0);
   --debug-expression-error-background: rgba(231, 116, 113, 0.3);
-  --editor-header-height: 29px;
+  --editor-header-height: 30px;
 }
 
 .theme-dark .editor-wrapper {

--- a/src/components/Editor/Editor.css
+++ b/src/components/Editor/Editor.css
@@ -9,7 +9,7 @@
   --editor-second-searchbar-height: 27px;
   --debug-line-error-border: rgb(255, 0, 0);
   --debug-expression-error-background: rgba(231, 116, 113, 0.3);
-  --editor-header-height: 30px;
+  --editor-header-height: 29px;
 }
 
 .theme-dark .editor-wrapper {

--- a/src/components/Editor/Tabs.css
+++ b/src/components/Editor/Tabs.css
@@ -5,7 +5,7 @@
 .source-header {
   border-bottom: 1px solid var(--theme-splitter-color);
   width: 100%;
-  height: 29px;
+  height: 30px;
   display: flex;
   align-items: flex-end;
 }

--- a/src/components/PrimaryPanes/Sources.css
+++ b/src/components/PrimaryPanes/Sources.css
@@ -93,7 +93,7 @@
   -moz-user-select: none;
   user-select: none;
   box-sizing: border-box;
-  height: 29px;
+  height: 30px;
 }
 
 .source-outline-tabs .tab {

--- a/src/components/SecondaryPanes/CommandBar.css
+++ b/src/components/SecondaryPanes/CommandBar.css
@@ -3,7 +3,7 @@
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
 .command-bar {
-  flex: 0 0 29px;
+  flex: 0 0 30px;
   border-bottom: 1px solid var(--theme-splitter-color);
   display: flex;
   overflow: hidden;


### PR DESCRIPTION
Associated Issue: #4756 

### Summary of Changes
Modified header variable to actually match the given value: https://github.com/devtools-html/debugger.html/blob/master/src/components/Editor/Tabs.css#L8

### Test Plan
Visual change, looks neat now.

### Screenshot
The issue was actually always there, not just in the dark theme. See the picture below:
![purple](https://user-images.githubusercontent.com/13036803/33093741-c2bb3eea-cef5-11e7-8fb7-0af2f6bdbc19.png)

It was not obvious in the other themes because the background was white.