### PR TITLE
Switch ProjectSearch PropTypes to Props

### DIFF
--- a/src/components/ProjectSearch/index.js
+++ b/src/components/ProjectSearch/index.js
@@ -4,6 +4,7 @@
 
 // @flow
 
+import PropTypes from "prop-types";
 import React, { Component } from "react";
 import { connect } from "react-redux";
 import { bindActionCreators } from "redux";
@@ -109,6 +110,9 @@ class ProjectSearch extends Component<Props> {
     return <div className="search-container">{this.renderTextSearch()}</div>;
   }
 }
+ProjectSearch.contextTypes = {
+  shortcuts: PropTypes.object
+};
 
 export default connect(
   state => ({

--- a/src/components/ProjectSearch/index.js
+++ b/src/components/ProjectSearch/index.js
@@ -4,7 +4,6 @@
 
 // @flow
 
-import PropTypes from "prop-types";
 import React, { Component } from "react";
 import { connect } from "react-redux";
 import { bindActionCreators } from "redux";
@@ -110,22 +109,6 @@ class ProjectSearch extends Component<Props> {
     return <div className="search-container">{this.renderTextSearch()}</div>;
   }
 }
-
-ProjectSearch.propTypes = {
-  sources: PropTypes.object.isRequired,
-  results: PropTypes.object,
-  textSearchQuery: PropTypes.string,
-  setActiveSearch: PropTypes.func.isRequired,
-  closeActiveSearch: PropTypes.func.isRequired,
-  closeProjectSearch: PropTypes.func.isRequired,
-  searchSources: PropTypes.func,
-  activeSearch: PropTypes.string,
-  selectLocation: PropTypes.func.isRequired
-};
-
-ProjectSearch.contextTypes = {
-  shortcuts: PropTypes.object
-};
 
 export default connect(
   state => ({


### PR DESCRIPTION
Associated Issue: #2804

### Summary of Changes

* Removed PropTypes to Props in ProjectSearch

### Test Plan

Tell us a little a bit about how you tested your patch.

Example test plan:

- [x]  yarn test
 - [x] yarn run flow
