### PR TITLE
Synchronize wasmparser with m-c.

### DIFF
--- a/assets/panel/WASMPARSER_UPGRADING
+++ b/assets/panel/WASMPARSER_UPGRADING
@@ -1,0 +1,14 @@
+# wasmparser version
+
+Current vesion is: $(WASMPARSER_VERSION)
+
+# Upgrade process
+
+1. Pull latest release from npm and extract WasmDis.js and WasmParser.js, e.g.
+
+```
+curl https://registry.npmjs.org/wasmparser/-/wasmparser-$(WASMPARSER_VERSION).tgz | tar -x --strip-components 2 package/dist/{WasmDis,WasmParser}.js
+```
+
+2. Remove reference to source maps (last line)
+


### PR DESCRIPTION
Associated Issue: automation of bug1426251-like tasks

### Summary of Changes

* Copies WasmParser.js/WasmDis.js files into
* Produces valid WASMPARSER_UPGRADING help file

