### PR TITLE
CI: add mochitests using the debugger and located in non-debugger test suites

### DIFF
--- a/bin/ci/run-tests.js
+++ b/bin/ci/run-tests.js
@@ -58,7 +58,17 @@ Object.keys(fileSizes).forEach(key => {
 });
 
 const otherTests = [
-  "browser_net_open_in_debugger.js"
+  "devtools/client/framework/test/browser_browser_toolbox_debugger.js",
+  "devtools/client/framework/test/browser_keybindings_01.js",
+  "devtools/client/framework/test/browser_toolbox_getpanelwhenready.js",
+  "devtools/client/inspector/markup/test/browser_markup_links_06.js",
+  "devtools/client/netmonitor/test/browser_net_open_in_debugger.js",
+  "devtools/client/netmonitor/test/browser_net_view-source-debugger.js",
+  "devtools/client/webconsole/new-console-output/test/mochitest/browser_jsterm_autocomplete_in_debugger_stackframe.js",
+  "devtools/client/webconsole/new-console-output/test/mochitest/browser_webconsole_eval_in_debugger_stackframe1.js",
+  "devtools/client/webconsole/new-console-output/test/mochitest/browser_webconsole_eval_in_debugger_stackframe2.js",
+  "devtools/client/webconsole/new-console-output/test/mochitest/browser_webconsole_location_debugger_link.js",
+  "devtools/client/webconsole/new-console-output/test/mochitest/browser_webconsole_stacktrace_location_debugger_link.js",
 ];
 
 console.log(chalk.blue("Running Tests"));


### PR DESCRIPTION
WIP.

Added all the tests I could find the devtools that rely on the new debugger. In theory they should all be tested as well. If it increases the testing time too much, we can look in more details on try to remove  tests that seem redundant regarding their usage of the debugger.

Let's see what the CI says.