### PR TITLE
The (index) is not a directory

### DIFF
--- a/src/utils/sources-tree/utils.js
+++ b/src/utils/sources-tree/utils.js
@@ -30,7 +30,10 @@ export function isDirectory(url: Object) {
   // Assume that all urls point to files except when they end with '/'
   // Or directory node has children
   return (
-    parts.length === 0 || url.path.slice(-1) === "/" || nodeHasChildren(url)
+    (parts.length === 0 ||
+      url.path.slice(-1) === "/" ||
+      nodeHasChildren(url)) &&
+    url.name != "(index)"
   );
 }
 


### PR DESCRIPTION
At present we can right-click the `(index)` item in the source tree and set as root directory -- that isn't ideal.  It was happening because `isDirectory` was returning `true` for `(index)`, so we should change that.