### PR TITLE
Fix #5288 - Save directory root preference upon refresh; remove throttling

### DIFF
--- a/src/components/PrimaryPanes/SourcesTree.js
+++ b/src/components/PrimaryPanes/SourcesTree.js
@@ -43,7 +43,6 @@ import {
 } from "../../utils/sources-tree";
 
 import { copyToTheClipboard } from "../../utils/clipboard";
-import { throttle } from "../../utils/utils";
 import { features } from "../../utils/prefs";
 
 import type { SourcesMap, SourceRecord } from "../../reducers/types";
@@ -83,25 +82,13 @@ class SourcesTree extends Component<Props, State> {
 
   constructor(props) {
     super(props);
-    const { projectRoot, debuggeeUrl, sources } = this.props;
+    const { debuggeeUrl, sources, projectRoot } = this.props;
+
     this.state = createTree({
       projectRoot,
       debuggeeUrl,
       sources
     });
-  }
-
-  componentDidMount() {
-    this.mounted = true;
-  }
-
-  componentWillUnMount() {
-    this.mounted = false;
-  }
-
-  shouldComponentUpdate() {
-    this.queueUpdate();
-    return false;
   }
 
   componentWillReceiveProps(nextProps) {
@@ -167,14 +154,6 @@ class SourcesTree extends Component<Props, State> {
       );
     }
   }
-
-  queueUpdate = throttle(function() {
-    if (!this.mounted) {
-      return;
-    }
-
-    this.forceUpdate();
-  }, 50);
 
   focusItem = item => {
     this.setState({ focusedItem: item });

--- a/src/components/PrimaryPanes/index.js
+++ b/src/components/PrimaryPanes/index.js
@@ -114,6 +114,7 @@ class PrimaryPanes extends Component<Props> {
 
     return (
       <div className="sources-panel">
+        {this.renderTabs()}
         {selectedTab === "sources" ? <SourcesTree /> : <Outline />}
       </div>
     );

--- a/src/components/PrimaryPanes/index.js
+++ b/src/components/PrimaryPanes/index.js
@@ -109,30 +109,12 @@ class PrimaryPanes extends Component<Props> {
     }
   }
 
-  renderOutline() {
-    const { selectLocation } = this.props;
-
-    const outlineComp = features.outline ? (
-      <Outline selectLocation={selectLocation} />
-    ) : null;
-
-    return outlineComp;
-  }
-
-  renderSources() {
-    const { sources, selectLocation } = this.props;
-    return <SourcesTree sources={sources} selectLocation={selectLocation} />;
-  }
-
   render() {
     const { selectedTab } = this.props;
 
     return (
       <div className="sources-panel">
-        {this.renderTabs()}
-        {selectedTab === "sources"
-          ? this.renderSources()
-          : this.renderOutline()}
+        {selectedTab === "sources" ? <SourcesTree /> : <Outline />}
       </div>
     );
   }

--- a/src/reducers/ui.js
+++ b/src/reducers/ui.js
@@ -45,7 +45,7 @@ export const createUIState = makeRecord(
     activeSearch: null,
     contextMenu: {},
     shownSource: "",
-    projectDirectoryRoot: "",
+    projectDirectoryRoot: prefs.projectDirectoryRoot,
     startPanelCollapsed: prefs.startPanelCollapsed,
     endPanelCollapsed: prefs.endPanelCollapsed,
     frameworkGroupingOn: prefs.frameworkGroupingOn,

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -45,29 +45,8 @@ function endTruncateStr(str: any, size: number) {
   return str;
 }
 
-/**
- * @memberof utils/utils
- * @static
- */
-/**
- * @memberof utils/utils
- * @static
- */
-function throttle(func: any, ms: number) {
-  let timeout, _this;
-  return function(...args: any) {
-    _this = this;
-    if (!timeout) {
-      timeout = setTimeout(() => {
-        func.apply(_this, ...args);
-        timeout = null;
-      }, ms);
-    }
-  };
-}
-
 function waitForMs(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
-export { handleError, promisify, endTruncateStr, throttle, waitForMs };
+export { handleError, promisify, endTruncateStr, waitForMs };


### PR DESCRIPTION
Associated Issue: #5288 

### Summary of Changes

* Remove unnecessary throttling of source tree
* Sets default `projectDirectoryRoot` to preference value.
* You can now set a directory root, refresh, and see the source tree default to that root

### Test Plan

1.  Set a root directory
2.  Refresh the page
3.  Ensure that root directory is still the root of the source tree
4.  Unset root directory
5.  All resources should display

Example test plan:

- [x] Command-P opens the panel
- [x] Clicking “+” opens the panel
- [x] Clicking a source navigates to the source
- [x] Clicking "x" closes the panel

Here's the Debugger's Testing doc
https://docs.google.com/document/d/1oBMRxV8A2ag2t22YsQOxTdEv0mXKzIg0tggJjRkU1S0/edit#.
Feel free to improve it!

### Screenshots/Videos (OPTIONAL)
