### PR TITLE
[SourceTree] show loading sources

### DIFF
--- a/src/utils/sources-tree/utils.js
+++ b/src/utils/sources-tree/utils.js
@@ -48,7 +48,6 @@ export function isInvalidUrl(url: Object, source: SourceRecord) {
   return (
     IGNORED_URLS.indexOf(url) != -1 ||
     !source.get("url") ||
-    source.get("loadedState") === "loading" ||
     !url.group ||
     isPretty(source) ||
     isNotJavaScript(source)


### PR DESCRIPTION
Associated Issue: #5029

#### Summary

We were skipping sources that were loading, which was bad because they would not be added in the future. If we want to be safer we can keep loading sources out of the newSet, but i don't know if it's needed and it is slower:

```diff
diff --git a/src/components/PrimaryPanes/SourcesTree.js b/src/components/PrimaryPanes/SourcesTree.js
index f58b121..b5d593a 100644
--- a/src/components/PrimaryPanes/SourcesTree.js
+++ b/src/components/PrimaryPanes/SourcesTree.js
@@ -175,7 +175,9 @@ class SourcesTree extends Component<Props, State> {

     // TODO: do not run this every time a source is clicked,
     // only when a new source is added
-    const next = Set(nextProps.sources.valueSeq());
+    const next = Set(nextProps.sources.valueSeq()).filter(
+      source => !isLoading(source.toJS())
+    );
```

### Testing

Reviewed https://github.com/devtools-html/debugger.html/issues/3430 https://github.com/devtools-html/debugger.html/pull/3563