### PR TITLE
Disable CSS auto-prefixes for old IE

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -34,7 +34,11 @@ module.exports = ({ file, options, env }) => {
   return {
     plugins: [
       require("postcss-bidirection"),
-      require("autoprefixer"),
+      require("autoprefixer")({
+				browsers: ['last 2 Firefox versions', 'last 2 Chrome versions'],
+        flexbox: false,
+        grid: false
+			}),
       require("postcss-class-namespace")(),
       mapUrl(mapUrlDevelopment)
     ]


### PR DESCRIPTION
### Summary of Changes

I think a majority of user use modern browsers for running this debugger, so some prefixes for really old browsers are not needed.

### Test Plan

### Screenshots/Videos (OPTIONAL)
