### PR TITLE
Editor: close ConditionalPanel before adding breakpoint

### DIFF
--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -265,7 +265,7 @@ class Editor extends PureComponent<Props, State> {
 
   onToggleBreakpoint = (key, e) => {
     e.preventDefault();
-    const { selectedSource } = this.props;
+    const { selectedSource, conditionalPanelLine } = this.props;
 
     if (!selectedSource) {
       return;
@@ -275,7 +275,10 @@ class Editor extends PureComponent<Props, State> {
 
     if (e.shiftKey) {
       this.toggleConditionalPanel(line);
+    } else if (!conditionalPanelLine) {
+      this.props.toggleBreakpoint(line);
     } else {
+      this.toggleConditionalPanel(line);
       this.props.toggleBreakpoint(line);
     }
   };


### PR DESCRIPTION
Associated Issue: #4767 
### Summary of Changes

* Check if ConditonalPanel is open and closing it before trying to set a regular breakpoint