### PR TITLE
Don't parse symbols for WASM

### DIFF
--- a/src/utils/breakpoint/astBreakpointLocation.js
+++ b/src/utils/breakpoint/astBreakpointLocation.js
@@ -50,6 +50,10 @@ export async function getASTLocation(
   source: Source,
   location: Location
 ): Promise<ASTLocation> {
+  if (source.isWasm) {
+    return { name: undefined, offset: location };
+  }
+
   const symbols = await getSymbols(source);
   const functions = [...symbols.functions];
 


### PR DESCRIPTION
Associated Issue: #4519

### Summary of Changes

* gets shortcut for getASTLocation logic
