### PR TITLE
[ToggleButton] Fix for left side collapse pane icon was blurry

### DIFF
--- a/src/components/shared/Button/PaneToggle.css
+++ b/src/components/shared/Button/PaneToggle.css
@@ -8,12 +8,13 @@
   padding: 5px;
 }
 
-.toggle-button.vertical {
-  padding: 2.5px 2.5px;
+.toggle-button .togglePanes {
+  vertical-align: -2px;
 }
 
 .toggle-button svg {
   fill: var(--theme-comment);
+  vertical-align: 0;
 }
 
 :root.theme-dark .toggle-button svg {


### PR DESCRIPTION
Associated Issue: #5268

Fix for left side collapse pane icon

#### BEFORE
![devtoools-icon-before](https://user-images.githubusercontent.com/7465851/35765648-afacaa48-08c8-11e8-8511-f65c23b8465c.JPG)

#### AFTER
![devtoools-icon-after](https://user-images.githubusercontent.com/7465851/35765647-a99925dc-08c8-11e8-91bb-f5e4cd5aa56f.JPG)

