### PR TITLE
Refactor newSource

### DIFF
--- a/src/actions/breakpoints/tests/syncing.js
+++ b/src/actions/breakpoints/tests/syncing.js
@@ -63,6 +63,7 @@ const sourceMaps = {
     line: 3,
     column: undefined
   }),
+  getOriginalURLs: () => {},
   isOriginalId: () => true,
   getGeneratedLocation: () => ({})
 };

--- a/src/actions/sources/newSources.js
+++ b/src/actions/sources/newSources.js
@@ -15,8 +15,6 @@ import { togglePrettyPrint } from "./prettyPrint";
 import { selectLocation } from "../sources";
 import { getRawSourceURL, isPrettyURL } from "../../utils/source";
 
-import { prefs } from "../../utils/prefs";
-
 import {
   getSource,
   getPendingSelectedLocation,
@@ -121,20 +119,8 @@ function checkPendingBreakpoints(sourceId) {
  * @static
  */
 export function newSource(source: Source) {
-  return async ({ dispatch, getState }: ThunkArgs) => {
-    const _source = getSource(getState(), source.id);
-    if (_source) {
-      return;
-    }
-
-    dispatch({ type: "ADD_SOURCE", source });
-
-    if (prefs.clientSourceMapsEnabled) {
-      dispatch(loadSourceMap(source));
-    }
-
-    dispatch(checkSelectedSource(source));
-    dispatch(checkPendingBreakpoints(source.id));
+  return async ({ dispatch }: ThunkArgs) => {
+    await dispatch(newSources([source]));
   };
 }
 


### PR DESCRIPTION
### Summary of Changes

Small refactor to consolidate the logic between `newSource` and `newSources`. We don't use `newSource` in the app, but we do in the tests. In the future, it might be nice to have around too...