### PR TITLE
Skip preview test on windows

### DIFF
--- a/src/test/mochitest/browser.ini
+++ b/src/test/mochitest/browser.ini
@@ -104,8 +104,9 @@ skip-if = os == "win"
 [browser_dbg-pretty-print-console.js]
 [browser_dbg-pretty-print-paused.js]
 [browser_dbg-preview.js]
-skip-if = true # regular failures during release in Bug 1415300
+skip-if = os == "win"
 [browser_dbg-preview-source-maps.js]
+skip-if = os == "win"
 [browser_dbg-returnvalues.js]
 [browser_dbg-scopes-mutations.js]
 [browser_dbg-search-file.js]


### PR DESCRIPTION
We are seeing some failing tests on windows for `browser_dbg-preview-source-maps` I'm guessing that it is due to the cursor position.

I'm going to try also enabling the other preview test for all platforms, sans windows too