### PR TITLE
Add basic UI for rewinding when server indicates it can rewind

### DIFF
--- a/src/actions/navigation.js
+++ b/src/actions/navigation.js
@@ -54,10 +54,10 @@ export function navigate(url: string) {
   };
 }
 
-export function connect(url: string) {
+export function connect(url: string, canRewind: boolean) {
   return async function({ dispatch }: ThunkArgs) {
     await dispatch(updateWorkers());
-    dispatch({ type: "CONNECT", url });
+    dispatch({ type: "CONNECT", url, canRewind });
   };
 }
 

--- a/src/actions/pause/commands.js
+++ b/src/actions/pause/commands.js
@@ -1,3 +1,4 @@
+/* -*- indent-tabs-mode: nil; js-indent-level: 2; js-indent-level: 2 -*- */
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
@@ -11,7 +12,15 @@ import { addHiddenBreakpoint } from "../breakpoints";
 import { features } from "../../utils/prefs";
 
 import type { ThunkArgs } from "../types";
-type CommandType = "stepOver" | "stepIn" | "stepOut" | "resume";
+type CommandType =
+  | "stepOver"
+  | "stepIn"
+  | "stepOut"
+  | "resume"
+  | "rewind"
+  | "reverseStepOver"
+  | "reverseStepIn"
+  | "reverseStepOut";
 
 /**
  * Debugger commands like stepOver, stepIn, stepUp
@@ -82,6 +91,62 @@ export function resume() {
   return ({ dispatch, getState }: ThunkArgs) => {
     if (isPaused(getState())) {
       return dispatch(command("resume"));
+    }
+  };
+}
+
+/**
+ * rewind
+ * @memberof actions/pause
+ * @static
+ * @returns {Function} {@link command}
+ */
+export function rewind() {
+  return ({ dispatch, getState }: ThunkArgs) => {
+    if (isPaused(getState())) {
+      return dispatch(command("rewind"));
+    }
+  };
+}
+
+/**
+ * reverseStepIn
+ * @memberof actions/pause
+ * @static
+ * @returns {Function} {@link command}
+ */
+export function reverseStepIn() {
+  return ({ dispatch, getState }: ThunkArgs) => {
+    if (isPaused(getState())) {
+      return dispatch(command("reverseStepIn"));
+    }
+  };
+}
+
+/**
+ * reverseStepOver
+ * @memberof actions/pause
+ * @static
+ * @returns {Function} {@link command}
+ */
+export function reverseStepOver() {
+  return ({ dispatch, getState }: ThunkArgs) => {
+    if (isPaused(getState())) {
+      return dispatch(astCommand("reverseStepOver"));
+    }
+  };
+}
+
+/**
+ * reverseStepOut
+ * @memberof actions/pause
+ * @static
+ * @returns {Function} {@link command}
+ */
+export function reverseStepOut() {
+  return ({ dispatch, getState }: ThunkArgs) => {
+    if (isPaused(getState())) {
+      return dispatch(command("reverseStepOut"));
     }
   };
 }

--- a/src/actions/pause/index.js
+++ b/src/actions/pause/index.js
@@ -9,7 +9,16 @@
  * @module actions/pause
  */
 
-export { stepIn, stepOver, stepOut, resume } from "./commands";
+export {
+  stepIn,
+  stepOver,
+  stepOut,
+  resume,
+  rewind,
+  reverseStepIn,
+  reverseStepOver,
+  reverseStepOut
+} from "./commands";
 export { fetchScopes } from "./fetchScopes";
 export { paused } from "./paused";
 export { resumed } from "./resumed";

--- a/src/actions/pause/paused.js
+++ b/src/actions/pause/paused.js
@@ -35,7 +35,7 @@ export function paused(pauseInfo: Pause) {
       type: "PAUSED",
       why,
       frames,
-      selectedFrameId: frames[0].id,
+      selectedFrameId: frames[0] ? frames[0].id : undefined,
       loadedObjects: loadedObjects || []
     });
 
@@ -50,7 +50,9 @@ export function paused(pauseInfo: Pause) {
 
     await dispatch(mapFrames());
     const selectedFrame = getSelectedFrame(getState());
-    await dispatch(selectLocation(selectedFrame.location));
+    if (selectedFrame) {
+      await dispatch(selectLocation(selectedFrame.location));
+    }
 
     dispatch(togglePaneCollapse("end", false));
     dispatch(fetchScopes());

--- a/src/actions/types.js
+++ b/src/actions/types.js
@@ -285,7 +285,7 @@ type PauseAction =
     };
 
 type NavigateAction =
-  | { type: "CONNECT", url: string }
+  | { type: "CONNECT", url: string, canRewind: boolean }
   | { type: "NAVIGATE", url: string };
 
 type ASTAction =

--- a/src/client/firefox.js
+++ b/src/client/firefox.js
@@ -54,7 +54,8 @@ export async function onConnect(connection: any, actions: Object): Object {
   // bfcache) so explicity fire `newSource` events for all returned
   // sources.
   const sources = await clientCommands.fetchSources();
-  await actions.connect(tabTarget.url);
+  const traits = tabTarget.activeTab ? tabTarget.activeTab.traits : null;
+  await actions.connect(tabTarget.url, traits && traits.canRewind);
   await actions.newSources(sources);
 
   // If the threadClient is already paused, make sure to show a

--- a/src/client/firefox/commands.js
+++ b/src/client/firefox/commands.js
@@ -76,6 +76,30 @@ function stepOut(): Promise<*> {
   });
 }
 
+function rewind(): Promise<*> {
+  return new Promise(resolve => {
+    threadClient.rewind(resolve);
+  });
+}
+
+function reverseStepIn(): Promise<*> {
+  return new Promise(resolve => {
+    threadClient.reverseStepIn(resolve);
+  });
+}
+
+function reverseStepOver(): Promise<*> {
+  return new Promise(resolve => {
+    threadClient.reverseStepOver(resolve);
+  });
+}
+
+function reverseStepOut(): Promise<*> {
+  return new Promise(resolve => {
+    threadClient.reverseStepOut(resolve);
+  });
+}
+
 function breakOnNext(): Promise<*> {
   return threadClient.breakOnNext();
 }
@@ -304,6 +328,10 @@ const clientCommands = {
   stepIn,
   stepOut,
   stepOver,
+  rewind,
+  reverseStepIn,
+  reverseStepOut,
+  reverseStepOver,
   breakOnNext,
   sourceContents,
   getBreakpointByLocation,

--- a/src/client/firefox/create.js
+++ b/src/client/firefox/create.js
@@ -13,7 +13,10 @@ import type {
   SourcePayload
 } from "./types";
 
-export function createFrame(frame: FramePacket): Frame {
+export function createFrame(frame: FramePacket): ?Frame {
+  if (!frame) {
+    return null;
+  }
   let title;
   if (frame.type == "call") {
     const c = frame.callee;

--- a/src/client/firefox/types.js
+++ b/src/client/firefox/types.js
@@ -345,6 +345,10 @@ export type ThreadClient = {
   stepIn: Function => Promise<*>,
   stepOver: Function => Promise<*>,
   stepOut: Function => Promise<*>,
+  rewind: Function => Promise<*>,
+  reverseStepIn: Function => Promise<*>,
+  reverseStepOver: Function => Promise<*>,
+  reverseStepOut: Function => Promise<*>,
   breakOnNext: () => Promise<*>,
   // FIXME: unclear if SourceId or ActorId here
   source: ({ actor: SourceId }) => SourceClient,

--- a/src/components/SecondaryPanes/Breakpoints.js
+++ b/src/components/SecondaryPanes/Breakpoints.js
@@ -54,7 +54,7 @@ type Props = {
 };
 
 function isCurrentlyPausedAtBreakpoint(frame, why, breakpoint) {
-  if (!isInterrupted(why)) {
+  if (!frame || !isInterrupted(why)) {
     return false;
   }
 

--- a/src/components/SecondaryPanes/CommandBar.css
+++ b/src/components/SecondaryPanes/CommandBar.css
@@ -23,7 +23,11 @@ img.pause,
 img.stepOver,
 img.stepIn,
 img.stepOut,
-img.resume {
+img.resume,
+img.rewind,
+img.reverseStepOver,
+img.reverseStepIn,
+img.reverseStepOut {
   background-color: var(--theme-body-color);
 }
 
@@ -45,6 +49,26 @@ img.resume {
 
 .command-bar img.resume {
   mask: url(/images/resume.svg) no-repeat;
+}
+
+.command-bar img.rewind {
+  mask: url(/images/resume.svg) no-repeat;
+  transform: scaleX(-1);
+}
+
+.command-bar img.reverseStepOver {
+  mask: url(/images/stepOver.svg) no-repeat;
+  transform: scaleX(-1);
+}
+
+.command-bar img.reverseStepIn {
+  mask: url(/images/stepIn.svg) no-repeat;
+  transform: scaleX(-1);
+}
+
+.command-bar img.reverseStepOut {
+  mask: url(/images/stepOut.svg) no-repeat;
+  transform: scaleX(-1);
 }
 
 .command-bar > .pause-exceptions.uncaught.enabled > img.pause-exceptions {

--- a/src/components/SecondaryPanes/CommandBar.js
+++ b/src/components/SecondaryPanes/CommandBar.js
@@ -1,3 +1,4 @@
+/* -*- indent-tabs-mode: nil; js-indent-level: 2; js-indent-level: 2 -*- */
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
@@ -13,7 +14,8 @@ import {
   isPaused as getIsPaused,
   getIsWaitingOnBreak,
   getShouldPauseOnExceptions,
-  getShouldIgnoreCaughtExceptions
+  getShouldIgnoreCaughtExceptions,
+  getCanRewind
 } from "../../selectors";
 import { formatKeyShortcut } from "../../utils/text";
 import actions from "../../actions";
@@ -104,12 +106,17 @@ type Props = {
   stepOut: () => void,
   stepOver: () => void,
   breakOnNext: () => void,
+  rewind: () => void,
+  reverseStepIn: () => void,
+  reverseStepOut: () => void,
+  reverseStepOver: () => void,
   isPaused: boolean,
   pauseOnExceptions: (boolean, boolean) => void,
   shouldPauseOnExceptions: boolean,
   shouldIgnoreCaughtExceptions: boolean,
   isWaitingOnBreak: boolean,
-  horizontal: boolean
+  horizontal: boolean,
+  canRewind: boolean
 };
 
 class CommandBar extends Component<Props> {
@@ -192,7 +199,7 @@ class CommandBar extends Component<Props> {
       );
     }
 
-    if (features.removeCommandBarOptions) {
+    if (features.removeCommandBarOptions && !this.props.canRewind) {
       return;
     }
 
@@ -263,6 +270,41 @@ class CommandBar extends Component<Props> {
     );
   }
 
+  renderRewindButton() {
+    if (!this.props.canRewind || !this.props.isPaused) {
+      return;
+    }
+
+    return debugBtn(this.props.rewind, "rewind", "active", "Rewind Execution");
+  }
+
+  renderReverseStepButtons() {
+    if (!this.props.canRewind || !this.props.isPaused) {
+      return;
+    }
+
+    return [
+      debugBtn(
+        this.props.reverseStepOver,
+        "reverseStepOver",
+        "active",
+        "Reverse step over"
+      ),
+      debugBtn(
+        this.props.reverseStepIn,
+        "reverseStepIn",
+        "active",
+        "Reverse step in"
+      ),
+      debugBtn(
+        this.props.reverseStepOut,
+        "reverseStepOut",
+        "active",
+        "Reverse step out"
+      )
+    ];
+  }
+
   render() {
     return (
       <div
@@ -271,8 +313,10 @@ class CommandBar extends Component<Props> {
         })}
       >
         {this.renderPauseButton()}
+        {this.renderRewindButton()}
         {this.renderStepButtons()}
         {this.renderPauseOnExceptions()}
+        {this.renderReverseStepButtons()}
       </div>
     );
   }
@@ -288,7 +332,8 @@ export default connect(
       isPaused: getIsPaused(state),
       isWaitingOnBreak: getIsWaitingOnBreak(state),
       shouldPauseOnExceptions: getShouldPauseOnExceptions(state),
-      shouldIgnoreCaughtExceptions: getShouldIgnoreCaughtExceptions(state)
+      shouldIgnoreCaughtExceptions: getShouldIgnoreCaughtExceptions(state),
+      canRewind: getCanRewind(state)
     };
   },
   dispatch => bindActionCreators(actions, dispatch)

--- a/src/reducers/pause.js
+++ b/src/reducers/pause.js
@@ -25,6 +25,7 @@ type PauseState = {
   loadedObjects: Object,
   shouldPauseOnExceptions: boolean,
   shouldIgnoreCaughtExceptions: boolean,
+  canRewind: boolean,
   debuggeeUrl: string,
   command: string
 };
@@ -38,6 +39,7 @@ export const State = (): PauseState => ({
   loadedObjects: {},
   shouldPauseOnExceptions: prefs.pauseOnExceptions,
   shouldIgnoreCaughtExceptions: prefs.ignoreCaughtExceptions,
+  canRewind: false,
   debuggeeUrl: "",
   command: ""
 });
@@ -107,7 +109,11 @@ function update(state: PauseState = State(), action: Action): PauseState {
       };
 
     case "CONNECT":
-      return { ...State(), debuggeeUrl: action.url };
+      return {
+        ...State(),
+        debuggeeUrl: action.url,
+        canRewind: action.canRewind
+      };
 
     case "PAUSE_ON_EXCEPTIONS":
       const { shouldPauseOnExceptions, shouldIgnoreCaughtExceptions } = action;
@@ -192,6 +198,10 @@ export function getShouldPauseOnExceptions(state: OuterState) {
 
 export function getShouldIgnoreCaughtExceptions(state: OuterState) {
   return state.pause.shouldIgnoreCaughtExceptions;
+}
+
+export function getCanRewind(state: OuterState) {
+  return state.pause.canRewind;
 }
 
 export function getFrames(state: OuterState) {


### PR DESCRIPTION
### Summary of Changes

- Allow the debugger client to keep track of whether the server can rewind, as indicated by the server via the 'canRewind' property of the traits sent while attaching.

- Modify the debugger UI when interacting with a rewindable server, adding rewind and reverse-step buttons, and always showing the pause button (handy to have because a replaying process will zip forward to the end of the replay as fast as it can).

- Add some checks for the presence of a frame when paused.  Recording/replaying processes may pause when there are no JS frames on the stack.
