### PR TITLE
Determine the column of the current line being stepped on by the lead…

### DIFF
--- a/src/components/Editor/DebugLine.js
+++ b/src/components/Editor/DebugLine.js
@@ -61,9 +61,15 @@ export class DebugLine extends Component<Props> {
     const sourceId = selectedFrame.location.sourceId;
     const doc = getDocument(sourceId);
 
-    const { line, column } = toEditorPosition(selectedFrame.location);
+    let { line, column } = toEditorPosition(selectedFrame.location);
     const { markTextClass, lineClass } = this.getTextClasses(why);
     doc.addLineClass(line, "line", lineClass);
+
+    const lineText = doc.getLine(line);
+    const spaces = lineText.match(/^\s+/);
+    if (spaces) {
+      column = Math.max(column, spaces[0].length);
+    }
 
     this.debugExpression = doc.markText(
       { ch: column, line },

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -418,7 +418,13 @@ class Editor extends PureComponent<Props, State> {
     const { editor } = this.state;
 
     if (this.shouldScrollToLocation(nextProps)) {
-      const { line, column } = toEditorPosition(nextProps.selectedLocation);
+      let { line, column } = toEditorPosition(nextProps.selectedLocation);
+
+      const lineText = editor.editor.getLine(line);
+      const spaces = lineText.match(/^\s+/);
+      if (spaces) {
+        column = Math.max(column, spaces[0].length);
+      }
       scrollToColumn(editor.codeMirror, line, column);
     }
   }

--- a/src/components/Editor/tests/DebugLine.spec.js
+++ b/src/components/Editor/tests/DebugLine.spec.js
@@ -12,7 +12,8 @@ function createMockDocument(clear) {
   const doc = {
     addLineClass: jest.fn(),
     removeLineClass: jest.fn(),
-    markText: jest.genMockFunction().mockReturnValue({ clear })
+    markText: jest.genMockFunction().mockReturnValue({ clear }),
+    getLine: line => ""
   };
 
   return doc;

--- a/src/components/Editor/tests/Editor.spec.js
+++ b/src/components/Editor/tests/Editor.spec.js
@@ -30,6 +30,9 @@ function createMockEditor() {
       defaultTextHeight: () => 0,
       display: { gutters: { querySelector: jest.fn() } }
     },
+    editor: {
+      getLine: line => ""
+    },
     setText: jest.fn(),
     on: jest.fn(),
     off: jest.fn(),


### PR DESCRIPTION
Determine the column of the current line being stepped on by the leading spaces, also used in debugLine to highlight the statement starting at the right column.

Associated Issue: #5184 

### Summary of Changes

- Parsed debug line code for leading whitespace to determine the column the line begins on.
- This change was implemented in the automatic scrolling of debugger and to fix the highlighting of the line being debugged.

### Screenshots
**Before**
Before the fix, it can be seen that as we step through the code being debugged, on certain statements the debugger does not center correctly, most notably when the code on the line being debugged is out of view. It is seen in these scenarios to realign the view with the leftmost edge of the editor.

Also before the fix, it can be seen that when stepping these statements the line was highlighted from the leftmost edge all the way to the right, where it is supposed to start highlighting the debugged line at the start of the code on the line.
![01beforeiffix](https://user-images.githubusercontent.com/14250545/35841545-d0585d4e-0ab9-11e8-9bce-8baa95ffa067.gif)

**After**
After the fix, it can be seen that the editor realigns itself and starts highlighting the lines with the leftmost character of the example if statements. 
![01afteriffix](https://user-images.githubusercontent.com/14250545/35841639-4435bf22-0aba-11e8-8301-3fa49141442e.gif)


