### PR TITLE
Toggle Panes on Pause

### DIFF
--- a/assets/panel/prefs.js
+++ b/assets/panel/prefs.js
@@ -46,3 +46,4 @@ pref("devtools.debugger.features.root", false);
 pref("devtools.debugger.features.column-breakpoints", false);
 pref("devtools.debugger.features.map-scopes", true);
 pref("devtools.debugger.features.breakpoints-dropdown", false);
+pref("devtools.debugger.features.remove-command-bar-options", false);

--- a/src/actions/sources.js
+++ b/src/actions/sources.js
@@ -208,7 +208,12 @@ export function selectSource(id: string, options: SelectSourceOptions = {}) {
         await dispatch(loadSourceText(source.toJS()));
         await dispatch(setOutOfScopeLocations());
         const src = getSource(getState(), id).toJS();
-        if (shouldPrettyPrint(src) && isMinified(src.id, src.text)) {
+        const { autoPrettyPrint } = prefs;
+        if (
+          autoPrettyPrint &&
+          shouldPrettyPrint(src) &&
+          isMinified(src.id, src.text)
+        ) {
           await dispatch(togglePrettyPrint(src.id));
         }
       })()

--- a/src/components/Editor/Breakpoints.js
+++ b/src/components/Editor/Breakpoints.js
@@ -57,9 +57,7 @@ class Breakpoints extends Component<Props> {
   }
 }
 
-export default connect(
-  state => ({
-    breakpoints: getVisibleBreakpoints(state),
-    selectedSource: getSelectedSource(state)
-  }),
-)(Breakpoints);
+export default connect(state => ({
+  breakpoints: getVisibleBreakpoints(state),
+  selectedSource: getSelectedSource(state)
+}))(Breakpoints);

--- a/src/components/Editor/Tabs.js
+++ b/src/components/Editor/Tabs.js
@@ -427,7 +427,7 @@ class SourceTabs extends PureComponent<Props, State> {
 
     const Panel = <ul>{hiddenSourceTabs.map(this.renderDropdownSource)}</ul>;
 
-    return <Dropdown panel={Panel} icon={"»"}/>;
+    return <Dropdown panel={Panel} icon={"»"} />;
   }
 
   renderStartPanelToggleButton() {

--- a/src/components/PrimaryPanes/SourcesTree.js
+++ b/src/components/PrimaryPanes/SourcesTree.js
@@ -232,6 +232,10 @@ class SourcesTree extends Component<Props, State> {
       return <Svg name="webpack" />;
     }
 
+    if (item.path === "/Angular") {
+      return <Svg name="angular" />;
+    }
+
     if (depth === 0) {
       return (
         <img

--- a/src/components/ProjectSearch/TextSearch.js
+++ b/src/components/ProjectSearch/TextSearch.js
@@ -16,8 +16,26 @@ import "./TextSearch.css";
 import { getRelativePath } from "../../utils/sources-tree";
 import { highlightMatches } from "./textSearch/utils/highlight";
 import { statusType } from "../../reducers/project-text-search";
+import type { StatusType } from "../../reducers/project-text-search";
 
-export default class TextSearch extends Component {
+type Match = Object;
+type Result = {
+  filepath: string,
+  matches: Array<Match>,
+  sourceId: string
+};
+
+type Props = {
+  results: Result[],
+  status: StatusType,
+  query: string,
+  closeProjectSearch: Function,
+  searchSources: Function,
+  selectSource: Function,
+  searchBottomBar: Object
+};
+
+export default class TextSearch extends Component<Props> {
   constructor(props: Props) {
     super(props);
     this.state = {
@@ -215,17 +233,6 @@ export default class TextSearch extends Component {
     );
   }
 }
-
-TextSearch.propTypes = {
-  sources: PropTypes.object,
-  results: PropTypes.array,
-  status: PropTypes.string,
-  query: PropTypes.string,
-  closeProjectSearch: PropTypes.func,
-  searchSources: PropTypes.func,
-  selectSource: PropTypes.func,
-  searchBottomBar: PropTypes.object
-};
 
 TextSearch.contextTypes = {
   shortcuts: PropTypes.object

--- a/src/components/SecondaryPanes/CommandBar.js
+++ b/src/components/SecondaryPanes/CommandBar.js
@@ -151,6 +151,10 @@ class CommandBar extends Component<Props> {
     const className = isPaused ? "active" : "disabled";
     const isDisabled = !this.props.pause;
 
+    if (!isPaused && features.removeCommandBarOptions) {
+      return;
+    }
+
     return [
       debugBtn(
         this.props.stepOver,
@@ -186,6 +190,10 @@ class CommandBar extends Component<Props> {
         "active",
         L10N.getFormatStr("resumeButtonTooltip", formatKey("resume"))
       );
+    }
+
+    if (features.removeCommandBarOptions) {
+      return;
     }
 
     if (isWaitingOnBreak) {

--- a/src/components/SecondaryPanes/Frames/tests/Frames.js
+++ b/src/components/SecondaryPanes/Frames/tests/Frames.js
@@ -24,7 +24,6 @@ describe("Frames", () => {
   describe("Supports different number of frames", () => {
     it("empty frames", () => {
       const component = render();
-      expect(component).toMatchSnapshot();
       expect(component.find(".show-more").exists()).toBeFalsy();
     });
 

--- a/src/components/SecondaryPanes/Frames/tests/__snapshots__/Frames.js.snap
+++ b/src/components/SecondaryPanes/Frames/tests/__snapshots__/Frames.js.snap
@@ -228,18 +228,6 @@ exports[`Frames Library Frames toggling framework frames 2`] = `
 </div>
 `;
 
-exports[`Frames Supports different number of frames empty frames 1`] = `
-<div
-  className="pane frames"
->
-  <div
-    className="pane-info empty"
-  >
-    Not paused
-  </div>
-</div>
-`;
-
 exports[`Frames Supports different number of frames one frame 1`] = `
 <div
   className="pane frames"

--- a/src/components/SecondaryPanes/SecondaryPanes.css
+++ b/src/components/SecondaryPanes/SecondaryPanes.css
@@ -65,3 +65,11 @@
   width: 20em;
   overflow: auto;
 }
+
+.secondary-panes .accordion .scopes-pane.inactive {
+  visibility: hidden;
+}
+
+.secondary-panes .accordion .call-stack-pane.inactive {
+  visibility: hidden;
+}

--- a/src/components/SecondaryPanes/index.js
+++ b/src/components/SecondaryPanes/index.js
@@ -9,6 +9,7 @@ import React, { Component } from "react";
 import { connect } from "react-redux";
 import { bindActionCreators } from "redux";
 import { features } from "../../utils/prefs";
+import classnames from "classnames";
 
 import actions from "../../actions";
 import {
@@ -138,16 +139,13 @@ class SecondaryPanes extends Component<Props> {
   }
 
   getScopeItem() {
-
-    if (!this.props.pauseData) {
-      return;
-    }
-
     const isPaused = () => !!this.props.pauseData;
 
     return {
       header: L10N.getStr("scopes.header"),
-      className: "scopes-pane",
+      className: classnames("scopes-pane", {
+        inactive: !this.props.pauseData
+      }),
       component: Scopes,
       opened: prefs.scopesVisible,
       onToggle: opened => {
@@ -193,6 +191,7 @@ class SecondaryPanes extends Component<Props> {
     const scopesContent: any = this.props.horizontal
       ? this.getScopeItem()
       : null;
+
     const items: Array<SecondaryPanesItems> = [
       {
         header: L10N.getStr("breakpoints.header"),
@@ -203,7 +202,9 @@ class SecondaryPanes extends Component<Props> {
       },
       {
         header: L10N.getStr("callStack.header"),
-        className: "call-stack-pane",
+        className: classnames("call-stack-pane", {
+          inactive: !this.props.pauseData
+        }),
         component: Frames,
         opened: prefs.callStackVisible,
         onToggle: opened => {

--- a/src/components/SecondaryPanes/index.js
+++ b/src/components/SecondaryPanes/index.js
@@ -138,6 +138,11 @@ class SecondaryPanes extends Component<Props> {
   }
 
   getScopeItem() {
+
+    if (!this.props.pauseData) {
+      return;
+    }
+
     const isPaused = () => !!this.props.pauseData;
 
     return {

--- a/src/components/shared/Svg.css
+++ b/src/components/shared/Svg.css
@@ -115,3 +115,14 @@ html .arrow.expanded svg {
 .theme-dark .webpack {
   opacity: 0.5;
 }
+
+.angular svg {
+  width: 15px;
+  height: 15px;
+  margin-right: 5px;
+  vertical-align: sub;
+}
+
+.theme-dark .angular {
+  opacity: 0.5;
+}

--- a/src/reducers/project-text-search.js
+++ b/src/reducers/project-text-search.js
@@ -22,7 +22,7 @@ export type Search = {
   filepath: string,
   matches: I.List<any>
 };
-
+export type StatusType = "INITIAL" | "FETCHING" | "DONE" | "ERROR";
 export const statusType = {
   initial: "INITIAL",
   fetching: "FETCHING",

--- a/src/test/mochitest/browser_dbg-call-stack.js
+++ b/src/test/mochitest/browser_dbg-call-stack.js
@@ -1,4 +1,4 @@
-u/* Any copyright is dedicated to the Public Domain.
+/* Any copyright is dedicated to the Public Domain.
  * http://creativecommons.org/publicdomain/zero/1.0/ */
 
 // checks to see if the frame is selected and the title is correct

--- a/src/test/mochitest/browser_dbg-call-stack.js
+++ b/src/test/mochitest/browser_dbg-call-stack.js
@@ -1,4 +1,4 @@
-/* Any copyright is dedicated to the Public Domain.
+u/* Any copyright is dedicated to the Public Domain.
  * http://creativecommons.org/publicdomain/zero/1.0/ */
 
 // checks to see if the frame is selected and the title is correct
@@ -21,9 +21,6 @@ add_task(async function() {
   const dbg = await initDebugger("doc-script-switching.html");
 
   toggleCallStack(dbg);
-
-  const notPaused = findElement(dbg, "callStackBody").innerText;
-  is(notPaused, "Not paused", "Not paused message is shown");
 
   invokeInTab("firstCall");
   await waitForPaused(dbg);

--- a/src/utils/prefs.js
+++ b/src/utils/prefs.js
@@ -37,6 +37,7 @@ if (isDevelopment()) {
   pref("devtools.debugger.features.column-breakpoints", true);
   pref("devtools.debugger.features.map-scopes", true);
   pref("devtools.debugger.features.breakpoints-dropdown", true);
+  pref("devtools.debugger.features.remove-command-bar-options", true);
 }
 
 export const prefs = new PrefsHelper("devtools", {
@@ -67,7 +68,8 @@ export const features = new PrefsHelper("devtools.debugger.features", {
   root: ["Bool", "root", false],
   columnBreakpoints: ["Bool", "column-breakpoints", false],
   mapScopes: ["Bool", "map-scopes", true],
-  breakpointsDropdown: ["Bool", "breakpoints-dropdown", true]
+  breakpointsDropdown: ["Bool", "breakpoints-dropdown", true],
+  removeCommandBarOptions: ["Bool", "remove-command-bar-options", true]
 });
 
 if (prefs.debuggerPrefsSchemaVersion !== prefsSchemaVersion) {

--- a/src/utils/prefs.js
+++ b/src/utils/prefs.js
@@ -12,6 +12,7 @@ const prefsSchemaVersion = "1.0.3";
 const pref = Services.pref;
 
 if (isDevelopment()) {
+  pref("devtools.debugger.auto-pretty-print", true);
   pref("devtools.source-map.client-service.enabled", true);
   pref("devtools.debugger.pause-on-exceptions", false);
   pref("devtools.debugger.ignore-caught-exceptions", false);
@@ -39,6 +40,7 @@ if (isDevelopment()) {
 }
 
 export const prefs = new PrefsHelper("devtools", {
+  autoPrettyPrint: ["Bool", "debugger.auto-pretty-print"],
   clientSourceMapsEnabled: ["Bool", "source-map.client-service.enabled"],
   pauseOnExceptions: ["Bool", "debugger.pause-on-exceptions"],
   ignoreCaughtExceptions: ["Bool", "debugger.ignore-caught-exceptions"],

--- a/src/utils/sources-tree/getURL.js
+++ b/src/utils/sources-tree/getURL.js
@@ -46,6 +46,14 @@ export function getURL(
         filename: filename
       });
 
+    case "ng:":
+      // An Angular source is a special case
+      return merge(def, {
+        path: path,
+        group: "Angular",
+        filename: filename
+      });
+
     case "about:":
       // An about page is a special case
       return merge(def, {


### PR DESCRIPTION
### Summary of Changes

* Call-stack pane and scopes pane hidden if debugger is not paused

### Test Plan

- [x] Pausing the debugger reveals call-stack pane and scopes pane
- [x] Clicking the down arrow reveals call-stack and scope(s)
- [x] Resuming the debugger hides call-stack and scopes pane
- [x] Pausing the debugger again displays panes in the same state (open/closed) as the previous pause

### Screenshots/Videos (OPTIONAL)

A few test cases:
1. Neither pane is open when resumed (clean resume)
2. One of the panes are open when resumed (minor choppy resume)
3. Both panes are open when resumed (visible choppiness on resume)

- Cases 1 and 3 are displayed bellow

![toggle-panes](https://user-images.githubusercontent.com/22062107/33109252-881f82dc-cf0e-11e7-94a6-fdefc300f6c8.gif)

