### PR TITLE
Fix old debugger workers pref

### DIFF
--- a/assets/panel/prefs.js
+++ b/assets/panel/prefs.js
@@ -15,7 +15,7 @@ pref("devtools.debugger.source-maps-enabled", true);
 pref("devtools.debugger.pretty-print-enabled", true);
 pref("devtools.debugger.auto-pretty-print", false);
 pref("devtools.debugger.auto-black-box", true);
-pref("devtools.debugger.features.workers", false);
+pref("devtools.debugger.workers", false);
 
 // The default Debugger UI settings
 pref("devtools.debugger.prefs-schema-version", "1.0.0");
@@ -48,3 +48,4 @@ pref("devtools.debugger.features.column-breakpoints", false);
 pref("devtools.debugger.features.map-scopes", true);
 pref("devtools.debugger.features.breakpoints-dropdown", false);
 pref("devtools.debugger.features.remove-command-bar-options", false);
+pref("devtools.debugger.features.workers", false);


### PR DESCRIPTION


this fixes a bug we introduced in #4945 where the old debugger's worker pref became un-available

+ failing test `browser_jsterm_autocomplete_in_debugger_stackframe.js`
+ [workersEnabled](https://searchfox.org/mozilla-central/source/devtools/client/debugger/debugger-controller.js#1220)