### PR TITLE
Open worker in toolbox

### DIFF
--- a/assets/panel/prefs.js
+++ b/assets/panel/prefs.js
@@ -15,7 +15,7 @@ pref("devtools.debugger.source-maps-enabled", true);
 pref("devtools.debugger.pretty-print-enabled", true);
 pref("devtools.debugger.auto-pretty-print", false);
 pref("devtools.debugger.auto-black-box", true);
-pref("devtools.debugger.workers", false);
+pref("devtools.debugger.features.workers", false);
 
 // The default Debugger UI settings
 pref("devtools.debugger.prefs-schema-version", "1.0.0");

--- a/src/actions/toolbox.js
+++ b/src/actions/toolbox.js
@@ -5,6 +5,7 @@
 // @flow
 
 const { isDevelopment } = require("devtools-config");
+const { getWorker } = require("../selectors");
 
 import type { ThunkArgs } from "./types";
 
@@ -19,6 +20,20 @@ export function openLink(url: string) {
       win.focus();
     } else {
       openLinkCommand(url);
+    }
+  };
+}
+
+export function openWorkerToolbox(url: string) {
+  return async function({
+    getState,
+    openWorkerToolbox: openWorkerToolboxCommand
+  }: ThunkArgs) {
+    const worker = getWorker(getState(), url);
+    if (isDevelopment()) {
+      alert(url);
+    } else {
+      openWorkerToolboxCommand(worker);
     }
   };
 }

--- a/src/actions/types.js
+++ b/src/actions/types.js
@@ -42,7 +42,8 @@ export type ThunkArgs = {
   getState: () => State,
   client: any,
   sourceMaps: any,
-  openLink: (url: string) => void
+  openLink: (url: string) => void,
+  openWorkerToolbox: (url: string) => void
 };
 
 export type Thunk = ThunkArgs => any;

--- a/src/components/SecondaryPanes/Workers.css
+++ b/src/components/SecondaryPanes/Workers.css
@@ -13,4 +13,5 @@
   line-height: 1em;
   position: relative;
   transition: all 0.25s ease;
+  cursor: pointer;
 }

--- a/src/components/SecondaryPanes/Workers.js
+++ b/src/components/SecondaryPanes/Workers.js
@@ -3,21 +3,34 @@
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
 import React, { PureComponent } from "react";
-import "./Workers.css";
+import { bindActionCreators } from "redux";
 import { connect } from "react-redux";
-import { getWorkers } from "../../selectors";
 import type { List } from "immutable";
+
+import "./Workers.css";
+
+import actions from "../../actions";
+import { getWorkers } from "../../selectors";
 import type { Worker } from "../../types";
 
 export class Workers extends PureComponent {
   props: {
-    workers: List<Worker>
+    workers: List<Worker>,
+    openWorkerToolbox: string => void
   };
 
+  selectWorker(url) {
+    this.props.openWorkerToolbox(url);
+  }
+
   renderWorkers(workers) {
-    return workers.map(w => (
-      <div className="worker" key={w.url}>
-        {w.url}
+    return workers.map(worker => (
+      <div
+        className="worker"
+        key={worker.url}
+        onClick={() => this.selectWorker(worker.url)}
+      >
+        {worker.url}
       </div>
     ));
   }
@@ -38,7 +51,9 @@ export class Workers extends PureComponent {
   }
 }
 
-function mapStateToProps(state) {
-  return { workers: getWorkers(state) };
-}
-export default connect(mapStateToProps)(Workers);
+export default connect(
+  state => {
+    return { workers: getWorkers(state) };
+  },
+  dispatch => bindActionCreators(actions, dispatch)
+)(Workers);

--- a/src/components/SecondaryPanes/index.js
+++ b/src/components/SecondaryPanes/index.js
@@ -213,7 +213,7 @@ class SecondaryPanes extends Component<Props> {
       });
     }
 
-    if (isEnabled("workers")) {
+    if (features.workers) {
       items.push({
         header: L10N.getStr("workersHeader"),
         className: "workers-pane",

--- a/src/reducers/debuggee.js
+++ b/src/reducers/debuggee.js
@@ -43,3 +43,9 @@ const getDebuggeeWrapper = state => state.debuggee;
 export const getWorkers = createSelector(getDebuggeeWrapper, debuggeeState =>
   debuggeeState.get("workers")
 );
+
+type OuterState = { debuggee: DebuggeeState };
+
+export function getWorker(state: OuterState, url: string) {
+  return getWorkers(state).find(value => url);
+}


### PR DESCRIPTION
Associated Issue: #4033

Here's the Pull Request Doc
https://devtools-html.github.io/debugger.html/CONTRIBUTING.html#pull-requests

### Summary of Changes

* Add `openWorkerToolbox` action
* Added selectors

TODO
* Fix bug with worker not connectiing on opening the toolbox

### Test Plan

Tell us a little a bit about how you tested your patch.

Example test plan:

- [x] Load page with workers
- [x] When paused open the worker list
- [x] Click a worker
- [x] Clicking "x" closes the panel

