### PR TITLE
Use pushPref helper in mochitests to set temporary pref values

### DIFF
--- a/src/test/mochitest/browser_dbg-async-stepping.js
+++ b/src/test/mochitest/browser_dbg-async-stepping.js
@@ -3,7 +3,7 @@
 
 // Tests async stepping will step over await statements
 add_task(async function test() {
-  Services.prefs.setBoolPref("devtools.debugger.features.async-stepping", true);
+  await pushPref("devtools.debugger.features.async-stepping", true);
   const dbg = await initDebugger("doc-async.html", "async");
 
   await selectSource(dbg, "async");
@@ -17,11 +17,4 @@ add_task(async function test() {
   await stepOver(dbg);
   assertPausedLocation(dbg);
   assertDebugLine(dbg, 9);
-});
-
-registerCleanupFunction(() => {
-  Services.prefs.clearUserPref(
-    "devtools.debugger.features.async-stepping",
-    false
-  );
 });

--- a/src/test/mochitest/browser_dbg-chrome-create.js
+++ b/src/test/mochitest/browser_dbg-chrome-create.js
@@ -38,14 +38,13 @@ function onClose() {
 }
 
 registerCleanupFunction(function() {
-  Services.prefs.clearUserPref("devtools.debugger.remote-enabled");
   gProcess = null;
 });
 
 add_task(async function() {
   // Windows XP and 8.1 test slaves are terribly slow at this test.
   requestLongerTimeout(5);
-  Services.prefs.setBoolPref("devtools.debugger.remote-enabled", true);
+  await pushPref("devtools.debugger.remote-enabled", true);
 
   gProcess = await initChromeDebugger();
 

--- a/src/test/mochitest/browser_dbg-minified.js
+++ b/src/test/mochitest/browser_dbg-minified.js
@@ -16,7 +16,7 @@ function getScopeNodeValue(dbg, index) {
 }
 
 add_task(async function() {
-  Services.prefs.setBoolPref("devtools.debugger.features.map-scopes", true);
+  await pushPref("devtools.debugger.features.map-scopes", true);
 
   const dbg = await initDebugger("doc-minified2.html");
 

--- a/src/test/mochitest/browser_dbg-search-project.js
+++ b/src/test/mochitest/browser_dbg-search-project.js
@@ -35,10 +35,7 @@ function getResultsCount(dbg) {
 
 // Testing project search
 add_task(async function() {
-  Services.prefs.setBoolPref(
-    "devtools.debugger.project-text-search-enabled",
-    true
-  );
+  await pushPref("devtools.debugger.project-text-search-enabled", true);
 
   const dbg = await initDebugger("doc-script-switching.html", "switching-01");
 
@@ -60,11 +57,4 @@ add_task(async function() {
 
   const selectedSource = dbg.selectors.getSelectedSource(dbg.getState());
   ok(selectedSource.get("url").includes("switching-01"));
-});
-
-registerCleanupFunction(() => {
-  Services.prefs.clearUserPref(
-    "devtools.debugger.project-text-search-enabled",
-    false
-  );
 });

--- a/src/test/mochitest/browser_dbg-sourcemaps3.js
+++ b/src/test/mochitest/browser_dbg-sourcemaps3.js
@@ -25,7 +25,7 @@ async function waitForScopeNode(dbg, index) {
 add_task(async function() {
   // NOTE: the CORS call makes the test run times inconsistent
   requestLongerTimeout(2);
-  Services.prefs.setBoolPref("devtools.debugger.features.map-scopes", true);
+  await pushPref("devtools.debugger.features.map-scopes", true);
 
   const dbg = await initDebugger("doc-sourcemaps3.html");
   const { selectors: { getBreakpoint, getBreakpoints }, getState } = dbg;


### PR DESCRIPTION
Use the pushPref helper whenever possible in mochitests, otherwise the preference changes leak from one test to another. 

Also simplified some tests that used to set the preference and restore it on cleanup. First, there was no added value compared to pushPref. Secondly, the restore was not wrong. It should restore to the original value (read at the beginning of the test) rather than to a random set value (eg. false).

Let's see if tests still pass.