### PR TITLE
Refresh search results on modifier change

### DIFF
--- a/src/components/Editor/SearchBar.js
+++ b/src/components/Editor/SearchBar.js
@@ -232,7 +232,8 @@ class SearchBar extends Component<Props, State> {
   }
 
   renderSearchModifiers = () => {
-    const { modifiers, toggleFileSearchModifier } = this.props;
+    const { modifiers, toggleFileSearchModifier, query } = this.props;
+    const { doSearch } = this;
 
     function SearchModBtn({ modVal, className, svgName, tooltip }) {
       const preppedClass = classnames(className, {
@@ -241,7 +242,10 @@ class SearchBar extends Component<Props, State> {
       return (
         <button
           className={preppedClass}
-          onClick={() => toggleFileSearchModifier(modVal)}
+          onClick={() => {
+            toggleFileSearchModifier(modVal);
+            doSearch(query);
+          }}
           title={tooltip}
         >
           <Svg name={svgName} />


### PR DESCRIPTION
Associated Issue: #5082 

* Refresh search results when search modifier is changed

- [x] `yarn test`

### Screenshots/Videos (OPTIONAL)

![search-bug](https://user-images.githubusercontent.com/7821757/34869996-c4571c10-f7ae-11e7-9792-c91a208a1736.gif)

