### PR TITLE
Fix [QuickOpenModal] initial scroll

### DIFF
--- a/src/components/QuickOpenModal.js
+++ b/src/components/QuickOpenModal.js
@@ -96,12 +96,17 @@ export class QuickOpenModal extends Component<Props, State> {
   }
 
   componentDidUpdate(prevProps: Props) {
-    if (this.refs.resultList && this.refs.resultList.refs) {
-      scrollList(this.refs.resultList.refs, this.state.selectedIndex);
-    }
-
     const nowEnabled = !prevProps.enabled && this.props.enabled;
     const queryChanged = prevProps.query !== this.props.query;
+
+    if (this.refs.resultList && this.refs.resultList.refs) {
+      scrollList(
+        this.refs.resultList.refs,
+        this.state.selectedIndex,
+        nowEnabled || !queryChanged
+      );
+    }
+
     if (nowEnabled || queryChanged) {
       this.updateResults(this.props.query);
     }

--- a/src/components/shared/Modal.js
+++ b/src/components/shared/Modal.js
@@ -20,6 +20,8 @@ type ModalProps = {
   handleClose: () => any
 };
 
+export const transitionTimeout = 175;
+
 export class Modal extends React.Component<ModalProps> {
   onClick = (e: SyntheticEvent<HTMLElement>) => {
     e.stopPropagation();
@@ -59,7 +61,7 @@ export default function Slide({
   handleClose
 }: SlideProps) {
   return (
-    <Transition in={inProp} timeout={175} appear>
+    <Transition in={inProp} timeout={transitionTimeout} appear>
       {(status: TransitionStatus) => (
         <Modal
           status={status}

--- a/src/utils/result-list.js
+++ b/src/utils/result-list.js
@@ -3,9 +3,7 @@
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
 import { isFirefox } from "devtools-config";
-import {
-  transitionTimeout as modalTransitionTimeout
-} from "../components/shared/Modal";
+import { transitionTimeout } from "../components/shared/Modal";
 
 function scrollList(resultList, index, delayed = false) {
   if (!resultList.hasOwnProperty(index)) {
@@ -24,7 +22,7 @@ function scrollList(resultList, index, delayed = false) {
 
   if (delayed) {
     // Wait for Modal Transition timeout before scrolling to resultEl.
-    setTimeout(scroll, modalTransitionTimeout + 10);
+    setTimeout(scroll, transitionTimeout + 10);
     return;
   }
 

--- a/src/utils/result-list.js
+++ b/src/utils/result-list.js
@@ -3,7 +3,9 @@
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
 import { isFirefox } from "devtools-config";
-import { transitionTimeout as modalTransitionTimeout } from "../components/shared/Modal";
+import {
+  transitionTimeout as modalTransitionTimeout
+} from "../components/shared/Modal";
 
 function scrollList(resultList, index, delayed = false) {
   if (!resultList.hasOwnProperty(index)) {

--- a/src/utils/result-list.js
+++ b/src/utils/result-list.js
@@ -5,21 +5,28 @@
 import { isFirefox } from "devtools-config";
 import { transitionTimeout as modalTransitionTimeout } from "../components/shared/Modal";
 
-function scrollList(resultList, index) {
+function scrollList(resultList, index, delayed = false) {
   if (!resultList.hasOwnProperty(index)) {
     return;
   }
 
   const resultEl = resultList[index];
 
-  // Wait for Modal Transition timeout before scrolling to resultEl.
-  setTimeout(() => {
+  const scroll = () => {
     if (isFirefox()) {
       resultEl.scrollIntoView({ block: "center", behavior: "smooth" });
     } else {
       chromeScrollList(resultEl, index);
     }
-  }, modalTransitionTimeout + 10);
+  };
+
+  if (delayed) {
+    // Wait for Modal Transition timeout before scrolling to resultEl.
+    setTimeout(scroll, modalTransitionTimeout + 10);
+    return;
+  }
+
+  scroll();
 }
 
 function chromeScrollList(elem, index) {

--- a/src/utils/result-list.js
+++ b/src/utils/result-list.js
@@ -3,6 +3,7 @@
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
 import { isFirefox } from "devtools-config";
+import { transitionTimeout as modalTransitionTimeout } from "../components/shared/Modal";
 
 function scrollList(resultList, index) {
   if (!resultList.hasOwnProperty(index)) {
@@ -11,11 +12,14 @@ function scrollList(resultList, index) {
 
   const resultEl = resultList[index];
 
-  if (isFirefox()) {
-    resultEl.scrollIntoView({ block: "center", behavior: "smooth" });
-  } else {
-    chromeScrollList(resultEl, index);
-  }
+  // Wait for Modal Transition timeout before scrolling to resultEl.
+  setTimeout(() => {
+    if (isFirefox()) {
+      resultEl.scrollIntoView({ block: "center", behavior: "smooth" });
+    } else {
+      chromeScrollList(resultEl, index);
+    }
+  }, modalTransitionTimeout + 10);
 }
 
 function chromeScrollList(elem, index) {


### PR DESCRIPTION
Fixes #5284.

### Summary of Changes

* Apply delay if modal has just been enabled or if query didn't change. *(although `nowEnabled` is always `false` since `prevProps.enabled` is always `true` for some reason 🤔. maybe it's the because the `Modal` is wrapped with a `Transition`)*
* modify `scrollList` to accept optional delay flag

### Test Plan

- [x] Command-P opens the panel

### Screenshots/Videos (OPTIONAL)

![quickopen-modal-initial-scroll-fix](https://user-images.githubusercontent.com/601001/35770593-ec534106-0926-11e8-8f4b-2e43da08bf95.gif)
