### PR TITLE
Synchronize localization note fixes from Bug 1425280

### DIFF
--- a/assets/panel/debugger.properties
+++ b/assets/panel/debugger.properties
@@ -357,7 +357,7 @@ callStack.expand=Expand rows
 # for the summarizing the selected search result. e.g. 5 of 10 results.
 editor.searchResults=%d of %d results
 
-# LOCALIZATION NOTE (sourceSearch.singleResult): Copy shown when there is one result.
+# LOCALIZATION NOTE (editor.singleResult): Copy shown when there is one result.
 editor.singleResult=1 result
 
 # LOCALIZATION NOTE (editor.noResults): Editor Search bar message
@@ -411,7 +411,7 @@ editor.addConditionalBreakpoint.accesskey=c
 # input element inside ConditionalPanel component
 editor.conditionalPanel.placeholder=This breakpoint will pause when the expression is true
 
-# LOCALIZATION NOTE (editor.conditionalPanel.placeholder): Tooltip text for
+# LOCALIZATION NOTE (editor.conditionalPanel.close): Tooltip text for
 # close button inside ConditionalPanel component
 editor.conditionalPanel.close=Cancel edit breakpoint and close
 
@@ -557,7 +557,7 @@ welcome.searchFunction=%S to search for functions in file
 # prompt for searching for files.
 sourceSearch.search=Search sources…
 
-# LOCALIZATION NOTE (sourceSearch.noResults): The center pane Source Search
+# LOCALIZATION NOTE (sourceSearch.noResults2): The center pane Source Search
 # message when the query did not match any of the sources.
 sourceSearch.noResults2=No results found
 
@@ -638,7 +638,7 @@ variablesCloseButtonTooltip=Click to remove
 # in the variables list on a getter or setter which can be edited.
 variablesEditButtonTooltip=Click to set value
 
-# LOCALIZATION NOTE (variablesEditableValueTooltip): The text that is displayed
+# LOCALIZATION NOTE (variablesDomNodeValueTooltip): The text that is displayed
 # in a tooltip on the "open in inspector" button in the the variables list for a
 # DOMNode item.
 variablesDomNodeValueTooltip=Click to select the node in the inspector


### PR DESCRIPTION
Forgot to synchronize https://bugzilla.mozilla.org/show_bug.cgi?id=1425280 here, sorry about that.
(however this shows that we really need a tool to check this kind of things).

Fixes localization notes in debugger's properties file. Please include it in the current release to avoid overriding this in m-c.
