### PR TITLE
Preset the height of individual nodes and modified file svg top dista…

### DIFF
--- a/src/components/PrimaryPanes/Sources.css
+++ b/src/components/PrimaryPanes/Sources.css
@@ -21,7 +21,6 @@
   display: flex;
   overflow-x: hidden;
   overflow-y: auto;
-  padding-top: 11px;
 }
 
 .sources-list .managed-tree {

--- a/src/components/PrimaryPanes/Sources.css
+++ b/src/components/PrimaryPanes/Sources.css
@@ -33,6 +33,7 @@
 
 .sources-list .managed-tree .tree .node {
   padding: 0px 0px 0px 3px;
+  height: 21px;
   width: 100%;
 }
 

--- a/src/components/shared/Svg.css
+++ b/src/components/shared/Svg.css
@@ -17,13 +17,13 @@
 }
 
 .worker,
+.file,
 .folder {
   position: relative;
   top: 2px;
 }
 
 .domain,
-.file,
 .worker,
 .refresh,
 .add-button {


### PR DESCRIPTION
…nce.

Associated Issue: #5064 

Here's the Pull Request Doc
https://devtools-html.github.io/debugger.html/CONTRIBUTING.html#pull-requests

### Summary of Changes

* Preset the height of individual nodes.
* Modified file svg top distance.

### Test Plan

Traversing enough elements that the scroll is enabled, once the highlighted element starts to scroll it should stay in view.

-Start from the bottom of the left panel tree
-Traverse upwards using the up key
-Until the top is reached the highlighted element should remain in view

Here's the Debugger's Testing doc
https://docs.google.com/document/d/1oBMRxV8A2ag2t22YsQOxTdEv0mXKzIg0tggJjRkU1S0/edit#.
Feel free to improve it!

### Screenshots/Videos
As can be seen in the following image, the highlighted element is starting to leave the view, eventually if upward scrolling continues, it will leave the view.
<img width="253" alt="screen shot 2018-01-21 at 8 18 10 am" src="https://user-images.githubusercontent.com/14250545/35194723-d959cb52-fe85-11e7-9048-93a86c520009.png">

With the fix, the highlighted element remains in view while scrolling upwards or downwards.
<img width="253" alt="screen shot 2018-01-21 at 8 20 05 am" src="https://user-images.githubusercontent.com/14250545/35194725-dd530304-fe85-11e7-98fc-a4de8bffce5a.png">

Edit, also removed the extra padding below the tabs.
<img width="249" alt="screen shot 2018-01-21 at 10 12 30 am" src="https://user-images.githubusercontent.com/14250545/35195579-a0fda16c-fe93-11e7-8e17-4022f2b6dc5f.png">

