### PR TITLE
Fix syncing breakpoints when bps are removed

### DIFF
--- a/src/client/firefox/commands.js
+++ b/src/client/firefox/commands.js
@@ -25,7 +25,7 @@ import type {
   BPClients
 } from "./types";
 
-import { makeLocationId } from "../../utils/breakpoint";
+import { makePendingLocationId } from "../../utils/breakpoint";
 
 import { createSource, createBreakpointLocation } from "./create";
 
@@ -86,7 +86,7 @@ function sourceContents(sourceId: SourceId): Source {
 }
 
 function getBreakpointByLocation(location: Location) {
-  const id = makeLocationId(location);
+  const id = makePendingLocationId(location);
   const bpClient = bpClients[id];
 
   if (bpClient) {
@@ -121,7 +121,7 @@ function setBreakpoint(
     })
     .then(([{ actualLocation }, bpClient]) => {
       actualLocation = createBreakpointLocation(location, actualLocation);
-      const id = makeLocationId(actualLocation);
+      const id = makePendingLocationId(actualLocation);
       bpClients[id] = bpClient;
       bpClient.location.line = actualLocation.line;
       bpClient.location.column = actualLocation.column;
@@ -135,7 +135,7 @@ function removeBreakpoint(
   generatedLocation: Location
 ): Promise<void> | ?BreakpointResult {
   try {
-    const id = makeLocationId(generatedLocation);
+    const id = makePendingLocationId(generatedLocation);
     const bpClient = bpClients[id];
     if (!bpClient) {
       console.warn("No breakpoint to delete on server");

--- a/src/reducers/breakpoints.js
+++ b/src/reducers/breakpoints.js
@@ -66,6 +66,10 @@ function update(
     case "REMAP_BREAKPOINTS": {
       return remapBreakpoints(state, action);
     }
+
+    case "NAVIGATE": {
+      return initialState();
+    }
   }
 
   return state;

--- a/src/test/mochitest/browser_dbg-sourcemaps-reload.js
+++ b/src/test/mochitest/browser_dbg-sourcemaps-reload.js
@@ -34,7 +34,7 @@ add_task(async function() {
   let breakpoint = getBreakpoints(dbg)[0];
   is(breakpoint.location.line, 6);
 
-  let syncBp =  waitForDispatch(dbg, "SYNC_BREAKPOINT")
+  let syncBp =  waitForDispatch(dbg, "SYNC_BREAKPOINT");
   await reload(dbg);
 
   await waitForPaused(dbg);
@@ -46,14 +46,13 @@ add_task(async function() {
   is(breakpoint.generatedLocation.line, 73);
 
   await resume(dbg);
+  syncBp =  waitForDispatch(dbg, "SYNC_BREAKPOINT", 2)
+  await selectSource(dbg, "v1");
+  await addBreakpoint(dbg, "v1", 13);
 
-  syncBp =  waitForDispatch(dbg, "SYNC_BREAKPOINT")
   await reload(dbg);
-
   await waitForSource(dbg, "v1");
   await syncBp;
-
-  await selectSource(dbg, "v1")
   await waitForSelectedSource(dbg, "v1");
 
   is(getBreakpoints(dbg).length, 0, "No breakpoints")


### PR DESCRIPTION
Associated Issue: #3982

### Summary of Changes

When the breakpoint is at an original location that is no longer mapped to a generated source we want to remove it. In those cases we need to make sure that the breakpoint is removed from the breakpoint redux & client store.