### PR TITLE
color fixes

### DIFF
--- a/src/components/PrimaryPanes/Sources.css
+++ b/src/components/PrimaryPanes/Sources.css
@@ -51,10 +51,6 @@
   transform: rotate(0deg);
 }
 
-.theme-dark .sources-list .tree .node:not(.focused) img.arrow {
-  background: var(--theme-content-color3);
-}
-
 .theme-dark .source-list .tree .node.focused {
   background-color: var(--theme-tab-toolbar-background);
 }

--- a/src/components/SecondaryPanes/Expressions.css
+++ b/src/components/SecondaryPanes/Expressions.css
@@ -39,8 +39,7 @@
 .input-expression::placeholder {
   text-align: center;
   font-style: italic;
-  color: var(--theme-comment-alt);
-  opacity: 1;
+  color: var(--theme-comment);
 }
 
 .input-expression:focus {

--- a/src/components/SecondaryPanes/SecondaryPanes.css
+++ b/src/components/SecondaryPanes/SecondaryPanes.css
@@ -43,10 +43,6 @@
   cursor: default;
 }
 
-.theme-dark .secondary-panes .accordion .arrow svg {
-  fill: var(--theme-content-color3);
-}
-
 .secondary-panes .breakpoints-buttons {
   display: flex;
 }

--- a/src/components/WelcomeBox.css
+++ b/src/components/WelcomeBox.css
@@ -55,6 +55,7 @@
   text-align: left;
   float: left;
   margin-left: 25px;
+  color: var(--theme-comment);
 }
 
 html .welcomebox .toggle-button-end.collapsed {

--- a/src/components/shared/Accordion.css
+++ b/src/components/shared/Accordion.css
@@ -4,10 +4,12 @@
 
 :root {
   --accordion-header-background: var(--theme-toolbar-background);
+  --disclosure-arrow: #b2b2b2;
 }
 
 :root.theme-dark {
   --accordion-header-background: #222225;
+  --disclosure-arrow: #7f7f81;
 }
 
 .accordion {
@@ -80,5 +82,5 @@
 }
 
 .accordion .arrow svg {
-  fill: var(--theme-comment);
+  fill: var(--disclosure-arrow);
 }

--- a/src/components/shared/Accordion.css
+++ b/src/components/shared/Accordion.css
@@ -78,3 +78,7 @@
 .accordion .header-buttons button::-moz-focus-inner {
   border: none;
 }
+
+.accordion .arrow svg {
+  fill: var(--theme-comment);
+}

--- a/src/components/shared/Button/Close.css
+++ b/src/components/shared/Button/Close.css
@@ -16,7 +16,7 @@
 .close-btn .close {
   mask: url(/images/close.svg) no-repeat;
   mask-size: 100%;
-  background-color: var(--theme-comment-alt);
+  background-color: var(--theme-comment);
   width: 8px;
   height: 8px;
   transition: all 0.15s ease-in-out;

--- a/src/components/shared/SearchInput.css
+++ b/src/components/shared/SearchInput.css
@@ -57,7 +57,7 @@
 
 .search-field .magnifying-glass path,
 .search-field .magnifying-glass ellipse {
-  stroke: var(--theme-splitter-color);
+  stroke: var(--theme-comment);
 }
 
 .search-field input::placeholder {

--- a/src/components/shared/Svg.css
+++ b/src/components/shared/Svg.css
@@ -79,7 +79,7 @@ img.arrow {
   width: 9px;
   height: 9px;
   padding-top: 9px;
-  background: var(--theme-splitter-color);
+  background: var(--theme-comment);
   mask-size: 100%;
   display: inline-block;
   margin-bottom: 1px;

--- a/src/components/shared/Svg.css
+++ b/src/components/shared/Svg.css
@@ -79,7 +79,7 @@ img.arrow {
   width: 9px;
   height: 9px;
   padding-top: 9px;
-  background: var(--theme-comment);
+  background: var(--disclosure-arrow);
   mask-size: 100%;
   display: inline-block;
   margin-bottom: 1px;


### PR DESCRIPTION
@violasong 
@jasonLaster 
Associated Issue: #4544

### Summary of Changes

* slightly darken "add watch expression" placeholder - matches search input now.
* slightly lighten welcomebox shortcut message - `var(--theme-comment)`;
* darken, override styling from https://github.com/devtools-html/devtools-core/blob/master/packages/devtools-components/src/tree.css#L73-L79 to have the svg arrows on the right side be `var(--theme-comment)` color.
* darken the svg arrows on the left side to be the same color.
* darken the x button in the search input
* darken the magnifying glass and ellipse in the search input

### Screenshots
![screen shot 2018-02-05 at 11 09 00 am](https://user-images.githubusercontent.com/10803178/35814836-13f18954-0a65-11e8-8e59-f100e6891038.png)
![screen shot 2018-02-05 at 11 08 33 am](https://user-images.githubusercontent.com/10803178/35814839-16554348-0a65-11e8-8135-41923b319def.png)


![screen shot 2018-02-05 at 11 07 44 am](https://user-images.githubusercontent.com/10803178/35814754-d60fa68e-0a64-11e8-9b12-8a98fd2a6b4a.png)

![screen shot 2018-02-05 at 10 30 26 am](https://user-images.githubusercontent.com/10803178/35814693-ac158af6-0a64-11e8-972f-a729afde7205.png)

#### notes:
* I'm not sure about the modifiers - right now they are all set to `var(--theme-body-color);` perhaps they should also be `var(--theme-comment);`

