### PR TITLE
Ensure the 'jump to' context menu label cases are consistent

### DIFF
--- a/assets/panel/debugger.properties
+++ b/assets/panel/debugger.properties
@@ -75,7 +75,7 @@ pauseButtonItem=Pause on Next Statement
 # when the debugger will not pause on exceptions.
 ignoreExceptionsItem=Ignore exceptions
 
-# LOCALIZATION NOTE (pauseOnUncaughtExceptionsItem): The pause on exceptions dropdown 
+# LOCALIZATION NOTE (pauseOnUncaughtExceptionsItem): The pause on exceptions dropdown
 # item shown when a user is adding a new breakpoint.
 pauseOnUncaughtExceptionsItem=Pause on uncaught exceptions
 
@@ -431,7 +431,7 @@ framework.enableGrouping=Enable framework grouping
 framework.enableGrouping.accesskey=u
 
 # LOCALIZATION NOTE (generated): Source Map term for a server source location
-generated=Generated
+generated=generated
 
 # LOCALIZATION NOTE (original): Source Map term for a debugger UI source location
 original=original


### PR DESCRIPTION
"Jump to Generated location" -> "Jump to generated location"