### PR TITLE
[breakpoints] Use symbols from store

### DIFF
--- a/src/actions/breakpoints/addBreakpoint.js
+++ b/src/actions/breakpoints/addBreakpoint.js
@@ -9,7 +9,7 @@ import {
   getASTLocation,
   assertLocation
 } from "../../utils/breakpoint";
-import { getSource } from "../../selectors";
+import { getSource, getSymbols } from "../../selectors";
 import { getGeneratedLocation } from "../../utils/source-maps";
 
 export default async function addBreakpoint(
@@ -50,7 +50,8 @@ export default async function addBreakpoint(
     newGeneratedLocation
   );
 
-  const astLocation = await getASTLocation(sourceRecord, newLocation);
+  const symbols = getSymbols(getState(), sourceRecord);
+  const astLocation = await getASTLocation(sourceRecord, symbols, newLocation);
 
   const newBreakpoint = {
     id,

--- a/src/utils/breakpoint/astBreakpointLocation.js
+++ b/src/utils/breakpoint/astBreakpointLocation.js
@@ -8,6 +8,7 @@ import { getSymbols } from "../../workers/parser";
 
 import type { Scope, AstPosition } from "../../workers/parser/types";
 import type { Location, Source, ASTLocation } from "debugger-html";
+import type { Symbols } from "../../reducers/types";
 
 export function containsPosition(a: AstPosition, b: AstPosition) {
   const startsBefore =
@@ -46,15 +47,15 @@ export function findClosestScope(functions: Scope[], location: Location) {
   }, null);
 }
 
-export async function getASTLocation(
+export function getASTLocation(
   source: Source,
+  symbols: Symbols,
   location: Location
-): Promise<ASTLocation> {
+): ASTLocation {
   if (source.isWasm) {
     return { name: undefined, offset: location };
   }
 
-  const symbols = await getSymbols(source);
   const functions = [...symbols.functions];
 
   const scope = findClosestScope(functions, location);


### PR DESCRIPTION
Associated Issue: #5096

### Summary of Changes

Replaces a call to the parser getSymbols w/ a fetch from the redux store.