### PR TITLE
Render mapped scope list only when viewing original file

### DIFF
--- a/src/actions/pause/fetchScopes.js
+++ b/src/actions/pause/fetchScopes.js
@@ -4,7 +4,7 @@
 
 // @flow
 
-import { getSelectedFrame, getFrameScope } from "../../selectors";
+import { getSelectedFrame, getGeneratedFrameScope } from "../../selectors";
 import { mapScopes } from "./mapScopes";
 import { PROMISE } from "../utils/middleware/promise";
 
@@ -13,7 +13,7 @@ import type { ThunkArgs } from "../types";
 export function fetchScopes() {
   return async function({ dispatch, getState, client, sourceMaps }: ThunkArgs) {
     const frame = getSelectedFrame(getState());
-    if (!frame || getFrameScope(getState(), frame.id)) {
+    if (!frame || getGeneratedFrameScope(getState(), frame.id)) {
       return;
     }
 

--- a/src/actions/pause/fetchScopes.js
+++ b/src/actions/pause/fetchScopes.js
@@ -4,9 +4,7 @@
 
 // @flow
 
-import { getSource, getSelectedFrame, getFrameScope } from "../../selectors";
-import { features } from "../../utils/prefs";
-import { isGeneratedId } from "devtools-source-map";
+import { getSelectedFrame, getFrameScope } from "../../selectors";
 import { mapScopes } from "./mapScopes";
 import { PROMISE } from "../utils/middleware/promise";
 
@@ -25,26 +23,6 @@ export function fetchScopes() {
       [PROMISE]: client.getFrameScopes(frame)
     });
 
-    const generatedSourceRecord = getSource(
-      getState(),
-      frame.generatedLocation.sourceId
-    );
-
-    if (generatedSourceRecord.get("isWasm")) {
-      return;
-    }
-
-    const sourceRecord = getSource(getState(), frame.location.sourceId);
-    if (sourceRecord.get("isPrettyPrinted")) {
-      return;
-    }
-
-    if (isGeneratedId(frame.location.sourceId)) {
-      return;
-    }
-
-    if (features.mapScopes) {
-      dispatch(mapScopes(scopes, frame));
-    }
+    dispatch(mapScopes(scopes, frame));
   };
 }

--- a/src/actions/pause/fetchScopes.js
+++ b/src/actions/pause/fetchScopes.js
@@ -8,6 +8,7 @@ import { getSource, getSelectedFrame, getFrameScope } from "../../selectors";
 import { features } from "../../utils/prefs";
 import { isGeneratedId } from "devtools-source-map";
 import { mapScopes } from "./mapScopes";
+import { PROMISE } from "../utils/middleware/promise";
 
 import type { ThunkArgs } from "../types";
 
@@ -18,11 +19,10 @@ export function fetchScopes() {
       return;
     }
 
-    const scopes = await client.getFrameScopes(frame);
-    dispatch({
+    const scopes = dispatch({
       type: "ADD_SCOPES",
       frame,
-      scopes
+      [PROMISE]: client.getFrameScopes(frame)
     });
 
     const generatedSourceRecord = getSource(

--- a/src/actions/tests/expressions.spec.js
+++ b/src/actions/tests/expressions.spec.js
@@ -10,7 +10,7 @@ const mockThreadClient = {
       }
     });
   },
-  getFrameScopes: () => {},
+  getFrameScopes: async () => {},
   sourceContents: () => ({})
 };
 

--- a/src/actions/tests/helpers/threadClient.js
+++ b/src/actions/tests/helpers/threadClient.js
@@ -85,5 +85,5 @@ export const sourceThreadClient = {
       reject(`unknown source: ${sourceId}`);
     });
   },
-  getFrameScopes: () => {}
+  getFrameScopes: async () => {}
 };

--- a/src/actions/tests/pause.spec.js
+++ b/src/actions/tests/pause.spec.js
@@ -16,7 +16,7 @@ const mockThreadClient = {
       stepInResolve = _resolve;
     }),
   evaluate: () => new Promise(_resolve => {}),
-  getFrameScopes: frame => frame.scope,
+  getFrameScopes: async frame => frame.scope,
   sourceContents: sourceId => {
     return new Promise((resolve, reject) => {
       switch (sourceId) {

--- a/src/actions/types.js
+++ b/src/actions/types.js
@@ -228,7 +228,7 @@ type PauseAction =
   | {
       type: "PAUSED",
       why: Why,
-      scopes: Scope[],
+      scopes: Scope,
       frames: Frame[],
       selectedFrameId: string,
       loadedObjects: LoadedObject[]
@@ -239,7 +239,7 @@ type PauseAction =
       shouldIgnoreCaughtExceptions: boolean
     }
   | { type: "COMMAND", value: { type: string }, command: string }
-  | { type: "SELECT_FRAME", frame: Frame, scopes: Scope[] }
+  | { type: "SELECT_FRAME", frame: Frame }
   | {
       type: "SET_POPUP_OBJECT_PROPERTIES",
       objectId: string,
@@ -272,7 +272,7 @@ type PauseAction =
   | {
       type: "MAP_SCOPES",
       frame: Frame,
-      scopes: Scope[]
+      scopes: Scope
     }
   | {
       type: "MAP_FRAMES",
@@ -281,7 +281,7 @@ type PauseAction =
   | {
       type: "ADD_SCOPES",
       frame: Frame,
-      scopes: Scope[]
+      scopes: Scope
     };
 
 type NavigateAction =

--- a/src/actions/types.js
+++ b/src/actions/types.js
@@ -272,7 +272,8 @@ type PauseAction =
   | {
       type: "MAP_SCOPES",
       frame: Frame,
-      scopes: Scope
+      status: AsyncStatus,
+      value: Scope
     }
   | {
       type: "MAP_FRAMES",
@@ -281,7 +282,8 @@ type PauseAction =
   | {
       type: "ADD_SCOPES",
       frame: Frame,
-      scopes: Scope
+      status: AsyncStatus,
+      value: Scope
     };
 
 type NavigateAction =

--- a/src/components/SecondaryPanes/Scopes.js
+++ b/src/components/SecondaryPanes/Scopes.js
@@ -10,6 +10,7 @@ import actions from "../../actions";
 import { createObjectClient } from "../../client/firefox";
 
 import {
+  getSelectedSource,
   getSelectedFrame,
   getFrameScope,
   isPaused as getIsPaused,
@@ -103,9 +104,11 @@ class Scopes extends PureComponent<Props, State> {
 export default connect(
   state => {
     const selectedFrame = getSelectedFrame(state);
+    const selectedSource = getSelectedSource(state);
 
     const { scope: frameScopes, pending } = getFrameScope(
       state,
+      selectedSource && selectedSource.get("id"),
       selectedFrame.id
     ) || { pending: false };
 

--- a/src/components/SecondaryPanes/Scopes.js
+++ b/src/components/SecondaryPanes/Scopes.js
@@ -26,7 +26,8 @@ import "./Scopes.css";
 type Props = {
   isPaused: Pause,
   selectedFrame: Object,
-  frameScopes: Object,
+  frameScopes: Object | null,
+  isLoading: boolean,
   why: Why
 };
 
@@ -63,7 +64,7 @@ class Scopes extends PureComponent<Props, State> {
   }
 
   render() {
-    const { isPaused } = this.props;
+    const { isPaused, isLoading } = this.props;
     const { scopes } = this.state;
 
     if (scopes) {
@@ -81,13 +82,19 @@ class Scopes extends PureComponent<Props, State> {
         </div>
       );
     }
+
+    let stateText = L10N.getStr("scopes.notPaused");
+    if (isPaused) {
+      if (isLoading) {
+        stateText = L10N.getStr("loadingText");
+      } else {
+        stateText = L10N.getStr("scopes.notAvailable");
+      }
+    }
+
     return (
       <div className="pane scopes-list">
-        <div className="pane-info">
-          {isPaused
-            ? L10N.getStr("scopes.notAvailable")
-            : L10N.getStr("scopes.notPaused")}
-        </div>
+        <div className="pane-info">{stateText}</div>
       </div>
     );
   }
@@ -96,12 +103,16 @@ class Scopes extends PureComponent<Props, State> {
 export default connect(
   state => {
     const selectedFrame = getSelectedFrame(state);
-    const frameScopes = selectedFrame
-      ? getFrameScope(state, selectedFrame.id)
-      : null;
+
+    const { scope: frameScopes, pending } = getFrameScope(
+      state,
+      selectedFrame.id
+    ) || { pending: false };
+
     return {
       selectedFrame,
       isPaused: getIsPaused(state),
+      isLoading: pending,
       why: getPauseReason(state),
       frameScopes: frameScopes
     };

--- a/src/components/shared/Svg.css
+++ b/src/components/shared/Svg.css
@@ -124,7 +124,8 @@ html .arrow.expanded svg {
   fill: var(--theme-body-color);
 }
 
-.angular svg, .source-icon svg {
+.angular svg,
+.source-icon svg {
   width: 15px;
   height: 15px;
   margin-right: 5px;

--- a/src/reducers/pause.js
+++ b/src/reducers/pause.js
@@ -211,11 +211,6 @@ export function getSelectedScope(state: OuterState) {
   return getFrameScope(state, frameId);
 }
 
-export function getScopes(state: OuterState) {
-  const selectedFrameId = getSelectedFrameId(state);
-  return state.pause.frameScopes[selectedFrameId];
-}
-
 export function getSelectedFrameId(state: OuterState) {
   return state.pause.selectedFrameId;
 }

--- a/src/test/mochitest/browser_dbg-sourcemaps-reloading.js
+++ b/src/test/mochitest/browser_dbg-sourcemaps-reloading.js
@@ -2,7 +2,10 @@
  * http://creativecommons.org/publicdomain/zero/1.0/ */
 
 async function waitForBreakpointCount(dbg, count) {
-  return waitForState(dbg, state => dbg.selectors.getBreakpoints(state).size === count)
+  return waitForState(
+    dbg,
+    state => dbg.selectors.getBreakpoints(state).size === count
+  );
 }
 
 add_task(async function() {

--- a/src/test/mochitest/browser_dbg-sourcemaps.js
+++ b/src/test/mochitest/browser_dbg-sourcemaps.js
@@ -80,12 +80,12 @@ add_task(async function() {
   await stepIn(dbg);
   assertPausedLocation(dbg);
 
-  await dbg.actions.jumpToMappedSelectedLocation()
+  await dbg.actions.jumpToMappedSelectedLocation();
   await stepOver(dbg);
   assertPausedLocation(dbg);
   assertDebugLine(dbg, 71);
 
-  await dbg.actions.jumpToMappedSelectedLocation()
+  await dbg.actions.jumpToMappedSelectedLocation();
   await stepOut(dbg);
   await stepOut(dbg);
   assertPausedLocation(dbg);

--- a/src/test/mochitest/browser_dbg-sources-named-eval.js
+++ b/src/test/mochitest/browser_dbg-sources-named-eval.js
@@ -12,9 +12,9 @@ async function waitForSourceCount(dbg, i) {
 }
 
 function getLabel(dbg, index) {
-  return findElement(dbg, "sourceNode", index).textContent
-    .trim()
-    .replace(/^[\s\u200b]*/g, '');
+  return findElement(dbg, "sourceNode", index)
+    .textContent.trim()
+    .replace(/^[\s\u200b]*/g, "");
 }
 
 add_task(async function() {

--- a/src/test/mochitest/browser_dbg-sources.js
+++ b/src/test/mochitest/browser_dbg-sources.js
@@ -17,9 +17,9 @@ async function assertSourceCount(dbg, count) {
 }
 
 function getLabel(dbg, index) {
-  return findElement(dbg, "sourceNode", index).textContent
-    .trim()
-    .replace(/^[\s\u200b]*/g, '');
+  return findElement(dbg, "sourceNode", index)
+    .textContent.trim()
+    .replace(/^[\s\u200b]*/g, "");
 }
 
 add_task(async function() {
@@ -64,5 +64,9 @@ add_task(async function() {
   });
 
   await waitForSourceCount(dbg, 9);
-  is(getLabel(dbg, 7), "math.min.js", "math.min.js - The dynamic script exists");
+  is(
+    getLabel(dbg, 7),
+    "math.min.js",
+    "math.min.js - The dynamic script exists"
+  );
 });

--- a/src/test/mochitest/head.js
+++ b/src/test/mochitest/head.js
@@ -453,7 +453,7 @@ async function waitForMappedScopes(dbg) {
   await waitForState(
     dbg,
     state => {
-      const scopes = dbg.selectors.getScopes(state);
+      const scopes = dbg.selectors.getSelectedScope(state);
       return scopes && scopes.sourceBindings;
     },
     "mapped scopes"

--- a/src/test/mochitest/head.js
+++ b/src/test/mochitest/head.js
@@ -285,9 +285,15 @@ function assertNotPaused(dbg) {
  * @static
  */
 function assertPausedLocation(dbg) {
-  const { selectors: { getSelectedSource, getVisibleSelectedFrame }, getState } = dbg;
+  const {
+    selectors: { getSelectedSource, getVisibleSelectedFrame },
+    getState
+  } = dbg;
 
-  ok(isSelectedFrameSelected(dbg, getState()), "top frame's source is selected");
+  ok(
+    isSelectedFrameSelected(dbg, getState()),
+    "top frame's source is selected"
+  );
 
   // Check the pause location
   const frame = getVisibleSelectedFrame(getState());
@@ -1085,7 +1091,10 @@ function getCM(dbg) {
 
 // NOTE: still experimental, the screenshots might not be exactly correct
 async function takeScreenshot(dbg) {
-  let canvas = dbg.win.document.createElementNS("http://www.w3.org/1999/xhtml", "html:canvas");
+  let canvas = dbg.win.document.createElementNS(
+    "http://www.w3.org/1999/xhtml",
+    "html:canvas"
+  );
   let context = canvas.getContext("2d");
   canvas.width = dbg.win.innerWidth;
   canvas.height = dbg.win.innerHeight;


### PR DESCRIPTION
Associated Issue: #5254

### Summary of Changes

* Add a general "Loading..." state for the scope list pane
* Change the scope state to be asynchronous with status
* Split the scope list state into two separate sets for generated and mapped scopes, and render based on which file you are viewing.

### Test Plan

- [ ] Stop debugger in original sourcemap file
- [ ] Sources pane will show scopes based on original file
- [ ] Click to open the generated file and note that the scopes reflect the generated code

### Screenshots/Videos (OPTIONAL)
![scope-toggling](https://user-images.githubusercontent.com/132260/35649451-fdb265d0-068d-11e8-857e-9b31c4459765.gif)
