### PR TITLE
Makes error emoji behave sensibly

### DIFF
--- a/src/components/Editor/SearchBar.js
+++ b/src/components/Editor/SearchBar.js
@@ -280,13 +280,16 @@ class SearchBar extends Component<Props, State> {
     );
   };
 
+  shouldShowErrorEmoji() {
+    return true;
+  }
+
   render() {
     const { searchResults: { count }, searchOn } = this.props;
 
     if (!searchOn) {
       return <div />;
     }
-
     return (
       <div className="search-bar">
         <SearchInput
@@ -295,6 +298,7 @@ class SearchBar extends Component<Props, State> {
           placeholder={L10N.getStr("sourceSearch.search.placeholder")}
           summaryMsg={this.buildSummaryMsg()}
           onChange={this.onChange}
+          showErrorEmoji={this.shouldShowErrorEmoji()}
           onKeyDown={this.onKeyDown}
           handleNext={e => this.traverseResults(e, false)}
           handlePrev={e => this.traverseResults(e, true)}

--- a/src/components/Editor/SearchBar.js
+++ b/src/components/Editor/SearchBar.js
@@ -281,7 +281,8 @@ class SearchBar extends Component<Props, State> {
   };
 
   shouldShowErrorEmoji() {
-    return true;
+    const { query, searchResults: { count } } = this.props;
+    return !!query && !count;
   }
 
   render() {

--- a/src/components/Editor/tests/SearchBar.spec.js
+++ b/src/components/Editor/tests/SearchBar.spec.js
@@ -64,3 +64,35 @@ describe("doSearch", () => {
     expect(doSearchArgs).toMatchSnapshot();
   });
 });
+
+describe("showErrorEmoji", () => {
+  it("true if query + no results", () => {
+    const { component } = render({
+      query: "test",
+      searchResults: {
+        count: 0
+      }
+    });
+    expect(component).toMatchSnapshot();
+  });
+
+  it("false if no query + no results", () => {
+    const { component } = render({
+      query: "",
+      searchResults: {
+        count: 0
+      }
+    });
+    expect(component).toMatchSnapshot();
+  });
+
+  it("false if query + results", () => {
+    const { component } = render({
+      query: "test",
+      searchResults: {
+        count: 10
+      }
+    });
+    expect(component).toMatchSnapshot();
+  });
+});

--- a/src/components/Editor/tests/__snapshots__/SearchBar.spec.js.snap
+++ b/src/components/Editor/tests/__snapshots__/SearchBar.spec.js.snap
@@ -53,3 +53,162 @@ exports[`SearchBar should render 1`] = `
 `;
 
 exports[`doSearch should complete a search 1`] = `"query"`;
+
+exports[`showErrorEmoji false if no query + no results 1`] = `
+<div
+  className="search-bar"
+>
+  <SearchInput
+    count={0}
+    expanded={false}
+    handleClose={[Function]}
+    handleNext={[Function]}
+    handlePrev={[Function]}
+    onChange={[Function]}
+    onKeyDown={[Function]}
+    placeholder="Search in file…"
+    query=""
+    selectedItemId=""
+    showErrorEmoji={false}
+    size=""
+    summaryMsg=""
+  />
+  <div
+    className="search-bottom-bar"
+  >
+    <div
+      className="search-modifiers"
+    >
+      <span
+        className="search-type-name"
+      >
+        Modifiers:
+      </span>
+      <SearchModBtn
+        className="regex-match-btn"
+        modVal="regexMatch"
+        svgName="regex-match"
+        tooltip="Regex"
+      />
+      <SearchModBtn
+        className="case-sensitive-btn"
+        modVal="caseSensitive"
+        svgName="case-match"
+        tooltip="Case sensitive"
+      />
+      <SearchModBtn
+        className="whole-word-btn"
+        modVal="wholeWord"
+        svgName="whole-word-match"
+        tooltip="Whole word"
+      />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`showErrorEmoji false if query + results 1`] = `
+<div
+  className="search-bar"
+>
+  <SearchInput
+    count={10}
+    expanded={false}
+    handleClose={[Function]}
+    handleNext={[Function]}
+    handlePrev={[Function]}
+    onChange={[Function]}
+    onKeyDown={[Function]}
+    placeholder="Search in file…"
+    query="test"
+    selectedItemId=""
+    showErrorEmoji={false}
+    size=""
+    summaryMsg="-NaN of 10 results"
+  />
+  <div
+    className="search-bottom-bar"
+  >
+    <div
+      className="search-modifiers"
+    >
+      <span
+        className="search-type-name"
+      >
+        Modifiers:
+      </span>
+      <SearchModBtn
+        className="regex-match-btn"
+        modVal="regexMatch"
+        svgName="regex-match"
+        tooltip="Regex"
+      />
+      <SearchModBtn
+        className="case-sensitive-btn"
+        modVal="caseSensitive"
+        svgName="case-match"
+        tooltip="Case sensitive"
+      />
+      <SearchModBtn
+        className="whole-word-btn"
+        modVal="wholeWord"
+        svgName="whole-word-match"
+        tooltip="Whole word"
+      />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`showErrorEmoji true if query + no results 1`] = `
+<div
+  className="search-bar"
+>
+  <SearchInput
+    count={0}
+    expanded={false}
+    handleClose={[Function]}
+    handleNext={[Function]}
+    handlePrev={[Function]}
+    onChange={[Function]}
+    onKeyDown={[Function]}
+    placeholder="Search in file…"
+    query="test"
+    selectedItemId=""
+    showErrorEmoji={true}
+    size=""
+    summaryMsg="No results"
+  />
+  <div
+    className="search-bottom-bar"
+  >
+    <div
+      className="search-modifiers"
+    >
+      <span
+        className="search-type-name"
+      >
+        Modifiers:
+      </span>
+      <SearchModBtn
+        className="regex-match-btn"
+        modVal="regexMatch"
+        svgName="regex-match"
+        tooltip="Regex"
+      />
+      <SearchModBtn
+        className="case-sensitive-btn"
+        modVal="caseSensitive"
+        svgName="case-match"
+        tooltip="Case sensitive"
+      />
+      <SearchModBtn
+        className="whole-word-btn"
+        modVal="wholeWord"
+        svgName="whole-word-match"
+        tooltip="Whole word"
+      />
+    </div>
+  </div>
+</div>
+`;

--- a/src/components/Editor/tests/__snapshots__/SearchBar.spec.js.snap
+++ b/src/components/Editor/tests/__snapshots__/SearchBar.spec.js.snap
@@ -14,7 +14,7 @@ exports[`SearchBar should render 1`] = `
     placeholder="Search in file…"
     query=""
     selectedItemId=""
-    showErrorEmoji={true}
+    showErrorEmoji={false}
     size=""
     summaryMsg=""
   />

--- a/src/components/ProjectSearch.js
+++ b/src/components/ProjectSearch.js
@@ -273,10 +273,15 @@ export class ProjectSearch extends Component<Props, State> {
     }
   };
 
-  renderSummary = () =>
-    this.props.query !== ""
+  renderSummary = () => {
+    return this.props.query !== ""
       ? L10N.getFormatStr("sourceSearch.resultsSummary1", this.getResultCount())
       : "";
+  };
+
+  shouldShowErrorEmoji() {
+    return !this.getResultCount() && this.props.status === statusType.done;
+  }
 
   renderInput() {
     return (
@@ -285,7 +290,7 @@ export class ProjectSearch extends Component<Props, State> {
         count={this.getResultCount()}
         placeholder={L10N.getStr("projectTextSearch.placeholder")}
         size="big"
-        showErrorEmoji={this.props.status === statusType.done}
+        showErrorEmoji={this.shouldShowErrorEmoji()}
         summaryMsg={this.renderSummary()}
         onChange={this.inputOnChange}
         onFocus={() => this.setState({ inputFocused: true })}

--- a/src/components/QuickOpenModal.js
+++ b/src/components/QuickOpenModal.js
@@ -356,6 +356,24 @@ export class QuickOpenModal extends Component<Props, State> {
     });
   };
 
+  shouldShowErrorEmoji() {
+    const { query } = this.props;
+
+    if (this.isGotoQuery()) {
+      return !/^:\d*$/.test(query);
+    }
+
+    if (
+      this.isVariableQuery() ||
+      this.isFunctionQuery() ||
+      this.isShortcutQuery()
+    ) {
+      return !this.getResultCount();
+    }
+
+    return false;
+  }
+
   render() {
     const { enabled, query } = this.props;
     const { selectedIndex, results } = this.state;
@@ -379,6 +397,7 @@ export class QuickOpenModal extends Component<Props, State> {
           count={this.getResultCount()}
           placeholder={L10N.getStr("sourceSearch.search")}
           {...(showSummary === true ? { summaryMsg } : {})}
+          showErrorEmoji={this.shouldShowErrorEmoji()}
           onChange={this.onChange}
           onKeyDown={this.onKeyDown}
           handleClose={this.closeModal}

--- a/src/components/QuickOpenModal.js
+++ b/src/components/QuickOpenModal.js
@@ -358,20 +358,10 @@ export class QuickOpenModal extends Component<Props, State> {
 
   shouldShowErrorEmoji() {
     const { query } = this.props;
-
     if (this.isGotoQuery()) {
       return !/^:\d*$/.test(query);
     }
-
-    if (
-      this.isVariableQuery() ||
-      this.isFunctionQuery() ||
-      this.isShortcutQuery()
-    ) {
-      return !this.getResultCount();
-    }
-
-    return false;
+    return !this.getResultCount() && !!query;
   }
 
   render() {

--- a/src/components/shared/SearchInput.js
+++ b/src/components/shared/SearchInput.js
@@ -50,7 +50,6 @@ class SearchInput extends Component<Props> {
 
   static defaultProps = {
     size: "",
-    showErrorEmoji: true,
     expanded: false,
     selectedItemId: ""
   };
@@ -65,13 +64,9 @@ class SearchInput extends Component<Props> {
     }
   }
 
-  shouldShowErrorEmoji = () => {
-    const { count, query, showErrorEmoji } = this.props;
-    return showErrorEmoji && count === 0 && query.trim() !== "";
-  };
-
   renderSvg() {
-    if (this.shouldShowErrorEmoji()) {
+    const { showErrorEmoji } = this.props;
+    if (showErrorEmoji) {
       return <Svg name="sad-face" />;
     }
 
@@ -120,12 +115,13 @@ class SearchInput extends Component<Props> {
       handleClose,
       size,
       expanded,
-      selectedItemId
+      selectedItemId,
+      showErrorEmoji
     } = this.props;
 
     const inputProps = {
       className: classnames({
-        empty: this.shouldShowErrorEmoji()
+        empty: showErrorEmoji
       }),
       onChange,
       onKeyDown,

--- a/src/components/shared/tests/SearchInput.spec.js
+++ b/src/components/shared/tests/SearchInput.spec.js
@@ -18,6 +18,14 @@ describe("SearchInput", () => {
 
   it("renders", () => expect(wrapper).toMatchSnapshot());
 
+  it("shows nav buttons", () => {
+    wrapper.setProps({
+      handleNext: jest.fn(),
+      handlePrev: jest.fn()
+    });
+    expect(wrapper).toMatchSnapshot();
+  });
+
   it("shows svg error emoji", () => {
     wrapper.setProps({ showErrorEmoji: true });
     expect(wrapper).toMatchSnapshot();
@@ -25,14 +33,6 @@ describe("SearchInput", () => {
 
   it("shows svg magnifying glass", () => {
     wrapper.setProps({ showErrorEmoji: false });
-    expect(wrapper).toMatchSnapshot();
-  });
-
-  it("shows nav buttons", () => {
-    wrapper.setProps({
-      handleNext: jest.fn(),
-      handlePrev: jest.fn()
-    });
     expect(wrapper).toMatchSnapshot();
   });
 });

--- a/src/components/shared/tests/SearchInput.spec.js
+++ b/src/components/shared/tests/SearchInput.spec.js
@@ -4,27 +4,32 @@ import { shallow } from "enzyme";
 import SearchInput from "../SearchInput";
 
 describe("SearchInput", () => {
+  // !! wrapper is defined outside test scope
+  // so it will keep values between tests
   const wrapper = shallow(
     <SearchInput
       query=""
-      count={0}
+      count={5}
       placeholder="A placeholder"
       summaryMsg="So many results"
-      showErrorEmoji
+      showErrorEmoji={false}
     />
   );
-  it("render", () => expect(wrapper).toMatchSnapshot());
-  it("show svg (emoji)", () => {
-    wrapper.setProps({ query: "test" });
+
+  it("renders", () => expect(wrapper).toMatchSnapshot());
+
+  it("shows svg error emoji", () => {
+    wrapper.setProps({ showErrorEmoji: true });
     expect(wrapper).toMatchSnapshot();
   });
-  it("show svg magnifying glass", () => {
-    wrapper.setProps({ count: 3 });
+
+  it("shows svg magnifying glass", () => {
+    wrapper.setProps({ showErrorEmoji: false });
     expect(wrapper).toMatchSnapshot();
   });
-  it("show nav buttons", () => {
+
+  it("shows nav buttons", () => {
     wrapper.setProps({
-      count: 5,
       handleNext: jest.fn(),
       handlePrev: jest.fn()
     });

--- a/src/components/shared/tests/__snapshots__/SearchInput.spec.js.snap
+++ b/src/components/shared/tests/__snapshots__/SearchInput.spec.js.snap
@@ -99,11 +99,6 @@ exports[`SearchInput shows svg error emoji 1`] = `
     value=""
   />
   <div
-    className="summary"
-  >
-    So many results
-  </div>
-  <div
     className="search-nav-buttons"
   >
     <button
@@ -155,11 +150,6 @@ exports[`SearchInput shows svg magnifying glass 1`] = `
     spellCheck={false}
     value=""
   />
-  <div
-    className="summary"
-  >
-    So many results
-  </div>
   <div
     className="search-nav-buttons"
   >

--- a/src/components/shared/tests/__snapshots__/SearchInput.spec.js.snap
+++ b/src/components/shared/tests/__snapshots__/SearchInput.spec.js.snap
@@ -98,6 +98,37 @@ exports[`SearchInput shows svg error emoji 1`] = `
     spellCheck={false}
     value=""
   />
+  <div
+    className="summary"
+  >
+    So many results
+  </div>
+  <div
+    className="search-nav-buttons"
+  >
+    <button
+      className="nav-btn next"
+      key="arrow-down"
+      onClick={[Function]}
+      title="Next result"
+      type="arrow-down"
+    >
+      <Svg
+        name="arrow-down"
+      />
+    </button>
+    <button
+      className="nav-btn prev"
+      key="arrow-up"
+      onClick={[Function]}
+      title="Previous result"
+      type="arrow-up"
+    >
+      <Svg
+        name="arrow-up"
+      />
+    </button>
+  </div>
   <CloseButton
     buttonClass=""
   />
@@ -124,6 +155,37 @@ exports[`SearchInput shows svg magnifying glass 1`] = `
     spellCheck={false}
     value=""
   />
+  <div
+    className="summary"
+  >
+    So many results
+  </div>
+  <div
+    className="search-nav-buttons"
+  >
+    <button
+      className="nav-btn next"
+      key="arrow-down"
+      onClick={[Function]}
+      title="Next result"
+      type="arrow-down"
+    >
+      <Svg
+        name="arrow-down"
+      />
+    </button>
+    <button
+      className="nav-btn prev"
+      key="arrow-up"
+      onClick={[Function]}
+      title="Previous result"
+      type="arrow-up"
+    >
+      <Svg
+        name="arrow-up"
+      />
+    </button>
+  </div>
   <CloseButton
     buttonClass=""
   />

--- a/src/components/shared/tests/__snapshots__/SearchInput.spec.js.snap
+++ b/src/components/shared/tests/__snapshots__/SearchInput.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`SearchInput render 1`] = `
+exports[`SearchInput renders 1`] = `
 <div
   aria-expanded={false}
   aria-haspopup="listbox"
@@ -26,7 +26,7 @@ exports[`SearchInput render 1`] = `
 </div>
 `;
 
-exports[`SearchInput show nav buttons 1`] = `
+exports[`SearchInput shows nav buttons 1`] = `
 <div
   aria-expanded={false}
   aria-haspopup="listbox"
@@ -44,7 +44,7 @@ exports[`SearchInput show nav buttons 1`] = `
     className=""
     placeholder="A placeholder"
     spellCheck={false}
-    value="test"
+    value=""
   />
   <div
     className="search-nav-buttons"
@@ -78,7 +78,7 @@ exports[`SearchInput show nav buttons 1`] = `
 </div>
 `;
 
-exports[`SearchInput show svg (emoji) 1`] = `
+exports[`SearchInput shows svg error emoji 1`] = `
 <div
   aria-expanded={false}
   aria-haspopup="listbox"
@@ -96,7 +96,7 @@ exports[`SearchInput show svg (emoji) 1`] = `
     className="empty"
     placeholder="A placeholder"
     spellCheck={false}
-    value="test"
+    value=""
   />
   <CloseButton
     buttonClass=""
@@ -104,7 +104,7 @@ exports[`SearchInput show svg (emoji) 1`] = `
 </div>
 `;
 
-exports[`SearchInput show svg magnifying glass 1`] = `
+exports[`SearchInput shows svg magnifying glass 1`] = `
 <div
   aria-expanded={false}
   aria-haspopup="listbox"
@@ -122,7 +122,7 @@ exports[`SearchInput show svg magnifying glass 1`] = `
     className=""
     placeholder="A placeholder"
     spellCheck={false}
-    value="test"
+    value=""
   />
   <CloseButton
     buttonClass=""

--- a/src/components/tests/ProjectSearch.spec.js
+++ b/src/components/tests/ProjectSearch.spec.js
@@ -200,4 +200,27 @@ describe("ProjectSearch", () => {
     shortcuts.dispatch("Enter");
     expect(setExpanded).toHaveBeenCalledWith(testFile, false);
   });
+
+  describe("showErrorEmoji", () => {
+    it("false if not done & results", () => {
+      const component = render({
+        status: "searching",
+        results: testResults
+      });
+      expect(component).toMatchSnapshot();
+    });
+
+    it("false if not done & no results", () => {
+      const component = render({
+        status: "searching"
+      });
+      expect(component).toMatchSnapshot();
+    });
+
+    // "false if done & has results"
+    // is the same test as "found search results"
+
+    // "true if done & has no results"
+    // is the same test as "found no search results"
+  });
 });

--- a/src/components/tests/QuickOpenModal.spec.js
+++ b/src/components/tests/QuickOpenModal.spec.js
@@ -1,3 +1,5 @@
+/* eslint max-nested-callbacks: ["error", 4] */
+
 import React from "react";
 import { shallow, mount } from "enzyme";
 import { QuickOpenModal } from "../QuickOpenModal";
@@ -204,11 +206,18 @@ describe("QuickOpenModal", () => {
       expect(wrapper).toMatchSnapshot();
     });
 
-    xit("false when count + query", () => {
-      // set result count
-      // set query
-      // generate wrapper
-      // test if wrapper has showErrorEmoji set to false
+    it("false when count + query", () => {
+      const { wrapper } = generateModal(
+        {
+          enabled: true,
+          query: "dasdasdas"
+        },
+        "mount"
+      );
+      wrapper.setState(() => ({
+        results: [1, 2]
+      }));
+      expect(wrapper).toMatchSnapshot();
     });
 
     it("false when no query", () => {

--- a/src/components/tests/QuickOpenModal.spec.js
+++ b/src/components/tests/QuickOpenModal.spec.js
@@ -190,4 +190,61 @@ describe("QuickOpenModal", () => {
     expect(wrapper).toMatchSnapshot();
     expect(wrapper.state().results).toEqual(null);
   });
+
+  describe("showErrorEmoji", () => {
+    it("true when no count + query", () => {
+      const { wrapper } = generateModal(
+        {
+          enabled: true,
+          query: "test",
+          searchType: ""
+        },
+        "mount"
+      );
+      expect(wrapper).toMatchSnapshot();
+    });
+
+    xit("false when count + query", () => {
+      // set result count
+      // set query
+      // generate wrapper
+      // test if wrapper has showErrorEmoji set to false
+    });
+
+    it("false when no query", () => {
+      const { wrapper } = generateModal(
+        {
+          enabled: true,
+          query: "",
+          searchType: ""
+        },
+        "mount"
+      );
+      expect(wrapper).toMatchSnapshot();
+    });
+
+    it("false when goto numeric ':2222'", () => {
+      const { wrapper } = generateModal(
+        {
+          enabled: true,
+          query: ":2222",
+          searchType: "goto"
+        },
+        "mount"
+      );
+      expect(wrapper).toMatchSnapshot();
+    });
+
+    it("true when goto not numeric ':22k22'", () => {
+      const { wrapper } = generateModal(
+        {
+          enabled: true,
+          query: ":22k22",
+          searchType: "goto"
+        },
+        "mount"
+      );
+      expect(wrapper).toMatchSnapshot();
+    });
+  });
 });

--- a/src/components/tests/__snapshots__/ProjectSearch.spec.js.snap
+++ b/src/components/tests/__snapshots__/ProjectSearch.spec.js.snap
@@ -106,7 +106,7 @@ exports[`ProjectSearch found search results 1`] = `
           placeholder="Find in files…"
           query="match"
           selectedItemId=""
-          showErrorEmoji={true}
+          showErrorEmoji={false}
           size="big"
           summaryMsg="5 results"
         >

--- a/src/components/tests/__snapshots__/ProjectSearch.spec.js.snap
+++ b/src/components/tests/__snapshots__/ProjectSearch.spec.js.snap
@@ -702,6 +702,71 @@ exports[`ProjectSearch found search results 1`] = `
 
 exports[`ProjectSearch renders nothing when disabled 1`] = `""`;
 
+exports[`ProjectSearch showErrorEmoji false if not done & no results 1`] = `
+<div
+  className="search-container"
+>
+  <div
+    className="project-text-search"
+  >
+    <div
+      className="header"
+    >
+      <SearchInput
+        count={0}
+        expanded={false}
+        handleClose={[Function]}
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        placeholder="Find in files…"
+        query="foo"
+        selectedItemId=""
+        showErrorEmoji={false}
+        size="big"
+        summaryMsg="0 results"
+      />
+    </div>
+    <div
+      className="no-result-msg absolute-center"
+    >
+      No results found
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ProjectSearch showErrorEmoji false if not done & results 1`] = `
+<div
+  className="search-container"
+>
+  <div
+    className="project-text-search"
+  >
+    <div
+      className="header"
+    >
+      <SearchInput
+        count={5}
+        expanded={false}
+        handleClose={[Function]}
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        placeholder="Find in files…"
+        query="foo"
+        selectedItemId=""
+        showErrorEmoji={false}
+        size="big"
+        summaryMsg="5 results"
+      />
+    </div>
+  </div>
+</div>
+`;
+
 exports[`ProjectSearch turns off shortcuts on unmount 1`] = `
 <div
   className="search-container"

--- a/src/components/tests/__snapshots__/QuickOpenModal.spec.js.snap
+++ b/src/components/tests/__snapshots__/QuickOpenModal.spec.js.snap
@@ -333,7 +333,7 @@ exports[`QuickOpenModal Basic render with mount 1`] = `
               placeholder="Search sources…"
               query=""
               selectedItemId=""
-              showErrorEmoji={true}
+              showErrorEmoji={false}
               size=""
               summaryMsg="0 results"
             >
@@ -430,7 +430,7 @@ exports[`QuickOpenModal Renders when enabled 1`] = `
     placeholder="Search sources…"
     query=""
     selectedItemId=""
-    showErrorEmoji={true}
+    showErrorEmoji={false}
     size=""
     summaryMsg="0 results"
   />
@@ -622,7 +622,7 @@ exports[`QuickOpenModal closeModal 1`] = `
               placeholder="Search sources…"
               query=""
               selectedItemId=""
-              showErrorEmoji={true}
+              showErrorEmoji={false}
               size=""
               summaryMsg="0 results"
             >
@@ -771,7 +771,7 @@ exports[`QuickOpenModal updateResults on enable 2`] = `
               placeholder="Search sources…"
               query=""
               selectedItemId=""
-              showErrorEmoji={true}
+              showErrorEmoji={false}
               size=""
               summaryMsg="0 results"
             >

--- a/src/components/tests/__snapshots__/QuickOpenModal.spec.js.snap
+++ b/src/components/tests/__snapshots__/QuickOpenModal.spec.js.snap
@@ -703,6 +703,502 @@ exports[`QuickOpenModal closeModal 1`] = `
 </QuickOpenModal>
 `;
 
+exports[`QuickOpenModal showErrorEmoji false when goto numeric ':2222' 1`] = `
+<QuickOpenModal
+  clearHighlightLineRange={[Function]}
+  closeQuickOpen={[Function]}
+  enabled={true}
+  highlightLineRange={[Function]}
+  query=":2222"
+  searchType="goto"
+  selectLocation={[Function]}
+  setQuickOpenQuery={[Function]}
+  sources={Array []}
+  tabs={Array []}
+>
+  <Slide
+    handleClose={[Function]}
+    in={true}
+  >
+    <Transition
+      appear={true}
+      enter={true}
+      exit={true}
+      in={true}
+      mountOnEnter={false}
+      onEnter={[Function]}
+      onEntered={[Function]}
+      onEntering={[Function]}
+      onExit={[Function]}
+      onExited={[Function]}
+      onExiting={[Function]}
+      timeout={175}
+      unmountOnExit={false}
+    >
+      <Modal
+        handleClose={[Function]}
+        status="entering"
+      >
+        <div
+          className="modal-wrapper"
+          onClick={[Function]}
+        >
+          <div
+            className="modal entering"
+            onClick={[Function]}
+          >
+            <SearchInput
+              count={0}
+              expanded={false}
+              handleClose={[Function]}
+              onChange={[Function]}
+              onKeyDown={[Function]}
+              placeholder="Search sources…"
+              query=":2222"
+              selectedItemId=""
+              showErrorEmoji={false}
+              size=""
+            >
+              <div
+                aria-expanded={false}
+                aria-haspopup="listbox"
+                aria-owns="result-list"
+                className="search-field"
+                role="combobox"
+              >
+                <Svg
+                  name="magnifying-glass"
+                >
+                  <InlineSVG
+                    className="magnifying-glass "
+                    element="i"
+                    raw={false}
+                    src="<svg></svg>"
+                  >
+                    <i
+                      className="magnifying-glass "
+                      dangerouslySetInnerHTML={
+                        Object {
+                          "__html": "<svg></svg>",
+                        }
+                      }
+                      src={null}
+                    />
+                  </InlineSVG>
+                </Svg>
+                <input
+                  aria-activedescendant=""
+                  aria-autocomplete="list"
+                  aria-controls="result-list"
+                  className=""
+                  onChange={[Function]}
+                  onKeyDown={[Function]}
+                  placeholder="Search sources…"
+                  spellCheck={false}
+                  value=":2222"
+                />
+                <div
+                  className="summary"
+                />
+                <CloseButton
+                  buttonClass=""
+                  handleClick={[Function]}
+                >
+                  <div
+                    className="close-btn"
+                    onClick={[Function]}
+                  >
+                    <img
+                      className="close"
+                    />
+                  </div>
+                </CloseButton>
+              </div>
+            </SearchInput>
+          </div>
+        </div>
+      </Modal>
+    </Transition>
+  </Slide>
+</QuickOpenModal>
+`;
+
+exports[`QuickOpenModal showErrorEmoji false when no query 1`] = `
+<QuickOpenModal
+  clearHighlightLineRange={[Function]}
+  closeQuickOpen={[Function]}
+  enabled={true}
+  highlightLineRange={[Function]}
+  query=""
+  searchType=""
+  selectLocation={[Function]}
+  setQuickOpenQuery={[Function]}
+  sources={Array []}
+  tabs={Array []}
+>
+  <Slide
+    handleClose={[Function]}
+    in={true}
+  >
+    <Transition
+      appear={true}
+      enter={true}
+      exit={true}
+      in={true}
+      mountOnEnter={false}
+      onEnter={[Function]}
+      onEntered={[Function]}
+      onEntering={[Function]}
+      onExit={[Function]}
+      onExited={[Function]}
+      onExiting={[Function]}
+      timeout={175}
+      unmountOnExit={false}
+    >
+      <Modal
+        handleClose={[Function]}
+        status="entering"
+      >
+        <div
+          className="modal-wrapper"
+          onClick={[Function]}
+        >
+          <div
+            className="modal entering"
+            onClick={[Function]}
+          >
+            <SearchInput
+              count={0}
+              expanded={false}
+              handleClose={[Function]}
+              onChange={[Function]}
+              onKeyDown={[Function]}
+              placeholder="Search sources…"
+              query=""
+              selectedItemId=""
+              showErrorEmoji={false}
+              size=""
+            >
+              <div
+                aria-expanded={false}
+                aria-haspopup="listbox"
+                aria-owns="result-list"
+                className="search-field"
+                role="combobox"
+              >
+                <Svg
+                  name="magnifying-glass"
+                >
+                  <InlineSVG
+                    className="magnifying-glass "
+                    element="i"
+                    raw={false}
+                    src="<svg></svg>"
+                  >
+                    <i
+                      className="magnifying-glass "
+                      dangerouslySetInnerHTML={
+                        Object {
+                          "__html": "<svg></svg>",
+                        }
+                      }
+                      src={null}
+                    />
+                  </InlineSVG>
+                </Svg>
+                <input
+                  aria-activedescendant=""
+                  aria-autocomplete="list"
+                  aria-controls="result-list"
+                  className=""
+                  onChange={[Function]}
+                  onKeyDown={[Function]}
+                  placeholder="Search sources…"
+                  spellCheck={false}
+                  value=""
+                />
+                <div
+                  className="summary"
+                />
+                <CloseButton
+                  buttonClass=""
+                  handleClick={[Function]}
+                >
+                  <div
+                    className="close-btn"
+                    onClick={[Function]}
+                  >
+                    <img
+                      className="close"
+                    />
+                  </div>
+                </CloseButton>
+              </div>
+            </SearchInput>
+            <ResultList
+              expanded={false}
+              items={Array []}
+              key="results"
+              role="listbox"
+              selectItem={[Function]}
+              selected={0}
+              size="small"
+            >
+              <ul
+                aria-live="polite"
+                className="result-list small"
+                id="result-list"
+                role="listbox"
+              />
+            </ResultList>
+          </div>
+        </div>
+      </Modal>
+    </Transition>
+  </Slide>
+</QuickOpenModal>
+`;
+
+exports[`QuickOpenModal showErrorEmoji true when goto not numeric ':22k22' 1`] = `
+<QuickOpenModal
+  clearHighlightLineRange={[Function]}
+  closeQuickOpen={[Function]}
+  enabled={true}
+  highlightLineRange={[Function]}
+  query=":22k22"
+  searchType="goto"
+  selectLocation={[Function]}
+  setQuickOpenQuery={[Function]}
+  sources={Array []}
+  tabs={Array []}
+>
+  <Slide
+    handleClose={[Function]}
+    in={true}
+  >
+    <Transition
+      appear={true}
+      enter={true}
+      exit={true}
+      in={true}
+      mountOnEnter={false}
+      onEnter={[Function]}
+      onEntered={[Function]}
+      onEntering={[Function]}
+      onExit={[Function]}
+      onExited={[Function]}
+      onExiting={[Function]}
+      timeout={175}
+      unmountOnExit={false}
+    >
+      <Modal
+        handleClose={[Function]}
+        status="entering"
+      >
+        <div
+          className="modal-wrapper"
+          onClick={[Function]}
+        >
+          <div
+            className="modal entering"
+            onClick={[Function]}
+          >
+            <SearchInput
+              count={0}
+              expanded={false}
+              handleClose={[Function]}
+              onChange={[Function]}
+              onKeyDown={[Function]}
+              placeholder="Search sources…"
+              query=":22k22"
+              selectedItemId=""
+              showErrorEmoji={true}
+              size=""
+            >
+              <div
+                aria-expanded={false}
+                aria-haspopup="listbox"
+                aria-owns="result-list"
+                className="search-field"
+                role="combobox"
+              >
+                <Svg
+                  name="sad-face"
+                >
+                  <InlineSVG
+                    className="sad-face "
+                    element="i"
+                    raw={false}
+                    src="<svg></svg>"
+                  >
+                    <i
+                      className="sad-face "
+                      dangerouslySetInnerHTML={
+                        Object {
+                          "__html": "<svg></svg>",
+                        }
+                      }
+                      src={null}
+                    />
+                  </InlineSVG>
+                </Svg>
+                <input
+                  aria-activedescendant=""
+                  aria-autocomplete="list"
+                  aria-controls="result-list"
+                  className="empty"
+                  onChange={[Function]}
+                  onKeyDown={[Function]}
+                  placeholder="Search sources…"
+                  spellCheck={false}
+                  value=":22k22"
+                />
+                <div
+                  className="summary"
+                />
+                <CloseButton
+                  buttonClass=""
+                  handleClick={[Function]}
+                >
+                  <div
+                    className="close-btn"
+                    onClick={[Function]}
+                  >
+                    <img
+                      className="close"
+                    />
+                  </div>
+                </CloseButton>
+              </div>
+            </SearchInput>
+          </div>
+        </div>
+      </Modal>
+    </Transition>
+  </Slide>
+</QuickOpenModal>
+`;
+
+exports[`QuickOpenModal showErrorEmoji true when no count + query 1`] = `
+<QuickOpenModal
+  clearHighlightLineRange={[Function]}
+  closeQuickOpen={[Function]}
+  enabled={true}
+  highlightLineRange={[Function]}
+  query="test"
+  searchType=""
+  selectLocation={[Function]}
+  setQuickOpenQuery={[Function]}
+  sources={Array []}
+  tabs={Array []}
+>
+  <Slide
+    handleClose={[Function]}
+    in={true}
+  >
+    <Transition
+      appear={true}
+      enter={true}
+      exit={true}
+      in={true}
+      mountOnEnter={false}
+      onEnter={[Function]}
+      onEntered={[Function]}
+      onEntering={[Function]}
+      onExit={[Function]}
+      onExited={[Function]}
+      onExiting={[Function]}
+      timeout={175}
+      unmountOnExit={false}
+    >
+      <Modal
+        handleClose={[Function]}
+        status="entering"
+      >
+        <div
+          className="modal-wrapper"
+          onClick={[Function]}
+        >
+          <div
+            className="modal entering"
+            onClick={[Function]}
+          >
+            <SearchInput
+              count={0}
+              expanded={false}
+              handleClose={[Function]}
+              onChange={[Function]}
+              onKeyDown={[Function]}
+              placeholder="Search sources…"
+              query="test"
+              selectedItemId=""
+              showErrorEmoji={true}
+              size=""
+            >
+              <div
+                aria-expanded={false}
+                aria-haspopup="listbox"
+                aria-owns="result-list"
+                className="search-field"
+                role="combobox"
+              >
+                <Svg
+                  name="sad-face"
+                >
+                  <InlineSVG
+                    className="sad-face "
+                    element="i"
+                    raw={false}
+                    src="<svg></svg>"
+                  >
+                    <i
+                      className="sad-face "
+                      dangerouslySetInnerHTML={
+                        Object {
+                          "__html": "<svg></svg>",
+                        }
+                      }
+                      src={null}
+                    />
+                  </InlineSVG>
+                </Svg>
+                <input
+                  aria-activedescendant=""
+                  aria-autocomplete="list"
+                  aria-controls="result-list"
+                  className="empty"
+                  onChange={[Function]}
+                  onKeyDown={[Function]}
+                  placeholder="Search sources…"
+                  spellCheck={false}
+                  value="test"
+                />
+                <div
+                  className="summary"
+                />
+                <CloseButton
+                  buttonClass=""
+                  handleClick={[Function]}
+                >
+                  <div
+                    className="close-btn"
+                    onClick={[Function]}
+                  >
+                    <img
+                      className="close"
+                    />
+                  </div>
+                </CloseButton>
+              </div>
+            </SearchInput>
+          </div>
+        </div>
+      </Modal>
+    </Transition>
+  </Slide>
+</QuickOpenModal>
+`;
+
 exports[`QuickOpenModal updateResults on enable 1`] = `
 <QuickOpenModal
   clearHighlightLineRange={[Function]}

--- a/src/components/tests/__snapshots__/QuickOpenModal.spec.js.snap
+++ b/src/components/tests/__snapshots__/QuickOpenModal.spec.js.snap
@@ -703,6 +703,217 @@ exports[`QuickOpenModal closeModal 1`] = `
 </QuickOpenModal>
 `;
 
+exports[`QuickOpenModal showErrorEmoji false when count + query 1`] = `
+<QuickOpenModal
+  clearHighlightLineRange={[Function]}
+  closeQuickOpen={[Function]}
+  enabled={true}
+  highlightLineRange={[Function]}
+  query="dasdasdas"
+  searchType="sources"
+  selectLocation={[Function]}
+  setQuickOpenQuery={[Function]}
+  sources={Array []}
+  tabs={Array []}
+>
+  <Slide
+    handleClose={[Function]}
+    in={true}
+  >
+    <Transition
+      appear={true}
+      enter={true}
+      exit={true}
+      in={true}
+      mountOnEnter={false}
+      onEnter={[Function]}
+      onEntered={[Function]}
+      onEntering={[Function]}
+      onExit={[Function]}
+      onExited={[Function]}
+      onExiting={[Function]}
+      timeout={175}
+      unmountOnExit={false}
+    >
+      <Modal
+        handleClose={[Function]}
+        status="entering"
+      >
+        <div
+          className="modal-wrapper"
+          onClick={[Function]}
+        >
+          <div
+            className="modal entering"
+            onClick={[Function]}
+          >
+            <SearchInput
+              count={2}
+              expanded={true}
+              handleClose={[Function]}
+              onChange={[Function]}
+              onKeyDown={[Function]}
+              placeholder="Search sources…"
+              query="dasdasdas"
+              selectedItemId=""
+              showErrorEmoji={false}
+              size=""
+              summaryMsg="2 results"
+            >
+              <div
+                aria-expanded={true}
+                aria-haspopup="listbox"
+                aria-owns="result-list"
+                className="search-field"
+                role="combobox"
+              >
+                <Svg
+                  name="magnifying-glass"
+                >
+                  <InlineSVG
+                    className="magnifying-glass "
+                    element="i"
+                    raw={false}
+                    src="<svg></svg>"
+                  >
+                    <i
+                      className="magnifying-glass "
+                      dangerouslySetInnerHTML={
+                        Object {
+                          "__html": "<svg></svg>",
+                        }
+                      }
+                      src={null}
+                    />
+                  </InlineSVG>
+                </Svg>
+                <input
+                  aria-activedescendant=""
+                  aria-autocomplete="list"
+                  aria-controls="result-list"
+                  className=""
+                  onChange={[Function]}
+                  onKeyDown={[Function]}
+                  placeholder="Search sources…"
+                  spellCheck={false}
+                  value="dasdasdas"
+                />
+                <div
+                  className="summary"
+                >
+                  2 results
+                </div>
+                <CloseButton
+                  buttonClass=""
+                  handleClick={[Function]}
+                >
+                  <div
+                    className="close-btn"
+                    onClick={[Function]}
+                  >
+                    <img
+                      className="close"
+                    />
+                  </div>
+                </CloseButton>
+              </div>
+            </SearchInput>
+            <ResultList
+              expanded={true}
+              items={
+                Array [
+                  Object {
+                    "title": <div
+                      dangerouslySetInnerHTML={
+                            Object {
+                                  "__html": undefined,
+                                }
+                      }
+                />,
+                  },
+                  Object {
+                    "title": <div
+                      dangerouslySetInnerHTML={
+                            Object {
+                                  "__html": undefined,
+                                }
+                      }
+                />,
+                  },
+                ]
+              }
+              key="results"
+              role="listbox"
+              selectItem={[Function]}
+              selected={0}
+              size="big"
+            >
+              <ul
+                aria-live="polite"
+                className="result-list big"
+                id="result-list"
+                role="listbox"
+              >
+                <li
+                  aria-describedby="undefined-subtitle"
+                  aria-labelledby="undefined-title"
+                  className="result-item selected"
+                  key="undefinedundefined0"
+                  onClick={[Function]}
+                  role="option"
+                >
+                  <div
+                    className="title"
+                    id="undefined-title"
+                  >
+                    <div
+                      dangerouslySetInnerHTML={
+                        Object {
+                          "__html": undefined,
+                        }
+                      }
+                    />
+                  </div>
+                  <div
+                    className="subtitle"
+                    id="undefined-subtitle"
+                  />
+                </li>
+                <li
+                  aria-describedby="undefined-subtitle"
+                  aria-labelledby="undefined-title"
+                  className="result-item"
+                  key="undefinedundefined1"
+                  onClick={[Function]}
+                  role="option"
+                >
+                  <div
+                    className="title"
+                    id="undefined-title"
+                  >
+                    <div
+                      dangerouslySetInnerHTML={
+                        Object {
+                          "__html": undefined,
+                        }
+                      }
+                    />
+                  </div>
+                  <div
+                    className="subtitle"
+                    id="undefined-subtitle"
+                  />
+                </li>
+              </ul>
+            </ResultList>
+          </div>
+        </div>
+      </Modal>
+    </Transition>
+  </Slide>
+</QuickOpenModal>
+`;
+
 exports[`QuickOpenModal showErrorEmoji false when goto numeric ':2222' 1`] = `
 <QuickOpenModal
   clearHighlightLineRange={[Function]}

--- a/src/components/tests/__snapshots__/QuickOpenModal.spec.js.snap
+++ b/src/components/tests/__snapshots__/QuickOpenModal.spec.js.snap
@@ -798,11 +798,6 @@ exports[`QuickOpenModal showErrorEmoji false when count + query 1`] = `
                   spellCheck={false}
                   value="dasdasdas"
                 />
-                <div
-                  className="summary"
-                >
-                  2 results
-                </div>
                 <CloseButton
                   buttonClass=""
                   handleClick={[Function]}
@@ -1008,9 +1003,6 @@ exports[`QuickOpenModal showErrorEmoji false when goto numeric ':2222' 1`] = `
                   spellCheck={false}
                   value=":2222"
                 />
-                <div
-                  className="summary"
-                />
                 <CloseButton
                   buttonClass=""
                   handleClick={[Function]}
@@ -1127,9 +1119,6 @@ exports[`QuickOpenModal showErrorEmoji false when no query 1`] = `
                   placeholder="Search sources…"
                   spellCheck={false}
                   value=""
-                />
-                <div
-                  className="summary"
                 />
                 <CloseButton
                   buttonClass=""
@@ -1264,9 +1253,6 @@ exports[`QuickOpenModal showErrorEmoji true when goto not numeric ':22k22' 1`] =
                   spellCheck={false}
                   value=":22k22"
                 />
-                <div
-                  className="summary"
-                />
                 <CloseButton
                   buttonClass=""
                   handleClick={[Function]}
@@ -1383,9 +1369,6 @@ exports[`QuickOpenModal showErrorEmoji true when no count + query 1`] = `
                   placeholder="Search sources…"
                   spellCheck={false}
                   value="test"
-                />
-                <div
-                  className="summary"
                 />
                 <CloseButton
                   buttonClass=""


### PR DESCRIPTION
Associated Issue: #5157 

Gist:
The error emoji should appear only when there is an actual error.  This creates two situations:
a.) where we are searching for a line number - in this case anything but a number should trigger the error emoji and
b.) where we are searching for text. In this case the emoji should only trigger if there is a search query AND the result count is 0.

p.s. The case of an @ or # is already handled well, so no need to address it

Vid:
![source-search](https://user-images.githubusercontent.com/23530054/35765866-67b973c4-08cd-11e8-9add-6e6abbe2954a.gif)
