### PR TITLE
Disable map scopes in dev

### DIFF
--- a/src/utils/prefs.js
+++ b/src/utils/prefs.js
@@ -40,7 +40,7 @@ if (isDevelopment()) {
   pref("devtools.debugger.features.root", true);
   pref("devtools.debugger.features.column-breakpoints", false);
   pref("devtools.debugger.features.chrome-scopes", false);
-  pref("devtools.debugger.features.map-scopes", true);
+  pref("devtools.debugger.features.map-scopes", false);
   pref("devtools.debugger.features.breakpoints-dropdown", true);
   pref("devtools.debugger.features.remove-command-bar-options", true);
   pref("devtools.debugger.features.code-coverage", false);


### PR DESCRIPTION
We recently disabled map scopes when we're in the panel. I think we should do the same thing in dev because it is pretty slow and makes it difficult to do performance testing.