### PR TITLE
Toggle scope/calls-stack panes on pause

### DIFF
--- a/src/components/SecondaryPanes/index.js
+++ b/src/components/SecondaryPanes/index.js
@@ -185,7 +185,7 @@ class SecondaryPanes extends Component<Props> {
   }
 
   getStartItems() {
-    const scopesContent: any = this.props.horizontal
+    const scopesContent: any = this.props.horizontal && this.props.pauseData
       ? this.getScopeItem()
       : null;
     const items: Array<SecondaryPanesItems> = [

--- a/src/components/SecondaryPanes/index.js
+++ b/src/components/SecondaryPanes/index.js
@@ -208,6 +208,18 @@ class SecondaryPanes extends Component<Props> {
       scopesContent
     ];
 
+    if (this.props.pauseData) {
+      items.push({
+        header: L10N.getStr("callStack.header"),
+        className: "call-stack-pane",
+        component: Frames,
+        opened: prefs.callStackVisible,
+        onToggle: opened => {
+          prefs.callStackVisible = opened;
+        }
+      })
+    }
+
     if (isEnabled("eventListeners")) {
       items.push({
         header: L10N.getStr("eventListenersHeader"),

--- a/src/components/SecondaryPanes/index.js
+++ b/src/components/SecondaryPanes/index.js
@@ -196,15 +196,6 @@ class SecondaryPanes extends Component<Props> {
         component: Breakpoints,
         opened: true
       },
-      {
-        header: L10N.getStr("callStack.header"),
-        className: "call-stack-pane",
-        component: Frames,
-        opened: prefs.callStackVisible,
-        onToggle: opened => {
-          prefs.callStackVisible = opened;
-        }
-      },
       scopesContent
     ];
 

--- a/src/components/shared/Accordion.js
+++ b/src/components/shared/Accordion.js
@@ -38,7 +38,9 @@ class Accordion extends Component<Props, State> {
 
   componentWillReceiveProps(nextProps: Props) {
     const newOpened = this.state.opened.map((isOpen, i) => {
-      const { shouldOpen } = nextProps.items[i];
+      const shouldOpen = nextProps.items[i]
+        ? nextProps.items[i].shouldOpen
+        : false;
 
       return isOpen || (shouldOpen && shouldOpen());
     });

--- a/src/test/mochitest/browser_dbg-call-stack.js
+++ b/src/test/mochitest/browser_dbg-call-stack.js
@@ -20,13 +20,16 @@ function toggleButton(dbg) {
 add_task(async function() {
   const dbg = await initDebugger("doc-script-switching.html");
 
-  toggleCallStack(dbg);
+  const found = findElement(dbg, "callStackBody");
+  is(found, null, "Call stack is hidden");
 
   const notPaused = findElement(dbg, "callStackBody").innerText;
   is(notPaused, "Not paused", "Not paused message is shown");
 
   invokeInTab("firstCall");
   await waitForPaused(dbg);
+
+  toggleCallStack(dbg);
 
   ok(isFrameSelected(dbg, 1, "secondCall"), "the first frame is selected");
 
@@ -37,10 +40,10 @@ add_task(async function() {
 add_task(async function() {
   const dbg = await initDebugger("doc-frames.html");
 
-  toggleCallStack(dbg);
-
   invokeInTab("startRecursion");
   await waitForPaused(dbg);
+
+  toggleCallStack(dbg);
 
   ok(isFrameSelected(dbg, 1, "recurseA"), "the first frame is selected");
 

--- a/src/test/mochitest/browser_dbg-call-stack.js
+++ b/src/test/mochitest/browser_dbg-call-stack.js
@@ -23,9 +23,6 @@ add_task(async function() {
   const found = findElement(dbg, "callStackBody");
   is(found, null, "Call stack is hidden");
 
-  const notPaused = findElement(dbg, "callStackBody").innerText;
-  is(notPaused, "Not paused", "Not paused message is shown");
-
   invokeInTab("firstCall");
   await waitForPaused(dbg);
 


### PR DESCRIPTION
### Summary of Changes

* Only renders scopes pane when in paused state

### Test Plan

- [x] Pause debugger and scopes/call-stack panes are shown
- [x] Resume debugger and scopes/call-stack panes are not rendered

### Known Issues

- The test cases are a bit out of my pay grade. I was able to fix the call-stack tests, however, the absence of the scopes/call-stack pane(s) mess with a bunch of other tests.

### Screenshots/Videos

#### Cases
- [x] Scopes/call-stack panes are not rendered when respective accordion(s) are closed
- [x] Scopes/call-stack panes are not rendered when respective accordion(s) are open

![toggle-scopes-done](https://user-images.githubusercontent.com/22062107/34057511-3eaf1f64-e1a5-11e7-824b-7058aee9b6ec.gif)

