### PR TITLE
Refactor updateScopeBindings

### DIFF
--- a/src/utils/pause.js
+++ b/src/utils/pause.js
@@ -3,19 +3,9 @@
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
 // @flow
-import type { Pause, Frame, Location } from "../types";
+import type { Pause, Frame } from "../types";
 import { get } from "lodash";
-import { getScopes } from "../workers/parser";
-// eslint-disable-next-line max-len
-import { updateScopeBindings as coreUpdateScopeBindings } from "devtools-map-bindings/src/updateScopeBindings";
-
-import type {
-  MappedScopeBindings,
-  Scope,
-  SourceId,
-  SourceScope,
-  Why
-} from "debugger-html";
+import type { Why } from "debugger-html";
 
 export function updateFrameLocations(
   frames: Frame[],
@@ -34,32 +24,6 @@ export function updateFrameLocations(
       }))
     )
   );
-}
-
-type UpdateScopeBindingsContextArg = {
-  getLocationScopes: (
-    location: Location,
-    astScopes: ?(SourceScope[])
-  ) => Promise<MappedScopeBindings[] | null>,
-  loadSourceText: (sourceId: SourceId) => Promise<any>
-};
-
-export async function updateScopeBindings(
-  scope: ?Scope,
-  generatedLocation: Location,
-  originalLocation: Location,
-  { getLocationScopes, loadSourceText }: UpdateScopeBindingsContextArg
-): Promise<?Scope> {
-  return coreUpdateScopeBindings(scope, generatedLocation, originalLocation, {
-    async getSourceMapsScopes(location) {
-      const astScopes: ?(SourceScope[]) = await getScopes(location);
-      return getLocationScopes(location, astScopes);
-    },
-    async getOriginalSourceScopes(location) {
-      await loadSourceText(location.sourceId);
-      return getScopes(location);
-    }
-  });
 }
 
 // Map protocol pause "why" reason to a valid L10N key


### PR DESCRIPTION
### Summary of Changes

`updateScopeBindings` is particularly confusing at the moment. It is a function in `utils/pause` that wraps a function from devtools-map-bindings. It uses sourceMap functions and dispatches actions. 

This refactor moves it to `fetchScopes` where it will be treated as an action and is simpler.