### PR TITLE
Synchronize test changes to getSplitConsole from bug 1408949

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ env:
   global:
     - DISPLAY=':99.0'
     - YARN_VERSION='0.24.5'
-    - MC_COMMIT='b4cef8d1dff0' # https://hg.mozilla.org/mozilla-central/shortlog
+    - MC_COMMIT='22d2831cc1f4' # https://hg.mozilla.org/mozilla-central/shortlog
 
 notifications:
   slack:

--- a/src/test/mochitest/browser_dbg-console.js
+++ b/src/test/mochitest/browser_dbg-console.js
@@ -4,10 +4,6 @@
 function getSplitConsole(dbg) {
   const { toolbox, win } = dbg;
 
-  registerCleanupFunction(() => {
-    Services.prefs.clearUserPref("devtools.toolbox.splitconsoleEnabled");
-  });
-
   if (!win) {
     win = toolbox.win;
   }


### PR DESCRIPTION
### Summary of Changes

* Synchronize changes from [Bug 1408949](https://bugzilla.mozilla.org/show_bug.cgi?id=1408949)
* updated the m-c changeset so that shared-head.js clears `Services.prefs.clearUserPref("devtools.toolbox.splitconsoleHeight");`
