### PR TITLE
[WIP] Clear the sourceMapURL on fail to load source maps in order to enable pretty printing

### DIFF
--- a/src/actions/sources/newSources.js
+++ b/src/actions/sources/newSources.js
@@ -39,25 +39,25 @@ function createOriginalSource(
   };
 }
 
-// TODO: It would be nice to make getOriginalURLs a safer api
-async function loadOriginalSourceUrls(sourceMaps, generatedSource) {
-  try {
-    return await sourceMaps.getOriginalURLs(generatedSource);
-  } catch (e) {
-    console.error(e);
-    return null;
-  }
-}
-
 /**
  * @memberof actions/sources
  * @static
  */
-function loadSourceMap(generatedSource) {
+export function loadSourceMap(generatedSource: Source) {
   return async function({ dispatch, getState, sourceMaps }: ThunkArgs) {
-    const urls = await loadOriginalSourceUrls(sourceMaps, generatedSource);
+    let urls;
+    try {
+      urls = await sourceMaps.getOriginalURLs(generatedSource);
+    } catch (e) {
+      console.error(e);
+      urls = null;
+    }
     if (!urls) {
-      // If this source doesn't have a sourcemap, do nothing.
+      // If this source doesn't have a sourcemap, enable it for pretty printing
+      dispatch({
+        type: "UPDATE_SOURCE",
+        source: { ...generatedSource, sourceMapURL: "" }
+      });
       return;
     }
 

--- a/src/test/mochitest/browser_dbg-sourcemaps-reload.js
+++ b/src/test/mochitest/browser_dbg-sourcemaps-reload.js
@@ -53,7 +53,6 @@ add_task(async function() {
   await reload(dbg);
   await waitForSource(dbg, "v1");
   await syncBp;
-  await waitForSelectedSource(dbg, "v1");
 
   is(getBreakpoints(dbg).length, 0, "No breakpoints");
 });


### PR DESCRIPTION
Associated Issue: #1661
Reliant on https://github.com/devtools-html/devtools-core/pull/921 so `fetchSourceMap` properly throws error

### Summary of Changes
*  Started clearing the sourceMapURL on fail to load source maps
* Added unit test to test the above

### Test Plan
Setup to get a source with a source map that fails on load:
- [x] Clone https://github.com/spotify/web-api-auth-examples
- [x] Run the following :
    $ npm install
    $ cd authorization_code
    $ node app.js
- [x] Simulate a fail to load the source map. Example method: Add `return null` to line 45 of `actions/newSources`

To test the patch
- [x] Open `code.jquery.com` folder from the sources
- [x] Click on `jquery-1.10.1.min.js`
- [x] `jquery-1.10.1.min.js` is automatically pretty printed (as opposed to being unable to pretty print before the patch)

### Screenshots
Before:
![image](https://user-images.githubusercontent.com/12681350/36043558-a7867220-0d9d-11e8-8d4d-10a790cdc101.png)

After:
![image](https://user-images.githubusercontent.com/12681350/36043272-c53f9fea-0d9c-11e8-9e49-2c5e10194124.png)