### PR TITLE
Selects input text value on re-opening modal

### DIFF
--- a/src/components/shared/SearchInput.js
+++ b/src/components/shared/SearchInput.js
@@ -57,7 +57,7 @@ class SearchInput extends Component<Props> {
       const input = this.$input;
       input.focus();
       if (input.value != "") {
-        input.setSelectionRange(input.value.length + 1, input.value.length + 1);
+        input.select();
       }
     }
   }


### PR DESCRIPTION
Associated Issue: #5214

- Selects the text in the input of the search modal if there is text to be selected

=== Video
![select-text-research](https://user-images.githubusercontent.com/23530054/35698006-1f098188-078c-11e8-9dad-a67420b007ee.gif)

