### PR TITLE
Fix #4776 - Ensure no whitespace breakage in outline items

### DIFF
--- a/src/components/PrimaryPanes/Outline.css
+++ b/src/components/PrimaryPanes/Outline.css
@@ -40,6 +40,7 @@
   padding-right: 0.5rem;
   padding-top: 0.2rem;
   cursor: default;
+  white-space: nowrap;
 }
 
 .outline-list__element:hover {


### PR DESCRIPTION
Simple fix :)

<img width="262" alt="yay" src="https://user-images.githubusercontent.com/46655/33280435-a9175340-d367-11e7-91c4-8bb27a223727.png">
