### PR TITLE
Update mozilla-central sha for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
   global:
     - DISPLAY=':99.0'
     - YARN_VERSION='0.24.5'
-    - MC_COMMIT='e2bb11b88bd4' # https://hg.mozilla.org/mozilla-central/shortlog
+    - MC_COMMIT='c3d2757a5343' # https://hg.mozilla.org/mozilla-central/shortlog
 
 notifications:
   slack:


### PR DESCRIPTION
This new sha should unblock browser_browser_toolbox_debugger.js