### PR TITLE
Fis CI intermittent and maxListeners

### DIFF
--- a/src/test/tests-framework.js
+++ b/src/test/tests-framework.js
@@ -16,11 +16,16 @@ import { clearHistory } from "./utils/history";
 
 global.jasmine.DEFAULT_TIMEOUT_INTERVAL = 20000;
 
+function formatException(reason, p) {
+  console && console.log("Unhandled Rejection at:", p, "reason:", reason);
+}
+
 beforeAll(() => {
   startSourceMapWorker(getValue("workers.sourceMapURL"));
   startPrettyPrintWorker(getValue("workers.prettyPrintURL"));
   startParserWorker(getValue("workers.parserURL"));
   startSearchWorker(getValue("workers.searchURL"));
+  process.on("unhandledRejection", formatException);
 });
 
 afterAll(() => {
@@ -28,6 +33,7 @@ afterAll(() => {
   stopPrettyPrintWorker();
   stopParserWorker();
   stopSearchWorker();
+  process.removeListener("unhandledRejection", formatException);
 });
 
 beforeEach(() => {

--- a/src/test/tests-setup.js
+++ b/src/test/tests-setup.js
@@ -26,7 +26,3 @@ global.L10N = require("devtools-launchpad").L10N;
 global.L10N.setBundle(readFileSync("./assets/panel/debugger.properties"));
 
 setConfig(config);
-
-process.on("unhandledRejection", (reason, p) => {
-  console.log("Unhandled Rejection at:", p, "reason:", reason);
-});


### PR DESCRIPTION
Associated Issue: #4927 #4894 

### Summary of Changes

I found the source of the maxEventListeners bug in Jest while hunting down an intermittent on CI.
It turns out that we were binding our unhandledRejection listener on every test run. 
