### PR TITLE
Disable map scopes

### DIFF
--- a/assets/panel/prefs.js
+++ b/assets/panel/prefs.js
@@ -48,7 +48,7 @@ pref("devtools.debugger.features.shortcuts", true);
 pref("devtools.debugger.features.root", false);
 pref("devtools.debugger.features.column-breakpoints", false);
 pref("devtools.debugger.features.chrome-scopes", false);
-pref("devtools.debugger.features.map-scopes", true);
+pref("devtools.debugger.features.map-scopes", false);
 pref("devtools.debugger.features.breakpoints-dropdown", true);
 pref("devtools.debugger.features.remove-command-bar-options", false);
 pref("devtools.debugger.features.workers", true);


### PR DESCRIPTION
### Summary of Changes

We're currently mapping the scopes and bindings when we pause. This is causing some weird results w/ several transforms which we should investigate before we re-enable it.