### PR TITLE
Get symbols in select

### DIFF
--- a/src/actions/ast.js
+++ b/src/actions/ast.js
@@ -4,7 +4,12 @@
 
 // @flow
 
-import { getSource, hasSymbols, getSelectedLocation } from "../selectors";
+import {
+  getSource,
+  hasSymbols,
+  getSelectedLocation,
+  isPaused
+} from "../selectors";
 
 import { setInScopeLines } from "./ast/setInScopeLines";
 import {
@@ -86,16 +91,12 @@ export function setOutOfScopeLocations() {
   return async ({ dispatch, getState }: ThunkArgs) => {
     const location = getSelectedLocation(getState());
 
-    if (!location) {
+    if (!location || !location.line || !isPaused(getState())) {
       return;
     }
 
     const source = getSource(getState(), location.sourceId);
-
-    const locations =
-      !location.line || !source
-        ? null
-        : await findOutOfScopeLocations(source.toJS(), location);
+    const locations = await findOutOfScopeLocations(source.toJS(), location);
 
     dispatch({
       type: "OUT_OF_SCOPE_LOCATIONS",

--- a/src/actions/ast.js
+++ b/src/actions/ast.js
@@ -60,8 +60,8 @@ export function setSymbols(sourceId: SourceId) {
 
     const symbols = await getSymbols(source);
     dispatch({ type: "SET_SYMBOLS", source, symbols });
-    dispatch(setEmptyLines(source.id));
-    dispatch(setSourceMetaData(source.id));
+    dispatch(setEmptyLines(sourceId));
+    dispatch(setSourceMetaData(sourceId));
   };
 }
 
@@ -91,12 +91,16 @@ export function setOutOfScopeLocations() {
   return async ({ dispatch, getState }: ThunkArgs) => {
     const location = getSelectedLocation(getState());
 
-    if (!location || !location.line || !isPaused(getState())) {
+    if (!location) {
       return;
     }
 
     const source = getSource(getState(), location.sourceId);
-    const locations = await findOutOfScopeLocations(source.toJS(), location);
+
+    let locations = null;
+    if (location.line && source && isPaused(getState())) {
+      locations = await findOutOfScopeLocations(source.toJS(), location);
+    }
 
     dispatch({
       type: "OUT_OF_SCOPE_LOCATIONS",

--- a/src/actions/sources/loadSourceText.js
+++ b/src/actions/sources/loadSourceText.js
@@ -103,7 +103,6 @@ export function loadSourceText(source: SourceRecord) {
 
     if (!newSource.isWasm) {
       await parser.setSource(newSource);
-      dispatch(setSymbols(id));
     }
 
     // signal that the action is finished

--- a/src/actions/sources/loadSourceText.js
+++ b/src/actions/sources/loadSourceText.js
@@ -6,7 +6,6 @@
 
 import { isOriginalId } from "devtools-source-map";
 import { PROMISE } from "../utils/middleware/promise";
-import { setSymbols } from "../ast";
 import {
   getSource,
   getGeneratedSource,

--- a/src/actions/sources/select.js
+++ b/src/actions/sources/select.js
@@ -11,7 +11,7 @@
 
 import { isOriginalId } from "devtools-source-map";
 
-import { setOutOfScopeLocations } from "../ast";
+import { setOutOfScopeLocations, setSymbols } from "../ast";
 import { closeActiveSearch } from "../ui";
 
 import { togglePrettyPrint } from "./prettyPrint";
@@ -119,16 +119,18 @@ export function selectLocation(location: Location, tabIndex: string = "") {
 
     await dispatch(loadSourceText(source));
     const selectedSource = getSelectedSource(getState());
+    const sourceId = selectedSource.get("id");
     if (
       prefs.autoPrettyPrint &&
-      !getPrettySource(getState(), selectedSource.get("id")) &&
+      !getPrettySource(getState()) &&
       shouldPrettyPrint(selectedSource) &&
       isMinified(selectedSource)
     ) {
-      await dispatch(togglePrettyPrint(source.get("id")));
+      await dispatch(togglePrettyPrint(sourceId));
       dispatch(closeTab(source.get("url")));
     }
 
+    dispatch(setSymbols(sourceId));
     dispatch(setOutOfScopeLocations());
   };
 }

--- a/src/actions/sources/select.js
+++ b/src/actions/sources/select.js
@@ -119,6 +119,10 @@ export function selectLocation(location: Location, tabIndex: string = "") {
 
     await dispatch(loadSourceText(source));
     const selectedSource = getSelectedSource(getState());
+    if (!selectedSource) {
+      return;
+    }
+
     const sourceId = selectedSource.get("id");
     if (
       prefs.autoPrettyPrint &&

--- a/src/actions/sources/select.js
+++ b/src/actions/sources/select.js
@@ -126,7 +126,7 @@ export function selectLocation(location: Location, tabIndex: string = "") {
     const sourceId = selectedSource.get("id");
     if (
       prefs.autoPrettyPrint &&
-      !getPrettySource(getState()) &&
+      !getPrettySource(getState(), sourceId) &&
       shouldPrettyPrint(selectedSource) &&
       isMinified(selectedSource)
     ) {

--- a/src/actions/sources/tests/select.spec.js
+++ b/src/actions/sources/tests/select.spec.js
@@ -2,6 +2,7 @@ import {
   actions,
   selectors,
   createStore,
+  makeFrame,
   makeSource,
   waitForState
 } from "../../../utils/test-head";
@@ -27,6 +28,10 @@ describe("sources", () => {
     const { dispatch, getState } = store;
 
     await dispatch(actions.newSource(makeSource("foo1")));
+    await dispatch(
+      actions.paused({ frames: [makeFrame({ id: 1, sourceId: "foo1" })] })
+    );
+
     await dispatch(
       actions.selectLocation({ sourceId: "foo1", line: 1, column: 5 })
     );

--- a/src/actions/tests/ast.spec.js
+++ b/src/actions/tests/ast.spec.js
@@ -6,6 +6,7 @@ import {
   actions,
   makeSource,
   makeOriginalSource,
+  makeFrame,
   waitForState
 } from "../../utils/test-head";
 
@@ -57,11 +58,10 @@ describe("ast", () => {
     it("scopes", async () => {
       const store = createStore(threadClient);
       const { dispatch, getState } = store;
-
       const source = makeSource("scopes.js");
       await dispatch(actions.newSource(source));
       await dispatch(actions.loadSourceText(I.Map({ id: "scopes.js" })));
-
+      await dispatch(actions.setEmptyLines("scopes.js"));
       await waitForState(store, state => {
         const lines = getEmptyLines(state, source);
         return lines && lines.length > 0;
@@ -81,6 +81,7 @@ describe("ast", () => {
       await dispatch(actions.newSource(source));
 
       await dispatch(actions.loadSourceText(I.Map({ id: source.id })));
+      await dispatch(actions.setSourceMetaData(source.id));
 
       await waitForState(store, state => {
         const metaData = getSourceMetaData(state, source.id);
@@ -97,6 +98,7 @@ describe("ast", () => {
       const source = makeSource("base.js");
       await dispatch(actions.newSource(source));
       await dispatch(actions.loadSourceText(I.Map({ id: "base.js" })));
+      await dispatch(actions.setSourceMetaData("base.js"));
       await waitForState(store, state => {
         const metaData = getSourceMetaData(state, source.id);
         return metaData && metaData.isReactComponent === false;
@@ -115,6 +117,7 @@ describe("ast", () => {
         const base = makeSource("base.js");
         await dispatch(actions.newSource(base));
         await dispatch(actions.loadSourceText(I.Map({ id: "base.js" })));
+        await dispatch(actions.setSymbols("base.js"));
         await waitForState(
           store,
           state => getSymbols(state, base).functions.length > 0
@@ -158,6 +161,12 @@ describe("ast", () => {
       await dispatch(
         actions.selectLocation({ sourceId: "scopes.js", line: 5 })
       );
+      await dispatch(
+        actions.paused({
+          frames: [makeFrame({ id: 1, sourceId: "scopes.js" })]
+        })
+      );
+      await dispatch(actions.setOutOfScopeLocations("scopes.js"));
       await waitForState(store, state => getOutOfScopeLocations(state));
 
       const locations = getOutOfScopeLocations(getState());

--- a/src/actions/tests/helpers/threadClient.js
+++ b/src/actions/tests/helpers/threadClient.js
@@ -83,5 +83,6 @@ export const sourceThreadClient = {
 
       reject(`unknown source: ${sourceId}`);
     });
-  }
+  },
+  getFrameScopes: () => {}
 };

--- a/src/actions/tests/pause.spec.js
+++ b/src/actions/tests/pause.spec.js
@@ -3,7 +3,8 @@ import {
   selectors,
   createStore,
   waitForState,
-  makeSource
+  makeSource,
+  makeFrame
 } from "../../utils/test-head";
 
 const { isStepping } = selectors;
@@ -31,7 +32,7 @@ const mockThreadClient = {
 
 function createPauseInfo(overrides = {}) {
   return {
-    frames: [{ id: 1, scope: [], location: { sourceId: "foo1", line: 4 } }],
+    frames: [makeFrame({ id: 1, sourceId: "foo" })],
     loadedObjects: [],
     why: {},
     ...overrides

--- a/src/actions/tests/pause.spec.js
+++ b/src/actions/tests/pause.spec.js
@@ -25,6 +25,11 @@ const mockThreadClient = {
             source: "function foo1() {\n  return 5;\n}",
             contentType: "text/javascript"
           });
+        case "foo":
+          resolve({
+            source: "function foo() {\n  return -5;\n}",
+            contentType: "text/javascript"
+          });
       }
     });
   }
@@ -89,6 +94,7 @@ describe("pause", () => {
       const mockPauseInfo = createPauseInfo();
 
       await dispatch(actions.newSource(makeSource("foo1")));
+      await dispatch(actions.newSource(makeSource("foo")));
       dispatch(actions.addExpression("foo"));
       await waitForState(store, state => selectors.getExpression(state, "foo"));
 

--- a/src/actions/tests/pause.spec.js
+++ b/src/actions/tests/pause.spec.js
@@ -21,12 +21,12 @@ const mockThreadClient = {
     return new Promise((resolve, reject) => {
       switch (sourceId) {
         case "foo1":
-          resolve({
+          return resolve({
             source: "function foo1() {\n  return 5;\n}",
             contentType: "text/javascript"
           });
         case "foo":
-          resolve({
+          return resolve({
             source: "function foo() {\n  return -5;\n}",
             contentType: "text/javascript"
           });

--- a/src/utils/test-head.js
+++ b/src/utils/test-head.js
@@ -44,7 +44,7 @@ function commonLog(msg: string, data: any = {}) {
   console.log(`[INFO] ${msg} ${JSON.stringify(data)}`);
 }
 
-function makeFrame({ id, sourceId }, opts = {}) {
+function makeFrame({ id, sourceId }: Object, opts: Object = {}) {
   return { id, scope: [], location: { sourceId, line: 4 }, ...opts };
 }
 

--- a/src/utils/test-head.js
+++ b/src/utils/test-head.js
@@ -44,6 +44,10 @@ function commonLog(msg: string, data: any = {}) {
   console.log(`[INFO] ${msg} ${JSON.stringify(data)}`);
 }
 
+function makeFrame({ id, sourceId }, opts = {}) {
+  return { id, scope: [], location: { sourceId, line: 4 }, ...opts };
+}
+
 /**
  * @memberof utils/test-head
  * @static
@@ -109,6 +113,7 @@ export {
   reducers,
   createStore,
   commonLog,
+  makeFrame,
   makeSource,
   makeOriginalSource,
   makeSourceRecord,


### PR DESCRIPTION
Associated Issue: #5096 

### Summary of Changes

* Moves `getSymbols` from `loadSourceText` to `selectLocation`.
* The rationale is that loadSource could happen much on debuggee load, which is unnecessary 