### PR TITLE
(refactor) [Project search] Modify status update and error emoji (#5108)

### DIFF
--- a/src/actions/project-text-search.js
+++ b/src/actions/project-text-search.js
@@ -38,8 +38,7 @@ export function clearSearchResults() {
 
 export function clearSearch() {
   return ({ dispatch, getState }: ThunkArgs) => {
-    dispatch(clearSearchQuery());
-    dispatch(clearSearchResults());
+    dispatch({ type: "CLEAR_SEARCH" });
   };
 }
 

--- a/src/actions/project-text-search.js
+++ b/src/actions/project-text-search.js
@@ -53,9 +53,6 @@ export function closeProjectSearch() {
 
 export function searchSources(query: string) {
   return async ({ dispatch, getState }: ThunkArgs) => {
-    if (!query) {
-      return;
-    }
     await dispatch(clearSearchResults());
     await dispatch(addSearchQuery(query));
     dispatch(updateSearchStatus(statusType.fetching));

--- a/src/actions/project-text-search.js
+++ b/src/actions/project-text-search.js
@@ -18,28 +18,19 @@ import { statusType } from "../reducers/project-text-search";
 import type { ThunkArgs } from "./types";
 
 export function addSearchQuery(query: string) {
-  return ({ dispatch, getState }: ThunkArgs) => {
-    dispatch({ type: "ADD_QUERY", query });
-  };
+  return { type: "ADD_QUERY", query };
 }
 
 export function clearSearchQuery() {
-  return ({ dispatch, getState }: ThunkArgs) => {
-    dispatch({ type: "CLEAR_QUERY" });
-    dispatch(updateSearchStatus(statusType.initial));
-  };
+  return { type: "CLEAR_QUERY" };
 }
 
 export function clearSearchResults() {
-  return ({ dispatch, getState }: ThunkArgs) => {
-    dispatch({ type: "CLEAR_SEARCH_RESULTS" });
-  };
+  return { type: "CLEAR_SEARCH_RESULTS" };
 }
 
 export function clearSearch() {
-  return ({ dispatch, getState }: ThunkArgs) => {
-    dispatch({ type: "CLEAR_SEARCH" });
-  };
+  return { type: "CLEAR_SEARCH" };
 }
 
 export function updateSearchStatus(status: string) {
@@ -75,6 +66,9 @@ export function searchSource(sourceId: string, query: string) {
     }
 
     const matches = await findSourceMatches(sourceRecord.toJS(), query);
+    if (!matches.length) {
+      return;
+    }
     dispatch({
       type: "ADD_SEARCH_RESULT",
       result: {

--- a/src/actions/project-text-search.js
+++ b/src/actions/project-text-search.js
@@ -26,12 +26,20 @@ export function addSearchQuery(query: string) {
 export function clearSearchQuery() {
   return ({ dispatch, getState }: ThunkArgs) => {
     dispatch({ type: "CLEAR_QUERY" });
+    dispatch(updateSearchStatus(statusType.initial));
   };
 }
 
 export function clearSearchResults() {
   return ({ dispatch, getState }: ThunkArgs) => {
     dispatch({ type: "CLEAR_SEARCH_RESULTS" });
+  };
+}
+
+export function clearSearch() {
+  return ({ dispatch, getState }: ThunkArgs) => {
+    dispatch(clearSearchQuery());
+    dispatch(clearSearchResults());
   };
 }
 
@@ -45,6 +53,9 @@ export function closeProjectSearch() {
 
 export function searchSources(query: string) {
   return async ({ dispatch, getState }: ThunkArgs) => {
+    if (!query) {
+      return;
+    }
     await dispatch(clearSearchResults());
     await dispatch(addSearchQuery(query));
     dispatch(updateSearchStatus(statusType.fetching));
@@ -56,6 +67,7 @@ export function searchSources(query: string) {
     for (const source of validSources) {
       await dispatch(searchSource(source.get("id"), query));
     }
+    dispatch(updateSearchStatus(statusType.done));
   };
 }
 
@@ -75,8 +87,5 @@ export function searchSource(sourceId: string, query: string) {
         matches
       }
     });
-    if (matches.length) {
-      dispatch(updateSearchStatus(statusType.done));
-    }
   };
 }

--- a/src/actions/tests/project-text-search.spec.js
+++ b/src/actions/tests/project-text-search.spec.js
@@ -6,10 +6,10 @@ import {
 } from "../../utils/test-head";
 
 const {
+  getSource,
   getTextSearchQuery,
   getTextSearchResults,
-  getTextSearchStatus,
-  getSource
+  getTextSearchStatus
 } = selectors;
 
 import I from "immutable";

--- a/src/actions/tests/project-text-search.spec.js
+++ b/src/actions/tests/project-text-search.spec.js
@@ -8,8 +8,8 @@ import {
 const {
   getTextSearchQuery,
   getTextSearchResults,
-  getSource,
-  getTextSearchStatus
+  getTextSearchStatus,
+  getSource
 } = selectors;
 
 import I from "immutable";
@@ -59,9 +59,11 @@ describe("project text search", () => {
 
     dispatch(actions.addSearchQuery(mockQuery));
     expect(getTextSearchQuery(getState())).toEqual(mockQuery);
-
+    dispatch(actions.updateSearchStatus("DONE"));
     dispatch(actions.clearSearchQuery());
     expect(getTextSearchQuery(getState())).toEqual("");
+    const status = getTextSearchStatus(getState());
+    expect(status).toEqual("INITIAL");
   });
 
   it("should search all the loaded sources based on the query", async () => {
@@ -135,5 +137,7 @@ describe("project text search", () => {
 
     expect(results).toMatchSnapshot();
     expect(results.size).toEqual(0);
+    const status = getTextSearchStatus(getState());
+    expect(status).toEqual("INITIAL");
   });
 });

--- a/src/actions/types.js
+++ b/src/actions/types.js
@@ -341,7 +341,8 @@ export type ProjectTextSearchAction =
     }
   | { type: "CLEAR_QUERY" }
   | { type: "UPDATE_STATUS", status: string }
-  | { type: "CLEAR_SEARCH_RESULTS" };
+  | { type: "CLEAR_SEARCH_RESULTS" }
+  | { type: "CLEAR_SEARCH" };
 
 export type FileTextSearchAction =
   | {

--- a/src/components/ProjectSearch.js
+++ b/src/components/ProjectSearch.js
@@ -78,7 +78,7 @@ function getFilePath(item: Item, index?: number) {
     : `${item.sourceId}-${item.line}-${item.column}-${index || "$"}`;
 }
 
-function sanitizeQuery(query) {
+function sanitizeQuery(query: string): string {
   // no '\' at end of query
   return query.replace(/\\$/, "");
 }
@@ -161,7 +161,10 @@ export class ProjectSearch extends Component<Props, State> {
       return;
     }
     this.focusedItem = null;
-    this.props.searchSources(sanitizeQuery(this.state.inputValue));
+    const query = sanitizeQuery(this.state.inputValue);
+    if (query) {
+      this.props.searchSources(query);
+    }
   };
 
   onEnterPress = () => {

--- a/src/components/ProjectSearch.js
+++ b/src/components/ProjectSearch.js
@@ -68,6 +68,7 @@ type Props = {
   closeProjectSearch: () => void,
   searchSources: (query: string) => void,
   clearSearch: () => void,
+  updateSearchStatus: (type: StatusType) => void,
   selectLocation: (location: Location, tabIndex?: string) => void
 };
 
@@ -78,7 +79,8 @@ function getFilePath(item: Item, index?: number) {
 }
 
 function sanitizeQuery(query) {
-  return query.replace(/\\$/, ""); // no '\' at end of query
+  // no '\' at end of query
+  return query.replace(/\\$/, "");
 }
 
 export class ProjectSearch extends Component<Props, State> {

--- a/src/components/ProjectSearch.js
+++ b/src/components/ProjectSearch.js
@@ -68,7 +68,6 @@ type Props = {
   closeProjectSearch: () => void,
   searchSources: (query: string) => void,
   clearSearch: () => void,
-  updateSearchStatus: (type: StatusType) => void,
   selectLocation: (location: Location, tabIndex?: string) => void
 };
 
@@ -180,13 +179,10 @@ export class ProjectSearch extends Component<Props, State> {
 
   inputOnChange = (e: SyntheticInputEvent<HTMLInputElement>) => {
     const inputValue = e.target.value;
-    const { status, clearSearch, updateSearchStatus } = this.props;
+    const { clearSearch } = this.props;
     this.setState({ inputValue });
     if (inputValue === "") {
       clearSearch();
-    }
-    if (status !== statusType.initial) {
-      updateSearchStatus(statusType.initial);
     }
   };
 

--- a/src/components/ProjectSearch.js
+++ b/src/components/ProjectSearch.js
@@ -180,10 +180,13 @@ export class ProjectSearch extends Component<Props, State> {
 
   inputOnChange = (e: SyntheticInputEvent<HTMLInputElement>) => {
     const inputValue = e.target.value;
-    this.props.updateSearchStatus(statusType.initial);
+    const { status, clearSearch, updateSearchStatus } = this.props;
     this.setState({ inputValue });
     if (inputValue === "") {
-      this.props.clearSearch();
+      clearSearch();
+    }
+    if (status !== statusType.initial) {
+      updateSearchStatus(statusType.initial);
     }
   };
 

--- a/src/components/ProjectSearch.js
+++ b/src/components/ProjectSearch.js
@@ -281,7 +281,7 @@ export class ProjectSearch extends Component<Props, State> {
         count={this.getResultCount()}
         placeholder={L10N.getStr("projectTextSearch.placeholder")}
         size="big"
-        status={this.props.status}
+        showErrorEmoji={this.props.status === statusType.done}
         summaryMsg={this.renderSummary()}
         onChange={this.inputOnChange}
         onFocus={() => this.setState({ inputFocused: true })}

--- a/src/components/ProjectSearch.js
+++ b/src/components/ProjectSearch.js
@@ -67,6 +67,7 @@ type Props = {
   setActiveSearch: (activeSearch?: ActiveSearchType) => void,
   closeProjectSearch: () => void,
   searchSources: (query: string) => void,
+  clearSearch: () => void,
   selectLocation: (location: Location, tabIndex?: string) => void
 };
 
@@ -74,6 +75,10 @@ function getFilePath(item: Item, index?: number) {
   return item.type === "RESULT"
     ? `${item.sourceId}-${index || "$"}`
     : `${item.sourceId}-${item.line}-${item.column}-${index || "$"}`;
+}
+
+function sanitizeQuery(query) {
+  return query.replace(/\\$/, ""); // no '\' at end of query
 }
 
 export class ProjectSearch extends Component<Props, State> {
@@ -154,7 +159,7 @@ export class ProjectSearch extends Component<Props, State> {
       return;
     }
     this.focusedItem = null;
-    this.props.searchSources(this.state.inputValue);
+    this.props.searchSources(sanitizeQuery(this.state.inputValue));
   };
 
   onEnterPress = () => {
@@ -170,7 +175,11 @@ export class ProjectSearch extends Component<Props, State> {
 
   inputOnChange = (e: SyntheticInputEvent<HTMLInputElement>) => {
     const inputValue = e.target.value;
+    this.props.updateSearchStatus(statusType.initial);
     this.setState({ inputValue });
+    if (inputValue === "") {
+      this.props.clearSearch();
+    }
   };
 
   renderFile = (
@@ -272,6 +281,7 @@ export class ProjectSearch extends Component<Props, State> {
         count={this.getResultCount()}
         placeholder={L10N.getStr("projectTextSearch.placeholder")}
         size="big"
+        status={this.props.status}
         summaryMsg={this.renderSummary()}
         onChange={this.inputOnChange}
         onFocus={() => this.setState({ inputFocused: true })}

--- a/src/components/shared/SearchInput.js
+++ b/src/components/shared/SearchInput.js
@@ -10,8 +10,6 @@ import classnames from "classnames";
 import CloseButton from "./Button/Close";
 import "./SearchInput.css";
 
-import { statusType } from "../../reducers/project-text-search";
-
 const arrowBtn = (onClick, type, className, tooltip) => {
   const props = {
     onClick,
@@ -34,7 +32,6 @@ type Props = {
   placeholder: string,
   summaryMsg: string,
   size: string,
-  status: string,
   showErrorEmoji: boolean,
   onChange: (e: SyntheticInputEvent<HTMLInputElement>) => void,
   handleClose: (e: SyntheticMouseEvent<HTMLDivElement>) => void,
@@ -66,13 +63,8 @@ class SearchInput extends Component<Props> {
   }
 
   shouldShowErrorEmoji = () => {
-    const { count, query, showErrorEmoji, status } = this.props;
-    return (
-      showErrorEmoji &&
-      count === 0 &&
-      query.trim() !== "" &&
-      status === statusType.done
-    );
+    const { count, query, showErrorEmoji } = this.props;
+    return showErrorEmoji && count === 0 && query.trim() !== "";
   };
 
   renderSvg() {

--- a/src/components/shared/SearchInput.js
+++ b/src/components/shared/SearchInput.js
@@ -10,6 +10,8 @@ import classnames from "classnames";
 import CloseButton from "./Button/Close";
 import "./SearchInput.css";
 
+import { statusType } from "../../reducers/project-text-search";
+
 const arrowBtn = (onClick, type, className, tooltip) => {
   const props = {
     onClick,
@@ -32,6 +34,7 @@ type Props = {
   placeholder: string,
   summaryMsg: string,
   size: string,
+  status: string,
   showErrorEmoji: boolean,
   onChange: (e: SyntheticInputEvent<HTMLInputElement>) => void,
   handleClose: (e: SyntheticMouseEvent<HTMLDivElement>) => void,
@@ -63,8 +66,13 @@ class SearchInput extends Component<Props> {
   }
 
   shouldShowErrorEmoji = () => {
-    const { count, query, showErrorEmoji } = this.props;
-    return count === 0 && query.trim() !== "" && showErrorEmoji;
+    const { count, query, showErrorEmoji, status } = this.props;
+    return (
+      showErrorEmoji &&
+      count === 0 &&
+      query.trim() !== "" &&
+      status === statusType.done
+    );
   };
 
   renderSvg() {

--- a/src/components/tests/ProjectSearch.spec.js
+++ b/src/components/tests/ProjectSearch.spec.js
@@ -52,6 +52,8 @@ function render(overrides = {}, mounted = false) {
     activeSearch: "project",
     closeProjectSearch: jest.fn(),
     searchSources: jest.fn(),
+    clearSearch: jest.fn(),
+    updateSearchStatus: jest.fn(),
     selectLocation: jest.fn(),
     ...overrides
   };

--- a/src/components/tests/__snapshots__/ProjectSearch.spec.js.snap
+++ b/src/components/tests/__snapshots__/ProjectSearch.spec.js.snap
@@ -36,6 +36,7 @@ exports[`ProjectSearch found no search results 1`] = `
 exports[`ProjectSearch found search results 1`] = `
 <ProjectSearch
   activeSearch="project"
+  clearSearch={[Function]}
   closeProjectSearch={[Function]}
   query="match"
   results={
@@ -81,6 +82,7 @@ exports[`ProjectSearch found search results 1`] = `
   selectLocation={[Function]}
   sources={Object {}}
   status="DONE"
+  updateSearchStatus={[Function]}
 >
   <div
     className="search-container"

--- a/src/reducers/project-text-search.js
+++ b/src/reducers/project-text-search.js
@@ -76,16 +76,11 @@ function update(
       });
 
     case "CLEAR_SEARCH":
+    case "CLOSE_PROJECT_SEARCH":
       return state.merge({
         query: "",
         results: state.get("results").clear(),
         status: statusType.initial
-      });
-
-    case "CLOSE_PROJECT_SEARCH":
-      return state.merge({
-        query: "",
-        results: state.get("results").clear()
       });
   }
   return state;

--- a/src/reducers/project-text-search.js
+++ b/src/reducers/project-text-search.js
@@ -72,6 +72,12 @@ function update(
         results: state.get("results").clear()
       });
 
+    case "CLEAR_SEARCH":
+      const newSate = state.remove("query");
+      return newSate.merge({
+        results: state.get("results").clear()
+      });
+
     case "CLOSE_PROJECT_SEARCH":
       return state.merge({
         query: "",

--- a/src/reducers/project-text-search.js
+++ b/src/reducers/project-text-search.js
@@ -58,7 +58,10 @@ function update(
       return state.update("query", value => actionCopy.query);
 
     case "CLEAR_QUERY":
-      return state.remove("query");
+      return state.merge({
+        query: "",
+        status: statusType.initial
+      });
 
     case "ADD_SEARCH_RESULT":
       const results = state.get("results");
@@ -73,9 +76,10 @@ function update(
       });
 
     case "CLEAR_SEARCH":
-      const newSate = state.remove("query");
-      return newSate.merge({
-        results: state.get("results").clear()
+      return state.merge({
+        query: "",
+        results: state.get("results").clear(),
+        status: statusType.initial
       });
 
     case "CLOSE_PROJECT_SEARCH":


### PR DESCRIPTION
Associated Issue: #5108

### Summary of Changes

With this commit, the Status behavior is stored differently in reducers.

- INITIAL -> Search not yet performed
- FETCHING -> Search in progress
- DONE -> Search completed | Smiley Shown | After all sources searched
    - (not fired after each source as before)

- Render error emoji only on done
    - Removes a slight jitter in the UI when the results are still inflight.

- Use the shouldShowErrorEmoji predicate instead of passing status

### Screenshots/Videos (OPTIONAL)

![](http://g.recordit.co/6FLTjyZahH.gif)

### Test Plan
- CmdOrCtrl+Shift+F
- As per above

