### PR TITLE
Toggling the conditional bp pane should not open bookmarks

### DIFF
--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -193,7 +193,7 @@ class Editor extends PureComponent<Props, State> {
     shortcuts.on(L10N.getStr("toggleBreakpoint.key"), this.onToggleBreakpoint);
     shortcuts.on(
       L10N.getStr("toggleCondPanel.key"),
-      this.toggleConditionalPanel
+      this.onToggleConditionalPanel
     );
     shortcuts.on("Esc", this.onEscape);
     shortcuts.on(searchAgainPrevKey, this.onSearchAgain);
@@ -239,6 +239,7 @@ class Editor extends PureComponent<Props, State> {
 
   onToggleBreakpoint = (key, e) => {
     e.preventDefault();
+    e.stopPropagation();
     const { selectedSource, conditionalPanelLine } = this.props;
 
     if (!selectedSource) {
@@ -255,6 +256,13 @@ class Editor extends PureComponent<Props, State> {
       this.toggleConditionalPanel(line);
       this.props.toggleBreakpoint(line);
     }
+  };
+
+  onToggleConditionalPanel = (key, e) => {
+    e.stopPropagation();
+    e.preventDefault();
+    const line = this.getCurrentLine();
+    this.toggleConditionalPanel(line);
   };
 
   onKeyDown(e) {
@@ -374,10 +382,6 @@ class Editor extends PureComponent<Props, State> {
       closeConditionalPanel,
       openConditionalPanel
     } = this.props;
-
-    if (!line || isNaN(line)) {
-      line = this.getCurrentLine();
-    }
 
     if (conditionalPanelLine) {
       return closeConditionalPanel();


### PR DESCRIPTION
### Summary of Changes

cmd+shift+b should toggle the cb panel without opening the bookmarks bar :)