### PR TITLE
Map original 'this' and 'arguments' to correct bindings where possible

### DIFF
--- a/src/utils/pause/scopes/utils.js
+++ b/src/utils/pause/scopes/utils.js
@@ -40,9 +40,7 @@ export function getFramePopVariables(why: Why, path: string): NamedValue[] {
   return vars;
 }
 
-export function getThisVariable(frame: any, path: string): ?NamedValue {
-  const this_ = frame.this;
-
+export function getThisVariable(this_: any, path: string): ?NamedValue {
   if (!this_) {
     return null;
   }

--- a/src/workers/parser/visitor.js
+++ b/src/workers/parser/visitor.js
@@ -91,7 +91,7 @@ function isNode(node?: Node, type: string): boolean {
   return node ? node.type === type : false;
 }
 
-function getFunctionScope(scope: TempScope): TempScope {
+function getVarScope(scope: TempScope): TempScope {
   let s = scope;
   while (s.type !== "function" && s.type !== "module") {
     if (!s.parent) {
@@ -290,7 +290,7 @@ function createParseJSScopeVisitor(sourceId: SourceId): ParseJSScopeVisitor {
         if (path.isFunctionDeclaration() && isNode(tree.id, "Identifier")) {
           // This ignores Annex B function declaration hoisting, which
           // is probably a fine assumption.
-          const fnScope = getFunctionScope(parent);
+          const fnScope = getVarScope(parent);
           scope.names[tree.id.name] = {
             type: fnScope === scope ? "var" : "let",
             declarations: [tree.id.loc],
@@ -357,7 +357,7 @@ function createParseJSScopeVisitor(sourceId: SourceId): ParseJSScopeVisitor {
           !path.parentPath.isXStatement({ left: tree }))
       ) {
         // Finds right lexical environment
-        const hoistAt = !isLetOrConst(tree) ? getFunctionScope(parent) : parent;
+        const hoistAt = !isLetOrConst(tree) ? getVarScope(parent) : parent;
         tree.declarations.forEach(declarator => {
           parseDeclarator(declarator.id, hoistAt, tree.kind);
         });

--- a/src/workers/parser/visitor.js
+++ b/src/workers/parser/visitor.js
@@ -303,6 +303,26 @@ function createParseJSScopeVisitor(sourceId: SourceId): ParseJSScopeVisitor {
         parent = scope;
         return;
       }
+      if (path.isClass()) {
+        if (path.isClassDeclaration() && path.get("id").isIdentifier()) {
+          parent.names[tree.id.name] = {
+            type: "let",
+            declarations: [tree.id.loc],
+            refs: []
+          };
+        }
+
+        if (path.get("id").isIdentifier()) {
+          savedParents.set(path, parent);
+          parent = createTempScope("block", "Class", parent, location);
+
+          parent.names[tree.id.name] = {
+            type: "const",
+            declarations: [tree.id.loc],
+            refs: []
+          };
+        }
+      }
       if (path.isForXStatement() || path.isForStatement()) {
         const init = tree.init || tree.left;
         if (isNode(init, "VariableDeclaration") && isLetOrConst(init)) {

--- a/src/workers/parser/visitor.js
+++ b/src/workers/parser/visitor.js
@@ -349,7 +349,13 @@ function createParseJSScopeVisitor(sourceId: SourceId): ParseJSScopeVisitor {
         }
         return;
       }
-      if (path.isVariableDeclaration()) {
+      if (
+        path.isVariableDeclaration() &&
+        (path.node.kind === "var" ||
+          // Lexical declarations in for statements are handled above.
+          !path.parentPath.isForStatement({ init: tree }) ||
+          !path.parentPath.isXStatement({ left: tree }))
+      ) {
         // Finds right lexical environment
         const hoistAt = !isLetOrConst(tree) ? getFunctionScope(parent) : parent;
         tree.declarations.forEach(declarator => {


### PR DESCRIPTION
Associated Issue: #5252

### Summary of Changes

* Fixes a few bugs in the visitor scope analysis
* Uses scope information to try to map `this` and `arguments`

### Test Plan

Kind of hard to test this one because Babel at least doesn't generate maps with good mappings for these. I'll make a PR for babel to map them properly.

### Screenshots/Videos (OPTIONAL)

These shots are taken with a local copy of Babel that actually generates good maps for `this` and `arguments` 😬 

* Note the successful inclusion of the correct `this` in this case, even though the user is inside of a transformed arrow function.

    ![screen shot 2018-02-01 at 5 16 40 pm](https://user-images.githubusercontent.com/132260/35711806-b838c1de-0773-11e8-9c26-aa7252ea8130.png)

* Here note that `this` can only be transformed if there is a `this` reference in the same function scope as the breakpoint itself, as the debugger server does not send us binding information about `this` in other scopes. `arguments` still works because the parent scope has a reference to `arguments`. If neither location referenced either one, they would be excluded from the scope list entirely.

    ![screen shot 2018-02-01 at 5 33 57 pm](https://user-images.githubusercontent.com/132260/35712335-6435d4ca-0776-11e8-9924-50061cf28d55.png)