### PR TITLE
Fix firefox.mcPath documentation.

### DIFF
--- a/docs/running-as-firefox-panel.md
+++ b/docs/running-as-firefox-panel.md
@@ -48,7 +48,9 @@ However if you have firefox installed elsewhere you can update this in `configs/
 called
 
 ```json
-mcPath: './firefox' // expecting firefox to be under `debugger.html/firefox`
+{
+  "firefox.mcPath": "./firefox" // expecting firefox to be under `debugger.html/firefox`
+}
 ```
 
 You can change this to what works for you!


### PR DESCRIPTION
I had to do a local.json file like this in order to make `yarn copy-assets` to work.