### PR TITLE
Makes windows with new sources open at line 1 column 1

### DIFF
--- a/src/actions/sources.js
+++ b/src/actions/sources.js
@@ -247,6 +247,11 @@ export function selectLocation(location: Location, tabIndex: string = "") {
 
     dispatch(addTab(source.toJS(), 0));
 
+    if (source.get("loadedState") == "unloaded") {
+      if (!location.line) location.line = 1;
+      if (!location.column) location.column = 1;
+    }
+
     return dispatch({
       type: "SELECT_SOURCE",
       source: source.toJS(),

--- a/src/actions/tests/ast.spec.js
+++ b/src/actions/tests/ast.spec.js
@@ -180,7 +180,9 @@ describe("ast", () => {
         const locations = getOutOfScopeLocations(getState());
         const lines = getInScopeLines(getState());
 
-        expect(locations).toEqual(null);
+        expect(locations).toEqual([
+          { end: { column: 21, line: 1 }, start: { column: 13, line: 1 } }
+        ]);
         expect(lines).toEqual([1]);
       });
     });
@@ -222,8 +224,11 @@ describe("ast", () => {
 
         const locations = getOutOfScopeLocations(getState());
         const lines = getInScopeLines(getState());
-        expect(locations).toEqual(null);
-        expect(lines).toEqual([1, 2, 3]);
+
+        expect(locations).toEqual([
+          { end: { column: 1, line: 2 }, start: { column: 13, line: 1 } }
+        ]);
+        expect(lines).toEqual([2, 3]);
       });
     });
   });

--- a/src/components/Editor/Preview/index.js
+++ b/src/components/Editor/Preview/index.js
@@ -11,6 +11,7 @@ import Popup from "./Popup";
 import {
   getPreview,
   getSelectedSource,
+  getInScopeLines,
   isSelectedFrameVisible
 } from "../../../selectors";
 import actions from "../../../actions";
@@ -134,6 +135,7 @@ export default connect(
   state => ({
     preview: getPreview(state),
     selectedSource: getSelectedSource(state),
+    linesInScope: getInScopeLines(state),
     selectedFrameVisible: isSelectedFrameVisible(state)
   }),
   {

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -442,6 +442,7 @@ class Editor extends PureComponent<Props, State> {
     // to flash the previously saved selected line.
     if (
       line !== null &&
+      this.lastJumpLine !== 1 &&
       this.lastJumpLine !== null &&
       (!selectedFrame || selectedFrame.location.line !== line)
     ) {


### PR DESCRIPTION
Associated Issue: #4393

### Summary of Changes

* Rationale: Due to new tabs opened inheriting scroll state from previously focused tabs we have to manually scroll the container up if the source is new. 
* Makes container scroll to top if `loadedState != loaded` i.e. the document has not been loaded before.
* Disables flow checking on property .scrollTo, since flow does not understand it

### Test Plan

- open long tab
- scroll down to a line outside of the original view
- open new tab
- new tab is scrolled to the top
(in the old version it would be at the same line as the tab before)


