### PR TITLE
Fix pane ordering

### DIFF
--- a/src/components/SecondaryPanes/index.js
+++ b/src/components/SecondaryPanes/index.js
@@ -240,10 +240,10 @@ class SecondaryPanes extends Component<Props> {
     items.push(this.getBreakpointsItem());
 
     if (this.props.isPaused) {
+      items.push(this.getCallStackItem());
       if (this.props.horizontal) {
         items.push(this.getScopeItem());
       }
-      items.push(this.getCallStackItem());
     }
 
     if (isEnabled("eventListeners")) {


### PR DESCRIPTION

### Summary of Changes

When we landed the #4974 work, we accidentally flipped the ordering of the scopes and call stack panes. 