### PR TITLE
Update CallSites flag

### DIFF
--- a/src/components/Editor/CallSites.js
+++ b/src/components/Editor/CallSites.js
@@ -4,7 +4,6 @@
 
 import React, { Component } from "react";
 import { connect } from "react-redux";
-import { features } from "../../utils/prefs";
 
 import { range, keyBy, isEqualWith } from "lodash";
 
@@ -58,22 +57,18 @@ class CallSites extends Component {
     const { editor } = this.props;
     const codeMirrorWrapper = editor.codeMirror.getWrapperElement();
 
-    if (features.columnBreakpoints) {
-      codeMirrorWrapper.addEventListener("click", e => this.onTokenClick(e));
-      document.body.addEventListener("keydown", this.onKeyDown);
-      document.body.addEventListener("keyup", this.onKeyUp);
-    }
+    codeMirrorWrapper.addEventListener("click", e => this.onTokenClick(e));
+    document.body.addEventListener("keydown", this.onKeyDown);
+    document.body.addEventListener("keyup", this.onKeyUp);
   }
 
   componentDidUnMount() {
     const { editor } = this.props;
     const codeMirrorWrapper = editor.codeMirror.getWrapperElement();
 
-    if (features.columnBreakpoints) {
-      codeMirrorWrapper.addEventListener("click", e => this.onTokenClick(e));
-      document.body.removeEventListener("keydown", e => this.onKeyDown);
-      document.body.removeEventListener("keyup", this.onKeyUp);
-    }
+    codeMirrorWrapper.addEventListener("click", e => this.onTokenClick(e));
+    document.body.removeEventListener("keydown", e => this.onKeyDown);
+    document.body.removeEventListener("keyup", this.onKeyUp);
   }
 
   onKeyUp(e) {

--- a/src/components/Editor/CallSites.js
+++ b/src/components/Editor/CallSites.js
@@ -62,12 +62,12 @@ class CallSites extends Component {
     document.body.addEventListener("keyup", this.onKeyUp);
   }
 
-  componentDidUnMount() {
+  componentWillUnmount() {
     const { editor } = this.props;
     const codeMirrorWrapper = editor.codeMirror.getWrapperElement();
 
-    codeMirrorWrapper.addEventListener("click", e => this.onTokenClick(e));
-    document.body.removeEventListener("keydown", e => this.onKeyDown);
+    codeMirrorWrapper.removeEventListener("click", e => this.onTokenClick(e));
+    document.body.removeEventListener("keydown", this.onKeyDown);
     document.body.removeEventListener("keyup", this.onKeyUp);
   }
 

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -12,6 +12,7 @@ import { debugGlobal } from "devtools-launchpad";
 import { isLoaded } from "../../utils/source";
 import { isFirefox } from "devtools-config";
 import { SourceEditor } from "devtools-source-editor";
+import { features } from "../../utils/prefs";
 
 import {
   getActiveSearch,
@@ -560,18 +561,19 @@ class Editor extends PureComponent<Props, State> {
     if (!editor || !selectedSource || !isLoaded(selectedSource)) {
       return null;
     }
+
     return (
       <div>
         <DebugLine editor={editor} />
         <EmptyLines editor={editor} />
         <Breakpoints editor={editor} />
-        <CallSites editor={editor} />
         <Preview editor={editor} />;
         <Footer editor={editor} horizontal={horizontal} />
         <HighlightLines editor={editor} />
         <EditorMenu editor={editor} />
         <GutterMenu editor={editor} />
         <ConditionalPanel editor={editor} />
+        {features.columnBreakpoints ? <CallSites editor={editor} /> : null}
         {this.renderHitCounts()}
       </div>
     );


### PR DESCRIPTION
Associated Issue: #4896

### Summary of Changes

Our callsite flag which is used to feature flag the Column Breakpoints UI previously rendered the breakpoints in the background and just disabled the event handling so they wouldn't be shown. 

This means that we were paying the price of fetching and rendering the breakpoints with codemirror, with none of the benefits.

Here are the perf wins we'll see in minified files. Most of the time is spent fetching the column breakpoints:

<img width="1552" alt="screen shot 2017-12-09 at 11 24 11 am" src="https://user-images.githubusercontent.com/254562/33797313-c1579878-dcd3-11e7-9c55-dd32303936ca.png">

<img width="1552" alt="screen shot 2017-12-09 at 11 23 57 am" src="https://user-images.githubusercontent.com/254562/33797314-c161d3e2-dcd3-11e7-9d39-9b943282a346.png">

### Further Improvements

The first half of the time is spent in `setText` the second half is spent in `getCallSites`

<img width="801" alt="screen shot 2017-12-09 at 11 31 25 am" src="https://user-images.githubusercontent.com/254562/33797387-d0082e2c-dcd4-11e7-9fc3-087e5bd0c706.png">

We'll want to look into speeding up `setText` as well.

<img width="1552" alt="screen shot 2017-12-09 at 11 30 01 am" src="https://user-images.githubusercontent.com/254562/33797395-f240096a-dcd4-11e7-8924-31bf4f856b45.png">
<img width="1552" alt="screen shot 2017-12-09 at 11 29 50 am" src="https://user-images.githubusercontent.com/254562/33797396-f24a8868-dcd4-11e7-84a0-3213b7e5351e.png">
