### PR TITLE
Conditional breakpoint panel responsiveness and visual fixes

### DIFF
--- a/src/components/Editor/ConditionalPanel.css
+++ b/src/components/Editor/ConditionalPanel.css
@@ -11,6 +11,7 @@
   background: var(--theme-toolbar-background);
   border-top: 1px solid var(--theme-splitter-color);
   border-bottom: 1px solid var(--theme-splitter-color);
+  padding-right: 16px;
 }
 
 .conditional-breakpoint-panel .prompt {

--- a/src/components/Editor/ConditionalPanel.js
+++ b/src/components/Editor/ConditionalPanel.js
@@ -30,6 +30,8 @@ type Props = {
 export class ConditionalPanel extends PureComponent<Props> {
   cbPanel: null | Object;
   input: ?HTMLInputElement;
+  panelNode: ?HTMLDivElement;
+  scrollParent: ?HTMLElement;
 
   constructor() {
     super();
@@ -76,9 +78,10 @@ export class ConditionalPanel extends PureComponent<Props> {
   }
 
   repositionOnScroll = () => {
-    const { scrollLeft } = this.scrollParent;
-
-    this.panelNode.style.transform = `translateX(${scrollLeft}px)`;
+    if (this.panelNode && this.scrollParent) {
+      const { scrollLeft } = this.scrollParent;
+      this.panelNode.style.transform = `translateX(${scrollLeft}px)`;
+    }
   };
 
   componentWillUpdate(nextProps: Props) {
@@ -102,20 +105,23 @@ export class ConditionalPanel extends PureComponent<Props> {
       }
     );
     if (this.input) {
-      this.input.focus();
-
-      let parent = this.input.parentNode;
-      while (parent && parent.classList) {
-        parent = parent.parentNode;
-        if (parent.classList.contains("CodeMirror-scroll")) {
+      let parent: ?Node = this.input.parentNode;
+      while (parent) {
+        if (
+          parent instanceof HTMLElement &&
+          parent.classList.contains("CodeMirror-scroll")
+        ) {
           this.scrollParent = parent;
           break;
         }
+        parent = (parent.parentNode: ?Node);
       }
 
       if (this.scrollParent) {
         this.scrollParent.addEventListener("scroll", this.repositionOnScroll);
       }
+
+      this.input.focus();
     }
   }
 

--- a/src/components/Editor/ConditionalPanel.js
+++ b/src/components/Editor/ConditionalPanel.js
@@ -70,7 +70,16 @@ export class ConditionalPanel extends PureComponent<Props> {
       this.cbPanel.clear();
       this.cbPanel = null;
     }
+    if (this.scrollParent) {
+      this.scrollParent.removeEventListener("scroll", this.repositionOnScroll);
+    }
   }
+
+  repositionOnScroll = () => {
+    const { scrollLeft } = this.scrollParent;
+
+    this.panelNode.style.transform = `translateX(${scrollLeft}px)`;
+  };
 
   componentWillUpdate(nextProps: Props) {
     if (nextProps.line) {
@@ -94,6 +103,19 @@ export class ConditionalPanel extends PureComponent<Props> {
     );
     if (this.input) {
       this.input.focus();
+
+      let parent = this.input.parentNode;
+      while (parent && parent.classList) {
+        parent = parent.parentNode;
+        if (parent.classList.contains("CodeMirror-scroll")) {
+          this.scrollParent = parent;
+          break;
+        }
+      }
+
+      if (this.scrollParent) {
+        this.scrollParent.addEventListener("scroll", this.repositionOnScroll);
+      }
     }
   }
 
@@ -106,6 +128,7 @@ export class ConditionalPanel extends PureComponent<Props> {
         className="conditional-breakpoint-panel"
         onClick={() => this.keepFocusOnInput()}
         onBlur={this.props.closeConditionalPanel}
+        ref={node => (this.panelNode = node)}
       >
         <div className="prompt">»</div>
         <input

--- a/src/components/Editor/ConditionalPanel.js
+++ b/src/components/Editor/ConditionalPanel.js
@@ -84,10 +84,23 @@ export class ConditionalPanel extends PureComponent<Props> {
     }
   };
 
+  componentWillMount() {
+    if (this.props.line) {
+      return this.renderToWidget(this.props);
+    }
+  }
+
   componentWillUpdate(nextProps: Props) {
     if (nextProps.line) {
       return this.renderToWidget(nextProps);
     }
+    return this.clearConditionalPanel();
+  }
+
+  componentWillUnmount() {
+    // This is called if CodeMirror is re-initializing itself before the
+    // user closes the conditional panel. Clear the widget, and re-render it
+    // as soon as this component gets remounted
     return this.clearConditionalPanel();
   }
 
@@ -119,6 +132,7 @@ export class ConditionalPanel extends PureComponent<Props> {
 
       if (this.scrollParent) {
         this.scrollParent.addEventListener("scroll", this.repositionOnScroll);
+        this.repositionOnScroll();
       }
 
       this.input.focus();

--- a/src/components/Editor/Editor.css
+++ b/src/components/Editor/Editor.css
@@ -19,6 +19,11 @@
 
 .editor-wrapper .CodeMirror-linewidget {
   margin-right: -7px;
+  overflow: visible;
+}
+
+.editor-wrapper .CodeMirror-sizer {
+  min-width: 0 !important;
 }
 
 .theme-dark {


### PR DESCRIPTION
Associated Issue: #4703 

### Summary of Changes
#### Fixes conditional breakpoint panel shrinking
This is achieved by adding some right padding to the breakpoint panel, and removing the minimum width of the `.CodeMirror-sizer`. I haven't noticed any side effects related to disabling the min-width.
#### Fixes conditional breakpoint panel horizontally when the user scrolls
The gutters seem to be fixed in place the same way: they listen for `scroll` events on the `.CodeMirror-scroll` div, and then move themselves `x` pixels to the left, where `x` is `.CodeMirror-scroll`'s `scrollLeft`. If we need to fix more things this way, we might be able to abstract the scroll-listening logic from `ConditionalPanel.js` in the future.

### Test Plan
- [ ] Open the conditional breakpoint panel
- [ ] Make the screen smaller, and ensure the Close Button (x) is always visible
- [ ] Make the screen small enough so that the horizontal scrollbar appears
- [ ] Scroll from left to right, and ensure the breakpoint panel stays fixed in place

### Screenshots/Videos
#### Firefox
![conditionalpanel](https://user-images.githubusercontent.com/1445834/33291844-d474db50-d38c-11e7-8cfe-e6d3676c1e47.gif)
![firefoxresize](https://user-images.githubusercontent.com/1445834/33383800-d9258c0e-d4e9-11e7-9cef-3e266ac2450c.gif)
#### Chrome
![chromeresize](https://user-images.githubusercontent.com/1445834/33383806-dcfd2a94-d4e9-11e7-96ed-24633243ebdf.gif)
![chromeresize](https://user-images.githubusercontent.com/1445834/33383943-4d12a214-d4ea-11e7-8ea1-78e01e4fe5ee.gif)

(scroll repositioning is a bit jankier in horizontal mode, though the number gutters suffer from this too)

