### PR TITLE
Changed the itemHeight in the SourcesTree.js to maintain highlighted …

### DIFF
--- a/src/components/PrimaryPanes/SourcesTree.js
+++ b/src/components/PrimaryPanes/SourcesTree.js
@@ -361,7 +361,7 @@ class SourcesTree extends Component<Props, State> {
       getChildren: item => (nodeHasChildren(item) ? item.contents : []),
       getRoots: () => sourceTree.contents,
       getPath: this.getPath,
-      itemHeight: 21,
+      itemHeight: 20,
       autoExpandDepth: expanded ? 0 : 1,
       autoExpandAll: false,
       onFocus: this.focusItem,


### PR DESCRIPTION
…item when scrolling.

Associated Issue: #5064 

Here's the Pull Request Doc
https://devtools-html.github.io/debugger.html/CONTRIBUTING.html#pull-requests

### Summary of Changes

* Changed the itemHeight in the SourcesTree.js to maintain highlighted item when scrolling.

### Test Plan

-N/A

Example test plan:

- [x] Command-P opens the panel
- [x] Clicking “+” opens the panel
- [x] Clicking a source navigates to the source
- [x] Clicking "x" closes the panel

Here's the Debugger's Testing doc
https://docs.google.com/document/d/1oBMRxV8A2ag2t22YsQOxTdEv0mXKzIg0tggJjRkU1S0/edit#.
Feel free to improve it!

### Screenshots/Videos (OPTIONAL)
