### PR TITLE
[QuickOpen] Fix for go to line showing matching files

### DIFF
--- a/src/components/QuickOpenModal.js
+++ b/src/components/QuickOpenModal.js
@@ -102,7 +102,9 @@ export class QuickOpenModal extends Component<Props, State> {
       const results = this.props.sources;
       return this.setState({ results });
     }
-
+    if (this.isGotoQuery()) {
+      return this.setState({ results: [] });
+    }
     if (this.isGotoSourceQuery()) {
       const [baseQuery] = query.split(":");
       const results = filter(this.props.sources, baseQuery);
@@ -149,9 +151,6 @@ export class QuickOpenModal extends Component<Props, State> {
 
     if (this.isShortcutQuery()) {
       return this.showShortcuts(query);
-    }
-    if (this.isGotoQuery()) {
-      return this.searchSources(null);
     }
     return this.searchSources(query);
   };

--- a/src/components/QuickOpenModal.js
+++ b/src/components/QuickOpenModal.js
@@ -152,6 +152,9 @@ export class QuickOpenModal extends Component<Props, State> {
     if (this.isShortcutQuery()) {
       return this.showShortcuts(query);
     }
+    if (this.isGotoQuery()) {
+      return this.searchSources(null);
+    }
     return this.searchSources(query);
   };
 

--- a/src/components/QuickOpenModal.js
+++ b/src/components/QuickOpenModal.js
@@ -102,9 +102,6 @@ export class QuickOpenModal extends Component<Props, State> {
       const results = this.props.sources;
       return this.setState({ results });
     }
-    if (this.isGotoQuery()) {
-      return this.setState({ results: [] });
-    }
     if (this.isGotoSourceQuery()) {
       const [baseQuery] = query.split(":");
       const results = filter(this.props.sources, baseQuery);
@@ -141,6 +138,10 @@ export class QuickOpenModal extends Component<Props, State> {
   };
 
   updateResults = (query: string) => {
+    if (this.isGotoQuery()) {
+      return;
+    }
+
     if (query == "") {
       return this.showTopSources();
     }
@@ -152,12 +153,6 @@ export class QuickOpenModal extends Component<Props, State> {
     if (this.isShortcutQuery()) {
       return this.showShortcuts(query);
     }
-<<<<<<< HEAD
-    if (this.isGotoQuery()) {
-      return this.searchSources(null);
-    }
-=======
->>>>>>> fix type error
     return this.searchSources(query);
   };
 
@@ -252,7 +247,7 @@ export class QuickOpenModal extends Component<Props, State> {
     const { selectedSource, setQuickOpenQuery } = this.props;
     setQuickOpenQuery(e.target.value);
     const noSource = !selectedSource || !selectedSource.get("text");
-    if (this.isSymbolSearch() && noSource) {
+    if ((this.isSymbolSearch() && noSource) || this.isGotoQuery()) {
       return;
     }
     this.updateResults(e.target.value);
@@ -262,7 +257,7 @@ export class QuickOpenModal extends Component<Props, State> {
     const { enabled, query } = this.props;
     const { results, selectedIndex } = this.state;
 
-    if (!enabled || !results) {
+    if (!this.isGotoQuery() && (!enabled || !results)) {
       return;
     }
 
@@ -272,11 +267,13 @@ export class QuickOpenModal extends Component<Props, State> {
         return this.gotoLocation(location);
       }
 
-      if (this.isShortcutQuery()) {
-        return this.setModifier(results[selectedIndex]);
-      }
+      if (results) {
+        if (this.isShortcutQuery()) {
+          return this.setModifier(results[selectedIndex]);
+        }
 
-      return this.selectResultItem(e, results[selectedIndex]);
+        return this.selectResultItem(e, results[selectedIndex]);
+      }
     }
 
     if (e.key === "Tab") {

--- a/src/components/QuickOpenModal.js
+++ b/src/components/QuickOpenModal.js
@@ -152,9 +152,12 @@ export class QuickOpenModal extends Component<Props, State> {
     if (this.isShortcutQuery()) {
       return this.showShortcuts(query);
     }
+<<<<<<< HEAD
     if (this.isGotoQuery()) {
       return this.searchSources(null);
     }
+=======
+>>>>>>> fix type error
     return this.searchSources(query);
   };
 

--- a/src/components/QuickOpenModal.js
+++ b/src/components/QuickOpenModal.js
@@ -150,7 +150,9 @@ export class QuickOpenModal extends Component<Props, State> {
     if (this.isShortcutQuery()) {
       return this.showShortcuts(query);
     }
-
+    if (this.isGotoQuery()) {
+      return this.searchSources(null);
+    }
     return this.searchSources(query);
   };
 

--- a/src/components/tests/QuickOpenModal.spec.js
+++ b/src/components/tests/QuickOpenModal.spec.js
@@ -172,4 +172,20 @@ describe("QuickOpenModal", () => {
       maxResults: 1000
     });
   });
+
+  test("Simple goto search query = :abc & searchType = goto", () => {
+    const { wrapper } = generateModal(
+      {
+        enabled: true,
+        query: ":abc",
+        searchType: "goto",
+        symbols: {
+          functions: [],
+          variables: []
+        }
+      },
+      "mount"
+    );
+    expect(wrapper).toMatchSnapshot();
+  });
 });

--- a/src/components/tests/QuickOpenModal.spec.js
+++ b/src/components/tests/QuickOpenModal.spec.js
@@ -187,5 +187,6 @@ describe("QuickOpenModal", () => {
       "mount"
     );
     expect(wrapper).toMatchSnapshot();
+    expect(wrapper.state().results).toEqual([]);
   });
 });

--- a/src/components/tests/QuickOpenModal.spec.js
+++ b/src/components/tests/QuickOpenModal.spec.js
@@ -187,6 +187,6 @@ describe("QuickOpenModal", () => {
       "mount"
     );
     expect(wrapper).toMatchSnapshot();
-    expect(wrapper.state().results).toEqual([]);
+    expect(wrapper.state().results).toEqual(null);
   });
 });

--- a/src/components/tests/__snapshots__/QuickOpenModal.spec.js.snap
+++ b/src/components/tests/__snapshots__/QuickOpenModal.spec.js.snap
@@ -520,17 +520,6 @@ exports[`QuickOpenModal Simple goto search query = :abc & searchType = goto 1`] 
                 </CloseButton>
               </div>
             </SearchInput>
-            <ResultList
-              items={Array []}
-              key="results"
-              selectItem={[Function]}
-              selected={0}
-              size="small"
-            >
-              <ul
-                className="result-list small"
-              />
-            </ResultList>
           </div>
         </div>
       </Modal>

--- a/src/components/tests/__snapshots__/QuickOpenModal.spec.js.snap
+++ b/src/components/tests/__snapshots__/QuickOpenModal.spec.js.snap
@@ -412,6 +412,133 @@ exports[`QuickOpenModal Renders when enabled 1`] = `
 </Slide>
 `;
 
+exports[`QuickOpenModal Simple goto search query = :abc & searchType = goto 1`] = `
+<QuickOpenModal
+  clearHighlightLineRange={[Function]}
+  closeQuickOpen={[Function]}
+  enabled={true}
+  highlightLineRange={[Function]}
+  query=":abc"
+  searchType="goto"
+  selectLocation={[Function]}
+  setQuickOpenQuery={[Function]}
+  sources={Array []}
+  symbols={
+    Object {
+      "functions": Array [],
+      "variables": Array [],
+    }
+  }
+>
+  <Slide
+    handleClose={[Function]}
+    in={true}
+  >
+    <Transition
+      appear={true}
+      enter={true}
+      exit={true}
+      in={true}
+      mountOnEnter={false}
+      onEnter={[Function]}
+      onEntered={[Function]}
+      onEntering={[Function]}
+      onExit={[Function]}
+      onExited={[Function]}
+      onExiting={[Function]}
+      timeout={175}
+      unmountOnExit={false}
+    >
+      <Modal
+        handleClose={[Function]}
+        status="entering"
+      >
+        <div
+          className="modal-wrapper"
+          onClick={[Function]}
+        >
+          <div
+            className="modal entering"
+            onClick={[Function]}
+          >
+            <SearchInput
+              count={0}
+              handleClose={[Function]}
+              onChange={[Function]}
+              onKeyDown={[Function]}
+              placeholder="Search sources…"
+              query=":abc"
+              showErrorEmoji={true}
+              size=""
+            >
+              <div
+                className="search-field"
+              >
+                <Svg
+                  name="sad-face"
+                >
+                  <InlineSVG
+                    className="sad-face "
+                    element="i"
+                    raw={false}
+                    src="<svg></svg>"
+                  >
+                    <i
+                      className="sad-face "
+                      dangerouslySetInnerHTML={
+                        Object {
+                          "__html": "<svg></svg>",
+                        }
+                      }
+                      src={null}
+                    />
+                  </InlineSVG>
+                </Svg>
+                <input
+                  className="empty"
+                  onChange={[Function]}
+                  onKeyDown={[Function]}
+                  placeholder="Search sources…"
+                  spellCheck={false}
+                  value=":abc"
+                />
+                <div
+                  className="summary"
+                />
+                <CloseButton
+                  buttonClass=""
+                  handleClick={[Function]}
+                >
+                  <div
+                    className="close-btn"
+                    onClick={[Function]}
+                  >
+                    <img
+                      className="close"
+                    />
+                  </div>
+                </CloseButton>
+              </div>
+            </SearchInput>
+            <ResultList
+              items={Array []}
+              key="results"
+              selectItem={[Function]}
+              selected={0}
+              size="small"
+            >
+              <ul
+                className="result-list small"
+              />
+            </ResultList>
+          </div>
+        </div>
+      </Modal>
+    </Transition>
+  </Slide>
+</QuickOpenModal>
+`;
+
 exports[`QuickOpenModal closeModal 1`] = `
 <QuickOpenModal
   clearHighlightLineRange={[Function]}


### PR DESCRIPTION
Associated Issue: #5086

### Summary of Changes

* Added case for preventing goto from performing a search

### Test Plan

Tested by typing alphabetical characters after ":", and observed the behavior to work how it should.

before: 
![image](https://user-images.githubusercontent.com/23143862/35191645-507af70c-fe4e-11e7-916f-5f81b1a4d53d.png)

after:
![image](https://user-images.githubusercontent.com/23143862/35191649-635a0908-fe4e-11e7-9264-b43861231a31.png)



