### PR TITLE
Show source text when devtools opens

### DIFF
--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -228,7 +228,7 @@ class Editor extends PureComponent<Props, State> {
     this.setSize(nextProps);
   }
 
-  componentDidUpdate(prevProps) {
+  componentDidUpdate(prevProps, prevState) {
     // This is in `componentDidUpdate` so helper functions can expect
     // `this.props` to be the current props. This lifecycle method is
     // responsible for updating the editor annotations.
@@ -252,6 +252,14 @@ class Editor extends PureComponent<Props, State> {
     // loaded.
     if (selectedSource && isLoaded(selectedSource)) {
       this.highlightLine();
+    }
+
+    // NOTE: when devtools are opened, the editor is not set when
+    // the source loads so we need to wait until the editor is
+    // set to update the text and size.
+    if (!prevState.editor && this.state.editor) {
+      this.setText(this.props);
+      this.setSize(this.props);
     }
   }
 


### PR DESCRIPTION
Associated Issue: #4868

### Summary of Changes

This addresses a recent issue where reloading the debugger would no longer show the selected source.

The issue was timing related where the source loaded before the editor had been setup. This fixes it by showing the source text when the editor is created.