### PR TITLE
Fix timing connect issue

### DIFF
--- a/src/actions/navigation.js
+++ b/src/actions/navigation.js
@@ -56,7 +56,7 @@ export function navigate(url: string) {
 
 export function connect(url: string) {
   return async function({ dispatch }: ThunkArgs) {
-    dispatch(updateWorkers());
+    await dispatch(updateWorkers());
     dispatch({ type: "CONNECT", url });
   };
 }

--- a/src/actions/tests/navigation.spec.js
+++ b/src/actions/tests/navigation.spec.js
@@ -1,8 +1,10 @@
 import { createStore, selectors, actions } from "../../utils/test-head";
 describe("navigation", () => {
-  it("connect sets the debuggeeUrl", () => {
-    const { dispatch, getState } = createStore();
-    dispatch(actions.connect("http://test.com/foo"));
+  it("connect sets the debuggeeUrl", async () => {
+    const { dispatch, getState } = createStore({
+      fetchWorkers: () => Promise.resolve({ workers: [] })
+    });
+    await dispatch(actions.connect("http://test.com/foo"));
     expect(selectors.getDebuggeeUrl(getState())).toEqual("http://test.com/foo");
   });
 });

--- a/src/client/firefox.js
+++ b/src/client/firefox.js
@@ -46,7 +46,7 @@ export async function onConnect(connection: any, actions: Object): Object {
   // bfcache) so explicity fire `newSource` events for all returned
   // sources.
   const sources = await clientCommands.fetchSources();
-  actions.connect(tabTarget.url);
+  await actions.connect(tabTarget.url);
   await actions.newSources(sources);
 
   // If the threadClient is already paused, make sure to show a


### PR DESCRIPTION

### Summary of Changes

This test `devtools/client/netmonitor/test/browser_net_open_in_debugger.js` found a timing issue where we needed to wait for connect to finish fetching the workers before we concluded the debugger was open...

  