### PR TITLE
Speedup sync bp

### DIFF
--- a/src/actions/ast.js
+++ b/src/actions/ast.js
@@ -4,7 +4,12 @@
 
 // @flow
 
-import { getSource, hasSymbols, getSelectedLocation } from "../selectors";
+import {
+  getSource,
+  hasSymbols,
+  getSelectedLocation,
+  getSymbols as _getSymbols
+} from "../selectors";
 
 import { setInScopeLines } from "./ast/setInScopeLines";
 import {
@@ -47,13 +52,17 @@ export function setSymbols(sourceId: SourceId) {
       return;
     }
 
+    if (_getSymbols(getState(), sourceRecord)) {
+      return;
+    }
+
     const source = sourceRecord.toJS();
 
     if (!source.text || source.isWasm || hasSymbols(getState(), source)) {
       return;
     }
 
-    const symbols = await getSymbols(source);
+    const symbols = await getSymbols(source.id);
     dispatch({ type: "SET_SYMBOLS", source, symbols });
     dispatch(setEmptyLines(source.id));
     dispatch(setSourceMetaData(source.id));
@@ -72,7 +81,7 @@ export function setEmptyLines(sourceId: SourceId) {
       return;
     }
 
-    const emptyLines = await getEmptyLines(source);
+    const emptyLines = await getEmptyLines(source.id);
 
     dispatch({
       type: "SET_EMPTY_LINES",
@@ -95,7 +104,7 @@ export function setOutOfScopeLocations() {
     const locations =
       !location.line || !source
         ? null
-        : await findOutOfScopeLocations(source.toJS(), location);
+        : await findOutOfScopeLocations(source.id, location);
 
     dispatch({
       type: "OUT_OF_SCOPE_LOCATIONS",

--- a/src/actions/breakpoints/addBreakpoint.js
+++ b/src/actions/breakpoints/addBreakpoint.js
@@ -9,7 +9,7 @@ import {
   getASTLocation,
   assertLocation
 } from "../../utils/breakpoint";
-import { getSource } from "../../selectors";
+import { getSource, getSymbols } from "../../selectors";
 import { getGeneratedLocation } from "../../utils/source-maps";
 
 export default async function addBreakpoint(
@@ -50,7 +50,8 @@ export default async function addBreakpoint(
     newGeneratedLocation
   );
 
-  const astLocation = await getASTLocation(sourceRecord, newLocation);
+  const symbols = getSymbols(getState, sourceRecord);
+  const astLocation = await getASTLocation(sourceRecord, symbols, newLocation);
 
   const newBreakpoint = {
     id,

--- a/src/actions/pause/paused.js
+++ b/src/actions/pause/paused.js
@@ -14,6 +14,7 @@ import { removeBreakpoint } from "../breakpoints";
 import { evaluateExpressions } from "../expressions";
 import { selectLocation } from "../sources";
 import { togglePaneCollapse } from "../ui";
+import { setOutOfScopeLocations } from "../ast";
 
 import { fetchScopes } from "./fetchScopes";
 
@@ -54,5 +55,6 @@ export function paused(pauseInfo: Pause) {
 
     dispatch(togglePaneCollapse("end", false));
     dispatch(fetchScopes());
+    dispatch(setOutOfScopeLocations());
   };
 }

--- a/src/actions/sources/loadSourceText.js
+++ b/src/actions/sources/loadSourceText.js
@@ -6,7 +6,6 @@
 
 import { isOriginalId } from "devtools-source-map";
 import { PROMISE } from "../utils/middleware/promise";
-import { setSymbols } from "../ast";
 import {
   getSource,
   getGeneratedSource,
@@ -97,8 +96,9 @@ export function loadSourceText(source: SourceRecord) {
 
     if (!newSource.isWasm) {
       await parser.setSource(newSource);
-      dispatch(setSymbols(id));
     }
+
+    console.log("LOAD_SOURCE_TEXT LOADED");
 
     // signal that the action is finished
     deferred.resolve();

--- a/src/actions/sources/newSources.js
+++ b/src/actions/sources/newSources.js
@@ -41,14 +41,23 @@ function createOriginalSource(
   };
 }
 
+// TODO: It would be nice to make getOriginalURLs a safer api
+async function loadOriginalSourceUrls(sourceMaps, generatedSource) {
+  try {
+    return await sourceMaps.getOriginalURLs(generatedSource);
+  } catch (e) {
+    console.error(e);
+    return null;
+  }
+}
+
 /**
  * @memberof actions/sources
  * @static
  */
 function loadSourceMap(generatedSource) {
   return async function({ dispatch, getState, sourceMaps }: ThunkArgs) {
-    const urls = await sourceMaps.getOriginalURLs(generatedSource);
-
+    const urls = await loadOriginalSourceUrls(sourceMaps, generatedSource);
     if (!urls) {
       // If this source doesn't have a sourcemap, do nothing.
       return;

--- a/src/actions/sources/select.js
+++ b/src/actions/sources/select.js
@@ -11,7 +11,7 @@
 
 import { isOriginalId } from "devtools-source-map";
 
-import { setOutOfScopeLocations } from "../ast";
+import { setSymbols, setOutOfScopeLocations } from "../ast";
 import { closeActiveSearch } from "../ui";
 
 import { togglePrettyPrint } from "./prettyPrint";
@@ -129,7 +129,7 @@ export function selectLocation(location: Location, tabIndex: string = "") {
       dispatch(closeTab(source.get("url")));
     }
 
-    dispatch(setOutOfScopeLocations());
+    dispatch(setSymbols(selectedSource.get("id")));
   };
 }
 

--- a/src/utils/breakpoint/astBreakpointLocation.js
+++ b/src/utils/breakpoint/astBreakpointLocation.js
@@ -48,13 +48,13 @@ export function findClosestScope(functions: Scope[], location: Location) {
 
 export async function getASTLocation(
   source: Source,
+  symbols: Object,
   location: Location
 ): Promise<ASTLocation> {
   if (source.isWasm) {
     return { name: undefined, offset: location };
   }
 
-  const symbols = await getSymbols(source);
   const functions = [...symbols.functions];
 
   const scope = findClosestScope(functions, location);
@@ -71,7 +71,7 @@ export async function getASTLocation(
 }
 
 export async function findScopeByName(source: Source, name: ?string) {
-  const symbols = await getSymbols(source);
+  const symbols = await getSymbols(source.id);
   const functions = symbols.functions;
 
   return functions.find(node => node.name === name);

--- a/src/workers/parser/findOutOfScopeLocations.js
+++ b/src/workers/parser/findOutOfScopeLocations.js
@@ -116,10 +116,10 @@ function sortByStart(a: AstLocation, b: AstLocation) {
  * location.
  */
 function findOutOfScopeLocations(
-  source: Source,
+  sourceId: string,
   position: AstPosition
 ): AstLocation[] {
-  const { functions, comments } = findSymbols(source);
+  const { functions, comments } = findSymbols(sourceId);
   const commentLocations = comments.map(c => c.location);
   let locations = functions
     .map(getLocation)

--- a/src/workers/parser/frameworks.js
+++ b/src/workers/parser/frameworks.js
@@ -4,8 +4,8 @@
 
 import getSymbols from "./getSymbols";
 
-export function isReactComponent(source) {
-  const { imports, classes, callExpressions } = getSymbols(source);
+export function isReactComponent(sourceId) {
+  const { imports, classes, callExpressions } = getSymbols(sourceId);
   return (
     (importsReact(imports) || requiresReact(callExpressions)) &&
     extendsComponent(classes)

--- a/src/workers/parser/getEmptyLines.js
+++ b/src/workers/parser/getEmptyLines.js
@@ -34,12 +34,12 @@ function getExecutableLines(ast) {
   return uniq(lines);
 }
 
-export default function getEmptyLines(sourceToJS) {
-  if (!sourceToJS) {
+export default function getEmptyLines(sourceId) {
+  if (!sourceId) {
     return null;
   }
 
-  const ast = getAst(sourceToJS);
+  const ast = getAst(sourceId);
   if (!ast || !ast.comments) {
     return [];
   }

--- a/src/workers/parser/getScopes.js
+++ b/src/workers/parser/getScopes.js
@@ -20,7 +20,7 @@ export default function getScopes(location: Location): SourceScope[] {
   let parsedScopes = parsedScopesCache.get(sourceId);
   if (!parsedScopes) {
     const visitor = createParseJSScopeVisitor(sourceId);
-    traverseAst(getSource(sourceId), visitor.traverseVisitor);
+    traverseAst(sourceId, visitor.traverseVisitor);
     parsedScopes = visitor.toParsedScopes();
     parsedScopesCache.set(sourceId, parsedScopes);
   }

--- a/src/workers/parser/getSymbols.js
+++ b/src/workers/parser/getSymbols.js
@@ -5,10 +5,12 @@
 // @flow
 
 import flatten from "lodash/flatten";
+import * as t from "babel-types";
+
+import { getSource } from "./sources";
 import { traverseAst } from "./utils/ast";
 import { isVariable, isFunction, getVariables } from "./utils/helpers";
 import { inferClassName } from "./utils/inferClassName";
-import * as t from "babel-types";
 import getFunctionName from "./utils/getFunctionName";
 
 import type { Source } from "debugger-html";
@@ -212,7 +214,7 @@ function extractSymbol(path, symbols) {
   }
 }
 
-function extractSymbols(source: Source) {
+function extractSymbols(sourceId) {
   const symbols = {
     functions: [],
     variables: [],
@@ -226,7 +228,7 @@ function extractSymbols(source: Source) {
     hasJsx: false
   };
 
-  const ast = traverseAst(source, {
+  const ast = traverseAst(sourceId, {
     enter(path: NodePath) {
       try {
         extractSymbol(path, symbols);
@@ -239,20 +241,6 @@ function extractSymbols(source: Source) {
   // comments are extracted separately from the AST
   symbols.comments = getComments(ast);
 
-  return symbols;
-}
-
-export default function getSymbols(source: Source): SymbolDeclarations {
-  if (symbolDeclarations.has(source.id)) {
-    const symbols = symbolDeclarations.get(source.id);
-    if (symbols) {
-      return symbols;
-    }
-  }
-
-  const symbols = extractSymbols(source);
-
-  symbolDeclarations.set(source.id, symbols);
   return symbols;
 }
 
@@ -400,4 +388,18 @@ function getSnippet(path, prevPath, expression = "") {
 
 export function clearSymbols() {
   symbolDeclarations = new Map();
+}
+
+export default function getSymbols(sourceId: string): SymbolDeclarations {
+  if (symbolDeclarations.has(sourceId)) {
+    const symbols = symbolDeclarations.get(sourceId);
+    if (symbols) {
+      return symbols;
+    }
+  }
+
+  const symbols = extractSymbols(sourceId);
+
+  symbolDeclarations.set(sourceId, symbols);
+  return symbols;
 }

--- a/src/workers/parser/utils/ast.js
+++ b/src/workers/parser/utils/ast.js
@@ -8,6 +8,7 @@ import parseScriptTags from "parse-script-tags";
 import * as babylon from "babylon";
 import traverse from "babel-traverse";
 import isEmpty from "lodash/isEmpty";
+import { getSource } from "../sources";
 
 import type { Source } from "debugger-html";
 
@@ -60,15 +61,12 @@ export function parseScript(text: string, opts?: Object) {
   return _parse(text, opts);
 }
 
-export function getAst(source: Source) {
-  if (!source || !source.text) {
-    return {};
+export function getAst(sourceId: string) {
+  if (ASTs.has(sourceId)) {
+    return ASTs.get(sourceId);
   }
 
-  if (ASTs.has(source.id)) {
-    return ASTs.get(source.id);
-  }
-
+  const source = getSource(sourceId);
   let ast = {};
   const { contentType } = source;
   if (contentType == "text/html") {
@@ -86,8 +84,8 @@ export function clearASTs() {
 }
 
 type Visitor = { enter: Function };
-export function traverseAst(source: Source, visitor: Visitor) {
-  const ast = getAst(source);
+export function traverseAst(sourceId, visitor: Visitor) {
+  const ast = getAst(sourceId);
   if (isEmpty(ast)) {
     return null;
   }


### PR DESCRIPTION
### Summary of Changes

When the page loads with breakpoints, the debugger can take a really long time to show the saved breakpoints. 

The reason for this is that syncing an original bp involves loading & parsing the generated source. We need to load the generated source, but we do not need to parse it!

Secondary perf wins:

* we pass the entire source object to the worker every time we make a call. We can save serializing time by avoiding that
* we can avoid unnecessary calls.


This PR is probably too big to land by itself, I hope to land a couple of smaller changes:

- [ ] refactor the api to source id: #5098
- [x] refactor newSource #5099
- [ ] addBreakpoint should use symbols from the store
- [x] getSymbols when we select the source #5105
- [x]  speedup generated file parsing #5101