### PR TITLE
Fix #5326 - Make outline's code look like the editor

### DIFF
--- a/src/components/PrimaryPanes/Outline.css
+++ b/src/components/PrimaryPanes/Outline.css
@@ -4,6 +4,7 @@
 
 .outline {
   overflow-y: auto;
+  font-family: var(--monospace-font-family);
 }
 
 .outline .outline-pane-info {
@@ -28,11 +29,27 @@
   padding: 0;
 }
 
+.outline-list__class-list .function-signature .function-name {
+  color: var(--theme-highlight-green);
+}
+
+.outline-list .function-signature .paren {
+  color: inherit;
+}
+
 .outline-list h2 {
   font-weight: normal;
   font-size: 1em;
   margin: 10px 0 10px 10px;
-  color: var(--theme-body-color);
+  color: var(--blue-55);
+}
+
+.theme-dark .outline-list h2 {
+  color: var(--theme-highlight-blue);
+}
+
+.outline-list h2 .keyword {
+  color: var(--theme-highlight-red);
 }
 
 .outline-list__element {

--- a/src/components/PrimaryPanes/Outline.js
+++ b/src/components/PrimaryPanes/Outline.js
@@ -68,9 +68,17 @@ export class Outline extends Component<Props> {
     const classFunc = functions.find(func => func.name === klass);
     const classFunctions = functions.filter(func => func.klass === klass);
 
+    const heading = classFunc ? (
+      <h2>{this.renderFunction(classFunc)}</h2>
+    ) : (
+      <h2>
+        <span className="keyword">class</span> {klass}
+      </h2>
+    );
+
     return (
       <div className="outline-list__class" key={klass}>
-        <h2>{classFunc ? this.renderFunction(classFunc) : `class ${klass}`}</h2>
+        {heading}
         <ul className="outline-list__class-list">
           {classFunctions.map(func => this.renderFunction(func))}
         </ul>


### PR DESCRIPTION
Since we're representing code in the outline, it would be sweet to have the code highlighted like the editor:

<img width="767" alt="outline-dark" src="https://user-images.githubusercontent.com/46655/35874303-c97475ee-0b31-11e8-90e0-5e850afc711a.png">

<img width="735" alt="outline-light" src="https://user-images.githubusercontent.com/46655/35874310-cb444322-0b31-11e8-82d2-d41301ac4484.png">
