### PR TITLE
Remove breakpoint in codemirror commented line

### DIFF
--- a/src/actions/breakpoints.js
+++ b/src/actions/breakpoints.js
@@ -320,7 +320,7 @@ export function toggleBreakpoint(line: number, column?: number) {
     const bp = getBreakpointAtLocation(state, { line, column });
     const isEmptyLine = isEmptyLineInSource(state, line, selectedSource.toJS());
 
-    if (isEmptyLine || (bp && bp.loading)) {
+    if ((!bp && isEmptyLine) || (bp && bp.loading)) {
       return;
     }
 


### PR DESCRIPTION
Associated Issue: #4534 

Summary of Changes

Toggle breakpoint method has been changed to check existence of breakpoint on commented out line

Test Plan

- Open the source file to be debugged
- Place a breakpoint on any valid line in the file
- Make changes to the source file by commenting out the line where debugger was placed
- Click back in the browser and click on the file to be debugged again (or click forward in browser)
- The breakpoint should be visible on the commented out line
- Click on the breakpoint and it should be removed

