### PR TITLE
Update locales to not include cmdOrCtrl

### DIFF
--- a/assets/panel/debugger.properties
+++ b/assets/panel/debugger.properties
@@ -163,26 +163,38 @@ blackboxCheckboxTooltip2=Toggle blackboxing
 
 # LOCALIZATION NOTE (sources.search.key2): Key shortcut to open the search for
 # searching all the source files the debugger has seen.
+# Do not localize "CmdOrCtrl+P", or change the format of the string. These are
+# key identifiers, not messages displayed to the user.
 sources.search.key2=CmdOrCtrl+P
 
 # LOCALIZATION NOTE (sources.search.alt.key): A second key shortcut to open the
 # search for searching all the source files the debugger has seen.
+# Do not localize "CmdOrCtrl+O", or change the format of the string. These are
+# key identifiers, not messages displayed to the user.
 sources.search.alt.key=CmdOrCtrl+O
 
 # LOCALIZATION NOTE (projectTextSearch.key): A key shortcut to open the
 # full project text search for searching all the files the debugger has seen.
+# Do not localize "CmdOrCtrl+Shift+F", or change the format of the string. These are
+# key identifiers, not messages displayed to the user.
 projectTextSearch.key=CmdOrCtrl+Shift+F
 
 # LOCALIZATION NOTE (functionSearch.key): A key shortcut to open the
 # modal for searching functions in a file.
+# Do not localize "CmdOrCtrl+Shift+O", or change the format of the string. These are
+# key identifiers, not messages displayed to the user.
 functionSearch.key=CmdOrCtrl+Shift+O
 
 # LOCALIZATION NOTE (toggleBreakpoint.key): A key shortcut to toggle
 # breakpoints.
+# Do not localize "CmdOrCtrl+B", or change the format of the string. These are
+# key identifiers, not messages displayed to the user.
 toggleBreakpoint.key=CmdOrCtrl+B
 
 # LOCALIZATION NOTE (toggleCondPanel.key): A key shortcut to toggle
 # the conditional breakpoint panel.
+# Do not localize "CmdOrCtrl+Shift+B", or change the format of the string. These are
+# key identifiers, not messages displayed to the user.
 toggleCondPanel.key=CmdOrCtrl+Shift+B
 
 # LOCALIZATION NOTE (stepOut.key): A key shortcut to
@@ -215,6 +227,8 @@ sources.noSourcesAvailable=This page has no sources
 
 # LOCALIZATION NOTE (sourceSearch.search.key2): Key shortcut to open the search
 # for searching within a the currently opened files in the editor
+# Do not localize "CmdOrCtrl+F", or change the format of the string. These are
+# key identifiers, not messages displayed to the user.
 sourceSearch.search.key2=CmdOrCtrl+F
 
 # LOCALIZATION NOTE (sourceSearch.search.placeholder): placeholder text in
@@ -223,10 +237,14 @@ sourceSearch.search.placeholder=Search in file…
 
 # LOCALIZATION NOTE (sourceSearch.search.again.key2): Key shortcut to highlight
 # the next occurrence of the last search triggered from a source search
+# Do not localize "CmdOrCtrl+G", or change the format of the string. These are
+# key identifiers, not messages displayed to the user.
 sourceSearch.search.again.key2=CmdOrCtrl+G
 
 # LOCALIZATION NOTE (sourceSearch.search.againPrev.key2): Key shortcut to highlight
 # the previous occurrence of the last search triggered from a source search
+# Do not localize "CmdOrCtrl+Shift+G", or change the format of the string. These are
+# key identifiers, not messages displayed to the user.
 sourceSearch.search.againPrev.key2=CmdOrCtrl+Shift+G
 
 # LOCALIZATION NOTE (sourceSearch.resultsSummary1): Shows a summary of
@@ -686,6 +704,8 @@ functionSearchSeparatorLabel=←
 
 # LOCALIZATION NOTE(gotoLineModal.placeholder): The placeholder
 # text displayed when the user searches for specific lines in a file
+# Do not localize "CmdOrCtrl+Shift+;", or change the format of the string. These are
+# key identifiers, not messages displayed to the user.
 gotoLineModal.placeholder=Go to line…
 gotoLineModal.key=CmdOrCtrl+Shift+;
 gotoLineModal.title=Go to a line number in a file
@@ -702,6 +722,8 @@ symbolSearch.search.variablesPlaceholder.title=Search for a variable in a file
 
 # LOCALIZATION NOTE(symbolSearch.search.key2): The Key Shortcut for
 # searching for a function or variable
+# Do not localize "CmdOrCtrl+Shift+O", or change the format of the string. These are
+# key identifiers, not messages displayed to the user.
 symbolSearch.search.key2=CmdOrCtrl+Shift+O
 
 # LOCALIZATION NOTE(symbolSearch.searchModifier.modifiersLabel): A label


### PR DESCRIPTION
Fixes #4701

### Summary of Changes

* Moves CmdOrCtrl to a string
* bumps locale keys