### PR TITLE
use newSources for sourcemapped sources

### DIFF
--- a/src/actions/sources.js
+++ b/src/actions/sources.js
@@ -144,6 +144,9 @@ function loadSourceMap(generatedSource) {
         }: Source)
     );
 
+    // TODO: check if this line is really needed, it introduces
+    // a lot of lag to the application.
+    await dispatch(loadSourceText(generatedSource));
     dispatch(newSources(originalSources));
   };
 }

--- a/src/actions/sources.js
+++ b/src/actions/sources.js
@@ -144,13 +144,7 @@ function loadSourceMap(generatedSource) {
         }: Source)
     );
 
-    dispatch({ type: "ADD_SOURCES", sources: originalSources });
-
-    await dispatch(loadSourceText(generatedSource));
-    originalSources.forEach(async source => {
-      await checkSelectedSource(getState(), dispatch, source);
-      checkPendingBreakpoints(getState(), dispatch, source.id);
-    });
+    dispatch(newSources(originalSources));
   };
 }
 


### PR DESCRIPTION
there was an issue in which new sources that are added via sourcemapped
sources, would disappear on reload.
