### PR TITLE
Making search sources autocomplete functionality accessible.

### DIFF
--- a/src/components/Editor/tests/__snapshots__/SearchBar.spec.js.snap
+++ b/src/components/Editor/tests/__snapshots__/SearchBar.spec.js.snap
@@ -5,6 +5,7 @@ exports[`SearchBar should render 1`] = `
   className="search-bar"
 >
   <SearchInput
+    expanded={false}
     handleClose={[Function]}
     handleNext={[Function]}
     handlePrev={[Function]}
@@ -12,6 +13,7 @@ exports[`SearchBar should render 1`] = `
     onKeyDown={[Function]}
     placeholder="Search in file…"
     query=""
+    selectedItemId=""
     showErrorEmoji={true}
     size=""
     summaryMsg=""

--- a/src/components/QuickOpenModal.js
+++ b/src/components/QuickOpenModal.js
@@ -368,6 +368,8 @@ export class QuickOpenModal extends Component<Props, State> {
     const showSummary =
       this.isSourcesQuery() || this.isSymbolSearch() || this.isShortcutQuery();
     const newResults = results && results.slice(0, 100);
+    const items = this.highlightMatching(query, newResults || []);
+    const expanded = !!items && items.length > 0;
     return (
       <Modal in={enabled} handleClose={this.closeModal}>
         <SearchInput
@@ -378,14 +380,17 @@ export class QuickOpenModal extends Component<Props, State> {
           onChange={this.onChange}
           onKeyDown={this.onKeyDown}
           handleClose={this.closeModal}
+          expanded={expanded}
+          selectedItemId={expanded ? items[selectedIndex].id : ""}
         />
         {newResults && (
           <ResultList
             key="results"
-            items={this.highlightMatching(query, newResults)}
+            items={items}
             selected={selectedIndex}
             selectItem={this.selectResultItem}
             ref="resultList"
+            expanded={expanded}
             {...(this.isSourceSearch() ? { size: "big" } : {})}
           />
         )}

--- a/src/components/shared/ResultList.js
+++ b/src/components/shared/ResultList.js
@@ -16,14 +16,16 @@ type Props = {
     item: any,
     index: number
   ) => void,
-  size: string
+  size: string,
+  role: string
 };
 
 export default class ResultList extends Component<Props> {
   displayName: "ResultList";
 
   static defaultProps = {
-    size: "small"
+    size: "small",
+    role: "listbox"
   };
 
   constructor(props: Props) {
@@ -38,6 +40,9 @@ export default class ResultList extends Component<Props> {
       key: `${item.id}${item.value}${index}`,
       ref: String(index),
       title: item.value,
+      "aria-labelledby": `${item.id}-title`,
+      "aria-describedby": `${item.id}-subtitle`,
+      role: "option",
       className: classnames("result-item", {
         selected: index === selected
       })
@@ -45,17 +50,26 @@ export default class ResultList extends Component<Props> {
 
     return (
       <li {...props}>
-        <div className="title">{item.title}</div>
-        <div className="subtitle">{item.subtitle}</div>
+        <div id={`${item.id}-title`} className="title">
+          {item.title}
+        </div>
+        <div id={`${item.id}-subtitle`} className="subtitle">
+          {item.subtitle}
+        </div>
       </li>
     );
   }
 
   render() {
-    const { size, items } = this.props;
+    const { size, items, role } = this.props;
 
     return (
-      <ul className={classnames("result-list", size)}>
+      <ul
+        className={classnames("result-list", size)}
+        id="result-list"
+        role={role}
+        aria-live="polite"
+      >
         {items.map(this.renderListItem)}
       </ul>
     );

--- a/src/components/shared/SearchInput.js
+++ b/src/components/shared/SearchInput.js
@@ -33,6 +33,8 @@ type Props = {
   summaryMsg: string,
   size: string,
   showErrorEmoji: boolean,
+  expanded: boolean,
+  selectedItemId?: string,
   onChange: (e: SyntheticInputEvent<HTMLInputElement>) => void,
   handleClose: (e: SyntheticMouseEvent<HTMLDivElement>) => void,
   onKeyUp?: (e: SyntheticKeyboardEvent<HTMLInputElement>) => void,
@@ -49,7 +51,9 @@ class SearchInput extends Component<Props> {
 
   static defaultProps = {
     size: "",
-    showErrorEmoji: true
+    showErrorEmoji: true,
+    expanded: false,
+    selectedItemId: ""
   };
 
   componentDidMount() {
@@ -116,7 +120,9 @@ class SearchInput extends Component<Props> {
       onFocus,
       onBlur,
       handleClose,
-      size
+      size,
+      expanded,
+      selectedItemId
     } = this.props;
 
     const inputProps = {
@@ -128,6 +134,10 @@ class SearchInput extends Component<Props> {
       onKeyUp,
       onFocus,
       onBlur,
+      "aria-autocomplete": "list",
+      "aria-controls": "result-list",
+      "aria-activedescendant":
+        expanded && selectedItemId ? `${selectedItemId}-title` : "",
       placeholder,
       value: query,
       spellCheck: false,
@@ -135,7 +145,13 @@ class SearchInput extends Component<Props> {
     };
 
     return (
-      <div className={classnames("search-field", size)}>
+      <div
+        className={classnames("search-field", size)}
+        role="combobox"
+        aria-haspopup="listbox"
+        aria-owns="result-list"
+        aria-expanded={expanded}
+      >
         {this.renderSvg()}
         <input {...inputProps} />
         <div className="summary">{summaryMsg || ""}</div>

--- a/src/components/shared/tests/__snapshots__/ResultList.spec.js.snap
+++ b/src/components/shared/tests/__snapshots__/ResultList.spec.js.snap
@@ -2,38 +2,51 @@
 
 exports[`Result list should render the component 1`] = `
 <ul
+  aria-live="polite"
   className="result-list small"
+  id="result-list"
+  role="listbox"
 >
   <li
+    aria-describedby="0-subtitle"
+    aria-labelledby="0-title"
     className="result-item"
     key="0value0"
     onClick={[Function]}
+    role="option"
     title="value"
   >
     <div
       className="title"
+      id="0-title"
     >
       title
     </div>
     <div
       className="subtitle"
+      id="0-subtitle"
     >
       subtitle
     </div>
   </li>
   <li
+    aria-describedby="1-subtitle"
+    aria-labelledby="1-title"
     className="result-item selected"
     key="1value 11"
     onClick={[Function]}
+    role="option"
     title="value 1"
   >
     <div
       className="title"
+      id="1-title"
     >
       title 1
     </div>
     <div
       className="subtitle"
+      id="1-subtitle"
     >
       subtitle 1
     </div>

--- a/src/components/shared/tests/__snapshots__/SearchInput.spec.js.snap
+++ b/src/components/shared/tests/__snapshots__/SearchInput.spec.js.snap
@@ -2,12 +2,19 @@
 
 exports[`SearchInput render 1`] = `
 <div
+  aria-expanded={false}
+  aria-haspopup="listbox"
+  aria-owns="result-list"
   className="search-field"
+  role="combobox"
 >
   <Svg
     name="magnifying-glass"
   />
   <input
+    aria-activedescendant=""
+    aria-autocomplete="list"
+    aria-controls="result-list"
     className=""
     placeholder="A placeholder"
     spellCheck={false}
@@ -26,12 +33,19 @@ exports[`SearchInput render 1`] = `
 
 exports[`SearchInput show nav buttons 1`] = `
 <div
+  aria-expanded={false}
+  aria-haspopup="listbox"
+  aria-owns="result-list"
   className="search-field"
+  role="combobox"
 >
   <Svg
     name="magnifying-glass"
   />
   <input
+    aria-activedescendant=""
+    aria-autocomplete="list"
+    aria-controls="result-list"
     className=""
     placeholder="A placeholder"
     spellCheck={false}
@@ -76,12 +90,19 @@ exports[`SearchInput show nav buttons 1`] = `
 
 exports[`SearchInput show svg (emoji) 1`] = `
 <div
+  aria-expanded={false}
+  aria-haspopup="listbox"
+  aria-owns="result-list"
   className="search-field"
+  role="combobox"
 >
   <Svg
     name="sad-face"
   />
   <input
+    aria-activedescendant=""
+    aria-autocomplete="list"
+    aria-controls="result-list"
     className="empty"
     placeholder="A placeholder"
     spellCheck={false}
@@ -100,12 +121,19 @@ exports[`SearchInput show svg (emoji) 1`] = `
 
 exports[`SearchInput show svg magnifying glass 1`] = `
 <div
+  aria-expanded={false}
+  aria-haspopup="listbox"
+  aria-owns="result-list"
   className="search-field"
+  role="combobox"
 >
   <Svg
     name="magnifying-glass"
   />
   <input
+    aria-activedescendant=""
+    aria-autocomplete="list"
+    aria-controls="result-list"
     className=""
     placeholder="A placeholder"
     spellCheck={false}

--- a/src/components/tests/__snapshots__/ProjectSearch.spec.js.snap
+++ b/src/components/tests/__snapshots__/ProjectSearch.spec.js.snap
@@ -12,6 +12,7 @@ exports[`ProjectSearch found no search results 1`] = `
     >
       <SearchInput
         count={0}
+        expanded={false}
         handleClose={[Function]}
         onBlur={[Function]}
         onChange={[Function]}
@@ -19,6 +20,7 @@ exports[`ProjectSearch found no search results 1`] = `
         onKeyDown={[Function]}
         placeholder="Find in files…"
         query="foo"
+        selectedItemId=""
         showErrorEmoji={true}
         size="big"
         summaryMsg="0 results"
@@ -95,6 +97,7 @@ exports[`ProjectSearch found search results 1`] = `
       >
         <SearchInput
           count={5}
+          expanded={false}
           handleClose={[Function]}
           onBlur={[Function]}
           onChange={[Function]}
@@ -102,12 +105,17 @@ exports[`ProjectSearch found search results 1`] = `
           onKeyDown={[Function]}
           placeholder="Find in files…"
           query="match"
+          selectedItemId=""
           showErrorEmoji={true}
           size="big"
           summaryMsg="5 results"
         >
           <div
+            aria-expanded={false}
+            aria-haspopup="listbox"
+            aria-owns="result-list"
             className="search-field big"
+            role="combobox"
           >
             <Svg
               name="magnifying-glass"
@@ -130,6 +138,9 @@ exports[`ProjectSearch found search results 1`] = `
               </InlineSVG>
             </Svg>
             <input
+              aria-activedescendant=""
+              aria-autocomplete="list"
+              aria-controls="result-list"
               className=""
               onBlur={[Function]}
               onChange={[Function]}
@@ -708,6 +719,7 @@ exports[`ProjectSearch turns off shortcuts on unmount 1`] = `
     >
       <SearchInput
         count={0}
+        expanded={false}
         handleClose={[Function]}
         onBlur={[Function]}
         onChange={[Function]}
@@ -715,6 +727,7 @@ exports[`ProjectSearch turns off shortcuts on unmount 1`] = `
         onKeyDown={[Function]}
         placeholder="Find in files…"
         query=""
+        selectedItemId=""
         showErrorEmoji={true}
         size="big"
         summaryMsg=""
@@ -736,6 +749,7 @@ exports[`ProjectSearch where <Enter> has not been pressed 1`] = `
     >
       <SearchInput
         count={0}
+        expanded={false}
         handleClose={[Function]}
         onBlur={[Function]}
         onChange={[Function]}
@@ -743,6 +757,7 @@ exports[`ProjectSearch where <Enter> has not been pressed 1`] = `
         onKeyDown={[Function]}
         placeholder="Find in files…"
         query=""
+        selectedItemId=""
         showErrorEmoji={true}
         size="big"
         summaryMsg=""

--- a/src/components/tests/__snapshots__/QuickOpenModal.spec.js.snap
+++ b/src/components/tests/__snapshots__/QuickOpenModal.spec.js.snap
@@ -52,17 +52,23 @@ exports[`QuickOpenModal Basic render with mount & searchType = functions 1`] = `
           >
             <SearchInput
               count={0}
+              expanded={false}
               handleClose={[Function]}
               onChange={[Function]}
               onKeyDown={[Function]}
               placeholder="Search sources…"
               query="@"
+              selectedItemId=""
               showErrorEmoji={true}
               size=""
               summaryMsg="0 results"
             >
               <div
+                aria-expanded={false}
+                aria-haspopup="listbox"
+                aria-owns="result-list"
                 className="search-field"
+                role="combobox"
               >
                 <Svg
                   name="sad-face"
@@ -85,6 +91,9 @@ exports[`QuickOpenModal Basic render with mount & searchType = functions 1`] = `
                   </InlineSVG>
                 </Svg>
                 <input
+                  aria-activedescendant=""
+                  aria-autocomplete="list"
+                  aria-controls="result-list"
                   className="empty"
                   onChange={[Function]}
                   onKeyDown={[Function]}
@@ -113,14 +122,19 @@ exports[`QuickOpenModal Basic render with mount & searchType = functions 1`] = `
               </div>
             </SearchInput>
             <ResultList
+              expanded={false}
               items={Array []}
               key="results"
+              role="listbox"
               selectItem={[Function]}
               selected={0}
               size="small"
             >
               <ul
+                aria-live="polite"
                 className="result-list small"
+                id="result-list"
+                role="listbox"
               />
             </ResultList>
           </div>
@@ -183,17 +197,23 @@ exports[`QuickOpenModal Basic render with mount & searchType = variables 1`] = `
           >
             <SearchInput
               count={0}
+              expanded={false}
               handleClose={[Function]}
               onChange={[Function]}
               onKeyDown={[Function]}
               placeholder="Search sources…"
               query="#"
+              selectedItemId=""
               showErrorEmoji={true}
               size=""
               summaryMsg="0 results"
             >
               <div
+                aria-expanded={false}
+                aria-haspopup="listbox"
+                aria-owns="result-list"
                 className="search-field"
+                role="combobox"
               >
                 <Svg
                   name="sad-face"
@@ -216,6 +236,9 @@ exports[`QuickOpenModal Basic render with mount & searchType = variables 1`] = `
                   </InlineSVG>
                 </Svg>
                 <input
+                  aria-activedescendant=""
+                  aria-autocomplete="list"
+                  aria-controls="result-list"
                   className="empty"
                   onChange={[Function]}
                   onKeyDown={[Function]}
@@ -244,14 +267,19 @@ exports[`QuickOpenModal Basic render with mount & searchType = variables 1`] = `
               </div>
             </SearchInput>
             <ResultList
+              expanded={false}
               items={Array []}
               key="results"
+              role="listbox"
               selectItem={[Function]}
               selected={0}
               size="small"
             >
               <ul
+                aria-live="polite"
                 className="result-list small"
+                id="result-list"
+                role="listbox"
               />
             </ResultList>
           </div>
@@ -308,17 +336,23 @@ exports[`QuickOpenModal Basic render with mount 1`] = `
           >
             <SearchInput
               count={0}
+              expanded={false}
               handleClose={[Function]}
               onChange={[Function]}
               onKeyDown={[Function]}
               placeholder="Search sources…"
               query=""
+              selectedItemId=""
               showErrorEmoji={true}
               size=""
               summaryMsg="0 results"
             >
               <div
+                aria-expanded={false}
+                aria-haspopup="listbox"
+                aria-owns="result-list"
                 className="search-field"
+                role="combobox"
               >
                 <Svg
                   name="magnifying-glass"
@@ -341,6 +375,9 @@ exports[`QuickOpenModal Basic render with mount 1`] = `
                   </InlineSVG>
                 </Svg>
                 <input
+                  aria-activedescendant=""
+                  aria-autocomplete="list"
+                  aria-controls="result-list"
                   className=""
                   onChange={[Function]}
                   onKeyDown={[Function]}
@@ -369,14 +406,19 @@ exports[`QuickOpenModal Basic render with mount 1`] = `
               </div>
             </SearchInput>
             <ResultList
+              expanded={false}
               items={Array []}
               key="results"
+              role="listbox"
               selectItem={[Function]}
               selected={0}
               size="big"
             >
               <ul
+                aria-live="polite"
                 className="result-list big"
+                id="result-list"
+                role="listbox"
               />
             </ResultList>
           </div>
@@ -396,18 +438,22 @@ exports[`QuickOpenModal Renders when enabled 1`] = `
 >
   <SearchInput
     count={0}
+    expanded={false}
     handleClose={[Function]}
     onChange={[Function]}
     onKeyDown={[Function]}
     placeholder="Search sources…"
     query=""
+    selectedItemId=""
     showErrorEmoji={true}
     size=""
     summaryMsg="0 results"
   />
   <ResultList
+    expanded={false}
     items={Array []}
     key="results"
+    role="listbox"
     selectItem={[Function]}
     selected={0}
     size="big"
@@ -467,16 +513,22 @@ exports[`QuickOpenModal Simple goto search query = :abc & searchType = goto 1`] 
           >
             <SearchInput
               count={0}
+              expanded={false}
               handleClose={[Function]}
               onChange={[Function]}
               onKeyDown={[Function]}
               placeholder="Search sources…"
               query=":abc"
+              selectedItemId=""
               showErrorEmoji={true}
               size=""
             >
               <div
+                aria-expanded={false}
+                aria-haspopup="listbox"
+                aria-owns="result-list"
                 className="search-field"
+                role="combobox"
               >
                 <Svg
                   name="sad-face"
@@ -499,6 +551,9 @@ exports[`QuickOpenModal Simple goto search query = :abc & searchType = goto 1`] 
                   </InlineSVG>
                 </Svg>
                 <input
+                  aria-activedescendant=""
+                  aria-autocomplete="list"
+                  aria-controls="result-list"
                   className="empty"
                   onChange={[Function]}
                   onKeyDown={[Function]}
@@ -578,17 +633,23 @@ exports[`QuickOpenModal closeModal 1`] = `
           >
             <SearchInput
               count={0}
+              expanded={false}
               handleClose={[Function]}
               onChange={[Function]}
               onKeyDown={[Function]}
               placeholder="Search sources…"
               query=""
+              selectedItemId=""
               showErrorEmoji={true}
               size=""
               summaryMsg="0 results"
             >
               <div
+                aria-expanded={false}
+                aria-haspopup="listbox"
+                aria-owns="result-list"
                 className="search-field"
+                role="combobox"
               >
                 <Svg
                   name="magnifying-glass"
@@ -611,6 +672,9 @@ exports[`QuickOpenModal closeModal 1`] = `
                   </InlineSVG>
                 </Svg>
                 <input
+                  aria-activedescendant=""
+                  aria-autocomplete="list"
+                  aria-controls="result-list"
                   className=""
                   onChange={[Function]}
                   onKeyDown={[Function]}
@@ -639,14 +703,19 @@ exports[`QuickOpenModal closeModal 1`] = `
               </div>
             </SearchInput>
             <ResultList
+              expanded={false}
               items={Array []}
               key="results"
+              role="listbox"
               selectItem={[Function]}
               selected={0}
               size="big"
             >
               <ul
+                aria-live="polite"
                 className="result-list big"
+                id="result-list"
+                role="listbox"
               />
             </ResultList>
           </div>
@@ -718,17 +787,23 @@ exports[`QuickOpenModal updateResults on enable 2`] = `
           >
             <SearchInput
               count={0}
+              expanded={false}
               handleClose={[Function]}
               onChange={[Function]}
               onKeyDown={[Function]}
               placeholder="Search sources…"
               query=""
+              selectedItemId=""
               showErrorEmoji={true}
               size=""
               summaryMsg="0 results"
             >
               <div
+                aria-expanded={false}
+                aria-haspopup="listbox"
+                aria-owns="result-list"
                 className="search-field"
+                role="combobox"
               >
                 <Svg
                   name="magnifying-glass"
@@ -751,6 +826,9 @@ exports[`QuickOpenModal updateResults on enable 2`] = `
                   </InlineSVG>
                 </Svg>
                 <input
+                  aria-activedescendant=""
+                  aria-autocomplete="list"
+                  aria-controls="result-list"
                   className=""
                   onChange={[Function]}
                   onKeyDown={[Function]}
@@ -779,14 +857,19 @@ exports[`QuickOpenModal updateResults on enable 2`] = `
               </div>
             </SearchInput>
             <ResultList
+              expanded={false}
               items={Array []}
               key="results"
+              role="listbox"
               selectItem={[Function]}
               selected={0}
               size="big"
             >
               <ul
+                aria-live="polite"
                 className="result-list big"
+                id="result-list"
+                role="listbox"
               />
             </ResultList>
           </div>


### PR DESCRIPTION
Associated Issue: #4071 

### Summary of Changes

- [x] aria-autocomplete="list" added in the search input field
- [x] aria-controls= ‘result-list’ added in the search input
- [x] aria-expanded added to show when the results are shown/hidden
- [x] aria-live="polite" added to result-list
- [x] result-list has a role of 'listbox' and each individual result has a role of 'option'.
- [x] aria-activedescendant points to the ID of the currently highlighted result item.
- [x] aria-labelledby points to ".title" child and aria-describedby points to ".subttitle" using IDs.

Test Plan

Original pull request authors used ChromeVox for Google Chrome as our screenreader.

Example test plan:

1. Open TodoMVC example

From debugger:

2. Command-P opens the panel
3. type in ‘js’
4. you should here the first result’s filepath
5. you should be read the next items filepath as you scroll through the result list

