### PR TITLE
[Sources] - fix paddings in sources tree and outline list

### DIFF
--- a/src/components/PrimaryPanes/Outline.css
+++ b/src/components/PrimaryPanes/Outline.css
@@ -17,7 +17,7 @@
 
 .outline-list {
   list-style-type: none;
-  width: 100%;
+  flex: 1 0 100%;
   padding: 10px 0px;
   margin: 0;
 }
@@ -36,17 +36,11 @@
 }
 
 .outline-list__element {
-  padding-bottom: 0.5rem;
-  padding-right: 0.5rem;
-  padding-top: 0.2rem;
+  padding: 3px 10px 3px 10px;
   cursor: default;
   white-space: nowrap;
 }
 
 .outline-list__element:hover {
   background: var(--theme-toolbar-background-hover);
-}
-
-.outline-list__element .function {
-  padding-left: 10px;
 }

--- a/src/components/PrimaryPanes/Sources.css
+++ b/src/components/PrimaryPanes/Sources.css
@@ -31,8 +31,7 @@
 }
 
 .sources-list .managed-tree .tree .node {
-  padding: 0px 0px 0px 3px;
-  height: 21px;
+  padding: 0px 10px 0px 3px;
   width: 100%;
 }
 

--- a/src/components/shared/ManagedTree.css
+++ b/src/components/shared/ManagedTree.css
@@ -12,6 +12,9 @@
   white-space: nowrap;
   overflow: auto;
   min-width: 100%;
+
+  display: grid;
+  align-content: start;
 }
 
 .managed-tree .tree button {


### PR DESCRIPTION
### Summary of Changes

* fix height in sources tree, there was blue line under selected item 
* unify padding around items in outline list
* and fix https://github.com/devtools-html/debugger.html/issues/5149

### Test Plan

### Screenshots/Videos (OPTIONAL)
* sources tree BEFORE
![firefox-tree](https://user-images.githubusercontent.com/7465851/35197348-4b1e29f6-fede-11e7-8e24-6d94a3b54131.JPG)
* sources tree AFTER
![firefox-tree-after](https://user-images.githubusercontent.com/7465851/35198011-a45f4892-fee8-11e7-8d5f-48bcf895676a.JPG)
* outline list BEFORE
![firefox-outline](https://user-images.githubusercontent.com/7465851/35198056-46678aaa-fee9-11e7-957d-2ec18b6f022f.JPG)
* outline list AFTER
![firefox-outline-after](https://user-images.githubusercontent.com/7465851/35198059-4ee4695a-fee9-11e7-94f4-77648298da2f.JPG)



