### PR TITLE
Change horizontal and vertical realignment to only occur when line is out of bounds.

### DIFF
--- a/src/components/Editor/Editor.css
+++ b/src/components/Editor/Editor.css
@@ -126,6 +126,10 @@ html[dir="rtl"] .editor-mount {
   height: 100%;
 }
 
+.CodeMirror-scroll {
+  margin-right: 0px;
+}
+
 .editor-wrapper .editor-mount {
   width: 100%;
   background-color: var(--theme-body-background);

--- a/src/components/Editor/Editor.css
+++ b/src/components/Editor/Editor.css
@@ -126,10 +126,6 @@ html[dir="rtl"] .editor-mount {
   height: 100%;
 }
 
-.CodeMirror-scroll {
-  margin-right: 0px;
-}
-
 .editor-wrapper .editor-mount {
   width: 100%;
   background-color: var(--theme-body-background);

--- a/src/components/Editor/tests/Editor.spec.js
+++ b/src/components/Editor/tests/Editor.spec.js
@@ -20,6 +20,14 @@ function createMockEditor() {
       scrollTo: jest.fn(),
       charCoords: ({ line, ch }) => ({ top: line, left: ch }),
       getScrollerElement: () => ({ offsetWidth: 0, offsetHeight: 0 }),
+      getScrollInfo: () => ({
+        top: 0,
+        left: 0,
+        clientWidth: 0,
+        clientHeight: 0
+      }),
+      defaultCharWidth: () => 0,
+      defaultTextHeight: () => 0,
       display: { gutters: { querySelector: jest.fn() } }
     },
     setText: jest.fn(),

--- a/src/utils/editor/index.js
+++ b/src/utils/editor/index.js
@@ -108,7 +108,7 @@ function isVisible(codeMirror: any, top: number, left: number) {
   const inXView = withinBounds(
     left,
     scrollArea.left,
-    scrollArea.left + scrollArea.clientWidth - charWidth
+    scrollArea.left + (scrollArea.clientWidth - 30) - charWidth
   );
 
   const fontHeight = codeMirror.defaultTextHeight();

--- a/src/utils/editor/index.js
+++ b/src/utils/editor/index.js
@@ -88,11 +88,37 @@ export function scrollToColumn(codeMirror: any, line: number, column: number) {
     "local"
   );
 
-  const scroller = codeMirror.getScrollerElement();
-  const centeredX = Math.max(left - scroller.offsetWidth / 2, 0);
-  const centeredY = Math.max(top - scroller.offsetHeight / 2, 0);
+  if (!isVisible(codeMirror, top, left)) {
+    const scroller = codeMirror.getScrollerElement();
+    const centeredX = Math.max(left - scroller.offsetWidth / 2, 0);
+    const centeredY = Math.max(top - scroller.offsetHeight / 2, 0);
 
-  codeMirror.scrollTo(centeredX, centeredY);
+    codeMirror.scrollTo(centeredX, centeredY);
+  }
+}
+
+function isVisible(codeMirror: any, top: number, left: number) {
+  function withinBounds(x, min, max) {
+    return x >= min && x <= max;
+  }
+
+  const scrollArea = codeMirror.getScrollInfo();
+
+  const charWidth = codeMirror.defaultCharWidth();
+  const inXView = withinBounds(
+    left,
+    scrollArea.left,
+    scrollArea.left + scrollArea.clientWidth - charWidth
+  );
+
+  const fontHeight = codeMirror.defaultTextHeight();
+  const inYView = withinBounds(
+    top,
+    scrollArea.top,
+    scrollArea.top + scrollArea.clientHeight - fontHeight
+  );
+
+  return inXView && inYView;
 }
 
 export function toSourceLocation(

--- a/src/utils/editor/tests/editor.spec.js
+++ b/src/utils/editor/tests/editor.spec.js
@@ -145,6 +145,7 @@ const codeMirror = {
     offsetWidth: 100,
     offsetHeight: 100
   })),
+  getScrollInfo: () => {},
   removeLineClass: jest.fn(),
   operation: jest.fn(cb => cb()),
   charCoords: jest.fn(() => ({


### PR DESCRIPTION
Associated Issue: #5138 

Here's the Pull Request Doc
https://devtools-html.github.io/debugger.html/CONTRIBUTING.html#pull-requests

### Summary of Changes

-Check if the line is currently visible.
-Only realign the line to be centered if the line is out of bounds.

### Test Plan
N/A

Here's the Debugger's Testing doc
https://docs.google.com/document/d/1oBMRxV8A2ag2t22YsQOxTdEv0mXKzIg0tggJjRkU1S0/edit#.
Feel free to improve it!

Before: 
- As can be seen before, on every step in the debugger the editor was being realigned horizontally and vertically.
![beforestepdebug](https://user-images.githubusercontent.com/14250545/35310212-88069b4c-006d-11e8-98b3-264c0f42a803.gif)

After:
- After the changes the editor will only be realigned when the line goes out of the bounds of the editor.
![afterstepper](https://user-images.githubusercontent.com/14250545/35310252-b9cc93f2-006d-11e8-97f3-abe4c2c6f822.gif)

Before:
- Negative on the margin on the right side of the scroll area was increasing the clientWidth of the scrollArea.
<img width="764" alt="screen shot 2018-01-23 at 6 49 05 pm" src="https://user-images.githubusercontent.com/14250545/35310438-9e8d662e-006e-11e8-82c2-d2e32e6e0e40.png">

After:
- Removed extra margin on the right side of the scroll area.
<img width="714" alt="screen shot 2018-01-23 at 6 49 21 pm" src="https://user-images.githubusercontent.com/14250545/35310441-a42199b6-006e-11e8-8c0b-88a7da7d5341.png">

Also added some necessary functions to be mocked in Editor.spec.js, that are used in the isVisible function.