### PR TITLE
Fix destructuring

### DIFF
--- a/src/workers/parser/getSymbols.js
+++ b/src/workers/parser/getSymbols.js
@@ -200,6 +200,9 @@ function extractSymbol(path, symbols) {
   if (t.isVariableDeclarator(path)) {
     const node = path.node.id;
     const { start, end } = path.node.loc;
+    if (t.isArrayPattern(node)) {
+      return;
+    }
 
     symbols.identifiers.push({
       name: node.name,

--- a/src/workers/parser/tests/__snapshots__/getSymbols.spec.js.snap
+++ b/src/workers/parser/tests/__snapshots__/getSymbols.spec.js.snap
@@ -371,6 +371,7 @@ variables:
 [(12, 17), (12, 27)]   foooo
 [(14, 6), (14, 16)]   foo
 [(14, 23), (14, 31)]   z
+[(16, 7), (16, 15)]   prefName
 
 callExpressions:
 [(1, 21), (1, 28)]   compute
@@ -379,6 +380,7 @@ callExpressions:
 memberExpressions:
 [(7, 35), (7, 42)] [(7, 31), (7, 42)] arr.entries entries
 [(8, 10), (8, 13)] [(8, 2), (8, 13)] console.log log
+[(16, 34), (16, 46)] [(16, 19), (16, 47)] prefsBlueprint.accessorName accessorName
 
 objectProperties:
 [(1, 8), (1, 9)]  b b
@@ -441,6 +443,10 @@ identifiers:
 [(14, 7), (14, 10)]  key key
 [(14, 13), (14, 16)]  foo foo
 [(14, 23), (14, 24)]  z z
+[(16, 4), (16, 47)]
+[(16, 7), (16, 15)]  prefName prefName
+[(16, 19), (16, 33)]  prefsBlueprint prefsBlueprint
+[(16, 34), (16, 46)]  accessorName accessorName
 
 classes:
 

--- a/src/workers/parser/tests/__snapshots__/getSymbols.spec.js.snap
+++ b/src/workers/parser/tests/__snapshots__/getSymbols.spec.js.snap
@@ -412,14 +412,11 @@ identifiers:
 [(2, 18), (2, 22)]  last last
 [(2, 24), (2, 25)]  l l
 [(2, 30), (2, 33)]  obj obj
-[(4, 6), (4, 35)]
 [(4, 7), (4, 8)]  a a
 [(4, 13), (4, 17)]  rest rest
 [(4, 21), (4, 28)]  compute compute
 [(4, 29), (4, 34)]  stuff stuff
-[(5, 6), (5, 17)]
 [(5, 7), (5, 8)]  x x
-[(7, 11), (7, 27)]
 [(7, 12), (7, 17)]  index index
 [(7, 19), (7, 26)]  element element
 [(7, 31), (7, 34)]  arr arr
@@ -443,7 +440,6 @@ identifiers:
 [(14, 7), (14, 10)]  key key
 [(14, 13), (14, 16)]  foo foo
 [(14, 23), (14, 24)]  z z
-[(16, 4), (16, 47)]
 [(16, 7), (16, 15)]  prefName prefName
 [(16, 19), (16, 33)]  prefsBlueprint prefsBlueprint
 [(16, 34), (16, 46)]  accessorName accessorName

--- a/src/workers/parser/tests/fixtures/destructuring.js
+++ b/src/workers/parser/tests/fixtures/destructuring.js
@@ -12,3 +12,5 @@ const { a: aa = 10, b: bb = 5 } = { a: 3 };
 const { temp: [{ foo: foooo }] } = obj;
 
 let { [key]: foo } = { z: "bar" };
+
+let [, prefName] = prefsBlueprint[accessorName];

--- a/src/workers/parser/utils/helpers.js
+++ b/src/workers/parser/utils/helpers.js
@@ -78,7 +78,9 @@ export function getVariables(dec: Node) {
       return [];
     }
 
-    return dec.id.elements.map(element => {
+    // NOTE: it's possible that an element is empty
+    // e.g. const [, a] = arr
+    return dec.id.elements.filter(element => element).map(element => {
       return {
         name: element.name || element.argument.name,
         location: element.loc


### PR DESCRIPTION
### Summary of Changes

#5013 fixed the issue where we could throw an exception while getting symbols. This fixes the bug we were seeing in the debugger bundle.

As a fun fact, I found the bug by dropping the bundle into a test fixture and running it directly. This was easier than debugging the browser toolbox's parser worker :)

  