### PR TITLE
Fixed whitespace at the bottom of center pane after searching files

### DIFF
--- a/src/components/ProjectSearch/TextSearch.css
+++ b/src/components/ProjectSearch/TextSearch.css
@@ -88,7 +88,7 @@
 
 .project-text-search .managed-tree {
   overflow-y: auto;
-  height: calc(100% - 81px);
+  height: 100%;
 }
 
 .project-text-search .managed-tree .tree {


### PR DESCRIPTION
**Post fix:**
![screenshot from 2017-11-28 14-06-16](https://user-images.githubusercontent.com/24966772/33341714-6e1326e6-d445-11e7-96c4-003d314bf7e2.png)
![screenshot from 2017-11-28 14-06-48](https://user-images.githubusercontent.com/24966772/33341718-70252664-d445-11e7-80de-6da7b5234991.png)

**Prior to fix:**
![screenshot from 2017-11-28 14-19-25](https://user-images.githubusercontent.com/24966772/33342287-398e26a8-d447-11e7-87d1-b6d84767bf49.png)
![screenshot from 2017-11-28 14-19-34](https://user-images.githubusercontent.com/24966772/33342288-3b37667c-d447-11e7-8b58-6e14a1a0e862.png)



