### PR TITLE
Fixes loadSourceText async loading for wasm.

### DIFF
--- a/src/actions/sources/loadSourceText.js
+++ b/src/actions/sources/loadSourceText.js
@@ -89,17 +89,16 @@ export function loadSourceText(source: SourceRecord) {
     });
 
     const newSource = getSource(getState(), source.get("id")).toJS();
-    if (newSource.isWasm) {
-      return;
-    }
 
-    if (isOriginalId(newSource.id)) {
+    if (isOriginalId(newSource.id) && !newSource.isWasm) {
       const generatedSource = getGeneratedSource(getState(), source.toJS());
       await dispatch(loadSourceText(generatedSource));
     }
 
-    await setSource(newSource);
-    dispatch(setSymbols(id));
+    if (!newSource.isWasm) {
+      await setSource(newSource);
+      dispatch(setSymbols(id));
+    }
 
     // signal that the action is finished
     deferred.resolve();

--- a/src/actions/sources/loadSourceText.js
+++ b/src/actions/sources/loadSourceText.js
@@ -13,7 +13,7 @@ import {
   getSources,
   getTextSearchQuery
 } from "../../selectors";
-import { setSource } from "../../workers/parser";
+import * as parser from "../../workers/parser";
 import { isThirdParty, isLoading, isLoaded } from "../../utils/source";
 
 import defer from "../../utils/defer";
@@ -96,7 +96,7 @@ export function loadSourceText(source: SourceRecord) {
     }
 
     if (!newSource.isWasm) {
-      await setSource(newSource);
+      await parser.setSource(newSource);
       dispatch(setSymbols(id));
     }
 


### PR DESCRIPTION
Regressed after 81b70c614cfbc2

### Summary of Changes

* Changes loadSourceText logic to allow wasm source to finish the request

### Test Plan

1. Open https://mdn.github.io/webassembly-examples/js-api-examples/memory.html
2. Start debugger
3. Refresh the debuggee
4. Locate/open wasm source and set breakpoint at 0x52 address (at "i32.load")
5. Refresh the debuggee

Notice at source is loaded and stopped at the desired location