### PR TITLE
Add go to line shortcut in shortcuts modal

### DIFF
--- a/assets/panel/debugger.properties
+++ b/assets/panel/debugger.properties
@@ -567,16 +567,16 @@ watchExpressions.refreshButton=Refresh
 # LOCALIZATION NOTE (welcome.search): The center pane welcome panel's
 # search prompt. e.g. cmd+p to search for files. On windows, it's ctrl, on
 # a mac we use the unicode character.
-welcome.search=%S to search for sources
+welcome.search=%S To search for sources
 
 # LOCALIZATION NOTE (welcome.findInFiles): The center pane welcome panel's
 # search prompt. e.g. cmd+f to search for files. On windows, it's ctrl+shift+f, on
 # a mac we use the unicode character.
-welcome.findInFiles=%S to find in files
+welcome.findInFiles=%S To find in files
 
 # LOCALIZATION NOTE (welcome.searchFunction): Label displayed in the welcome
 # panel. %S is replaced by the keyboard shortcut to search for functions.
-welcome.searchFunction=%S to search for functions in file
+welcome.searchFunction=%S To search for functions in file
 
 # LOCALIZATION NOTE (sourceSearch.search): The center pane Source Search
 # prompt for searching for files.
@@ -704,10 +704,10 @@ functionSearchSeparatorLabel=←
 
 # LOCALIZATION NOTE(gotoLineModal.placeholder): The placeholder
 # text displayed when the user searches for specific lines in a file
-# Do not localize "CmdOrCtrl+Shift+;", or change the format of the string. These are
+# Do not localize "CmdOrCtrl+;", or change the format of the string. These are
 # key identifiers, not messages displayed to the user.
 gotoLineModal.placeholder=Go to line…
-gotoLineModal.key=CmdOrCtrl+Shift+;
+gotoLineModal.key=CmdOrCtrl+;
 gotoLineModal.title=Go to a line number in a file
 
 # LOCALIZATION NOTE(symbolSearch.search.functionsPlaceholder): The placeholder
@@ -845,6 +845,10 @@ shortcuts.stepOut=Step Out
 # LOCALIZATION NOTE (shortcuts.fileSearch): text describing
 # keyboard shortcut action for source file search
 shortcuts.fileSearch=Source File Search
+
+# LOCALIZATION NOTE (shortcuts.gotoLine): text describing
+# keyboard shortcut for jumping to a specific line
+shortcuts.gotoLine=Go to line
 
 # LOCALIZATION NOTE (shortcuts.searchAgain): text describing
 # keyboard shortcut action for searching again

--- a/src/components/ShortcutsModal.js
+++ b/src/components/ShortcutsModal.js
@@ -86,6 +86,10 @@ export class ShortcutsModal extends Component<Props> {
           L10N.getStr("shortcuts.functionSearch"),
           formatKeyShortcut(L10N.getStr("functionSearch.key"))
         )}
+         {this.renderShorcutItem(
+           L10N.getStr("shortcuts.gotoLine"),
+           formatKeyShortcut(L10N.getStr("gotoLineModal.key"))
+         )}
       </ul>
     );
   }


### PR DESCRIPTION
Associated Issue: #4804 

### Summary of Changes

* Add go to line shortcut `CtrlorCmd+:` in shortcut modal.

### Screenshots

![screenshot-2017-12-16 debugger 2](https://user-images.githubusercontent.com/21259802/34070513-c3b9dd3c-e28d-11e7-94b9-9d8c7ccba246.png)

