### PR TITLE
[Breakpoints] Clean up extracted context menu #5223 completed

### DIFF
--- a/src/components/SecondaryPanes/Breakpoints.js
+++ b/src/components/SecondaryPanes/Breakpoints.js
@@ -4,15 +4,18 @@
 
 // @flow
 import React, { PureComponent } from "react";
-import { connect } from "react-redux";
 import { bindActionCreators } from "redux";
-
-import classnames from "classnames";
+import { connect } from "react-redux";
 import * as I from "immutable";
-import { sortBy } from "lodash";
+import classnames from "classnames";
 import { createSelector } from "reselect";
+import { sortBy } from "lodash";
 
 import actions from "../../actions";
+import CloseButton from "../shared/Button/Close";
+import { endTruncateStr } from "../../utils/utils";
+import { features } from "../../utils/prefs";
+import { getFilename } from "../../utils/source";
 import {
   getSources,
   getSourceInSources,
@@ -20,14 +23,10 @@ import {
   getPauseReason,
   getTopFrame
 } from "../../selectors";
-import { makeLocationId } from "../../utils/breakpoint";
 import { isInterrupted } from "../../utils/pause";
-import { features } from "../../utils/prefs";
-import { getFilename } from "../../utils/source";
-import { endTruncateStr } from "../../utils/utils";
-
+import { makeLocationId } from "../../utils/breakpoint";
 import showContextMenu from "./BreakpointsContextMenu";
-import CloseButton from "../shared/Button/Close";
+
 import type { Breakpoint, Location } from "../../types";
 
 import "./Breakpoints.css";

--- a/src/components/SecondaryPanes/Breakpoints.js
+++ b/src/components/SecondaryPanes/Breakpoints.js
@@ -4,13 +4,14 @@
 
 // @flow
 import React, { PureComponent } from "react";
-import * as I from "immutable";
-
 import { connect } from "react-redux";
-import { createSelector } from "reselect";
 import { bindActionCreators } from "redux";
-import { features } from "../../utils/prefs";
+
 import classnames from "classnames";
+import * as I from "immutable";
+import { sortBy } from "lodash";
+import { createSelector } from "reselect";
+
 import actions from "../../actions";
 import {
   getSources,
@@ -20,15 +21,16 @@ import {
   getTopFrame
 } from "../../selectors";
 import { makeLocationId } from "../../utils/breakpoint";
-import { endTruncateStr } from "../../utils/utils";
-import { getFilename } from "../../utils/source";
 import { isInterrupted } from "../../utils/pause";
-import CloseButton from "../shared/Button/Close";
-import "./Breakpoints.css";
-import { sortBy } from "lodash";
-import showContextMenu from "./BreakpointsContextMenu";
+import { features } from "../../utils/prefs";
+import { getFilename } from "../../utils/source";
+import { endTruncateStr } from "../../utils/utils";
 
+import showContextMenu from "./BreakpointsContextMenu";
+import CloseButton from "../shared/Button/Close";
 import type { Breakpoint, Location } from "../../types";
+
+import "./Breakpoints.css";
 
 type LocalBreakpoint = Breakpoint & {
   location: any,

--- a/src/components/SecondaryPanes/BreakpointsContextMenu.js
+++ b/src/components/SecondaryPanes/BreakpointsContextMenu.js
@@ -206,7 +206,7 @@ export default function showContextMenu(props) {
 
     { item: disableSelfItem, hidden: () => hideDisableSelfItem },
     { item: disableAllItem, hidden: () => hideDisableAllItem },
-    { item: disableOthersItem, hidden: () => hideDisableOthersTem },
+    { item: disableOthersItem, hidden: () => hideDisableOtherstItem },
     {
       item: { type: "separator" }
     },

--- a/src/components/SecondaryPanes/BreakpointsContextMenu.js
+++ b/src/components/SecondaryPanes/BreakpointsContextMenu.js
@@ -1,4 +1,4 @@
-import { showMenu, buildMenu } from "devtools-contextmenu";
+import { buildMenu, showMenu } from "devtools-contextmenu";
 
 export default function showContextMenu(props) {
   const {
@@ -80,7 +80,7 @@ export default function showContextMenu(props) {
     b => b.disabled && b !== breakpoint
   );
 
-  const deleteSelf = {
+  const deleteSelfItem = {
     id: "node-menu-delete-self",
     label: deleteSelfLabel,
     accesskey: deleteSelfKey,
@@ -88,7 +88,7 @@ export default function showContextMenu(props) {
     click: () => removeBreakpoint(breakpoint.location)
   };
 
-  const deleteAll = {
+  const deleteAllItem = {
     id: "node-menu-delete-all",
     label: deleteAllLabel,
     accesskey: deleteAllKey,
@@ -96,7 +96,7 @@ export default function showContextMenu(props) {
     click: () => removeAllBreakpoints()
   };
 
-  const deleteOthers = {
+  const deleteOthersItem = {
     id: "node-menu-delete-other",
     label: deleteOthersLabel,
     accesskey: deleteOthersKey,
@@ -104,7 +104,7 @@ export default function showContextMenu(props) {
     click: () => removeBreakpoints(otherBreakpoints)
   };
 
-  const enableSelf = {
+  const enableSelfItem = {
     id: "node-menu-enable-self",
     label: enableSelfLabel,
     accesskey: enableSelfKey,
@@ -112,7 +112,7 @@ export default function showContextMenu(props) {
     click: () => toggleDisabledBreakpoint(breakpoint.location.line)
   };
 
-  const enableAll = {
+  const enableAllItem = {
     id: "node-menu-enable-all",
     label: enableAllLabel,
     accesskey: enableAllKey,
@@ -120,7 +120,7 @@ export default function showContextMenu(props) {
     click: () => toggleAllBreakpoints(false)
   };
 
-  const enableOthers = {
+  const enableOthersItem = {
     id: "node-menu-enable-others",
     label: enableOthersLabel,
     accesskey: enableOthersKey,
@@ -128,7 +128,7 @@ export default function showContextMenu(props) {
     click: () => toggleBreakpoints(false, otherDisabledBreakpoints)
   };
 
-  const disableSelf = {
+  const disableSelfItem = {
     id: "node-menu-disable-self",
     label: disableSelfLabel,
     accesskey: disableSelfKey,
@@ -136,7 +136,7 @@ export default function showContextMenu(props) {
     click: () => toggleDisabledBreakpoint(breakpoint.location.line)
   };
 
-  const disableAll = {
+  const disableAllItem = {
     id: "node-menu-disable-all",
     label: disableAllLabel,
     accesskey: disableAllKey,
@@ -144,14 +144,14 @@ export default function showContextMenu(props) {
     click: () => toggleAllBreakpoints(true)
   };
 
-  const disableOthers = {
+  const disableOthersItem = {
     id: "node-menu-disable-others",
     label: disableOthersLabel,
     accesskey: disableOthersKey,
     click: () => toggleBreakpoints(true, otherEnabledBreakpoints)
   };
 
-  const removeCondition = {
+  const removeConditionItem = {
     id: "node-menu-remove-condition",
     label: removeConditionLabel,
     accesskey: removeConditionKey,
@@ -159,7 +159,7 @@ export default function showContextMenu(props) {
     click: () => setBreakpointCondition(breakpoint.location)
   };
 
-  const addCondition = {
+  const addConditionItem = {
     id: "node-menu-add-condition",
     label: addConditionLabel,
     accesskey: addConditionKey,
@@ -169,7 +169,7 @@ export default function showContextMenu(props) {
     }
   };
 
-  const editCondition = {
+  const editConditionItem = {
     id: "node-menu-edit-condition",
     label: editConditionLabel,
     accesskey: editConditionKey,
@@ -187,37 +187,37 @@ export default function showContextMenu(props) {
   const hideDisableSelf = breakpoint.disabled;
 
   const items = [
-    { item: enableSelf, hidden: () => hideEnableSelf },
-    { item: enableAll, hidden: () => hideEnableAll },
-    { item: enableOthers, hidden: () => hideEnableOthers },
+    { item: enableSelfItem, hidden: () => hideEnableSelf },
+    { item: enableAllItem, hidden: () => hideEnableAll },
+    { item: enableOthersItem, hidden: () => hideEnableOthers },
     {
       item: { type: "separator" },
       hidden: () => hideEnableSelf && hideEnableAll && hideEnableOthers
     },
-    { item: deleteSelf },
-    { item: deleteAll },
-    { item: deleteOthers, hidden: () => breakpoints.size === 1 },
+    { item: deleteSelfItem },
+    { item: deleteAllItem },
+    { item: deleteOthersItem, hidden: () => breakpoints.size === 1 },
     {
       item: { type: "separator" },
       hidden: () => hideDisableSelf && hideDisableAll && hideDisableOthers
     },
 
-    { item: disableSelf, hidden: () => hideDisableSelf },
-    { item: disableAll, hidden: () => hideDisableAll },
-    { item: disableOthers, hidden: () => hideDisableOthers },
+    { item: disableSelfItem, hidden: () => hideDisableSelf },
+    { item: disableAllItem, hidden: () => hideDisableAll },
+    { item: disableOthersItem, hidden: () => hideDisableOthers },
     {
       item: { type: "separator" }
     },
     {
-      item: addCondition,
+      item: addConditionItem,
       hidden: () => breakpoint.condition
     },
     {
-      item: editCondition,
+      item: editConditionItem,
       hidden: () => !breakpoint.condition
     },
     {
-      item: removeCondition,
+      item: removeConditionItem,
       hidden: () => !breakpoint.condition
     }
   ];

--- a/src/components/SecondaryPanes/BreakpointsContextMenu.js
+++ b/src/components/SecondaryPanes/BreakpointsContextMenu.js
@@ -179,32 +179,34 @@ export default function showContextMenu(props) {
     }
   };
 
-  const hideEnableSelf = !breakpoint.disabled;
-  const hideEnableAll = disabledBreakpoints.size === 0;
-  const hideEnableOthers = otherDisabledBreakpoints.size === 0;
-  const hideDisableAll = enabledBreakpoints.size === 0;
-  const hideDisableOthers = otherEnabledBreakpoints.size === 0;
-  const hideDisableSelf = breakpoint.disabled;
+  const hideEnableSelfItem = !breakpoint.disabled;
+  const hideEnableAllItem = disabledBreakpoints.size === 0;
+  const hideEnableOthersItem = otherDisabledBreakpoints.size === 0;
+  const hideDisableAllItem = enabledBreakpoints.size === 0;
+  const hideDisableOthersItem = otherEnabledBreakpoints.size === 0;
+  const hideDisableSelfItem = breakpoint.disabled;
 
   const items = [
-    { item: enableSelfItem, hidden: () => hideEnableSelf },
-    { item: enableAllItem, hidden: () => hideEnableAll },
-    { item: enableOthersItem, hidden: () => hideEnableOthers },
+    { item: enableSelfItem, hidden: () => hideEnableSelfItem },
+    { item: enableAllItem, hidden: () => hideEnableAllItem },
+    { item: enableOthersItem, hidden: () => hideEnableOthersItem },
     {
       item: { type: "separator" },
-      hidden: () => hideEnableSelf && hideEnableAll && hideEnableOthers
+      hidden: () =>
+        hideEnableSelfItem && hideEnableAllItem && hideEnableOthersItem
     },
     { item: deleteSelfItem },
     { item: deleteAllItem },
     { item: deleteOthersItem, hidden: () => breakpoints.size === 1 },
     {
       item: { type: "separator" },
-      hidden: () => hideDisableSelf && hideDisableAll && hideDisableOthers
+      hidden: () =>
+        hideDisableSelfItem && hideDisableAllItem && hideDisableOthersItem
     },
 
-    { item: disableSelfItem, hidden: () => hideDisableSelf },
-    { item: disableAllItem, hidden: () => hideDisableAll },
-    { item: disableOthersItem, hidden: () => hideDisableOthers },
+    { item: disableSelfItem, hidden: () => hideDisableSelfItem },
+    { item: disableAllItem, hidden: () => hideDisableAllItem },
+    { item: disableOthersItem, hidden: () => hideDisableOthersTem },
     {
       item: { type: "separator" }
     },

--- a/src/components/SecondaryPanes/BreakpointsContextMenu.js
+++ b/src/components/SecondaryPanes/BreakpointsContextMenu.js
@@ -206,7 +206,7 @@ export default function showContextMenu(props) {
 
     { item: disableSelfItem, hidden: () => hideDisableSelfItem },
     { item: disableAllItem, hidden: () => hideDisableAllItem },
-    { item: disableOthersItem, hidden: () => hideDisableOtherstItem },
+    { item: disableOthersItem, hidden: () => hideDisableOthersItem },
     {
       item: { type: "separator" }
     },

--- a/src/components/shared/Svg.css
+++ b/src/components/shared/Svg.css
@@ -124,7 +124,8 @@ html .arrow.expanded svg {
   fill: var(--theme-body-color);
 }
 
-.angular svg, .source-icon svg {
+.angular svg,
+.source-icon svg {
   width: 15px;
   height: 15px;
   margin-right: 5px;

--- a/src/test/mochitest/browser_dbg-sourcemaps-reloading.js
+++ b/src/test/mochitest/browser_dbg-sourcemaps-reloading.js
@@ -2,7 +2,10 @@
  * http://creativecommons.org/publicdomain/zero/1.0/ */
 
 async function waitForBreakpointCount(dbg, count) {
-  return waitForState(dbg, state => dbg.selectors.getBreakpoints(state).size === count)
+  return waitForState(
+    dbg,
+    state => dbg.selectors.getBreakpoints(state).size === count
+  );
 }
 
 add_task(async function() {

--- a/src/test/mochitest/browser_dbg-sourcemaps.js
+++ b/src/test/mochitest/browser_dbg-sourcemaps.js
@@ -80,12 +80,12 @@ add_task(async function() {
   await stepIn(dbg);
   assertPausedLocation(dbg);
 
-  await dbg.actions.jumpToMappedSelectedLocation()
+  await dbg.actions.jumpToMappedSelectedLocation();
   await stepOver(dbg);
   assertPausedLocation(dbg);
   assertDebugLine(dbg, 71);
 
-  await dbg.actions.jumpToMappedSelectedLocation()
+  await dbg.actions.jumpToMappedSelectedLocation();
   await stepOut(dbg);
   await stepOut(dbg);
   assertPausedLocation(dbg);

--- a/src/test/mochitest/browser_dbg-sources-named-eval.js
+++ b/src/test/mochitest/browser_dbg-sources-named-eval.js
@@ -12,9 +12,9 @@ async function waitForSourceCount(dbg, i) {
 }
 
 function getLabel(dbg, index) {
-  return findElement(dbg, "sourceNode", index).textContent
-    .trim()
-    .replace(/^[\s\u200b]*/g, '');
+  return findElement(dbg, "sourceNode", index)
+    .textContent.trim()
+    .replace(/^[\s\u200b]*/g, "");
 }
 
 add_task(async function() {

--- a/src/test/mochitest/browser_dbg-sources.js
+++ b/src/test/mochitest/browser_dbg-sources.js
@@ -17,9 +17,9 @@ async function assertSourceCount(dbg, count) {
 }
 
 function getLabel(dbg, index) {
-  return findElement(dbg, "sourceNode", index).textContent
-    .trim()
-    .replace(/^[\s\u200b]*/g, '');
+  return findElement(dbg, "sourceNode", index)
+    .textContent.trim()
+    .replace(/^[\s\u200b]*/g, "");
 }
 
 add_task(async function() {
@@ -64,5 +64,9 @@ add_task(async function() {
   });
 
   await waitForSourceCount(dbg, 9);
-  is(getLabel(dbg, 7), "math.min.js", "math.min.js - The dynamic script exists");
+  is(
+    getLabel(dbg, 7),
+    "math.min.js",
+    "math.min.js - The dynamic script exists"
+  );
 });

--- a/src/test/mochitest/head.js
+++ b/src/test/mochitest/head.js
@@ -285,9 +285,15 @@ function assertNotPaused(dbg) {
  * @static
  */
 function assertPausedLocation(dbg) {
-  const { selectors: { getSelectedSource, getVisibleSelectedFrame }, getState } = dbg;
+  const {
+    selectors: { getSelectedSource, getVisibleSelectedFrame },
+    getState
+  } = dbg;
 
-  ok(isSelectedFrameSelected(dbg, getState()), "top frame's source is selected");
+  ok(
+    isSelectedFrameSelected(dbg, getState()),
+    "top frame's source is selected"
+  );
 
   // Check the pause location
   const frame = getVisibleSelectedFrame(getState());
@@ -1085,7 +1091,10 @@ function getCM(dbg) {
 
 // NOTE: still experimental, the screenshots might not be exactly correct
 async function takeScreenshot(dbg) {
-  let canvas = dbg.win.document.createElementNS("http://www.w3.org/1999/xhtml", "html:canvas");
+  let canvas = dbg.win.document.createElementNS(
+    "http://www.w3.org/1999/xhtml",
+    "html:canvas"
+  );
   let context = canvas.getContext("2d");
   canvas.width = dbg.win.innerWidth;
   canvas.height = dbg.win.innerHeight;


### PR DESCRIPTION
Associated Issue: #<issue number>

Here's the Pull Request Doc
https://devtools-html.github.io/debugger.html/CONTRIBUTING.html#pull-requests

### Summary of Changes

fixes issue 5223
Clean up extracted context menu
rearranged imports and fixed vairable names

### Test Plan

Passed all original test

Example test plan:

- [x] Command-P opens the panel
- [x] Clicking “+” opens the panel
- [x] Clicking a source navigates to the source
- [x] Clicking "x" closes the panel

Here's the Debugger's Testing doc
https://docs.google.com/document/d/1oBMRxV8A2ag2t22YsQOxTdEv0mXKzIg0tggJjRkU1S0/edit#.
Feel free to improve it!

### Screenshots/Videos (OPTIONAL)
