### PR TITLE
Fix jest directory excludes

### DIFF
--- a/package.json
+++ b/package.json
@@ -177,7 +177,8 @@
       "/node_modules/",
       "/helpers/",
       "/fixtures/",
-      "src/test/mochitest/examples/"
+      "src/test/mochitest/examples/",
+      "<rootDir>/firefox"
     ],
     "collectCoverageFrom": [
       "src/**/*.js",


### PR DESCRIPTION
when firefox was installed, jest was searching there as well