### PR TITLE
Support pausing immediately

### DIFF
--- a/src/actions/navigation.js
+++ b/src/actions/navigation.js
@@ -41,13 +41,13 @@ export function willNavigate(_: any, event: Object) {
     clearASTs();
     clearScopes();
     clearSources();
-    sourceQueue.clear();
-
     dispatch(navigate(event.url));
   };
 }
 
 export function navigate(url: string) {
+  sourceQueue.clear();
+
   return {
     type: "NAVIGATE",
     url

--- a/src/client/firefox/events.js
+++ b/src/client/firefox/events.js
@@ -61,7 +61,7 @@ async function paused(_: "paused", packet: PausedPacket) {
 
   if (why.type != "alreadyPaused") {
     const pause = createPause(packet, response);
-    sourceQueue.flush();
+    await sourceQueue.flush();
     actions.paused(pause);
   }
 }

--- a/src/test/mochitest/browser_dbg-sourcemaps-reloading.js
+++ b/src/test/mochitest/browser_dbg-sourcemaps-reloading.js
@@ -27,6 +27,7 @@ add_task(async function() {
     "Breakpoint has correct line"
   );
 
+  await addBreakpoint(dbg, entrySrc, 5);
   await addBreakpoint(dbg, entrySrc, 15);
   await disableBreakpoint(dbg, entrySrc, 15);
 
@@ -34,7 +35,10 @@ add_task(async function() {
   await reload(dbg, "opts.js");
   await waitForDispatch(dbg, "LOAD_SOURCE_TEXT");
 
-  is(getBreakpoints(getState()).size, 2, "One breakpoint exists");
+  await waitForPaused(dbg);
+  assertPausedLocation(dbg);
+
+  is(getBreakpoints(getState()).size, 3, "Three breakpoints exist");
 
   ok(
     getBreakpoint(getState(), { sourceId: entrySrc.id, line: 13 }),

--- a/src/utils/source-queue.js
+++ b/src/utils/source-queue.js
@@ -2,20 +2,19 @@ import { throttle } from "lodash";
 
 let newSources;
 let createSource;
-let queuedSources;
 let supportsWasm = false;
+let queuedSources;
 
-const queue = throttle(() => {
-  if (!newSources || !createSource) {
-    return;
-  }
-  newSources(
-    queuedSources.map(source => {
-      return createSource(source, { supportsWasm });
-    })
-  );
+async function dispatchNewSources() {
+  const sources = queuedSources;
   queuedSources = [];
-}, 100);
+
+  await newSources(
+    sources.map(source => createSource(source, { supportsWasm }))
+  );
+}
+
+const queue = throttle(dispatchNewSources, 100);
 
 export default {
   initialize: options => {


### PR DESCRIPTION
Associated Issue: #5057 

### Summary of Changes

When we pause we need to wait for sources to be registered in redux and the parser worker. This is why when we pause we flush the newSources queue. The issue is we also need to wait on original sources  to be fetched from the source map worker :)

### Screenshots

| Before | After |
| -- | --- |
| ![b] | ![a] |

[b]: https://user-images.githubusercontent.com/254562/34797795-97a8bbe8-f627-11e7-83d9-92519b673696.png
[a]: https://user-images.githubusercontent.com/254562/34797796-97b52748-f627-11e7-97a1-53ec01d44faa.png

