### PR TITLE
Added license header to all examples in mochitest directory

### DIFF
--- a/src/test/mochitest/examples/doc-asm.html
+++ b/src/test/mochitest/examples/doc-asm.html
@@ -1,5 +1,6 @@
-<!-- Any copyright is dedicated to the Public Domain.
-     http://creativecommons.org/publicdomain/zero/1.0/ -->
+ <!-- This Source Code Form is subject to the terms of the Mozilla Public
+    - License, v. 2.0. If a copy of the MPL was not distributed with this
+    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <!DOCTYPE html>
 <html>
   <head>

--- a/src/test/mochitest/examples/doc-async.html
+++ b/src/test/mochitest/examples/doc-async.html
@@ -1,5 +1,6 @@
-<!-- Any copyright is dedicated to the Public Domain.
-     http://creativecommons.org/publicdomain/zero/1.0/ -->
+ <!-- This Source Code Form is subject to the terms of the Mozilla Public
+    - License, v. 2.0. If a copy of the MPL was not distributed with this
+    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <!DOCTYPE html>
 <html>
   <head>

--- a/src/test/mochitest/examples/doc-content-script-sources.html
+++ b/src/test/mochitest/examples/doc-content-script-sources.html
@@ -1,5 +1,6 @@
-<!-- Any copyright is dedicated to the Public Domain.
-     http://creativecommons.org/publicdomain/zero/1.0/ -->
+ <!-- This Source Code Form is subject to the terms of the Mozilla Public
+    - License, v. 2.0. If a copy of the MPL was not distributed with this
+    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <!DOCTYPE html>
 <html>
   <head>

--- a/src/test/mochitest/examples/doc-debugger-statements.html
+++ b/src/test/mochitest/examples/doc-debugger-statements.html
@@ -1,3 +1,6 @@
+ <!-- This Source Code Form is subject to the terms of the Mozilla Public
+    - License, v. 2.0. If a copy of the MPL was not distributed with this
+    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <html>
   <head>
     <title>Debugger Statements</title>

--- a/src/test/mochitest/examples/doc-exceptions.html
+++ b/src/test/mochitest/examples/doc-exceptions.html
@@ -1,3 +1,6 @@
+ <!-- This Source Code Form is subject to the terms of the Mozilla Public
+    - License, v. 2.0. If a copy of the MPL was not distributed with this
+    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <html>
   <head>
     <title>Debugger test page</title>

--- a/src/test/mochitest/examples/doc-frames.html
+++ b/src/test/mochitest/examples/doc-frames.html
@@ -1,3 +1,6 @@
+ <!-- This Source Code Form is subject to the terms of the Mozilla Public
+    - License, v. 2.0. If a copy of the MPL was not distributed with this
+    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <html>
   <head>
     <title>Frames</title>

--- a/src/test/mochitest/examples/doc-iframes.html
+++ b/src/test/mochitest/examples/doc-iframes.html
@@ -1,3 +1,6 @@
+ <!-- This Source Code Form is subject to the terms of the Mozilla Public
+    - License, v. 2.0. If a copy of the MPL was not distributed with this
+    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <html>
   <head>
     <title>Iframe</title>

--- a/src/test/mochitest/examples/doc-minified.html
+++ b/src/test/mochitest/examples/doc-minified.html
@@ -1,5 +1,6 @@
-<!-- Any copyright is dedicated to the Public Domain.
-     http://creativecommons.org/publicdomain/zero/1.0/ -->
+ <!-- This Source Code Form is subject to the terms of the Mozilla Public
+    - License, v. 2.0. If a copy of the MPL was not distributed with this
+    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <!doctype html>
 
 <html>

--- a/src/test/mochitest/examples/doc-minified2.html
+++ b/src/test/mochitest/examples/doc-minified2.html
@@ -1,5 +1,6 @@
-<!-- Any copyright is dedicated to the Public Domain.
-     http://creativecommons.org/publicdomain/zero/1.0/ -->
+ <!-- This Source Code Form is subject to the terms of the Mozilla Public
+    - License, v. 2.0. If a copy of the MPL was not distributed with this
+    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <!doctype html>
 
 <html>

--- a/src/test/mochitest/examples/doc-return-values.html
+++ b/src/test/mochitest/examples/doc-return-values.html
@@ -1,3 +1,6 @@
+ <!-- This Source Code Form is subject to the terms of the Mozilla Public
+    - License, v. 2.0. If a copy of the MPL was not distributed with this
+    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <html>
   <head>
     <title>Return Values</title>

--- a/src/test/mochitest/examples/doc-script-mutate.html
+++ b/src/test/mochitest/examples/doc-script-mutate.html
@@ -1,5 +1,6 @@
-<!-- Any copyright is dedicated to the Public Domain.
-     http://creativecommons.org/publicdomain/zero/1.0/ -->
+ <!-- This Source Code Form is subject to the terms of the Mozilla Public
+    - License, v. 2.0. If a copy of the MPL was not distributed with this
+    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <!doctype html>
 
 <html>

--- a/src/test/mochitest/examples/doc-script-switching.html
+++ b/src/test/mochitest/examples/doc-script-switching.html
@@ -1,5 +1,6 @@
-<!-- Any copyright is dedicated to the Public Domain.
-     http://creativecommons.org/publicdomain/zero/1.0/ -->
+ <!-- This Source Code Form is subject to the terms of the Mozilla Public
+    - License, v. 2.0. If a copy of the MPL was not distributed with this
+    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <!doctype html>
 
 <html>

--- a/src/test/mochitest/examples/doc-scripts.html
+++ b/src/test/mochitest/examples/doc-scripts.html
@@ -1,5 +1,6 @@
-<!-- Any copyright is dedicated to the Public Domain.
-     http://creativecommons.org/publicdomain/zero/1.0/ -->
+ <!-- This Source Code Form is subject to the terms of the Mozilla Public
+    - License, v. 2.0. If a copy of the MPL was not distributed with this
+    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <!DOCTYPE html>
 <html>
   <head>

--- a/src/test/mochitest/examples/doc-sourcemap-bogus.html
+++ b/src/test/mochitest/examples/doc-sourcemap-bogus.html
@@ -1,5 +1,6 @@
-<!-- Any copyright is dedicated to the Public Domain.
-     http://creativecommons.org/publicdomain/zero/1.0/ -->
+ <!-- This Source Code Form is subject to the terms of the Mozilla Public
+    - License, v. 2.0. If a copy of the MPL was not distributed with this
+    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <!DOCTYPE html>
 <html>
   <head>

--- a/src/test/mochitest/examples/doc-sourcemaps.html
+++ b/src/test/mochitest/examples/doc-sourcemaps.html
@@ -1,5 +1,6 @@
-<!-- Any copyright is dedicated to the Public Domain.
-     http://creativecommons.org/publicdomain/zero/1.0/ -->
+ <!-- This Source Code Form is subject to the terms of the Mozilla Public
+    - License, v. 2.0. If a copy of the MPL was not distributed with this
+    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <!DOCTYPE html>
 <html>
   <head>

--- a/src/test/mochitest/examples/doc-sourcemaps2.html
+++ b/src/test/mochitest/examples/doc-sourcemaps2.html
@@ -1,3 +1,6 @@
+ <!-- This Source Code Form is subject to the terms of the Mozilla Public
+    - License, v. 2.0. If a copy of the MPL was not distributed with this
+    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <!DOCTYPE html>
 <html>
   <head>

--- a/src/test/mochitest/examples/doc-sourcemaps3.html
+++ b/src/test/mochitest/examples/doc-sourcemaps3.html
@@ -1,3 +1,6 @@
+ <!-- This Source Code Form is subject to the terms of the Mozilla Public
+    - License, v. 2.0. If a copy of the MPL was not distributed with this
+    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <!DOCTYPE html>
 <html>
   <head>

--- a/src/test/mochitest/examples/doc-sources.html
+++ b/src/test/mochitest/examples/doc-sources.html
@@ -1,5 +1,6 @@
-<!-- Any copyright is dedicated to the Public Domain.
-     http://creativecommons.org/publicdomain/zero/1.0/ -->
+ <!-- This Source Code Form is subject to the terms of the Mozilla Public
+    - License, v. 2.0. If a copy of the MPL was not distributed with this
+    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <!DOCTYPE html>
 <html>
   <head>

--- a/src/test/mochitest/examples/doc-wasm-sourcemaps.html
+++ b/src/test/mochitest/examples/doc-wasm-sourcemaps.html
@@ -1,5 +1,6 @@
-<!-- Any copyright is dedicated to the Public Domain.
-     http://creativecommons.org/publicdomain/zero/1.0/ -->
+ <!-- This Source Code Form is subject to the terms of the Mozilla Public
+    - License, v. 2.0. If a copy of the MPL was not distributed with this
+    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <!DOCTYPE html>
 <html>
   <head>


### PR DESCRIPTION
Associated Issue: #4870 

-  License header added to all examples in mochitest directory


