### PR TITLE
Re-add accidentally removed mochitest

### DIFF
--- a/src/test/mochitest/browser_dbg-reload.js
+++ b/src/test/mochitest/browser_dbg-reload.js
@@ -1,0 +1,40 @@
+/* Any copyright is dedicated to the Public Domain.
+ http://creativecommons.org/publicdomain/zero/1.0/ */
+
+/*
+ * Test reloading:
+ * 1. reload the source
+ * 2. re-sync breakpoints
+ */
+
+async function waitForBreakpoint(dbg, location) {
+  return waitForState(
+    dbg,
+    state => {
+      return dbg.selectors.getBreakpoint(dbg.getState(), location);
+    },
+    "Waiting for breakpoint"
+  );
+}
+
+add_task(async function() {
+  const dbg = await initDebugger("reload/doc_reload.html", "sjs_code_reload");
+
+  await selectSource(dbg, "sjs_code_reload");
+  await waitForSelectedSource(dbg, "sjs_code_reload");
+  await addBreakpoint(dbg, "sjs_code_reload", 2);
+
+  await reload(dbg, "sjs_code_reload");
+
+  const source = findSource(dbg, "sjs_code_reload");
+  const location = { sourceId: source.id, line: 6 };
+
+  await waitForBreakpoint(dbg, location);
+
+  const breakpoints = dbg.selectors.getBreakpoints(dbg.getState());
+  const breakpointList = breakpoints.valueSeq().toJS();
+  const breakpoint = breakpointList[0];
+
+  is(breakpointList.length, 1);
+  is(breakpoint.location.line, 6);
+});


### PR DESCRIPTION
accidentally removed a mochitest in the revert PR...

As a note, the `mochii -ci` passed w/o no error output when mochitest had a fatal error. We should improve the CI runner so that it fails in these cases and shows the errors

<img width="1440" alt="screen shot 2018-01-27 at 7 50 20 pm" src="https://user-images.githubusercontent.com/254562/35477843-59041cda-039b-11e8-8960-3ae416cdb8c8.png">

<img width="1045" alt="screen shot 2018-01-27 at 7 48 57 pm" src="https://user-images.githubusercontent.com/254562/35477844-590f63c4-039b-11e8-9a37-14d5ddf88be3.png">
