### PR TITLE
Removed PropTypes for Frames/index.js

### DIFF
--- a/src/components/SecondaryPanes/Frames/index.js
+++ b/src/components/SecondaryPanes/Frames/index.js
@@ -4,7 +4,6 @@
 
 // @flow
 
-import PropTypes from "prop-types";
 import React, { Component } from "react";
 import { bindActionCreators } from "redux";
 import { connect } from "react-redux";
@@ -76,7 +75,7 @@ class Frames extends Component<Props, State> {
     this.toggleFrameworkGrouping = this.toggleFrameworkGrouping.bind(this);
   }
 
-  shouldComponentUpdate(nextProps, nextState) {
+  shouldComponentUpdate(nextProps, nextState): boolean {
     const { frames, selectedFrame, frameworkGroupingOn } = this.props;
     const { showAllFrames } = this.state;
     return (
@@ -87,7 +86,7 @@ class Frames extends Component<Props, State> {
     );
   }
 
-  toggleFramesDisplay() {
+  toggleFramesDisplay(): void {
     this.setState({
       showAllFrames: !this.state.showAllFrames
     });
@@ -203,16 +202,6 @@ class Frames extends Component<Props, State> {
     );
   }
 }
-
-Frames.propTypes = {
-  frames: PropTypes.array,
-  frameworkGroupingOn: PropTypes.bool.isRequired,
-  toggleFrameworkGrouping: PropTypes.func.isRequired,
-  selectedFrame: PropTypes.object,
-  selectFrame: PropTypes.func.isRequired,
-  toggleBlackBox: PropTypes.func,
-  pause: PropTypes.object
-};
 
 function getSourceForFrame(sources, frame) {
   return getSourceInSources(sources, frame.location.sourceId);


### PR DESCRIPTION
Associated Issue: #2804 

Here's the Pull Request Doc
https://devtools-html.github.io/debugger.html/CONTRIBUTING.html#pull-requests

### Summary of Changes

* Removed redundant PropTypes declaration. It was already migrated to using flow Props

### Test Plan

Tell us a little a bit about how you tested your patch.

- Opened todoMVC example. 
- put a break anywhere
- resfresh a page to break
- check that secondary panes and frames are working as usual

Here's the Debugger's Testing doc
https://docs.google.com/document/d/1oBMRxV8A2ag2t22YsQOxTdEv0mXKzIg0tggJjRkU1S0/edit#.
Feel free to improve it!

### Screenshots/Videos (OPTIONAL)
![image](https://user-images.githubusercontent.com/69977/33373710-3c5a7d58-d557-11e7-8e8f-d7fb50939dd3.png)
