### PR TITLE
[Scopes] dont expand on pause

### DIFF
--- a/src/components/SecondaryPanes/index.js
+++ b/src/components/SecondaryPanes/index.js
@@ -138,7 +138,6 @@ class SecondaryPanes extends Component<Props> {
   }
 
   getScopeItem() {
-    const isPaused = () => !!this.props.pauseData;
     return {
       header: L10N.getStr("scopes.header"),
       className: "scopes-pane",
@@ -146,8 +145,7 @@ class SecondaryPanes extends Component<Props> {
       opened: prefs.scopesVisible,
       onToggle: opened => {
         prefs.scopesVisible = opened;
-      },
-      shouldOpen: isPaused
+      }
     };
   }
 

--- a/src/test/mochitest/browser_dbg-minified.js
+++ b/src/test/mochitest/browser_dbg-minified.js
@@ -26,6 +26,7 @@ add_task(async function() {
   invokeInTab("test");
   await waitForPaused(dbg);
   await waitForMappedScopes(dbg);
+  toggleScopes(dbg);
 
   is(getScopeNodeLabel(dbg, 1), "sum", "check scope label");
   is(getScopeNodeLabel(dbg, 2), "<this>", "check scope label");

--- a/src/test/mochitest/browser_dbg-navigation.js
+++ b/src/test/mochitest/browser_dbg-navigation.js
@@ -22,6 +22,7 @@ add_task(async function() {
   invokeInTab("main");
   await waitForPaused(dbg);
   await waitForLoadedSource(dbg, "simple1");
+  toggleScopes(dbg);
 
   assertPausedLocation(dbg);
   is(countSources(dbg), 5, "5 sources are loaded.");


### PR DESCRIPTION
Associated Issue: #4651

### Summary of Changes

We recently updated the frames component so that it wouldn't auto-open on pause. This is nice because users often want to step w/o seeing the call stack. 

This changes applies strategy for the scopes pane. It's useful because: 
1) it feels bad to see the scopes pane auto-open and not the frames pane.
2) users sometimes want to quickly step. 

