### PR TITLE
Fix #4924 - Prevent NaN result count

### DIFF
--- a/src/components/QuickOpenModal.js
+++ b/src/components/QuickOpenModal.js
@@ -242,7 +242,14 @@ export class QuickOpenModal extends Component<Props, State> {
     }
   };
 
-  resultCount = () => (this.state.results ? this.state.results.length : 0);
+  resultCount = () => {
+    const results = this.state.results;
+
+    if (results && results.length) {
+      return results.length;
+    }
+    return 0;
+  };
 
   isSymbolSearch = () =>
     ["functions", "variables"].includes(this.props.searchType);


### PR DESCRIPTION
To test:

- Press `Command + P` to open the search pane
- Type a few letters, then delete them; "0 results" should be the final label.