### PR TITLE
Fix syncing disabled breakpoints

### DIFF
--- a/src/actions/breakpoints/syncBreakpoint.js
+++ b/src/actions/breakpoints/syncBreakpoint.js
@@ -114,7 +114,8 @@ export async function syncClientBreakpoint(
       id,
       pendingBreakpoint,
       scopedLocation,
-      scopedGeneratedLocation
+      scopedGeneratedLocation,
+      previousLocation
     );
   }
 

--- a/src/actions/breakpoints/tests/__snapshots__/syncing.js.snap
+++ b/src/actions/breakpoints/tests/__snapshots__/syncing.js.snap
@@ -28,7 +28,12 @@ Object {
     },
     "text": "",
   },
-  "previousLocation": null,
+  "previousLocation": Object {
+    "column": undefined,
+    "line": 3,
+    "sourceId": "magic.js",
+    "sourceUrl": "http://localhost:8000/magic.js",
+  },
 }
 `;
 
@@ -60,7 +65,37 @@ Object {
     },
     "text": "",
   },
-  "previousLocation": null,
+  "previousLocation": Object {
+    "column": undefined,
+    "line": 3,
+    "sourceId": "magic.js",
+    "sourceUrl": "http://localhost:8000/magic.js",
+  },
+}
+`;
+
+exports[`reloading debuggee syncs with changed source and an existing disabled BP 1`] = `
+Immutable.Map {
+  http://localhost:8000/examples/magic.js:3:: Object {
+    "astLocation": Object {
+      "name": undefined,
+      "offset": Object {
+        "line": 3,
+      },
+    },
+    "condition": null,
+    "disabled": true,
+    "generatedLocation": Object {
+      "column": undefined,
+      "line": 1,
+      "sourceUrl": "http://localhost:8000/gen.js",
+    },
+    "location": Object {
+      "column": undefined,
+      "line": 3,
+      "sourceUrl": "http://localhost:8000/examples/magic.js",
+    },
+  },
 }
 `;
 
@@ -92,7 +127,12 @@ Object {
     },
     "text": "",
   },
-  "previousLocation": null,
+  "previousLocation": Object {
+    "column": undefined,
+    "line": 3,
+    "sourceId": "magic.js",
+    "sourceUrl": "http://localhost:8000/magic.js",
+  },
 }
 `;
 


### PR DESCRIPTION
Associated Issue: #5140

### Summary of Changes

This fixes a bug where we were not removing old disabled breakpoints when the breakpoint moved on sync.

I'm working on a follow up PR where I cleanup the unit tests and increase the coverage