### PR TITLE
[Project Search] Removed sources that have a minified version

### DIFF
--- a/src/actions/project-text-search.js
+++ b/src/actions/project-text-search.js
@@ -10,7 +10,7 @@
  */
 
 import { findSourceMatches } from "../workers/search";
-import { getSources, getSource } from "../selectors";
+import { getSources, getSource, hasPrettySource } from "../selectors";
 import { isThirdParty, isLoaded } from "../utils/source";
 import { loadAllSources } from "./sources";
 import { statusType } from "../reducers/project-text-search";
@@ -52,7 +52,12 @@ export function searchSources(query: string) {
     const sources = getSources(getState());
     const validSources = sources
       .valueSeq()
-      .filter(source => isLoaded(source) && !isThirdParty(source));
+      .filter(
+        source =>
+          isLoaded(source) &&
+          !hasPrettySource(getState(), source.get("id")) &&
+          !isThirdParty(source)
+      );
     for (const source of validSources) {
       await dispatch(searchSource(source.get("id"), query));
     }

--- a/src/actions/tests/__snapshots__/project-text-search.spec.js.snap
+++ b/src/actions/tests/__snapshots__/project-text-search.spec.js.snap
@@ -140,6 +140,53 @@ Immutable.List [
 ]
 `;
 
+exports[`project text search should ignore sources with minified versions 1`] = `
+Immutable.List [
+  Object {
+    "filepath": "http://localhost:8000/examples/bar",
+    "matches": Array [
+      Object {
+        "column": 9,
+        "line": 1,
+        "match": "bla",
+        "sourceId": "bar",
+        "text": "function bla(x, y) {",
+        "value": "function bla(x, y) {",
+      },
+    ],
+    "sourceId": "bar",
+  },
+  Object {
+    "filepath": "http://localhost:8000/examples/bar:formatted",
+    "matches": Array [
+      Object {
+        "column": 9,
+        "line": 1,
+        "match": "bla",
+        "sourceId": "bar:formatted",
+        "text": "function bla(x, y) {",
+        "value": "function bla(x, y) {",
+      },
+    ],
+    "sourceId": "bar:formatted",
+  },
+  Object {
+    "filepath": "http://localhost:8000/examples/bar:formatted",
+    "matches": Array [
+      Object {
+        "column": 9,
+        "line": 1,
+        "match": "bla",
+        "sourceId": "bar:formatted",
+        "text": "function bla(x, y) {",
+        "value": "function bla(x, y) {",
+      },
+    ],
+    "sourceId": "bar:formatted",
+  },
+]
+`;
+
 exports[`project text search should search a specific source 1`] = `
 Immutable.List [
   Object {

--- a/src/actions/tests/project-text-search.spec.js
+++ b/src/actions/tests/project-text-search.spec.js
@@ -36,6 +36,12 @@ const threadClient = {
             contentType: "text/javascript"
           });
           break;
+        case "bar:formatted":
+          resolve({
+            source: "function bla(x, y) {\n const bar = 4; return 2;\n}",
+            contentType: "text/javascript"
+          });
+          break;
       }
 
       reject(`unknown source: ${sourceId}`);
@@ -69,6 +75,21 @@ describe("project text search", () => {
     const mockQuery = "foo";
     const source1 = makeSource("foo1");
     const source2 = makeSource("foo2");
+
+    await dispatch(actions.newSource(source1));
+    await dispatch(actions.newSource(source2));
+
+    await dispatch(actions.searchSources(mockQuery));
+
+    const results = getTextSearchResults(getState());
+    expect(results).toMatchSnapshot();
+  });
+
+  it("should ignore sources with minified versions", async () => {
+    const { dispatch, getState } = createStore(threadClient);
+    const mockQuery = "bla";
+    const source1 = makeSource("bar");
+    const source2 = makeSource("bar:formatted");
 
     await dispatch(actions.newSource(source1));
     await dispatch(actions.newSource(source2));

--- a/src/reducers/sources.js
+++ b/src/reducers/sources.js
@@ -315,6 +315,10 @@ export function getPrettySource(state: OuterState, id: string) {
   return getSourceByURL(state, getPrettySourceURL(source.get("url")));
 }
 
+export function hasPrettySource(state: OuterState, id: string) {
+  return !!getPrettySource(state, id);
+}
+
 function getSourceByUrlInSources(sources: SourcesMap, url: string) {
   if (!url) {
     return null;


### PR DESCRIPTION
#5109 

### Summary of Changes

* Removed sources that have a minified version in project search

### Test Plan

Example test plan:

- Open https://arewesmoothyet.com/?mode=track&trackedStat=Devtools%20Hangs
- CMD-SHIFT-F for "trackedStat"
- Click on the first result
- Prettify file; needs some time
- Go back to search with CMD-SHIFT-F
- Focus search field and search again
- The non-minified file should be gone

### Screenshots/Videos
With changes:
![image](https://user-images.githubusercontent.com/12681350/35187790-99d0d05e-fdf7-11e7-961a-ce645379980d.png)

Before changes:
![image](https://user-images.githubusercontent.com/12681350/35187808-0b3f3672-fdf8-11e7-94a4-af1440e55a16.png)