### PR TITLE
Enable the map-scopes in the related tests

### DIFF
--- a/src/test/mochitest/browser_dbg-minified.js
+++ b/src/test/mochitest/browser_dbg-minified.js
@@ -16,6 +16,8 @@ function getScopeNodeValue(dbg, index) {
 }
 
 add_task(async function() {
+  Services.prefs.setBoolPref("devtools.debugger.features.map-scopes", true);
+
   const dbg = await initDebugger("doc-minified2.html");
 
   await waitForSources(dbg, "sum.js");

--- a/src/test/mochitest/browser_dbg-sourcemaps3.js
+++ b/src/test/mochitest/browser_dbg-sourcemaps3.js
@@ -25,6 +25,7 @@ async function waitForScopeNode(dbg, index) {
 add_task(async function() {
   // NOTE: the CORS call makes the test run times inconsistent
   requestLongerTimeout(2);
+  Services.prefs.setBoolPref("devtools.debugger.features.map-scopes", true);
 
   const dbg = await initDebugger("doc-sourcemaps3.html");
   const { selectors: { getBreakpoint, getBreakpoints }, getState } = dbg;


### PR DESCRIPTION
Associated Issue: #5111 

### Summary of Changes

We recently disabled the map-scopes feature because there are some issues with some of the mappings. This caused the tests to fail w/o flagging the feature on in those cases.

