### PR TITLE
[WIP] Display original scopes data from source maps.

### DIFF
--- a/flow-typed/debugger-html.js
+++ b/flow-typed/debugger-html.js
@@ -315,7 +315,10 @@ declare module "debugger-html" {
 
   declare type SyntheticScope = {
     type: string,
-    bindingsNames: string[]
+    bindingsNames: string[],
+    sourceBindings?: {
+      [originalName: string]: string
+    }
   };
 
   /**

--- a/src/actions/pause/fetchScopes.js
+++ b/src/actions/pause/fetchScopes.js
@@ -28,6 +28,9 @@ function mapScopes(scopes: Scope, frame: Frame) {
           const astScopes: ?(SourceScope[]) = await getScopes(location);
           return sourceMaps.getLocationScopes(location, astScopes);
         },
+        async getSourceMapsOriginalScopes(location) {
+          return sourceMaps.getOriginalScopes(location);
+        },
         async getOriginalSourceScopes(location) {
           const source = getSource(getState(), location.sourceId);
           await dispatch(loadSourceText(source));


### PR DESCRIPTION
Built on top of #4521 (redo of #4613)

Associated Issue: display scopes saved in source maps (experimental!)
Summary of Changes

* Display original scopes data from source maps.

Requires

 * https://github.com/yurydelendik/devtools-core/tree/fake-scopes
