### PR TITLE
Refactor source actions (1/x)

### DIFF
--- a/src/actions/navigation.js
+++ b/src/actions/navigation.js
@@ -6,7 +6,7 @@ import { clearDocuments } from "../utils/editor";
 import sourceQueue from "../utils/source-queue";
 import { getSources } from "../reducers/sources";
 import { waitForMs } from "../utils/utils";
-import { newSources } from "./sources";
+import { newSources } from "./sources/index";
 import {
   clearASTs,
   clearSymbols,

--- a/src/actions/sources.js
+++ b/src/actions/sources.js
@@ -9,19 +9,16 @@
  * @module actions/sources
  */
 
-import { PROMISE } from "./utils/middleware/promise";
-
 import { setOutOfScopeLocations } from "./ast";
-import { syncBreakpoint } from "./breakpoints";
 import { searchSource } from "./project-text-search";
 import { closeActiveSearch } from "./ui";
 
 import { createLocation } from "../utils/location";
 import { togglePrettyPrint } from "./sources/prettyPrint";
+import { addTab, closeTab } from "./sources/tabs";
 import { loadSourceText } from "./sources/loadSourceText";
 
 import { prefs } from "../utils/prefs";
-import { removeDocument } from "../utils/editor";
 import { isThirdParty, shouldPrettyPrint, isMinified } from "../utils/source";
 import { getGeneratedLocation } from "../utils/source-maps";
 import { isOriginalId } from "devtools-source-map";
@@ -31,146 +28,13 @@ import {
   getSources,
   getSourceByURL,
   getSelectedSource,
-  getPendingSelectedLocation,
-  getPendingBreakpointsForSource,
-  getSourceTabs,
-  getNewSelectedSourceId,
-  removeSourcesFromTabList,
   getPrettySource,
-  removeSourceFromTabList,
   getTextSearchQuery,
   getActiveSearch
 } from "../selectors";
 
-import type { Source, Location } from "../types";
+import type { Location } from "../types";
 import type { ThunkArgs } from "./types";
-
-// If a request has been made to show this source, go ahead and
-// select it.
-function checkSelectedSource(source) {
-  return async ({ dispatch, getState }: ThunkArgs) => {
-    const pendingLocation = getPendingSelectedLocation(getState());
-
-    if (pendingLocation && !!source.url && pendingLocation.url === source.url) {
-      await dispatch(
-        selectLocation({ ...pendingLocation, sourceId: source.id })
-      );
-    }
-  };
-}
-
-function checkPendingBreakpoints(sourceId) {
-  return async ({ dispatch, getState }: ThunkArgs) => {
-    // source may have been modified by selectLocation
-    const source = getSource(getState(), sourceId);
-
-    const pendingBreakpoints = getPendingBreakpointsForSource(
-      getState(),
-      source.get("url")
-    );
-
-    if (!pendingBreakpoints.size) {
-      return;
-    }
-
-    // load the source text if there is a pending breakpoint for it
-    await dispatch(loadSourceText(source));
-
-    const pendingBreakpointsArray = pendingBreakpoints.valueSeq().toJS();
-    for (const pendingBreakpoint of pendingBreakpointsArray) {
-      await dispatch(syncBreakpoint(sourceId, pendingBreakpoint));
-    }
-  };
-}
-
-/**
- * Handler for the debugger client's unsolicited newSource notification.
- * @memberof actions/sources
- * @static
- */
-export function newSource(source: Source) {
-  return async ({ dispatch, getState }: ThunkArgs) => {
-    const _source = getSource(getState(), source.id);
-    if (_source) {
-      return;
-    }
-
-    dispatch({ type: "ADD_SOURCE", source });
-
-    if (prefs.clientSourceMapsEnabled) {
-      dispatch(loadSourceMap(source));
-    }
-
-    dispatch(checkSelectedSource(source));
-    dispatch(checkPendingBreakpoints(source.id));
-  };
-}
-
-export function newSources(sources: Source[]) {
-  return async ({ dispatch, getState }: ThunkArgs) => {
-    const filteredSources = sources.filter(
-      source => !getSource(getState(), source.id)
-    );
-
-    if (filteredSources.length == 0) {
-      return;
-    }
-
-    dispatch({
-      type: "ADD_SOURCES",
-      sources: filteredSources
-    });
-
-    for (const source of filteredSources) {
-      dispatch(checkSelectedSource(source));
-      dispatch(checkPendingBreakpoints(source.id));
-    }
-
-    return Promise.all(
-      filteredSources.map(source => dispatch(loadSourceMap(source)))
-    );
-  };
-}
-
-function createOriginalSource(
-  originalUrl,
-  generatedSource,
-  sourceMaps
-): Source {
-  return {
-    url: originalUrl,
-    id: sourceMaps.generatedToOriginalId(generatedSource.id, originalUrl),
-    isPrettyPrinted: false,
-    isWasm: false,
-    isBlackBoxed: false,
-    loadedState: "unloaded"
-  };
-}
-
-/**
- * @memberof actions/sources
- * @static
- */
-function loadSourceMap(generatedSource) {
-  return async function({ dispatch, getState, sourceMaps }: ThunkArgs) {
-    const urls = await sourceMaps.getOriginalURLs(generatedSource);
-
-    if (!urls) {
-      // If this source doesn't have a sourcemap, do nothing.
-      return;
-    }
-
-    const originalSources = urls.map(url =>
-      createOriginalSource(url, generatedSource, sourceMaps)
-    );
-
-    // TODO: check if this line is really needed, it introduces
-    // a lot of lag to the application.
-    const generatedSourceRecord = getSource(getState(), generatedSource.id);
-    await dispatch(loadSourceText(generatedSourceRecord));
-    dispatch(newSources(originalSources));
-  };
-}
 
 declare type SelectSourceOptions = {
   tabIndex?: number,
@@ -298,70 +162,6 @@ export function jumpToMappedLocation(sourceLocation: any) {
     }
 
     return dispatch(selectLocation({ ...pairedLocation }));
-  };
-}
-
-export function addTab(source: Source, tabIndex: number) {
-  return {
-    type: "ADD_TAB",
-    source,
-    tabIndex
-  };
-}
-
-export function moveTab(url: string, tabIndex: number) {
-  return {
-    type: "MOVE_TAB",
-    url,
-    tabIndex
-  };
-}
-
-/**
- * @memberof actions/sources
- * @static
- */
-export function closeTab(url: string) {
-  return ({ dispatch, getState, client }: ThunkArgs) => {
-    removeDocument(url);
-    const tabs = removeSourceFromTabList(getSourceTabs(getState()), url);
-    const sourceId = getNewSelectedSourceId(getState(), tabs);
-
-    dispatch({ type: "CLOSE_TAB", url, tabs });
-    dispatch(selectSource(sourceId));
-  };
-}
-
-/**
- * @memberof actions/sources
- * @static
- */
-export function closeTabs(urls: string[]) {
-  return ({ dispatch, getState, client }: ThunkArgs) => {
-    urls.forEach(url => {
-      const source = getSourceByURL(getState(), url);
-      if (source) {
-        removeDocument(source.get("id"));
-      }
-    });
-
-    const tabs = removeSourcesFromTabList(getSourceTabs(getState()), urls);
-    const sourceId = getNewSelectedSourceId(getState(), tabs);
-
-    dispatch({ type: "CLOSE_TABS", urls, tabs });
-    dispatch(selectSource(sourceId));
-  };
-}
-
-export function toggleBlackBox(source: Source) {
-  return async ({ dispatch, getState, client, sourceMaps }: ThunkArgs) => {
-    const { isBlackBoxed, id } = source;
-
-    return dispatch({
-      type: "BLACKBOX",
-      source,
-      [PROMISE]: client.blackBox(id, isBlackBoxed)
-    });
   };
 }
 

--- a/src/actions/sources/blackbox.js
+++ b/src/actions/sources/blackbox.js
@@ -1,0 +1,26 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
+// @flow
+
+/**
+ * Redux actions for the sources state
+ * @module actions/sources
+ */
+
+import { PROMISE } from "../utils/middleware/promise";
+import type { Source } from "../../types";
+import type { ThunkArgs } from "../types";
+
+export function toggleBlackBox(source: Source) {
+  return async ({ dispatch, getState, client, sourceMaps }: ThunkArgs) => {
+    const { isBlackBoxed, id } = source;
+
+    return dispatch({
+      type: "BLACKBOX",
+      source,
+      [PROMISE]: client.blackBox(id, isBlackBoxed)
+    });
+  };
+}

--- a/src/actions/sources/index.js
+++ b/src/actions/sources/index.js
@@ -1,2 +1,11 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
+// @flow
+
 export { loadSourceText } from "./loadSourceText";
 export { togglePrettyPrint } from "./prettyPrint";
+export { newSource, newSources } from "./newSources";
+export { toggleBlackBox } from "./blackbox";
+export * from "./tabs";

--- a/src/actions/sources/newSources.js
+++ b/src/actions/sources/newSources.js
@@ -1,0 +1,152 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
+// @flow
+
+/**
+ * Redux actions for the sources state
+ * @module actions/sources
+ */
+
+import { syncBreakpoint } from "../breakpoints";
+import { loadSourceText } from "./loadSourceText";
+import { selectLocation } from "../sources";
+
+import { prefs } from "../../utils/prefs";
+
+import {
+  getSource,
+  getPendingSelectedLocation,
+  getPendingBreakpointsForSource
+} from "../../selectors";
+
+import type { Source } from "../../types";
+import type { ThunkArgs } from "../types";
+
+function createOriginalSource(
+  originalUrl,
+  generatedSource,
+  sourceMaps
+): Source {
+  return {
+    url: originalUrl,
+    id: sourceMaps.generatedToOriginalId(generatedSource.id, originalUrl),
+    isPrettyPrinted: false,
+    isWasm: false,
+    isBlackBoxed: false,
+    loadedState: "unloaded"
+  };
+}
+
+/**
+ * @memberof actions/sources
+ * @static
+ */
+function loadSourceMap(generatedSource) {
+  return async function({ dispatch, getState, sourceMaps }: ThunkArgs) {
+    const urls = await sourceMaps.getOriginalURLs(generatedSource);
+
+    if (!urls) {
+      // If this source doesn't have a sourcemap, do nothing.
+      return;
+    }
+
+    const originalSources = urls.map(url =>
+      createOriginalSource(url, generatedSource, sourceMaps)
+    );
+
+    // TODO: check if this line is really needed, it introduces
+    // a lot of lag to the application.
+    const generatedSourceRecord = getSource(getState(), generatedSource.id);
+    await dispatch(loadSourceText(generatedSourceRecord));
+    dispatch(newSources(originalSources));
+  };
+}
+
+// If a request has been made to show this source, go ahead and
+// select it.
+function checkSelectedSource(source) {
+  return async ({ dispatch, getState }: ThunkArgs) => {
+    const pendingLocation = getPendingSelectedLocation(getState());
+
+    if (pendingLocation && !!source.url && pendingLocation.url === source.url) {
+      await dispatch(
+        selectLocation({ ...pendingLocation, sourceId: source.id })
+      );
+    }
+  };
+}
+
+function checkPendingBreakpoints(sourceId) {
+  return async ({ dispatch, getState }: ThunkArgs) => {
+    // source may have been modified by selectLocation
+    const source = getSource(getState(), sourceId);
+
+    const pendingBreakpoints = getPendingBreakpointsForSource(
+      getState(),
+      source.get("url")
+    );
+
+    if (!pendingBreakpoints.size) {
+      return;
+    }
+
+    // load the source text if there is a pending breakpoint for it
+    await dispatch(loadSourceText(source));
+
+    const pendingBreakpointsArray = pendingBreakpoints.valueSeq().toJS();
+    for (const pendingBreakpoint of pendingBreakpointsArray) {
+      await dispatch(syncBreakpoint(sourceId, pendingBreakpoint));
+    }
+  };
+}
+
+/**
+ * Handler for the debugger client's unsolicited newSource notification.
+ * @memberof actions/sources
+ * @static
+ */
+export function newSource(source: Source) {
+  return async ({ dispatch, getState }: ThunkArgs) => {
+    const _source = getSource(getState(), source.id);
+    if (_source) {
+      return;
+    }
+
+    dispatch({ type: "ADD_SOURCE", source });
+
+    if (prefs.clientSourceMapsEnabled) {
+      dispatch(loadSourceMap(source));
+    }
+
+    dispatch(checkSelectedSource(source));
+    dispatch(checkPendingBreakpoints(source.id));
+  };
+}
+
+export function newSources(sources: Source[]) {
+  return async ({ dispatch, getState }: ThunkArgs) => {
+    const filteredSources = sources.filter(
+      source => !getSource(getState(), source.id)
+    );
+
+    if (filteredSources.length == 0) {
+      return;
+    }
+
+    dispatch({
+      type: "ADD_SOURCES",
+      sources: filteredSources
+    });
+
+    for (const source of filteredSources) {
+      dispatch(checkSelectedSource(source));
+      dispatch(checkPendingBreakpoints(source.id));
+    }
+
+    return Promise.all(
+      filteredSources.map(source => dispatch(loadSourceMap(source)))
+    );
+  };
+}

--- a/src/actions/sources/tabs.js
+++ b/src/actions/sources/tabs.js
@@ -1,0 +1,75 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
+// @flow
+
+/**
+ * Redux actions for the sources state
+ * @module actions/sources
+ */
+
+import { removeDocument } from "../../utils/editor";
+import { selectSource } from "../sources";
+
+import {
+  getSourceByURL,
+  getSourceTabs,
+  getNewSelectedSourceId,
+  removeSourcesFromTabList,
+  removeSourceFromTabList
+} from "../../selectors";
+
+import type { Source } from "../../types";
+import type { ThunkArgs } from "../types";
+
+export function addTab(source: Source, tabIndex: number) {
+  return {
+    type: "ADD_TAB",
+    source,
+    tabIndex
+  };
+}
+
+export function moveTab(url: string, tabIndex: number) {
+  return {
+    type: "MOVE_TAB",
+    url,
+    tabIndex
+  };
+}
+
+/**
+ * @memberof actions/sources
+ * @static
+ */
+export function closeTab(url: string) {
+  return ({ dispatch, getState, client }: ThunkArgs) => {
+    removeDocument(url);
+    const tabs = removeSourceFromTabList(getSourceTabs(getState()), url);
+    const sourceId = getNewSelectedSourceId(getState(), tabs);
+    dispatch({ type: "CLOSE_TAB", url, tabs });
+    dispatch(selectSource(sourceId));
+  };
+}
+
+/**
+ * @memberof actions/sources
+ * @static
+ */
+export function closeTabs(urls: string[]) {
+  return ({ dispatch, getState, client }: ThunkArgs) => {
+    urls.forEach(url => {
+      const source = getSourceByURL(getState(), url);
+      if (source) {
+        removeDocument(source.get("id"));
+      }
+    });
+
+    const tabs = removeSourcesFromTabList(getSourceTabs(getState()), urls);
+    dispatch({ type: "CLOSE_TABS", urls, tabs });
+
+    const sourceId = getNewSelectedSourceId(getState(), tabs);
+    dispatch(selectSource(sourceId));
+  };
+}


### PR DESCRIPTION
### Summary of Changes

* extract newSources
* extract tabs
* extract blackbox

Currently this is sitting on top of the pause refactor, so it's blocked by that work