### PR TITLE
Speedup quick open

### DIFF
--- a/src/components/tests/QuickOpenModal.spec.js
+++ b/src/components/tests/QuickOpenModal.spec.js
@@ -122,7 +122,10 @@ describe("QuickOpenModal", () => {
       "mount"
     );
     wrapper.find("input").simulate("change", { target: { value: "somefil" } });
-    expect(filter).toHaveBeenCalledWith([], "somefil", { key: "value" });
+    expect(filter).toHaveBeenCalledWith([], "somefil", {
+      key: "value",
+      maxResults: 1000
+    });
   });
 
   test("basic gotoSource search", () => {
@@ -140,7 +143,10 @@ describe("QuickOpenModal", () => {
     wrapper
       .find("input")
       .simulate("change", { target: { value: "somefil:33" } });
-    expect(filter).toHaveBeenCalledWith([], "somefil", { key: "value" });
+    expect(filter).toHaveBeenCalledWith([], "somefil", {
+      key: "value",
+      maxResults: 1000
+    });
   });
 
   test("basic symbol seach", () => {
@@ -161,6 +167,9 @@ describe("QuickOpenModal", () => {
     wrapper
       .find("input")
       .simulate("change", { target: { value: "@someFunc" } });
-    expect(filter).toHaveBeenCalledWith([], "someFunc", { key: "value" });
+    expect(filter).toHaveBeenCalledWith([], "someFunc", {
+      key: "value",
+      maxResults: 1000
+    });
   });
 });


### PR DESCRIPTION
Associated Issue: #5085 #4996

### Summary of Changes

* limit fuzz aldrin to 1000 results
* limit result list to 100 items
* show tabs on initial render... not sure about the UX here... 


### Slow version

<img width="682" alt="screen shot 2018-01-21 at 10 29 25 am" src="https://user-images.githubusercontent.com/254562/35196375-35133da2-fe9f-11e7-9fe4-9ff478f43b56.png">

### Fast version

<img width="789" alt="screen shot 2018-01-21 at 10 53 09 am" src="https://user-images.githubusercontent.com/254562/35196376-3cc11308-fe9f-11e7-871a-85f3ceaa6baf.png">
