### PR TITLE
Do not select the frame if the frame is already selected

### DIFF
--- a/src/components/SecondaryPanes/Frames/Frame.js
+++ b/src/components/SecondaryPanes/Frames/Frame.js
@@ -87,10 +87,7 @@ export default class FrameComponent extends Component<FrameComponentProps> {
     frame: Frame,
     selectedFrame: Frame
   ) {
-    if (
-      (e.nativeEvent.which == 3 && selectedFrame.id != frame.id) ||
-      selectedFrame.id === frame.id
-    ) {
+    if (e.nativeEvent.which == 3 || selectedFrame.id === frame.id) {
       return;
     }
     this.props.selectFrame(frame);

--- a/src/components/SecondaryPanes/Frames/Frame.js
+++ b/src/components/SecondaryPanes/Frames/Frame.js
@@ -87,7 +87,10 @@ export default class FrameComponent extends Component<FrameComponentProps> {
     frame: Frame,
     selectedFrame: Frame
   ) {
-    if (e.nativeEvent.which == 3 && selectedFrame.id != frame.id) {
+    if (
+      (e.nativeEvent.which == 3 && selectedFrame.id != frame.id) ||
+      selectedFrame.id === frame.id
+    ) {
       return;
     }
     this.props.selectFrame(frame);


### PR DESCRIPTION
Associated Issue: #4864

### Summary of Changes

* Do not select the frame if its already selected

### Test Plan

Tell us a little a bit about how you tested your patch.

Example test plan:

- [x] Go to https://www.google.com/
- [x] Open the debugger
- [x] select `(index)` 
- [x] Set a breakpoint on line 4
- [x] Refresh the web page
- [x] Right-click in the callstack
- [x] The context menu should not delay showing up
