### PR TITLE
WIP - Adds loading message for source tree if sources are loading and no items are displayed yet

### DIFF
--- a/src/components/PrimaryPanes/Sources.css
+++ b/src/components/PrimaryPanes/Sources.css
@@ -116,6 +116,29 @@
   border-left: 0;
 }
 
+.source-outline-tabs .tab .loader-spinner {
+  z-index: 100;
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  float: right;
+  border: 2px solid var(--theme-splitter-color);
+  border-top: 2px solid var(--theme-body-color);
+  border-radius: 50%;
+  width: 12px;
+  height: 12px;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
 .source-outline-tabs .tab:hover {
   background-color: var(--theme-toolbar-background-alt);
   border-color: var(--theme-splitter-color);

--- a/src/components/PrimaryPanes/Sources.css
+++ b/src/components/PrimaryPanes/Sources.css
@@ -69,6 +69,7 @@
   display: inline-block;
 }
 
+.sources-loading-message,
 .no-sources-message {
   width: 100%;
   font-style: italic;

--- a/src/components/PrimaryPanes/SourcesTree.js
+++ b/src/components/PrimaryPanes/SourcesTree.js
@@ -48,24 +48,25 @@ import { features } from "../../utils/prefs";
 import { setProjectDirectoryRoot } from "../../actions/ui";
 
 type Props = {
-  selectLocation: Object => void,
-  setExpandedState: any => void,
-  sources: SourcesMap,
-  shownSource?: string,
-  selectedSource?: SourceRecord,
   debuggeeUrl: string,
+  expanded?: any,
   projectRoot: string,
-  expanded?: any
+  selectLocation: Object => void,
+  selectedSource?: SourceRecord,
+  setExpandedState: any => void,
+  shownSource?: string,
+  sources: SourcesMap
 };
 
 type State = {
   focusedItem?: any,
-  parentMap: any,
-  sourceTree: any,
-  projectRoot: string,
-  uncollapsedTree: any,
+  highlightItems?: any,
+  isSourceTreeLoaded: boolean,
   listItems?: any,
-  highlightItems?: any
+  parentMap: any,
+  projectRoot: string,
+  sourceTree: any,
+  uncollapsedTree: any
 };
 
 class SourcesTree extends Component<Props, State> {
@@ -80,11 +81,14 @@ class SourcesTree extends Component<Props, State> {
 
   constructor(props) {
     super(props);
-    this.state = createTree(
-      this.props.sources,
-      this.props.debuggeeUrl,
-      this.props.projectRoot
-    );
+    this.state = {
+      ...createTree(
+        this.props.sources,
+        this.props.debuggeeUrl,
+        this.props.projectRoot
+      ),
+      isSourceTreeLoaded: true
+    };
     this.focusItem = this.focusItem.bind(this);
     this.selectItem = this.selectItem.bind(this);
     this.getPath = this.getPath.bind(this);
@@ -115,6 +119,14 @@ class SourcesTree extends Component<Props, State> {
   }
 
   componentWillReceiveProps(nextProps) {
+    // set isSourceTreeLoaded state
+    if (
+      this.props.debuggeeUrl != nextProps.debuggeeUrl ||
+      this.props.sources.size != nextProps.sources.size
+    ) {
+      this.setState({ ...this.state, isSourceTreeLoaded: false });
+    }
+
     if (
       this.props.projectRoot !== nextProps.projectRoot ||
       this.props.debuggeeUrl !== nextProps.debuggeeUrl
@@ -373,11 +385,15 @@ class SourcesTree extends Component<Props, State> {
     const tree = <ManagedTree {...treeProps} />;
 
     if (isEmpty) {
-      return (
-        <div className="no-sources-message">
-          {L10N.getStr("sources.noSourcesAvailable")}
-        </div>
-      );
+      if (!this.state.isSourceTreeLoaded) {
+        const returnMessage = L10N.getStr("loadingText");
+        const className = "sources-loading-message";
+        return <div className={className}>{returnMessage}</div>;
+      }
+
+      const returnMessage = L10N.getStr("sources.noSourcesAvailable");
+      const className = "no-sources-message";
+      return <div className={className}>{returnMessage}</div>;
     }
 
     const onKeyDown = e => {

--- a/src/components/PrimaryPanes/index.js
+++ b/src/components/PrimaryPanes/index.js
@@ -71,6 +71,7 @@ class PrimaryPanes extends Component<Props> {
         key="sources-tab"
       >
         {sources}
+        <div className="loader-spinner" />
       </div>,
       <div
         className={classnames("tab outline-tab", {


### PR DESCRIPTION
Associated Issue: #4863

### Summary of Changes

* Makes SourceTree component aware of isSourceTreeLoaded component state
* Adds display message for loading sources + changes in css
* Orders props & state alphabetically

### Screenshots/Videos
1st reload = reload of debugger (no loading indicator since sources are loaded before component is mounted)
2nd reload = reload of target window (loading indicator as sources are being loaded while debugger is displayed)
![loading-indicator](https://user-images.githubusercontent.com/23530054/34338047-f8cb81be-e964-11e7-887a-9df94df8b15e.gif)

