### PR TITLE
Changes flow behavior from server to on demand basis

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,17 +17,20 @@
   "scripts": {
     "start": "node bin/dev-server",
     "start-app": "TARGET=application node bin/dev-server",
-    "flow": "flow",
-    "eslint-check": "eslint --print-config .eslintrc.js | eslint-config-prettier-check",
+    "flow": "flow check",
+    "eslint-check":
+      "eslint --print-config .eslintrc.js | eslint-config-prettier-check",
     "prettier": "node bin/prettier.js",
     "license-check": "devtools-license-check",
     "links": "ls -l node_modules/ | grep ^l || echo 'no linked packages'",
     "lint": "run-p lint-css lint-js lint-md",
     "lint-css": "stylelint \"src/components/**/*.css\"",
     "lint-js": "eslint *.js \"src/**/*.js\" --fix",
-    "lint-md": "remark -u devtools-linters/markdown/preset -qf *.md src configs docs",
+    "lint-md":
+      "remark -u devtools-linters/markdown/preset -qf *.md src configs docs",
     "lint-fix": "yarn lint-js -- --fix",
-    "mochi": "mochii --mc ./firefox --interactive --default-test-path devtools/client/debugger/new",
+    "mochi":
+      "mochii --mc ./firefox --interactive --default-test-path devtools/client/debugger/new",
     "mochid": "yarn mochi -- --jsdebugger --",
     "mochir": "yarn mochi -- --repeat 10 --",
     "mochih": "yarn mochi -- --setenv MOZ_HEADLESS=1 --",
@@ -35,14 +38,20 @@
     "test:watch": "jest --watch",
     "test-coverage": "yarn test -- --coverage",
     "test-all": "yarn test; yarn lint; yarn flow",
-    "firefox": "start-firefox --start --location https://devtools-html.github.io/debugger-examples/",
-    "chrome": "start-chrome --location https://devtools-html.github.io/debugger-examples/",
+    "firefox":
+      "start-firefox --start --location https://devtools-html.github.io/debugger-examples/",
+    "chrome":
+      "start-chrome --location https://devtools-html.github.io/debugger-examples/",
     "copy-assets": "node bin/copy-assets --symlink",
     "copy-assets-watch": "node bin/copy-assets --watch --symlink",
-    "build-docs": "documentation build --format html --sort-order alpha --shallow  --document-exported --output docs/reference/ src/types.js src/utils/ src/reducers/ src/actions/ src/test/mochitest/head.js",
-    "flow-coverage": "flow-coverage-report --threshold 50 -i 'src/actions/*.js' -i 'src/reducers/*.js' -i 'src/utils/*.js' -i 'src/components/*.js' -i 'src/components/**/*.js' -t html -t text",
-    "flow-utils": "flow-coverage-report -i 'src/utils/*.js' -i 'src/utils/**/*.js' -t text",
-    "flow-redux": "flow-coverage-report  -i 'src/reducers/*.js' -i 'src/actions/*.js'  -t text",
+    "build-docs":
+      "documentation build --format html --sort-order alpha --shallow  --document-exported --output docs/reference/ src/types.js src/utils/ src/reducers/ src/actions/ src/test/mochitest/head.js",
+    "flow-coverage":
+      "flow-coverage-report --threshold 50 -i 'src/actions/*.js' -i 'src/reducers/*.js' -i 'src/utils/*.js' -i 'src/components/*.js' -i 'src/components/**/*.js' -t html -t text",
+    "flow-utils":
+      "flow-coverage-report -i 'src/utils/*.js' -i 'src/utils/**/*.js' -t text",
+    "flow-redux":
+      "flow-coverage-report  -i 'src/reducers/*.js' -i 'src/actions/*.js'  -t text",
     "flow-react": "flow-coverage-report -i 'src/components/**/*.js' -t text",
     "storybook": "start-storybook -p 6006",
     "snapshot": "NODE_ENV='development' build-storybook && percy-storybook",
@@ -90,18 +99,9 @@
     "svg-inline-react": "^1.0.2",
     "wasmparser": "^0.4.10"
   },
-  "files": [
-    "src",
-    "assets"
-  ],
+  "files": ["src", "assets"],
   "greenkeeper": {
-    "ignore": [
-      "react",
-      "react-dom",
-      "react-redux",
-      "redux",
-      "codemirror"
-    ]
+    "ignore": ["react", "react-dom", "react-redux", "redux", "codemirror"]
   },
   "main": "src/main.js",
   "author": "Jason Laster <jlaster@mozilla.com>",
@@ -165,44 +165,18 @@
     "workerjs": "github:jasonLaster/workerjs"
   },
   "lint-staged": {
-    "*.js": [
-      "prettier",
-      "git add"
-    ],
-    "src/*.js": [
-      "prettier",
-      "git add"
-    ],
-    "src/*/*.js": [
-      "prettier",
-      "git add"
-    ],
-    "src/*/!(mochitest)**/*.js": [
-      "prettier",
-      "git add"
-    ],
-    "src/*/!(mochitest)*/**/*.js": [
-      "prettier",
-      "git add"
-    ]
+    "*.js": ["prettier", "git add"],
+    "src/*.js": ["prettier", "git add"],
+    "src/*/*.js": ["prettier", "git add"],
+    "src/*/!(mochitest)**/*.js": ["prettier", "git add"],
+    "src/*/!(mochitest)*/**/*.js": ["prettier", "git add"]
   },
   "jest": {
     "rootDir": "src",
-    "testMatch": [
-      "**/tests/**/*.js"
-    ],
-    "testPathIgnorePatterns": [
-      "/node_modules/",
-      "/helpers/",
-      "/fixtures/"
-    ],
-    "transformIgnorePatterns": [
-      "node_modules/(?!devtools-)"
-    ],
-    "setupFiles": [
-      "<rootDir>/test/tests-setup.js",
-      "jest-localstorage-mock"
-    ],
+    "testMatch": ["**/tests/**/*.js"],
+    "testPathIgnorePatterns": ["/node_modules/", "/helpers/", "/fixtures/"],
+    "transformIgnorePatterns": ["node_modules/(?!devtools-)"],
+    "setupFiles": ["<rootDir>/test/tests-setup.js", "jest-localstorage-mock"],
     "snapshotSerializers": [
       "jest-serializer-babel-ast",
       "enzyme-to-json/serializer"


### PR DESCRIPTION
Associated Issue: #4883

Rationale:
Currently we use `flow` in its default behavior, which is short for `flow status`. `flow status` asks the currently running flow server for a list of errors which the flow server is supposed to be continually monitoring. If there is no server `flow status` will spawn one. Also it will sometimes cache results.

However, for the purpose of testing we use `flow` on an on demand basis - expecting a full and fresh set of results every time. This is the default behavior of `flow check`. A new flow server is initiated, errors are checked, the server exits. No caching, no verbose server initiated messages.

### Summary of Changes

* changed flow behavior from keeping the flow server running to on demand execution

### Test Plan
executed `yarn flow`
