### PR TITLE
Introduces hasJavaScript()

### DIFF
--- a/src/utils/source.js
+++ b/src/utils/source.js
@@ -59,6 +59,20 @@ export function shouldPrettyPrint(source: SourceRecord) {
 }
 
 /**
+ * Returns true if the specified source text contains inline javascript
+ *
+ * @return boolean
+ *         True if the source text likely contains javascript.
+ *
+ * @memberof utils/source
+ * @static
+ */
+export function hasJavaScript(source: SourceRecord): boolean {
+  const sourceText = source.get("text");
+  return /(<script|href=["']javascript)/i.test(sourceText);
+}
+
+/**
  * Returns true if the specified url and/or content type are specific to
  * javascript files.
  *


### PR DESCRIPTION
Associated Issue: #5312 

Introduces a function that checks if the source text contains inline javascript for future use of pretty printing.

Currently there is no check in place if the source text actually exists, so if we implement one there seem to be two scenarios:
1) we make the function return `undefined` to indicate no source text was provided as opposed to the regular `false` return for there not being a match.
2) we make the function return `false` since technically there was no match.

Also, the solution assumes 