### PR TITLE
Calls the correct pause info

### DIFF
--- a/src/actions/pause/fetchScopes.js
+++ b/src/actions/pause/fetchScopes.js
@@ -47,7 +47,6 @@ function mapScopes(scopes: Scope, frame: Frame) {
 export function fetchScopes() {
   return async function({ dispatch, getState, client, sourceMaps }: ThunkArgs) {
     const frame = getSelectedFrame(getState());
-
     if (!frame || getFrameScope(getState(), frame.id)) {
       return;
     }
@@ -69,7 +68,6 @@ export function fetchScopes() {
     }
 
     const sourceRecord = getSource(getState(), frame.location.sourceId);
-
     if (sourceRecord.get("isPrettyPrinted")) {
       return;
     }

--- a/src/actions/tests/pause.spec.js
+++ b/src/actions/tests/pause.spec.js
@@ -37,7 +37,7 @@ const mockThreadClient = {
 
 function createPauseInfo(overrides = {}) {
   return {
-    frames: [makeFrame({ id: 1, sourceId: "foo" })],
+    frames: [makeFrame({ id: 1, sourceId: "foo1" })],
     loadedObjects: [],
     why: {},
     ...overrides


### PR DESCRIPTION
Associated Issue: #5185

- A non-existent pauseInfo was called which resulted in an empty selector and the test passing with an error in the console despite the generatedSourceRecord in fetchScopes.js being undefined.  It seems the test now fails like it should.
