### PR TITLE
Bring back loading message to project text search

### DIFF
--- a/src/components/ProjectSearch.js
+++ b/src/components/ProjectSearch.js
@@ -247,6 +247,9 @@ export class ProjectSearch extends Component<Props, State> {
   renderResults = () => {
     const results = this.getResults();
     const { status } = this.props;
+    if (!this.props.query) {
+      return;
+    }
     if (results.length && status === statusType.done) {
       return (
         <ManagedTree
@@ -261,20 +264,11 @@ export class ProjectSearch extends Component<Props, State> {
         />
       );
     }
-    if (status === statusType.fetching) {
-      return (
-        <div className="no-result-msg absolute-center">
-          {L10N.getStr("loadingText")}
-        </div>
-      );
-    }
-    if (this.props.query && !results.length) {
-      return (
-        <div className="no-result-msg absolute-center">
-          {L10N.getStr("projectTextSearch.noResults")}
-        </div>
-      );
-    }
+    const msg =
+      status === statusType.fetching
+        ? L10N.getStr("loadingText")
+        : L10N.getStr("projectTextSearch.noResults");
+    return <div className="no-result-msg absolute-center">{msg}</div>;
   };
 
   renderSummary = () => {

--- a/src/components/ProjectSearch.js
+++ b/src/components/ProjectSearch.js
@@ -261,10 +261,14 @@ export class ProjectSearch extends Component<Props, State> {
         />
       );
     }
-    if (
-      status === statusType.fetching ||
-      (this.props.query && !results.length)
-    ) {
+    if (status === statusType.fetching) {
+      return (
+        <div className="no-result-msg absolute-center">
+          {L10N.getStr("loadingText")}
+        </div>
+      );
+    }
+    if (this.props.query && !results.length) {
       return (
         <div className="no-result-msg absolute-center">
           {L10N.getStr("projectTextSearch.noResults")}

--- a/src/components/tests/ProjectSearch.spec.js
+++ b/src/components/tests/ProjectSearch.spec.js
@@ -2,6 +2,7 @@ import React from "react";
 import { mount, shallow } from "enzyme";
 import { List } from "immutable";
 import { ProjectSearch } from "../ProjectSearch";
+import { statusType } from "../../reducers/project-text-search";
 
 const hooks = { on: [], off: [] };
 const shortcuts = {

--- a/src/components/tests/ProjectSearch.spec.js
+++ b/src/components/tests/ProjectSearch.spec.js
@@ -85,6 +85,14 @@ describe("ProjectSearch", () => {
     expect(component).toMatchSnapshot();
   });
 
+  it("should display loading message while search is in progress", () => {
+    const component = render({
+      query: "match",
+      status: statusType.fetching
+    });
+    expect(component).toMatchSnapshot();
+  });
+
   it("found search results", () => {
     const component = render(
       {
@@ -205,7 +213,7 @@ describe("ProjectSearch", () => {
   describe("showErrorEmoji", () => {
     it("false if not done & results", () => {
       const component = render({
-        status: "searching",
+        status: statusType.fetching,
         results: testResults
       });
       expect(component).toMatchSnapshot();
@@ -213,7 +221,7 @@ describe("ProjectSearch", () => {
 
     it("false if not done & no results", () => {
       const component = render({
-        status: "searching"
+        status: statusType.fetching
       });
       expect(component).toMatchSnapshot();
     });

--- a/src/components/tests/__snapshots__/ProjectSearch.spec.js.snap
+++ b/src/components/tests/__snapshots__/ProjectSearch.spec.js.snap
@@ -702,6 +702,41 @@ exports[`ProjectSearch found search results 1`] = `
 
 exports[`ProjectSearch renders nothing when disabled 1`] = `""`;
 
+exports[`ProjectSearch should display loading message while search is in progress 1`] = `
+<div
+  className="search-container"
+>
+  <div
+    className="project-text-search"
+  >
+    <div
+      className="header"
+    >
+      <SearchInput
+        count={0}
+        expanded={false}
+        handleClose={[Function]}
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        placeholder="Find in files…"
+        query="match"
+        selectedItemId=""
+        showErrorEmoji={false}
+        size="big"
+        summaryMsg="0 results"
+      />
+    </div>
+    <div
+      className="no-result-msg absolute-center"
+    >
+      Loading…
+    </div>
+  </div>
+</div>
+`;
+
 exports[`ProjectSearch showErrorEmoji false if not done & no results 1`] = `
 <div
   className="search-container"
@@ -731,7 +766,7 @@ exports[`ProjectSearch showErrorEmoji false if not done & no results 1`] = `
     <div
       className="no-result-msg absolute-center"
     >
-      No results found
+      Loading…
     </div>
   </div>
 </div>
@@ -762,6 +797,11 @@ exports[`ProjectSearch showErrorEmoji false if not done & results 1`] = `
         size="big"
         summaryMsg="5 results"
       />
+    </div>
+    <div
+      className="no-result-msg absolute-center"
+    >
+      Loading…
     </div>
   </div>
 </div>


### PR DESCRIPTION
Associated Issue: #5278

### Summary of Changes

* Show loading message while results are fetched
* Add test for loading

### Test Plan

- Open some large website 
- Do text search
- See if `Loading` is displayed while search is going on
Follow the gif please 

### Screenshots/Videos (OPTIONAL)]
![Gif](https://user-images.githubusercontent.com/11382805/35916061-724ba0d2-0c4c-11e8-9892-25d8fb878dea.gif)

