### PR TITLE
Address memory leak introduced by parse-script-tags

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,16 +18,19 @@
     "start": "node bin/dev-server",
     "start-app": "TARGET=application node bin/dev-server",
     "flow": "flow",
-    "eslint-check": "eslint --print-config .eslintrc.js | eslint-config-prettier-check",
+    "eslint-check":
+      "eslint --print-config .eslintrc.js | eslint-config-prettier-check",
     "prettier": "node bin/prettier.js",
     "license-check": "devtools-license-check",
     "links": "ls -l node_modules/ | grep ^l || echo 'no linked packages'",
     "lint": "run-p lint-css lint-js lint-md",
     "lint-css": "stylelint \"src/components/**/*.css\"",
     "lint-js": "eslint *.js \"src/**/*.js\" --fix",
-    "lint-md": "remark -u devtools-linters/markdown/preset -qf *.md src configs docs",
+    "lint-md":
+      "remark -u devtools-linters/markdown/preset -qf *.md src configs docs",
     "lint-fix": "yarn lint-js -- --fix",
-    "mochi": "mochii --mc ./firefox --interactive --default-test-path devtools/client/debugger/new",
+    "mochi":
+      "mochii --mc ./firefox --interactive --default-test-path devtools/client/debugger/new",
     "mochid": "yarn mochi -- --jsdebugger --",
     "mochir": "yarn mochi -- --repeat 10 --",
     "mochih": "yarn mochi -- --setenv MOZ_HEADLESS=1 --",
@@ -35,14 +38,20 @@
     "test:watch": "jest --watch",
     "test-coverage": "yarn test -- --coverage",
     "test-all": "yarn test; yarn lint; yarn flow",
-    "firefox": "start-firefox --start --location https://devtools-html.github.io/debugger-examples/",
-    "chrome": "start-chrome --location https://devtools-html.github.io/debugger-examples/",
+    "firefox":
+      "start-firefox --start --location https://devtools-html.github.io/debugger-examples/",
+    "chrome":
+      "start-chrome --location https://devtools-html.github.io/debugger-examples/",
     "copy-assets": "node bin/copy-assets --symlink",
     "copy-assets-watch": "node bin/copy-assets --watch --symlink",
-    "build-docs": "documentation build --format html --sort-order alpha --shallow  --document-exported --output docs/reference/ src/types.js src/utils/ src/reducers/ src/actions/ src/test/mochitest/head.js",
-    "flow-coverage": "flow-coverage-report --threshold 50 -i 'src/actions/*.js' -i 'src/reducers/*.js' -i 'src/utils/*.js' -i 'src/components/*.js' -i 'src/components/**/*.js' -t html -t text",
-    "flow-utils": "flow-coverage-report -i 'src/utils/*.js' -i 'src/utils/**/*.js' -t text",
-    "flow-redux": "flow-coverage-report  -i 'src/reducers/*.js' -i 'src/actions/*.js'  -t text",
+    "build-docs":
+      "documentation build --format html --sort-order alpha --shallow  --document-exported --output docs/reference/ src/types.js src/utils/ src/reducers/ src/actions/ src/test/mochitest/head.js",
+    "flow-coverage":
+      "flow-coverage-report --threshold 50 -i 'src/actions/*.js' -i 'src/reducers/*.js' -i 'src/utils/*.js' -i 'src/components/*.js' -i 'src/components/**/*.js' -t html -t text",
+    "flow-utils":
+      "flow-coverage-report -i 'src/utils/*.js' -i 'src/utils/**/*.js' -t text",
+    "flow-redux":
+      "flow-coverage-report  -i 'src/reducers/*.js' -i 'src/actions/*.js'  -t text",
     "flow-react": "flow-coverage-report -i 'src/components/**/*.js' -t text",
     "storybook": "start-storybook -p 6006",
     "snapshot": "NODE_ENV='development' build-storybook && percy-storybook",
@@ -76,7 +85,7 @@
     "lodash": "^4.17.4",
     "lodash.kebabcase": "^4.1.1",
     "md5": "^2.2.1",
-    "parse-script-tags": "^0.1.1",
+    "parse-script-tags": "^0.1.5",
     "pretty-fast": "^0.2.3",
     "prop-types": "^15.6.0",
     "react": "^15.6.2",
@@ -90,18 +99,9 @@
     "svg-inline-react": "^1.0.2",
     "wasmparser": "^0.4.10"
   },
-  "files": [
-    "src",
-    "assets"
-  ],
+  "files": ["src", "assets"],
   "greenkeeper": {
-    "ignore": [
-      "react",
-      "react-dom",
-      "react-redux",
-      "redux",
-      "codemirror"
-    ]
+    "ignore": ["react", "react-dom", "react-redux", "redux", "codemirror"]
   },
   "main": "src/main.js",
   "author": "Jason Laster <jlaster@mozilla.com>",
@@ -165,44 +165,18 @@
     "workerjs": "github:jasonLaster/workerjs"
   },
   "lint-staged": {
-    "*.js": [
-      "prettier",
-      "git add"
-    ],
-    "src/*.js": [
-      "prettier",
-      "git add"
-    ],
-    "src/*/*.js": [
-      "prettier",
-      "git add"
-    ],
-    "src/*/!(mochitest)**/*.js": [
-      "prettier",
-      "git add"
-    ],
-    "src/*/!(mochitest)*/**/*.js": [
-      "prettier",
-      "git add"
-    ]
+    "*.js": ["prettier", "git add"],
+    "src/*.js": ["prettier", "git add"],
+    "src/*/*.js": ["prettier", "git add"],
+    "src/*/!(mochitest)**/*.js": ["prettier", "git add"],
+    "src/*/!(mochitest)*/**/*.js": ["prettier", "git add"]
   },
   "jest": {
     "rootDir": "src",
-    "testMatch": [
-      "**/tests/**/*.js"
-    ],
-    "testPathIgnorePatterns": [
-      "/node_modules/",
-      "/helpers/",
-      "/fixtures/"
-    ],
-    "transformIgnorePatterns": [
-      "node_modules/(?!devtools-)"
-    ],
-    "setupFiles": [
-      "<rootDir>/test/tests-setup.js",
-      "jest-localstorage-mock"
-    ],
+    "testMatch": ["**/tests/**/*.js"],
+    "testPathIgnorePatterns": ["/node_modules/", "/helpers/", "/fixtures/"],
+    "transformIgnorePatterns": ["node_modules/(?!devtools-)"],
+    "setupFiles": ["<rootDir>/test/tests-setup.js", "jest-localstorage-mock"],
     "snapshotSerializers": [
       "jest-serializer-babel-ast",
       "enzyme-to-json/serializer"

--- a/src/workers/parser/utils/ast.js
+++ b/src/workers/parser/utils/ast.js
@@ -4,7 +4,7 @@
 
 // @flow
 
-import parseScriptTags from "parse-script-tags";
+import parseScriptTags from "parse-script-tags/customParse";
 import * as babylon from "babylon";
 import traverse from "babel-traverse";
 import isEmpty from "lodash/isEmpty";

--- a/yarn.lock
+++ b/yarn.lock
@@ -189,11 +189,7 @@
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/@types/inline-style-prefixer/-/inline-style-prefixer-3.0.1.tgz#8541e636b029124b747952e9a28848286d2b5bf6"
 
-"@types/node@*":
-  version "8.0.50"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.0.50.tgz#dc545448e128c88c4eec7cd64025fcc3b7604541"
-
-"@types/node@^7.0.12":
+"@types/node@*", "@types/node@^7.0.12":
   version "7.0.46"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-7.0.46.tgz#c3dedd25558c676b3d6303e51799abb9c3f8f314"
 
@@ -3215,16 +3211,9 @@ domhandler@^2.3.0:
   dependencies:
     domelementtype "1"
 
-domutils@1.5.1:
+domutils@1.5.1, domutils@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.5.1.tgz#dcd8488a26f563d61079e48c9f7b7e32373682cf"
-  dependencies:
-    dom-serializer "0"
-    domelementtype "1"
-
-domutils@^1.5.1:
-  version "1.6.2"
-  resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.6.2.tgz#1958cc0b4c9426e9ed367fb1c8e854891b0fa3ff"
   dependencies:
     dom-serializer "0"
     domelementtype "1"
@@ -7416,9 +7405,9 @@ parse-latin@^4.0.0:
     unist-util-modify-children "^1.0.0"
     unist-util-visit-children "^1.0.0"
 
-parse-script-tags@^0.1.1:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/parse-script-tags/-/parse-script-tags-0.1.3.tgz#abcc38665d4ff92bd5a2661b8f24c3e172db19d5"
+parse-script-tags@^0.1.15:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/parse-script-tags/-/parse-script-tags-0.1.5.tgz#9d1a5370dadb37845030537b6dbf736bb524505c"
   dependencies:
     babel-types "^6.24.1"
     babylon "^6.17.0"
@@ -9668,11 +9657,7 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-"statuses@>= 1.3.1 < 2":
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.4.0.tgz#bb73d446da2796106efcc1b601a253d6c46bd087"
-
-statuses@~1.3.1:
+"statuses@>= 1.3.1 < 2", statuses@~1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.3.1.tgz#faf51b9eb74aaef3b3acf4ad5f61abf24cb7b93e"
 


### PR DESCRIPTION
Associated Issue: #3307 

Here's the Pull Request Doc
https://devtools-html.github.io/debugger.html/CONTRIBUTING.html#pull-requests

### Summary of Changes

* Updates `parse-script-tags` dependency to 0.1.5
* Change parser to use `customParse` submodule to avoid including the `babylon` dependency in the build
