### PR TITLE
[Scopes]-fixed missing padding in scopes tree

### DIFF
--- a/src/components/SecondaryPanes/Scopes.css
+++ b/src/components/SecondaryPanes/Scopes.css
@@ -29,6 +29,10 @@
   overflow: auto;
 }
 
+.scopes-list {
+  padding-left: 4px;
+}
+
 .scopes-list .function-signature {
   display: inline-block;
 }


### PR DESCRIPTION
Associated Issue: #5151 

### Summary of Changes
* Added a 4px padding to the left-hand side of ```scopes-list``` class

### Test Plan
* A visual check that the Block node aligns with the Parent Scopes node.

### Screenshots/Videos (OPTIONAL)
![Before added padding](https://user-images.githubusercontent.com/10661000/35195043-59a08b82-feb5-11e7-82fb-b0698d12683d.png)
![4px padding added](https://user-images.githubusercontent.com/10661000/35195052-688c0c5c-feb5-11e7-9550-601ca2f96cb4.png)


