### PR TITLE
Reset SourcesTree when necessary

### DIFF
--- a/src/components/PrimaryPanes/SourcesTree.js
+++ b/src/components/PrimaryPanes/SourcesTree.js
@@ -118,9 +118,9 @@ class SourcesTree extends Component<Props, State> {
       // to project root, debugee url or lack of sources
       return this.setState(
         createTree({
-          projectRoot,
-          debuggeeUrl,
-          sources
+          sources: nextProps.sources,
+          debuggeeUrl: nextProps.debuggeeUrl,
+          projectRoot: nextProps.projectRoot
         })
       );
     }
@@ -182,11 +182,18 @@ class SourcesTree extends Component<Props, State> {
 
   getPath = item => {
     const { sources } = this.props;
-    const blackBoxedPart =
-      item.contents.get &&
-      sources.get(item.contents.get("id")).get("isBlackBoxed")
-        ? "update"
-        : "";
+    const obj = item.contents.get && item.contents.get("id");
+
+    let blackBoxedPart = "";
+
+    if (
+      typeof obj !== "undefined" &&
+      sources.has(obj) &&
+      sources.get(obj).get("isBlackBoxed")
+    ) {
+      blackBoxedPart = "update";
+    }
+
     return `${item.path}/${item.name}/${blackBoxedPart}`;
   };
 
@@ -211,8 +218,9 @@ class SourcesTree extends Component<Props, State> {
     }
 
     if (!nodeHasChildren(item)) {
-      const source = sources.get(item.contents.get("id"));
-      if (source.get("isBlackBoxed")) {
+      const obj = item.contents.get("id");
+      const source = sources.get(obj);
+      if (source && source.get("isBlackBoxed")) {
         return <img className="blackBox" />;
       }
       return <img className="file" />;

--- a/src/components/tests/SourcesTree.spec.js
+++ b/src/components/tests/SourcesTree.spec.js
@@ -1,0 +1,84 @@
+import React from "react";
+import { shallow } from "enzyme";
+import SourcesTree from "../../components/PrimaryPanes/SourcesTree";
+import * as I from "immutable";
+
+function generateDefaults(overrides) {
+  return {
+    autoExpandAll: true,
+    selectLocation: jest.fn(),
+    setExpandedState: jest.fn(),
+    sources: I.Map({
+      "server1.conn13.child1/39": createMockSource(
+        "server1.conn13.child1/39",
+        "http://mdn.com/one.js"
+      ),
+      "server1.conn13.child1/40": createMockSource(
+        "server1.conn13.child1/40",
+        "http://mdn.com/two.js"
+      ),
+      "server1.conn13.child1/41": createMockSource(
+        "server1.conn13.child1/41",
+        "http://mdn.com/three.js"
+      )
+    }),
+    debuggeeUrl: "http://mdn.com",
+    projectRoot: "",
+    ...overrides
+  };
+}
+
+function render(overrides = {}) {
+  const props = generateDefaults(overrides);
+  const component = shallow(<SourcesTree.WrappedComponent {...props} />);
+
+  component.instance().shouldComponentUpdate = () => true;
+
+  return { component, props };
+}
+
+function createMockSource(id, url) {
+  return I.Map({
+    id: id,
+    url: url,
+    isPrettyPrinted: false,
+    isWasm: false,
+    sourceMapURL: null,
+    isBlackBoxed: false,
+    loadedState: "unloaded"
+  });
+}
+
+describe("SourcesTree", () => {
+  it("Should show the tree with nothing expanded", async () => {
+    const { component } = render();
+
+    expect(component).toMatchSnapshot();
+  });
+
+  describe("When loading initial source", () => {
+    it("Shows the tree with one.js, two.js and three.js expanded", async () => {
+      const { component, props } = render({});
+
+      await component.setProps({
+        ...props,
+        expanded: ["one.js", "two.js", "three.js"]
+      });
+
+      expect(component).toMatchSnapshot();
+    });
+  });
+
+  describe("After changing expanded nodes", () => {
+    it("Shows the tree with four.js, five.js and six.js expanded", async () => {
+      const { component, props } = render({});
+
+      await component.setProps({
+        ...props,
+        expanded: ["four.js", "five.js", "six.js"]
+      });
+
+      expect(component).toMatchSnapshot();
+    });
+  });
+});

--- a/src/components/tests/__snapshots__/SourcesTree.spec.js.snap
+++ b/src/components/tests/__snapshots__/SourcesTree.spec.js.snap
@@ -1,0 +1,81 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SourcesTree After changing expanded nodes Shows the tree with four.js, five.js and six.js expanded 1`] = `
+<div
+  className="sources-list"
+  onKeyDown={[Function]}
+>
+  <ManagedTree
+    autoExpandAll={false}
+    autoExpandDepth={0}
+    expanded={
+      Array [
+        "four.js",
+        "five.js",
+        "six.js",
+      ]
+    }
+    getChildren={[Function]}
+    getParent={[Function]}
+    getPath={[Function]}
+    getRoots={[Function]}
+    itemHeight={21}
+    key="full"
+    onCollapse={[Function]}
+    onExpand={[Function]}
+    onFocus={[Function]}
+    renderItem={[Function]}
+  />
+</div>
+`;
+
+exports[`SourcesTree Should show the tree with nothing expanded 1`] = `
+<div
+  className="sources-list"
+  onKeyDown={[Function]}
+>
+  <ManagedTree
+    autoExpandAll={false}
+    autoExpandDepth={1}
+    getChildren={[Function]}
+    getParent={[Function]}
+    getPath={[Function]}
+    getRoots={[Function]}
+    itemHeight={21}
+    key="full"
+    onCollapse={[Function]}
+    onExpand={[Function]}
+    onFocus={[Function]}
+    renderItem={[Function]}
+  />
+</div>
+`;
+
+exports[`SourcesTree When loading initial source Shows the tree with one.js, two.js and three.js expanded 1`] = `
+<div
+  className="sources-list"
+  onKeyDown={[Function]}
+>
+  <ManagedTree
+    autoExpandAll={false}
+    autoExpandDepth={0}
+    expanded={
+      Array [
+        "one.js",
+        "two.js",
+        "three.js",
+      ]
+    }
+    getChildren={[Function]}
+    getParent={[Function]}
+    getPath={[Function]}
+    getRoots={[Function]}
+    itemHeight={21}
+    key="full"
+    onCollapse={[Function]}
+    onExpand={[Function]}
+    onFocus={[Function]}
+    renderItem={[Function]}
+  />
+</div>
+`;

--- a/src/test/mochitest/browser_dbg-sources.js
+++ b/src/test/mochitest/browser_dbg-sources.js
@@ -22,23 +22,22 @@ add_task(async function() {
   await waitForSources(dbg, "simple1", "simple2", "nested-source", "long.js");
 
   // Expand nodes and make sure more sources appear.
-  is(findAllElements(dbg, "sourceNodes").length, 2, "2 sources");
+  is(findAllElements(dbg, "sourceNodes").length, 2);
 
   await clickElement(dbg, "sourceArrow", 2);
-  is(findAllElements(dbg, "sourceNodes").length, 7, "7 sources");
+  is(findAllElements(dbg, "sourceNodes").length, 7);
 
   await clickElement(dbg, "sourceArrow", 3);
-  is(findAllElements(dbg, "sourceNodes").length, 8, "8 sources");
+  is(findAllElements(dbg, "sourceNodes").length, 8);
 
   // Select a source.
   ok(
     !findElementWithSelector(dbg, ".sources-list .focused"),
     "Source is not focused"
   );
-
+  const selected = waitForDispatch(dbg, "SELECT_SOURCE");
   await clickElement(dbg, "sourceNode", 4);
-  await waitForSelectedSource(dbg, "nested-source");
-
+  await selected;
   ok(
     findElementWithSelector(dbg, ".sources-list .focused"),
     "Source is focused"

--- a/src/utils/sources-tree/createTree.js
+++ b/src/utils/sources-tree/createTree.js
@@ -4,17 +4,19 @@
 
 // @flow
 
-import { createNode, createParentMap } from "./utils";
-import { collapseTree } from "./collapseTree";
 import { addToTree } from "./addToTree";
+import { collapseTree } from "./collapseTree";
+import { createNode, createParentMap } from "./utils";
 
 import type { SourcesMap } from "../../reducers/types";
 
-export function createTree(
+type Params = {
   sources: SourcesMap,
   debuggeeUrl: string,
   projectRoot: string
-) {
+};
+
+export function createTree({ sources, debuggeeUrl, projectRoot }: Params) {
   const uncollapsedTree = createNode("root", "", []);
   for (const source of sources.valueSeq()) {
     addToTree(uncollapsedTree, source, debuggeeUrl, projectRoot);

--- a/src/utils/sources-tree/index.js
+++ b/src/utils/sources-tree/index.js
@@ -7,20 +7,21 @@
  * @module utils/sources-tree
  */
 
-export { formatTree } from "./formatTree";
 export { addToTree } from "./addToTree";
-export { sortTree, sortEntireTree } from "./sortTree";
 export { collapseTree } from "./collapseTree";
-export { getDirectories } from "./getDirectories";
 export { createTree } from "./createTree";
-export { getURL, getFilenameFromPath } from "./getURL";
+export { formatTree } from "./formatTree";
+export { getDirectories } from "./getDirectories";
+export { getFilenameFromPath, getURL } from "./getURL";
+export { sortEntireTree, sortTree } from "./sortTree";
+export { updateTree } from "./updateTree";
 
 export {
-  nodeHasChildren,
-  isExactUrlMatch,
-  isDirectory,
   createNode,
   createParentMap,
   getRelativePath,
-  isNotJavaScript
+  isDirectory,
+  isExactUrlMatch,
+  isNotJavaScript,
+  nodeHasChildren
 } from "./utils";

--- a/src/utils/sources-tree/tests/__snapshots__/updateTree.spec.js.snap
+++ b/src/utils/sources-tree/tests/__snapshots__/updateTree.spec.js.snap
@@ -1,0 +1,102 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`calls updateTree.js adds one source 1`] = `
+"{
+  \\"name\\": \\"root\\",
+  \\"path\\": \\"\\",
+  \\"contents\\": [
+    {
+      \\"name\\": \\"davidwalsh.name\\",
+      \\"path\\": \\"/davidwalsh.name\\",
+      \\"contents\\": [
+        {
+          \\"name\\": \\"(index)\\",
+          \\"path\\": \\"https://davidwalsh.name/\\",
+          \\"contents\\": {
+            \\"id\\": \\"server1.conn13.child1/39\\",
+            \\"url\\": \\"https://davidwalsh.name/\\"
+          }
+        },
+        {
+          \\"name\\": \\"source1.js\\",
+          \\"path\\": \\"/davidwalsh.name/source1.js\\",
+          \\"contents\\": {
+            \\"id\\": \\"server1.conn13.child1/37\\",
+            \\"url\\": \\"https://davidwalsh.name/source1.js\\"
+          }
+        }
+      ]
+    }
+  ]
+}"
+`;
+
+exports[`calls updateTree.js adds two sources 1`] = `
+"{
+  \\"name\\": \\"root\\",
+  \\"path\\": \\"\\",
+  \\"contents\\": [
+    {
+      \\"name\\": \\"davidwalsh.name\\",
+      \\"path\\": \\"/davidwalsh.name\\",
+      \\"contents\\": [
+        {
+          \\"name\\": \\"(index)\\",
+          \\"path\\": \\"https://davidwalsh.name/\\",
+          \\"contents\\": {
+            \\"id\\": \\"server1.conn13.child1/39\\",
+            \\"url\\": \\"https://davidwalsh.name/\\"
+          }
+        },
+        {
+          \\"name\\": \\"source1.js\\",
+          \\"path\\": \\"/davidwalsh.name/source1.js\\",
+          \\"contents\\": {
+            \\"id\\": \\"server1.conn13.child1/37\\",
+            \\"url\\": \\"https://davidwalsh.name/source1.js\\"
+          }
+        },
+        {
+          \\"name\\": \\"source2.js\\",
+          \\"path\\": \\"/davidwalsh.name/source2.js\\",
+          \\"contents\\": {
+            \\"id\\": \\"server1.conn13.child1/40\\",
+            \\"url\\": \\"https://davidwalsh.name/source2.js\\"
+          }
+        }
+      ]
+    }
+  ]
+}"
+`;
+
+exports[`calls updateTree.js shows all the sources 1`] = `
+"{
+  \\"name\\": \\"root\\",
+  \\"path\\": \\"\\",
+  \\"contents\\": [
+    {
+      \\"name\\": \\"davidwalsh.name\\",
+      \\"path\\": \\"/davidwalsh.name\\",
+      \\"contents\\": [
+        {
+          \\"name\\": \\"(index)\\",
+          \\"path\\": \\"https://davidwalsh.name/\\",
+          \\"contents\\": {
+            \\"id\\": \\"server1.conn13.child1/39\\",
+            \\"url\\": \\"https://davidwalsh.name/\\"
+          }
+        },
+        {
+          \\"name\\": \\"source1.js\\",
+          \\"path\\": \\"/davidwalsh.name/source1.js\\",
+          \\"contents\\": {
+            \\"id\\": \\"server1.conn13.child1/37\\",
+            \\"url\\": \\"https://davidwalsh.name/source1.js\\"
+          }
+        }
+      ]
+    }
+  ]
+}"
+`;

--- a/src/utils/sources-tree/tests/addToTree.spec.js
+++ b/src/utils/sources-tree/tests/addToTree.spec.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 /* eslint max-nested-callbacks: ["error", 4]*/
 
 import { Map } from "immutable";
@@ -5,9 +9,9 @@ import { Map } from "immutable";
 import {
   addToTree,
   createNode,
-  nodeHasChildren,
   createTree,
-  formatTree
+  formatTree,
+  nodeHasChildren
 } from "../index";
 
 function createSourcesMap(sources) {
@@ -79,7 +83,10 @@ describe("sources-tree", () => {
       ];
 
       const sourceMap = createSourcesMap(sources);
-      const tree = createTree(sourceMap, "").sourceTree;
+      const tree = createTree({
+        sources: sourceMap,
+        debugeeURL: ""
+      }).sourceTree;
       expect(tree.contents).toHaveLength(1);
       const subtree = tree.contents[0];
       expect(subtree.contents).toHaveLength(2);
@@ -95,8 +102,10 @@ describe("sources-tree", () => {
       ];
 
       const sourceMap = createSourcesMap(sources);
-      const tree = createTree(sourceMap, "").sourceTree;
-
+      const tree = createTree({
+        sources: sourceMap,
+        debugeeURL: ""
+      }).sourceTree;
       expect(formatTree(tree)).toMatchSnapshot();
     });
 
@@ -113,7 +122,10 @@ describe("sources-tree", () => {
       ];
 
       const sourceMap = createSourcesMap(sources);
-      const tree = createTree(sourceMap, "").sourceTree;
+      const tree = createTree({
+        sources: sourceMap,
+        debugeeURL: ""
+      }).sourceTree;
       expect(tree.contents).toHaveLength(1);
       const subtree = tree.contents[0];
       expect(subtree.contents).toHaveLength(1);

--- a/src/utils/sources-tree/tests/updateTree.spec.js
+++ b/src/utils/sources-tree/tests/updateTree.spec.js
@@ -1,0 +1,98 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
+import { Map } from "immutable";
+import { updateTree, createTree } from "../index";
+
+function createSourcesMap(sources) {
+  const msources = sources.map((s, i) => new Map(s));
+  let sourcesMap = Map();
+  msources.forEach(s => {
+    sourcesMap = sourcesMap.mergeIn([s.get("id")], s);
+  });
+
+  return sourcesMap;
+}
+
+function formatTree(tree) {
+  return JSON.stringify(tree.uncollapsedTree, null, 2);
+}
+
+const sources = [
+  {
+    id: "server1.conn13.child1/39",
+    url: "https://davidwalsh.name/"
+  },
+  {
+    id: "server1.conn13.child1/37",
+    url: "https://davidwalsh.name/source1.js"
+  },
+  {
+    id: "server1.conn13.child1/40",
+    url: "https://davidwalsh.name/source2.js"
+  }
+];
+
+const debuggeeUrl = "blah";
+
+describe("calls updateTree.js", () => {
+  it("adds one source", () => {
+    const prevSources = createSourcesMap([sources[0]]);
+
+    const { sourceTree, uncollapsedTree } = createTree({
+      debuggeeUrl,
+      sources: prevSources
+    });
+
+    const newTree = updateTree({
+      debuggeeUrl,
+      prevSources,
+      newSources: createSourcesMap([sources[0], sources[1]]),
+      uncollapsedTree,
+      sourceTree
+    });
+
+    expect(formatTree(newTree)).toMatchSnapshot();
+  });
+
+  it("adds two sources", () => {
+    const prevSources = createSourcesMap([sources[0]]);
+
+    const { sourceTree, uncollapsedTree } = createTree({
+      debuggeeUrl,
+      sources: prevSources
+    });
+
+    const newTree = updateTree({
+      debuggeeUrl,
+      prevSources,
+      newSources: createSourcesMap([sources[0], sources[1], sources[2]]),
+      uncollapsedTree,
+      sourceTree
+    });
+
+    expect(formatTree(newTree)).toMatchSnapshot();
+  });
+
+  // NOTE: we currently only add sources to the tree and clear the tree
+  // on navigate.
+  it("shows all the sources", () => {
+    const prevSources = createSourcesMap([sources[0]]);
+
+    const { sourceTree, uncollapsedTree } = createTree({
+      debuggeeUrl,
+      sources: prevSources
+    });
+
+    const newTree = updateTree({
+      debuggeeUrl,
+      prevSources,
+      newSources: createSourcesMap([sources[1]]),
+      uncollapsedTree,
+      sourceTree
+    });
+
+    expect(formatTree(newTree)).toMatchSnapshot();
+  });
+});

--- a/src/utils/sources-tree/updateTree.js
+++ b/src/utils/sources-tree/updateTree.js
@@ -1,0 +1,51 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
+// @flow
+
+import { addToTree } from "./addToTree";
+import { collapseTree } from "./collapseTree";
+import { createParentMap } from "./utils";
+
+import type { SourcesMap } from "../../reducers/types";
+import type { Node } from "./types";
+
+function newSourcesSet(newSources, prevSources) {
+  const next = newSources.toSet();
+  const prev = prevSources.toSet();
+  return next.subtract(prev);
+}
+
+type Params = {
+  newSources: SourcesMap,
+  prevSources: SourcesMap,
+  uncollapsedTree: Node,
+  sourceTree: Node,
+  debuggeeUrl: string,
+  projectRoot: string
+};
+
+export function updateTree({
+  newSources,
+  prevSources,
+  debuggeeUrl,
+  projectRoot,
+  uncollapsedTree,
+  sourceTree
+}: Params) {
+  const newSet = newSourcesSet(newSources, prevSources);
+
+  for (const source of newSet) {
+    addToTree(uncollapsedTree, source, debuggeeUrl, projectRoot);
+  }
+
+  const newSourceTree = collapseTree(uncollapsedTree);
+
+  return {
+    uncollapsedTree,
+    sourceTree: newSourceTree,
+    parentMap: createParentMap(sourceTree),
+    focusedItem: null
+  };
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2105,8 +2105,8 @@ caniuse-api@^1.5.2:
     lodash.uniq "^4.5.0"
 
 caniuse-db@^1.0.30000529, caniuse-db@^1.0.30000634, caniuse-db@^1.0.30000639:
-  version "1.0.30000794"
-  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000794.tgz#bbe71104fa277ce4b362387d54905e8b88e52f35"
+  version "1.0.30000795"
+  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000795.tgz#644f03fab00dd8bd1693e5e1e70d86b31c5cfece"
 
 caniuse-lite@^1.0.30000791, caniuse-lite@^1.0.30000792:
   version "1.0.30000792"
@@ -3727,8 +3727,8 @@ eslint-plugin-babel@^4.1.2:
   resolved "https://registry.yarnpkg.com/eslint-plugin-babel/-/eslint-plugin-babel-4.1.2.tgz#79202a0e35757dd92780919b2336f1fa2fe53c1e"
 
 eslint-plugin-flowtype@^2.36.0:
-  version "2.41.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-flowtype/-/eslint-plugin-flowtype-2.41.1.tgz#0996e1ea1d501dfc945802453a304ae9e8098b78"
+  version "2.42.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-flowtype/-/eslint-plugin-flowtype-2.42.0.tgz#7fcc98df4ed9482a22ac10ba4ca48d649c4c733a"
   dependencies:
     lodash "^4.15.0"
 


### PR DESCRIPTION
Pull request #5004 introduced an issue where the SourcesTree was not updated when navigating to a new URL. In reality it was setting the tree using `props.blah` instead of `nextProps.blah`.

This also fixes a couple of undefined errors I was randomly getting in the console.