### PR TITLE
Loads non-loaded source before trying to prettyPrint

### DIFF
--- a/src/actions/sources.js
+++ b/src/actions/sources.js
@@ -342,8 +342,10 @@ export function togglePrettyPrint(sourceId: string) {
   return async ({ dispatch, getState, client, sourceMaps }: ThunkArgs) => {
     const source = getSource(getState(), sourceId).toJS();
 
-    if (!source || !isLoaded(source)) {
-      return {};
+    if (!source) return {};
+
+    if (!isLoaded(source)) {
+      await dispatch(loadSourceText(source));
     }
 
     assert(


### PR DESCRIPTION
Associated Issue: #3996

### Summary of Changes

* separated check for non-existing and not loaded source
* made source load if exists and not previously loaded

### Screenshots/Videos
![pretty-print-without-focus](https://user-images.githubusercontent.com/23530054/33592123-96048476-d989-11e7-880e-88fc3c943808.gif)

