### PR TITLE
[WIP] [QuickOpen] toggle include 3rd party modules

### DIFF
--- a/assets/panel/debugger.properties
+++ b/assets/panel/debugger.properties
@@ -205,6 +205,14 @@ projectTextSearch.placeholder=Find in files…
 # message when the query did not match any text of all files in a project.
 projectTextSearch.noResults=No results found
 
+# LOCALIZATION NOTE (sourceSearch.includeThirdPartiesToggle.includeTooltip): This is the tooltip that appears
+# on hovering the third party files inclusion toggle to start including files.
+sourceSearch.includeThirdPartiesToggle.includeTooltip=Include third party files
+
+# LOCALIZATION NOTE (sourceSearch.includeThirdPartiesToggle.excludeTooltip): This is the tooltip that appears
+# on hovering the third party files inclusion toggle to start excluding files.
+sourceSearch.includeThirdPartiesToggle.excludeTooltip=Exclude third party files
+
 # LOCALIZATION NOTE (sources.noSourcesAvailable): Text shown when the debugger
 # does not have any sources.
 sources.noSourcesAvailable=This page has no sources

--- a/src/actions/quick-open.js
+++ b/src/actions/quick-open.js
@@ -23,3 +23,7 @@ export function openQuickOpen(query?: string): QuickOpenAction {
 export function closeQuickOpen(): QuickOpenAction {
   return { type: "CLOSE_QUICK_OPEN" };
 }
+
+export function toggleQuickOpenIncludeThirdParties(): QuickOpenAction {
+  return { type: "TOGGLE_QUICK_OPEN_INCLUDE_THIRD_PARTIES" };
+}

--- a/src/actions/types.js
+++ b/src/actions/types.js
@@ -365,7 +365,8 @@ export type FileTextSearchAction =
 export type QuickOpenAction =
   | { type: "SET_QUICK_OPEN_QUERY", query: string }
   | { type: "OPEN_QUICK_OPEN", query?: string }
-  | { type: "CLOSE_QUICK_OPEN" };
+  | { type: "CLOSE_QUICK_OPEN" }
+  | { type: "TOGGLE_QUICK_OPEN_INCLUDE_THIRD_PARTIES" };
 
 export type CoverageAction = {
   type: "RECORD_COVERAGE",

--- a/src/components/QuickOpenModal.js
+++ b/src/components/QuickOpenModal.js
@@ -14,6 +14,7 @@ import {
   getQuickOpenEnabled,
   getQuickOpenQuery,
   getQuickOpenType,
+  getQuickOpenIncludeThirdParties,
   getSelectedSource,
   getSymbols
 } from "../selectors";
@@ -44,10 +45,12 @@ type Props = {
   query: string,
   searchType: QuickOpenType,
   symbols: FormattedSymbolDeclarations,
+  includeThirdParties: boolean,
   selectLocation: Location => void,
   setQuickOpenQuery: (query: string) => void,
   highlightLineRange: ({ start: number, end: number }) => void,
-  closeQuickOpen: () => void
+  closeQuickOpen: () => void,
+  toggleQuickOpenIncludeThirdParties: () => void
 };
 
 type State = {
@@ -81,7 +84,9 @@ export class QuickOpenModal extends Component<Props, State> {
 
     const nowEnabled = !prevProps.enabled && this.props.enabled;
     const queryChanged = prevProps.query !== this.props.query;
-    if (nowEnabled || queryChanged) {
+    const includeThirdPartiesChanged =
+      prevProps.includeThirdParties !== this.props.includeThirdParties;
+    if (nowEnabled || queryChanged || includeThirdPartiesChanged) {
       this.updateResults(this.props.query);
     }
   }
@@ -270,6 +275,10 @@ export class QuickOpenModal extends Component<Props, State> {
     return results && results.length ? results.length : 0;
   };
 
+  toggleIncludeThirdParties = () => {
+    this.props.toggleQuickOpenIncludeThirdParties();
+  };
+
   // Query helpers
   isFunctionQuery = () => this.props.searchType === "functions";
   isVariableQuery = () => this.props.searchType === "variables";
@@ -279,7 +288,7 @@ export class QuickOpenModal extends Component<Props, State> {
   isShortcutQuery = () => this.props.searchType === "shortcuts";
 
   render() {
-    const { enabled, query, searchType } = this.props;
+    const { enabled, query, searchType, includeThirdParties } = this.props;
     const { selectedIndex, results } = this.state;
 
     if (!enabled) {
@@ -304,9 +313,11 @@ export class QuickOpenModal extends Component<Props, State> {
           count={this.getResultCount()}
           placeholder={L10N.getStr("sourceSearch.search")}
           {...(showSummary === true ? { summaryMsg } : {})}
+          includeThirdParties={includeThirdParties}
           onChange={this.onChange}
           onKeyDown={this.onKeyDown}
           handleClose={this.closeModal}
+          toggleIncludeThirdParties={this.toggleIncludeThirdParties}
         />
         {results && (
           <ResultList
@@ -334,11 +345,15 @@ function mapStateToProps(state) {
   }
   return {
     enabled: getQuickOpenEnabled(state),
-    sources: formatSources(getSources(state)),
+    sources: formatSources(
+      getSources(state),
+      getQuickOpenIncludeThirdParties(state)
+    ),
     selectedSource,
     symbols: formatSymbols(symbols),
     query: getQuickOpenQuery(state),
-    searchType: getQuickOpenType(state)
+    searchType: getQuickOpenType(state),
+    includeThirdParties: getQuickOpenIncludeThirdParties(state)
   };
 }
 

--- a/src/components/shared/Button/IncludeThirdPartiesToggle.js
+++ b/src/components/shared/Button/IncludeThirdPartiesToggle.js
@@ -1,0 +1,30 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
+// @flow
+import React, { PureComponent } from "react";
+import Svg from "../Svg";
+
+type Props = {
+  includeThirdParties: boolean,
+  toggleIncludeThirdParties: () => void
+};
+
+class IncludeThirdPartiesToggle extends PureComponent<Props> {
+  render() {
+    const { includeThirdParties, toggleIncludeThirdParties } = this.props;
+    const title = includeThirdParties
+      ? L10N.getStr("sourceSearch.includeThirdPartiesToggle.includeTooltip")
+      : L10N.getStr("sourceSearch.includeThirdPartiesToggle.excludeTooltip");
+    const icon = includeThirdParties ? "arrow-up" : "arrow-down";
+
+    return (
+      <button onClick={toggleIncludeThirdParties} title={title}>
+        <Svg name={icon} />
+      </button>
+    );
+  }
+}
+
+export default IncludeThirdPartiesToggle;

--- a/src/components/shared/SearchInput.js
+++ b/src/components/shared/SearchInput.js
@@ -8,6 +8,7 @@ import React, { Component } from "react";
 import Svg from "./Svg";
 import classnames from "classnames";
 import CloseButton from "./Button/Close";
+import IncludeThirdPartiesToggle from "./Button/IncludeThirdPartiesToggle";
 import "./SearchInput.css";
 
 const arrowBtn = (onClick, type, className, tooltip) => {
@@ -33,6 +34,7 @@ type Props = {
   summaryMsg: string,
   size: string,
   showErrorEmoji: boolean,
+  includeThirdParties: boolean,
   onChange: (e: SyntheticInputEvent<HTMLInputElement>) => void,
   handleClose: (e: SyntheticMouseEvent<HTMLDivElement>) => void,
   onKeyUp?: (e: SyntheticKeyboardEvent<HTMLInputElement>) => void,
@@ -40,7 +42,8 @@ type Props = {
   onFocus?: (e: SyntheticFocusEvent<HTMLInputElement>) => void,
   onBlur?: (e: SyntheticFocusEvent<HTMLInputElement>) => void,
   handleNext?: (e: SyntheticMouseEvent<HTMLButtonElement>) => void,
-  handlePrev?: (e: SyntheticMouseEvent<HTMLButtonElement>) => void
+  handlePrev?: (e: SyntheticMouseEvent<HTMLButtonElement>) => void,
+  toggleIncludeThirdParties?: () => void
 };
 
 class SearchInput extends Component<Props> {
@@ -110,12 +113,14 @@ class SearchInput extends Component<Props> {
       query,
       placeholder,
       summaryMsg,
+      includeThirdParties,
       onChange,
       onKeyDown,
       onKeyUp,
       onFocus,
       onBlur,
       handleClose,
+      toggleIncludeThirdParties,
       size
     } = this.props;
 
@@ -134,12 +139,18 @@ class SearchInput extends Component<Props> {
       ref: c => (this.$input = c)
     };
 
+    const includeThirdPartiesToggleProps = {
+      includeThirdParties,
+      toggleIncludeThirdParties
+    };
+
     return (
       <div className={classnames("search-field", size)}>
         {this.renderSvg()}
         <input {...inputProps} />
         <div className="summary">{summaryMsg || ""}</div>
         {this.renderNav()}
+        <IncludeThirdPartiesToggle {...includeThirdPartiesToggleProps} />
         <CloseButton handleClick={handleClose} buttonClass={size} />
       </div>
     );

--- a/src/components/shared/tests/__snapshots__/SearchInput.spec.js.snap
+++ b/src/components/shared/tests/__snapshots__/SearchInput.spec.js.snap
@@ -18,6 +18,7 @@ exports[`SearchInput render 1`] = `
   >
     So many results
   </div>
+  <IncludeThirdPartiesToggle />
   <CloseButton
     buttonClass=""
   />
@@ -68,6 +69,7 @@ exports[`SearchInput show nav buttons 1`] = `
       />
     </button>
   </div>
+  <IncludeThirdPartiesToggle />
   <CloseButton
     buttonClass=""
   />
@@ -92,6 +94,7 @@ exports[`SearchInput show svg (emoji) 1`] = `
   >
     So many results
   </div>
+  <IncludeThirdPartiesToggle />
   <CloseButton
     buttonClass=""
   />
@@ -116,6 +119,7 @@ exports[`SearchInput show svg magnifying glass 1`] = `
   >
     So many results
   </div>
+  <IncludeThirdPartiesToggle />
   <CloseButton
     buttonClass=""
   />

--- a/src/components/tests/__snapshots__/ProjectSearch.spec.js.snap
+++ b/src/components/tests/__snapshots__/ProjectSearch.spec.js.snap
@@ -142,6 +142,32 @@ exports[`ProjectSearch found search results 1`] = `
             >
               5 results
             </div>
+            <IncludeThirdPartiesToggle>
+              <button
+                title="Exclude third party files"
+              >
+                <Svg
+                  name="arrow-down"
+                >
+                  <InlineSVG
+                    className="arrow-down "
+                    element="i"
+                    raw={false}
+                    src="<svg></svg>"
+                  >
+                    <i
+                      className="arrow-down "
+                      dangerouslySetInnerHTML={
+                        Object {
+                          "__html": "<svg></svg>",
+                        }
+                      }
+                      src={null}
+                    />
+                  </InlineSVG>
+                </Svg>
+              </button>
+            </IncludeThirdPartiesToggle>
             <CloseButton
               buttonClass="big"
               handleClick={[Function]}

--- a/src/components/tests/__snapshots__/QuickOpenModal.spec.js.snap
+++ b/src/components/tests/__snapshots__/QuickOpenModal.spec.js.snap
@@ -59,6 +59,7 @@ exports[`QuickOpenModal Basic render with mount & searchType = functions 1`] = `
               showErrorEmoji={true}
               size=""
               summaryMsg="0 results"
+              toggleIncludeThirdParties={[Function]}
             >
               <div
                 className="search-field"
@@ -96,6 +97,35 @@ exports[`QuickOpenModal Basic render with mount & searchType = functions 1`] = `
                 >
                   0 results
                 </div>
+                <IncludeThirdPartiesToggle
+                  toggleIncludeThirdParties={[Function]}
+                >
+                  <button
+                    onClick={[Function]}
+                    title="Exclude third party files"
+                  >
+                    <Svg
+                      name="arrow-down"
+                    >
+                      <InlineSVG
+                        className="arrow-down "
+                        element="i"
+                        raw={false}
+                        src="<svg></svg>"
+                      >
+                        <i
+                          className="arrow-down "
+                          dangerouslySetInnerHTML={
+                            Object {
+                              "__html": "<svg></svg>",
+                            }
+                          }
+                          src={null}
+                        />
+                      </InlineSVG>
+                    </Svg>
+                  </button>
+                </IncludeThirdPartiesToggle>
                 <CloseButton
                   buttonClass=""
                   handleClick={[Function]}
@@ -189,6 +219,7 @@ exports[`QuickOpenModal Basic render with mount & searchType = variables 1`] = `
               showErrorEmoji={true}
               size=""
               summaryMsg="0 results"
+              toggleIncludeThirdParties={[Function]}
             >
               <div
                 className="search-field"
@@ -226,6 +257,35 @@ exports[`QuickOpenModal Basic render with mount & searchType = variables 1`] = `
                 >
                   0 results
                 </div>
+                <IncludeThirdPartiesToggle
+                  toggleIncludeThirdParties={[Function]}
+                >
+                  <button
+                    onClick={[Function]}
+                    title="Exclude third party files"
+                  >
+                    <Svg
+                      name="arrow-down"
+                    >
+                      <InlineSVG
+                        className="arrow-down "
+                        element="i"
+                        raw={false}
+                        src="<svg></svg>"
+                      >
+                        <i
+                          className="arrow-down "
+                          dangerouslySetInnerHTML={
+                            Object {
+                              "__html": "<svg></svg>",
+                            }
+                          }
+                          src={null}
+                        />
+                      </InlineSVG>
+                    </Svg>
+                  </button>
+                </IncludeThirdPartiesToggle>
                 <CloseButton
                   buttonClass=""
                   handleClick={[Function]}
@@ -313,6 +373,7 @@ exports[`QuickOpenModal Basic render with mount 1`] = `
               showErrorEmoji={true}
               size=""
               summaryMsg="0 results"
+              toggleIncludeThirdParties={[Function]}
             >
               <div
                 className="search-field"
@@ -350,6 +411,35 @@ exports[`QuickOpenModal Basic render with mount 1`] = `
                 >
                   0 results
                 </div>
+                <IncludeThirdPartiesToggle
+                  toggleIncludeThirdParties={[Function]}
+                >
+                  <button
+                    onClick={[Function]}
+                    title="Exclude third party files"
+                  >
+                    <Svg
+                      name="arrow-down"
+                    >
+                      <InlineSVG
+                        className="arrow-down "
+                        element="i"
+                        raw={false}
+                        src="<svg></svg>"
+                      >
+                        <i
+                          className="arrow-down "
+                          dangerouslySetInnerHTML={
+                            Object {
+                              "__html": "<svg></svg>",
+                            }
+                          }
+                          src={null}
+                        />
+                      </InlineSVG>
+                    </Svg>
+                  </button>
+                </IncludeThirdPartiesToggle>
                 <CloseButton
                   buttonClass=""
                   handleClick={[Function]}
@@ -401,6 +491,7 @@ exports[`QuickOpenModal Renders when enabled 1`] = `
     showErrorEmoji={true}
     size=""
     summaryMsg="0 results"
+    toggleIncludeThirdParties={[Function]}
   />
   <ResultList
     items={Array []}
@@ -465,6 +556,7 @@ exports[`QuickOpenModal closeModal 1`] = `
               showErrorEmoji={true}
               size=""
               summaryMsg="0 results"
+              toggleIncludeThirdParties={[Function]}
             >
               <div
                 className="search-field"
@@ -502,6 +594,35 @@ exports[`QuickOpenModal closeModal 1`] = `
                 >
                   0 results
                 </div>
+                <IncludeThirdPartiesToggle
+                  toggleIncludeThirdParties={[Function]}
+                >
+                  <button
+                    onClick={[Function]}
+                    title="Exclude third party files"
+                  >
+                    <Svg
+                      name="arrow-down"
+                    >
+                      <InlineSVG
+                        className="arrow-down "
+                        element="i"
+                        raw={false}
+                        src="<svg></svg>"
+                      >
+                        <i
+                          className="arrow-down "
+                          dangerouslySetInnerHTML={
+                            Object {
+                              "__html": "<svg></svg>",
+                            }
+                          }
+                          src={null}
+                        />
+                      </InlineSVG>
+                    </Svg>
+                  </button>
+                </IncludeThirdPartiesToggle>
                 <CloseButton
                   buttonClass=""
                   handleClick={[Function]}
@@ -603,6 +724,7 @@ exports[`QuickOpenModal updateResults on enable 2`] = `
               showErrorEmoji={true}
               size=""
               summaryMsg="0 results"
+              toggleIncludeThirdParties={[Function]}
             >
               <div
                 className="search-field"
@@ -640,6 +762,35 @@ exports[`QuickOpenModal updateResults on enable 2`] = `
                 >
                   0 results
                 </div>
+                <IncludeThirdPartiesToggle
+                  toggleIncludeThirdParties={[Function]}
+                >
+                  <button
+                    onClick={[Function]}
+                    title="Exclude third party files"
+                  >
+                    <Svg
+                      name="arrow-down"
+                    >
+                      <InlineSVG
+                        className="arrow-down "
+                        element="i"
+                        raw={false}
+                        src="<svg></svg>"
+                      >
+                        <i
+                          className="arrow-down "
+                          dangerouslySetInnerHTML={
+                            Object {
+                              "__html": "<svg></svg>",
+                            }
+                          }
+                          src={null}
+                        />
+                      </InlineSVG>
+                    </Svg>
+                  </button>
+                </IncludeThirdPartiesToggle>
                 <CloseButton
                   buttonClass=""
                   handleClick={[Function]}

--- a/src/reducers/quick-open.js
+++ b/src/reducers/quick-open.js
@@ -28,7 +28,8 @@ type QuickOpenState = {
 export const State = makeRecord({
   enabled: false,
   query: "",
-  searchType: "sources"
+  searchType: "sources",
+  includeThirdParties: true
 });
 
 export default function update(
@@ -52,6 +53,10 @@ export default function update(
         query: action.query,
         searchType: parseQuickOpenQuery(action.query)
       });
+    case "TOGGLE_QUICK_OPEN_INCLUDE_THIRD_PARTIES":
+      return state.merge({
+        includeThirdParties: !state.includeThirdParties
+      });
     default:
       return state;
   }
@@ -71,4 +76,8 @@ export function getQuickOpenQuery(state: OuterState) {
 
 export function getQuickOpenType(state: OuterState): QuickOpenType {
   return state.quickOpen.get("searchType");
+}
+
+export function getQuickOpenIncludeThirdParties(state: OuterState): boolean {
+  return state.quickOpen.get("includeThirdParties");
 }

--- a/src/reducers/quick-open.js
+++ b/src/reducers/quick-open.js
@@ -29,7 +29,7 @@ export const State = makeRecord({
   enabled: false,
   query: "",
   searchType: "sources",
-  includeThirdParties: true
+  includeThirdParties: false
 });
 
 export default function update(

--- a/src/utils/quick-open.js
+++ b/src/utils/quick-open.js
@@ -109,10 +109,16 @@ export function formatShortcutResults(): Array<QuickOpenResult> {
   ];
 }
 
-export function formatSources(sources: SourcesMap): Array<QuickOpenResult> {
+export function formatSources(
+  sources: SourcesMap,
+  includeThirdParties: boolean = false
+): Array<QuickOpenResult> {
   return sources
     .valueSeq()
-    .filter(source => !isPretty(source) && !isThirdParty(source))
+    .filter(
+      source =>
+        !isPretty(source) && (includeThirdParties || !isThirdParty(source))
+    )
     .map(source => {
       const sourcePath = getSourcePath(source.get("url"));
       return {

--- a/yarn.lock
+++ b/yarn.lock
@@ -258,11 +258,7 @@
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/@types/inline-style-prefixer/-/inline-style-prefixer-3.0.1.tgz#8541e636b029124b747952e9a28848286d2b5bf6"
 
-"@types/node@*":
-  version "9.3.0"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-9.3.0.tgz#3a129cda7c4e5df2409702626892cb4b96546dd5"
-
-"@types/node@^7.0.12":
+"@types/node@*", "@types/node@^7.0.12":
   version "7.0.52"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-7.0.52.tgz#8990d3350375542b0c21a83cd0331e6a8fc86716"
 
@@ -318,11 +314,7 @@ acorn@^4.0.3, acorn@^4.0.4:
   version "4.0.13"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.13.tgz#105495ae5361d697bd195c825192e1ad7f253787"
 
-acorn@^5.0.0, acorn@^5.2.1:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.3.0.tgz#7446d39459c54fb49a80e6ee6478149b940ec822"
-
-acorn@~5.2.1:
+acorn@^5.0.0, acorn@^5.2.1, acorn@~5.2.1:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.2.1.tgz#317ac7821826c22c702d66189ab8359675f135d7"
 
@@ -3370,16 +3362,9 @@ domutils@1.1:
   dependencies:
     domelementtype "1"
 
-domutils@1.5.1:
+domutils@1.5.1, domutils@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.5.1.tgz#dcd8488a26f563d61079e48c9f7b7e32373682cf"
-  dependencies:
-    dom-serializer "0"
-    domelementtype "1"
-
-domutils@^1.5.1:
-  version "1.6.2"
-  resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.6.2.tgz#1958cc0b4c9426e9ed367fb1c8e854891b0fa3ff"
   dependencies:
     dom-serializer "0"
     domelementtype "1"
@@ -4032,13 +4017,9 @@ extract-text-webpack-plugin@^3.0.0:
     schema-utils "^0.3.0"
     webpack-sources "^1.0.1"
 
-extsprintf@1.3.0:
+extsprintf@1.3.0, extsprintf@^1.2.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.3.0.tgz#96918440e3041a7a414f8c52e3c574eb3c3e1e05"
-
-extsprintf@^1.2.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
 
 fast-deep-equal@^1.0.0:
   version "1.0.0"
@@ -10030,11 +10011,7 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-"statuses@>= 1.3.1 < 2":
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.4.0.tgz#bb73d446da2796106efcc1b601a253d6c46bd087"
-
-statuses@~1.3.1:
+"statuses@>= 1.3.1 < 2", statuses@~1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.3.1.tgz#faf51b9eb74aaef3b3acf4ad5f61abf24cb7b93e"
 


### PR DESCRIPTION
Associated Issue: #5142

### Summary of Changes

* Added toggle button in the source search quick open menu that enables or disables in the include of third party files, e.g. `node_modules` or `bower_compoments`

### Test Plan

- [x] Command-P opens the panel
- [x] Clicking “↓” adds third party files to the sources search results
- [x] Clicking “↑” adds third party files to the sources search results

### Screenshots/Videos (OPTIONAL)
![image](https://user-images.githubusercontent.com/12681350/35169450-9140a252-fd2a-11e7-982c-ba24900e8b55.png)
![image](https://user-images.githubusercontent.com/12681350/35169471-9ed00f8e-fd2a-11e7-8848-91d9d176f2bb.png)
