### PR TITLE
Protect getSymbols

### DIFF
--- a/src/workers/parser/tests/getSymbols.spec.js
+++ b/src/workers/parser/tests/getSymbols.spec.js
@@ -6,8 +6,10 @@ import cases from "jest-in-case";
 
 cases(
   "Parser.getSymbols",
-  ({ name, file, type }) =>
-    expect(formatSymbols(getSource(file, type))).toMatchSnapshot(),
+  ({ name, file, type }) => {
+    // console.log(formatSymbols(getSource(file, type)));
+    expect(formatSymbols(getSource(file, type))).toMatchSnapshot();
+  },
   [
     { name: "es6", file: "es6" },
     { name: "func", file: "func" },

--- a/src/workers/parser/utils/helpers.js
+++ b/src/workers/parser/utils/helpers.js
@@ -69,7 +69,15 @@ export function getMemberExpression(root: Node) {
 }
 
 export function getVariables(dec: Node) {
-  if (dec.id.type === "ArrayPattern") {
+  if (!dec.id) {
+    return [];
+  }
+
+  if (t.isArrayPattern(dec.id)) {
+    if (!dec.id.elements) {
+      return [];
+    }
+
     return dec.id.elements.map(element => {
       return {
         name: element.name || element.argument.name,


### PR DESCRIPTION
### Summary of Changes

I'm seeing some errors when i try to add a breakpoint `elements.map is undefined` I believe this is coming from a case in `getVariables`, but i have not been able to fully track it down yet

This change is the start of a fix, where we try/catch extractSymbol so that we don't fail if we don't understand a path
