### PR TITLE
Fix clearing debug line

### DIFF
--- a/src/components/Editor/DebugLine.js
+++ b/src/components/Editor/DebugLine.js
@@ -93,7 +93,7 @@ export class DebugLine extends Component<Props> {
     }
 
     const sourceId = selectedFrame.location.sourceId;
-    const { line } = toEditorPosition(sourceId, selectedFrame.location);
+    const { line } = toEditorPosition(selectedFrame.location);
     const doc = getDocument(sourceId);
     const { lineClass } = this.getTextClasses(pause);
     doc.removeLineClass(line, "line", lineClass);

--- a/src/test/mochitest/head.js
+++ b/src/test/mochitest/head.js
@@ -313,8 +313,14 @@ function assertDebugLine(dbg, line) {
   );
 
   const debugLine =
-    findElementWithSelector(dbg, ".new-debug-line") ||
-    findElementWithSelector(dbg, ".new-debug-line-error");
+    findElement(dbg, "debugLine") || findElement(dbg, "debugErrorLine");
+
+  is(
+    findAllElements(dbg, "debugLine").length +
+      findAllElements(dbg, "debugErrorLine").length,
+    1,
+    "There is only one line"
+  );
 
   ok(isVisibleInEditor(dbg, debugLine), "debug line is visible");
 
@@ -935,6 +941,8 @@ const selectors = {
   pauseOnExceptions: ".pause-exceptions",
   breakpoint: ".CodeMirror-code > .new-breakpoint",
   highlightLine: ".CodeMirror-code > .highlight-line",
+  debugLine: ".new-debug-line",
+  debugErrorLine: ".new-debug-line-error",
   codeMirror: ".CodeMirror",
   resume: ".resume.active",
   sourceTabs: ".source-tabs",

--- a/src/utils/editor/index.js
+++ b/src/utils/editor/index.js
@@ -88,7 +88,7 @@ function toEditorLine(sourceId: string, lineOrOffset: number): ?number {
     return wasmOffsetToLine(sourceId, lineOrOffset);
   }
 
-  return !lineOrOffset ? 1 : lineOrOffset - 1;
+  return lineOrOffset ? lineOrOffset - 1 : 1;
 }
 
 function toEditorPosition(location: AstPosition): EditorPosition {


### PR DESCRIPTION
Associated Issue: #4968 

### Summary of Changes

A last minute change to toEditorPosition broke the clearing mechanism for debug line. This fixes that and adds a test so that we don't have multiple debug lines in the future.