### PR TITLE
Revert "Throttle new sources (#4749)"

### DIFF
--- a/src/actions/sources.js
+++ b/src/actions/sources.js
@@ -114,19 +114,8 @@ export function newSources(sources: Source[]) {
       source => !getSource(getState(), source.id)
     );
 
-    if (filteredSources.length == 0) {
-      return;
-    }
-
-    dispatch({
-      type: "ADD_SOURCES",
-      sources: filteredSources
-    });
-
     for (const source of filteredSources) {
-      dispatch(loadSourceMap(source));
-      dispatch(checkSelectedSource(source));
-      dispatch(checkPendingBreakpoints(source.id));
+      dispatch(newSource(source));
     }
   };
 }
@@ -153,7 +142,6 @@ function createOriginalSource(
 function loadSourceMap(generatedSource) {
   return async function({ dispatch, getState, sourceMaps }: ThunkArgs) {
     const urls = await sourceMaps.getOriginalURLs(generatedSource);
-
     if (!urls) {
       // If this source doesn't have a sourcemap, do nothing.
       return;

--- a/src/client/firefox/types.js
+++ b/src/client/firefox/types.js
@@ -221,7 +221,7 @@ export type ListTabsResponse = {
 export type Actions = {
   paused: Pause => void,
   resumed: ResumedPacket => void,
-  newSources: (Source[]) => void,
+  newSource: Source => void,
   fetchEventListeners: () => void
 };
 

--- a/src/reducers/sources.js
+++ b/src/reducers/sources.js
@@ -55,14 +55,16 @@ function update(
 
   switch (action.type) {
     case "ADD_SOURCE": {
-      return updateSource(state, action.source);
+      const source = action.source;
+      return updateSource(state, source);
     }
 
     case "ADD_SOURCES": {
-      return action.sources.reduce(
-        (newState, source) => updateSource(newState, source),
-        state
-      );
+      action.sources.forEach(source => {
+        state = state.mergeIn(["sources", source.id], source);
+      });
+
+      return state;
     }
 
     case "SELECT_SOURCE":

--- a/src/test/mochitest/browser_dbg-breaking.js
+++ b/src/test/mochitest/browser_dbg-breaking.js
@@ -13,7 +13,7 @@ add_task(async function() {
   reload(dbg);
   await waitForPaused(dbg);
 
-  await waitForSelectedSource(dbg, "doc-scripts.html");
+  await waitForLoadedSource(dbg, "doc-scripts.html");
   assertPausedLocation(dbg);
   await resume(dbg);
 


### PR DESCRIPTION
Reverts the throttle optimization because it had a memory leak w/ try.

We're working on a fix now 