### PR TITLE
Add takeScreenshot API

### DIFF
--- a/src/test/mochitest/head.js
+++ b/src/test/mochitest/head.js
@@ -1082,3 +1082,14 @@ function getCM(dbg) {
   const el = dbg.win.document.querySelector(".CodeMirror");
   return el.CodeMirror;
 }
+
+// NOTE: still experimental, the screenshots might not be exactly correct
+async function takeScreenshot(dbg) {
+  let canvas = dbg.win.document.createElementNS("http://www.w3.org/1999/xhtml", "html:canvas");
+  let context = canvas.getContext("2d");
+  canvas.width = dbg.win.innerWidth;
+  canvas.height = dbg.win.innerHeight;
+  context.drawWindow(dbg.win, 0, 0, canvas.width, canvas.height, "white");
+  await waitForTime(1000);
+  dump(`[SCREENSHOT] ${canvas.toDataURL()}\n`);
+}


### PR DESCRIPTION
Adds a screenshot helper

```diff
diff --git a/src/test/mochitest/browser_dbg-sources.js b/src/test/mochitest/browser_dbg-sources.js
index 217baf6..caf2dcd 100644
--- a/src/test/mochitest/browser_dbg-sources.js
+++ b/src/test/mochitest/browser_dbg-sources.js
@@ -32,6 +32,7 @@ add_task(async function() {
   assertSourceCount(dbg, 2);
   await clickElement(dbg, "sourceArrow", 2);

+  await takeScreenshot(dbg);
   assertSourceCount(dbg, 7);
   await clickElement(dbg, "sourceArrow", 3);
```

https://bitty.io/anonymous/ecb38f683670af8a0aa34905689b349a


### Screenshots

<img width="1351" alt="screen shot 2018-01-30 at 6 06 04 pm" src="https://user-images.githubusercontent.com/254562/35596533-48115556-05e8-11e8-8752-fc8d1ff86a2b.png">

<img width="810" alt="screen shot 2018-01-30 at 6 06 44 pm" src="https://user-images.githubusercontent.com/254562/35596561-64a16648-05e8-11e8-8e11-9a133e8d53e9.png">
