### PR TITLE
Makes new tabs open after old ones

### DIFF
--- a/src/reducers/sources.js
+++ b/src/reducers/sources.js
@@ -216,7 +216,7 @@ function updateTabList(state: OuterState, url: ?string, tabIndex?: number) {
       tabs = tabs.delete(urlIndex).insert(tabIndex, url);
     }
   } else {
-    tabs = tabs.insert(0, url);
+    tabs = tabs.insert(tabs.size, url);
   }
 
   prefs.tabs = tabs.toJS();


### PR DESCRIPTION
Associated Issue: #4794

### Summary of Changes

* Makes new tabs open after old ones by checking the size of the tabs list and using it as reference for opening new ones

### Screenshots/Videos
![new-tab](https://user-images.githubusercontent.com/23530054/33243223-23e35c30-d2e2-11e7-89ba-286143fd79e9.gif)

