### PR TITLE
Speed up generated source parsing

### DIFF
--- a/src/actions/tests/ast.spec.js
+++ b/src/actions/tests/ast.spec.js
@@ -5,6 +5,7 @@ import {
   selectors,
   actions,
   makeSource,
+  makeOriginalSource,
   waitForState
 } from "../../utils/test-head";
 
@@ -43,7 +44,7 @@ const sourceTexts = {
   "base.js": "function base(boo) {}",
   "foo.js": "function base(boo) { return this.bazz; } outOfScope",
   "scopes.js": readFixture("scopes.js"),
-  "reactComponent.js": readFixture("reactComponent.js")
+  "reactComponent.js-original": readFixture("reactComponent.js")
 };
 
 const evaluationResult = {
@@ -75,12 +76,12 @@ describe("ast", () => {
     it("should detect react components", async () => {
       const store = createStore(threadClient);
       const { dispatch, getState } = store;
-      const source = makeSource("reactComponent.js");
+      const source = makeOriginalSource("reactComponent.js");
+
       await dispatch(actions.newSource(source));
 
-      await dispatch(
-        actions.loadSourceText(I.Map({ id: "reactComponent.js" }))
-      );
+      await dispatch(actions.loadSourceText(I.Map({ id: source.id })));
+
       await waitForState(store, state => {
         const metaData = getSourceMetaData(state, source.id);
         return metaData && metaData.isReactComponent;

--- a/src/utils/test-head.js
+++ b/src/utils/test-head.js
@@ -57,6 +57,11 @@ function makeSource(name: string, props: any = {}) {
   };
 }
 
+function makeOriginalSource(name: string, props?: Object) {
+  const source = makeSource(name, props);
+  return { ...source, id: `${name}-original` };
+}
+
 function makeSourceRecord(name: string, props: any = {}) {
   return I.Map(makeSource(name, props));
 }
@@ -105,6 +110,7 @@ export {
   createStore,
   commonLog,
   makeSource,
+  makeOriginalSource,
   makeSourceRecord,
   makeSymbolDeclaration,
   waitForState,

--- a/src/utils/tests/function.spec.js
+++ b/src/utils/tests/function.spec.js
@@ -1,12 +1,12 @@
 import { findFunctionText } from "../function";
 
 import getSymbols from "../../workers/parser/getSymbols";
-import { getSource } from "../../workers/parser/tests/helpers";
+import { getOriginalSource } from "../../workers/parser/tests/helpers";
 
 describe("function", () => {
   describe("findFunctionText", () => {
     it("finds function", () => {
-      const source = getSource("func");
+      const source = getOriginalSource("func");
       const symbols = getSymbols(source);
 
       const text = findFunctionText(14, source, symbols);
@@ -14,7 +14,7 @@ describe("function", () => {
     });
 
     it("finds function signature", () => {
-      const source = getSource("func");
+      const source = getOriginalSource("func");
       const symbols = getSymbols(source);
 
       const text = findFunctionText(13, source, symbols);
@@ -22,7 +22,7 @@ describe("function", () => {
     });
 
     it("misses function closing brace", () => {
-      const source = getSource("func");
+      const source = getOriginalSource("func");
       const symbols = getSymbols(source);
 
       const text = findFunctionText(15, source, symbols);
@@ -32,7 +32,7 @@ describe("function", () => {
     });
 
     it("finds property function", () => {
-      const source = getSource("func");
+      const source = getOriginalSource("func");
       const symbols = getSymbols(source);
 
       const text = findFunctionText(25, source, symbols);
@@ -40,7 +40,7 @@ describe("function", () => {
     });
 
     it("finds class function", () => {
-      const source = getSource("func");
+      const source = getOriginalSource("func");
       const symbols = getSymbols(source);
 
       const text = findFunctionText(29, source, symbols);
@@ -48,7 +48,7 @@ describe("function", () => {
     });
 
     it("cant find function", () => {
-      const source = getSource("func");
+      const source = getOriginalSource("func");
       const symbols = getSymbols(source);
 
       const text = findFunctionText(17, source, symbols);

--- a/src/workers/parser/tests/closest.spec.js
+++ b/src/workers/parser/tests/closest.spec.js
@@ -2,7 +2,7 @@
 
 import { getClosestScope, getClosestExpression } from "../utils/closest";
 
-import { getSource } from "./helpers";
+import { getSource, getOriginalSource } from "./helpers";
 
 describe("parser", () => {
   describe("getClosestExpression", () => {
@@ -63,7 +63,7 @@ describe("parser", () => {
 
   describe("getClosestScope", () => {
     it("finds the scope at the beginning", () => {
-      const scope = getClosestScope(getSource("func"), {
+      const scope = getClosestScope(getOriginalSource("func"), {
         line: 5,
         column: 8
       });
@@ -73,7 +73,7 @@ describe("parser", () => {
     });
 
     it("finds a scope given at the end", () => {
-      const scope = getClosestScope(getSource("func"), {
+      const scope = getClosestScope(getOriginalSource("func"), {
         line: 9,
         column: 1
       });
@@ -83,7 +83,7 @@ describe("parser", () => {
     });
 
     it("Can find the function declaration for square", () => {
-      const scope = getClosestScope(getSource("func"), {
+      const scope = getClosestScope(getOriginalSource("func"), {
         line: 1,
         column: 1
       });

--- a/src/workers/parser/tests/framework.spec.js
+++ b/src/workers/parser/tests/framework.spec.js
@@ -1,9 +1,11 @@
 import { isReactComponent } from "../frameworks";
-import { getSource } from "./helpers";
+import { getSource, getOriginalSource } from "./helpers";
 
 describe("Parser.frameworks", () => {
   it("should be a react component", () => {
-    expect(isReactComponent(getSource("frameworks/component"))).toBe(true);
+    expect(isReactComponent(getOriginalSource("frameworks/component"))).toBe(
+      true
+    );
   });
 
   it("should handle es5 implementation of a component", () => {

--- a/src/workers/parser/tests/getEmptyLines.spec.js
+++ b/src/workers/parser/tests/getEmptyLines.spec.js
@@ -1,4 +1,4 @@
-import { getSource } from "./helpers";
+import { getSource, getOriginalSource } from "./helpers";
 import getEmptyLines from "../getEmptyLines";
 
 describe("getEmptyLines", () => {
@@ -11,6 +11,6 @@ describe("getEmptyLines", () => {
   });
 
   it("class", () => {
-    expect(getEmptyLines(getSource("class"))).toMatchSnapshot();
+    expect(getEmptyLines(getOriginalSource("class"))).toMatchSnapshot();
   });
 });

--- a/src/workers/parser/tests/getSymbols.spec.js
+++ b/src/workers/parser/tests/getSymbols.spec.js
@@ -1,21 +1,24 @@
 /* eslint max-nested-callbacks: ["error", 4]*/
 
 import { formatSymbols } from "../utils/formatSymbols";
-import { getSource } from "./helpers";
+import { getSource, getOriginalSource } from "./helpers";
 import cases from "jest-in-case";
 
 cases(
   "Parser.getSymbols",
-  ({ name, file, type }) => {
+  ({ name, file, original, type }) => {
     // console.log(formatSymbols(getSource(file, type)));
-    expect(formatSymbols(getSource(file, type))).toMatchSnapshot();
+    const source = original
+      ? getOriginalSource(file, type)
+      : getSource(file, type);
+    expect(formatSymbols(source)).toMatchSnapshot();
   },
   [
-    { name: "es6", file: "es6" },
-    { name: "func", file: "func" },
+    { name: "es6", file: "es6", original: true },
+    { name: "func", file: "func", original: true },
     { name: "math", file: "math" },
     { name: "proto", file: "proto" },
-    { name: "class", file: "class" },
+    { name: "class", file: "class", original: true },
     { name: "var", file: "var" },
     { name: "expression", file: "expression" },
     { name: "allSymbols", file: "allSymbols" },
@@ -25,10 +28,10 @@ cases(
       file: "parseScriptTags",
       type: "html"
     },
-    { name: "component", file: "component" },
-    { name: "react component", file: "frameworks/component" },
-    { name: "flow", file: "flow" },
-    { name: "jsx", file: "jsx" },
+    { name: "component", file: "component", original: true },
+    { name: "react component", file: "frameworks/component", original: true },
+    { name: "flow", file: "flow", original: true },
+    { name: "jsx", file: "jsx", original: true },
     { name: "destruct", file: "destructuring" }
   ]
 );

--- a/src/workers/parser/tests/helpers/index.js
+++ b/src/workers/parser/tests/helpers/index.js
@@ -13,3 +13,8 @@ export function getSource(name, type = "js") {
     contentType
   };
 }
+
+export function getOriginalSource(name, type) {
+  const source = getSource(name, type);
+  return { ...source, id: `${name}-original` };
+}

--- a/src/workers/parser/utils/ast.js
+++ b/src/workers/parser/utils/ast.js
@@ -20,7 +20,7 @@ function _parse(code, opts) {
 const sourceOptions = {
   generated: {},
   original: {
-    sourceType: "script",
+    sourceType: "module",
     plugins: [
       "jsx",
       "flow",
@@ -55,9 +55,7 @@ function parse(text: ?string, opts?: Object) {
 // Custom parser for parse-script-tags that adapts its input structure to
 // our parser's signature
 function htmlParser({ source, line }) {
-  return parse(source, {
-    startLine: line
-  });
+  return parse(source, { startLine: line });
 }
 
 export function parseScript(text: string, opts?: Object) {

--- a/src/workers/parser/utils/ast.js
+++ b/src/workers/parser/utils/ast.js
@@ -14,9 +14,13 @@ import type { Source } from "debugger-html";
 let ASTs = new Map();
 
 function _parse(code, opts) {
-  return babylon.parse(code, {
-    ...opts,
-    sourceType: "module",
+  return babylon.parse(code, opts);
+}
+
+const sourceOptions = {
+  generated: {},
+  original: {
+    sourceType: "script",
     plugins: [
       "jsx",
       "flow",
@@ -30,8 +34,8 @@ function _parse(code, opts) {
       "dynamicImport",
       "templateInvalidEscapes"
     ]
-  });
-}
+  }
+};
 
 function parse(text: ?string, opts?: Object) {
   let ast;
@@ -74,7 +78,9 @@ export function getAst(source: Source) {
   if (contentType == "text/html") {
     ast = parseScriptTags(source.text, htmlParser) || {};
   } else if (contentType && contentType.match(/(javascript|jsx)/)) {
-    ast = parse(source.text);
+    const type = source.id.includes("original") ? "original" : "generated";
+    const options = sourceOptions[type];
+    ast = parse(source.text, options);
   }
 
   ASTs.set(source.id, ast);


### PR DESCRIPTION
Associated Issue: #5096 

### Summary of Changes

Working on #5096, the biggest slow down comes from parsing + traversing the large generated files (aka bundles). The debugger bundles can take ~12 seconds in the debugger worker. When it's parsed in a jest test it's about ~7 seconds. 

When we parse the file without the babylon plugins, the time goes down to ~3 seconds. This could be a big savings in the debugger as we only need to parse + traverse the bundle once. 
