### PR TITLE
5084 - [CallStack] clicking the selected frame does not jump

### DIFF
--- a/src/components/SecondaryPanes/Frames/Frame.js
+++ b/src/components/SecondaryPanes/Frames/Frame.js
@@ -87,7 +87,7 @@ export default class FrameComponent extends Component<FrameComponentProps> {
     frame: Frame,
     selectedFrame: Frame
   ) {
-    if (e.nativeEvent.which == 3 || selectedFrame.id === frame.id) {
+    if (e.nativeEvent.which == 3) {
       return;
     }
     this.props.selectFrame(frame);
@@ -98,7 +98,7 @@ export default class FrameComponent extends Component<FrameComponentProps> {
     frame: Frame,
     selectedFrame: Frame
   ) {
-    if (event.key != "Enter" || selectedFrame.id == frame.id) {
+    if (event.key != "Enter") {
       return;
     }
     this.props.selectFrame(frame);


### PR DESCRIPTION
Associated Issue: #5084 

### Summary of Changes
Do `selectFrame` still on `onMouseDown`/`onKeyUp` even the frame given is selected already. To re-select the frame will trigger `selectLocation` again [1] so it will jump back to the paused line if scroll the line out of the view. If the line was within the view, then it just select the selected frame more one time.

[1] [https://github.com/devtools-html/debugger.html/blob/7985f7e5e17de7ae026b609b7e740696663c8a2b/src/actions/pause/selectFrame.js#L25](https://github.com/devtools-html/debugger.html/blob/7985f7e5e17de7ae026b609b7e740696663c8a2b/src/actions/pause/selectFrame.js#L25)

### Screenshots/Videos
![5084](https://user-images.githubusercontent.com/5627487/35818983-66da1718-0adc-11e8-8a52-32bdd6171af1.gif)
