### PR TITLE
Fix #5283 : Unclickable search result in project search 

### DIFF
--- a/src/components/ProjectSearch.css
+++ b/src/components/ProjectSearch.css
@@ -29,6 +29,7 @@
   padding: 4px 0 4px 30px;
   line-height: 16px;
   font-size: 10px;
+  width: 100%;
 }
 
 .project-text-search .matches-summary {


### PR DESCRIPTION
Associated Issue: #5283

Here's the Pull Request Doc
https://devtools-html.github.io/debugger.html/CONTRIBUTING.html#pull-requests

### Summary of Changes

Set result node in project search take full width

### Screenshots/Videos (OPTIONAL)
![zeppelin3](https://user-images.githubusercontent.com/11382805/35763591-edf45ed4-08f2-11e8-92ee-a10a2f068541.gif)
