### PR TITLE
Toggle Panes on Pause

### DIFF
--- a/src/components/SecondaryPanes/Frames/tests/Frames.js
+++ b/src/components/SecondaryPanes/Frames/tests/Frames.js
@@ -24,7 +24,6 @@ describe("Frames", () => {
   describe("Supports different number of frames", () => {
     it("empty frames", () => {
       const component = render();
-      expect(component).toMatchSnapshot();
       expect(component.find(".show-more").exists()).toBeFalsy();
     });
 

--- a/src/components/SecondaryPanes/Frames/tests/__snapshots__/Frames.js.snap
+++ b/src/components/SecondaryPanes/Frames/tests/__snapshots__/Frames.js.snap
@@ -228,18 +228,6 @@ exports[`Frames Library Frames toggling framework frames 2`] = `
 </div>
 `;
 
-exports[`Frames Supports different number of frames empty frames 1`] = `
-<div
-  className="pane frames"
->
-  <div
-    className="pane-info empty"
-  >
-    Not paused
-  </div>
-</div>
-`;
-
 exports[`Frames Supports different number of frames one frame 1`] = `
 <div
   className="pane frames"

--- a/src/components/SecondaryPanes/SecondaryPanes.css
+++ b/src/components/SecondaryPanes/SecondaryPanes.css
@@ -65,3 +65,11 @@
   width: 20em;
   overflow: auto;
 }
+
+.secondary-panes .accordion .scopes-pane.inactive {
+  visibility: hidden;
+}
+
+.secondary-panes .accordion .call-stack-pane.inactive {
+  visibility: hidden;
+}

--- a/src/components/SecondaryPanes/index.js
+++ b/src/components/SecondaryPanes/index.js
@@ -9,6 +9,7 @@ import React, { Component } from "react";
 import { connect } from "react-redux";
 import { bindActionCreators } from "redux";
 import { features } from "../../utils/prefs";
+import classnames from "classnames";
 
 import actions from "../../actions";
 import {
@@ -142,7 +143,9 @@ class SecondaryPanes extends Component<Props> {
 
     return {
       header: L10N.getStr("scopes.header"),
-      className: "scopes-pane",
+      className: classnames("scopes-pane", {
+        inactive: !this.props.pauseData
+      }),
       component: Scopes,
       opened: prefs.scopesVisible,
       onToggle: opened => {
@@ -198,7 +201,9 @@ class SecondaryPanes extends Component<Props> {
       },
       {
         header: L10N.getStr("callStack.header"),
-        className: "call-stack-pane",
+        className: classnames("call-stack-pane", {
+          inactive: !this.props.pauseData
+        }),
         component: Frames,
         opened: prefs.callStackVisible,
         onToggle: opened => {

--- a/src/test/mochitest/browser_dbg-call-stack.js
+++ b/src/test/mochitest/browser_dbg-call-stack.js
@@ -22,9 +22,6 @@ add_task(async function() {
 
   toggleCallStack(dbg);
 
-  const notPaused = findElement(dbg, "callStackBody").innerText;
-  is(notPaused, "Not paused", "Not paused message is shown");
-
   invokeInTab("firstCall");
   await waitForPaused(dbg);
 


### PR DESCRIPTION
### Summary of Changes

* Call-stack pane and scopes pane hidden if debugger is not paused

### Test Plan

- [x] Pausing the debugger reveals call-stack pane and scopes pane
- [x] Clicking the down arrow reveals call-stack and scope(s)
- [x] Resuming the debugger hides call-stack and scopes pane
- [x] Pausing the debugger again displays panes in the same state (open/closed) as the previous pause

### Screenshots/Videos (OPTIONAL)

A few test cases:
1. Neither pane is open when resumed (clean resume)
2. One of the panes are open when resumed (minor choppy resume)
3. Both panes are open when resumed (visible choppiness on resume)

- Cases 1 and 3 are displayed below (sorry for the blue flashing - my inspector was open)

![toggle-panes](https://user-images.githubusercontent.com/22062107/33109252-881f82dc-cf0e-11e7-94a6-fdefc300f6c8.gif)