### PR TITLE
increase contrast in welcomebox and search placeholder

### DIFF
--- a/src/components/Editor/SearchBar.css
+++ b/src/components/Editor/SearchBar.css
@@ -60,7 +60,7 @@
 }
 
 .search-bottom-bar .search-modifiers button svg {
-  fill: var(--theme-comment-alt);
+  fill: var(--theme-body-color);
   height: 16px;
   width: 16px;
 }
@@ -92,7 +92,7 @@
   margin: 0 0 0 6px;
   border: none;
   background: transparent;
-  color: var(--theme-comment-alt);
+  color: var(--theme-body-color);
 }
 
 .search-bottom-bar .search-type-toggles .search-type-btn:active {

--- a/src/components/WelcomeBox.css
+++ b/src/components/WelcomeBox.css
@@ -13,7 +13,6 @@
   padding: 50px 0 0 0;
   text-align: center;
   font-size: 1.25em;
-  color: var(--theme-comment-alt);
   background-color: var(--theme-toolbar-background);
   font-weight: lighter;
   z-index: 10;

--- a/src/components/shared/SearchInput.css
+++ b/src/components/shared/SearchInput.css
@@ -61,7 +61,7 @@
 }
 
 .search-field input::placeholder {
-  color: var(--theme-body-color-inactive);
+  color: var(--theme-toolbar-color);
 }
 
 .search-field input:focus {


### PR DESCRIPTION
@jasonLaster 

Associated Issue: #4544

### Summary of Changes

* darken search box placeholder text
* darken welcome box shortcut text
* darken search-modifiers

### TODO:
* so far, things are appearing a little too dark
* the pale disclosure arrow icons, plus button icon, "add watch expression", and x buttons in the file tabs should be grey-40 also


