### PR TITLE
remove unused parts of the welcome box and restyle with flexbox

### DIFF
--- a/src/components/WelcomeBox.css
+++ b/src/components/WelcomeBox.css
@@ -23,14 +23,6 @@
   background-color: var(--theme-body-background);
 }
 
-.alignlabel {
-  display: inline-block;
-}
-
-.welcomebox .normal-layout {
-  display: none;
-}
-
 .welcomebox .command-bar-button {
   position: absolute;
   top: auto;
@@ -39,43 +31,42 @@
   bottom: 0;
 }
 
+.alignlabel {
+  display: flex;
+  white-space: nowrap;
+}
+
 .shortcutKeys {
-  text-align: right;
-  float: left;
   font-family: Courier;
+}
+
+.shortcutKey,
+.shortcutLabel {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .shortcutKey {
-  display: inline-block;
-  margin-right: 10px;
+  text-align: right;
+  padding-right: 10px;
   font-family: Courier;
 }
 
-.shortcutFunction {
+.shortcutLabel {
   text-align: left;
-  float: left;
-  margin-left: 25px;
+  padding-left: 10px;
+}
+
+.shortcutFunction {
+  flex: 1;
   color: var(--theme-comment);
+}
+
+.shortcutFunction p {
+  display: flex;
 }
 
 html .welcomebox .toggle-button-end.collapsed {
   bottom: 1px;
-}
-
-@media (max-width: 430px) {
-  .welcomebox .small-size-layout {
-    display: inline-block;
-  }
-
-  .welcomebox .normal-layout {
-    display: none;
-  }
-
-  .shortcutFunction {
-    margin-left: 0;
-  }
-
-  .shortcutKey {
-    display: block;
-  }
 }

--- a/src/components/WelcomeBox.js
+++ b/src/components/WelcomeBox.js
@@ -57,32 +57,18 @@ class WelcomeBox extends Component<Props> {
 
     return (
       <div className="welcomebox">
-        <div className="alignlabel small-size-layout">
+        <div className="alignlabel">
           <div className="shortcutFunction">
             <p onClick={() => openQuickOpen()}>
               <span className="shortcutKey">{searchSourcesShortcut}</span>
-              {searchSourcesLabel}
+              <span className="shortcutLabel">{searchSourcesLabel}</span>
             </p>
             <p onClick={setActiveSearch.bind(null, "project")}>
               <span className="shortcutKey">{searchProjectShortcut}</span>
-              {searchProjectLabel}
+              <span className="shortcutLabel">{searchProjectLabel}</span>
             </p>
           </div>
           {this.renderToggleButton()}
-        </div>
-        <div className="alignlabel normal-layout">
-          <div className="shortcutKeys">
-            <p onClick={() => openQuickOpen()}>{searchSourcesShortcut}</p>
-            <p onClick={setActiveSearch.bind(null, "project")}>
-              {searchProjectShortcut}
-            </p>
-          </div>
-          <div className="shortcutFunction">
-            <p onClick={() => openQuickOpen()}>{searchSourcesLabel}</p>
-            <p onClick={setActiveSearch.bind(null, "project")}>
-              {searchProjectLabel}
-            </p>
-          </div>
         </div>
       </div>
     );


### PR DESCRIPTION
Associated Issue: #5201

### Summary of Changes

* remove the entire `.normal-layout` div, use the `.small-size-layout` type for all cases
* restyle using flexbox to fit any size layout.

### Test Plan
* can someone please test this on windows, I find it difficult since I'm running a VM for it. Let me know if the two fonts are misaligned.

### Screenshots/Videos (OPTIONAL)
<img width="825" alt="screen shot 2018-02-07 at 4 56 15 pm" src="https://user-images.githubusercontent.com/10803178/35943736-0bf9722e-0c28-11e8-9b01-46e3387c7dcc.png">
<img width="287" alt="screen shot 2018-02-07 at 4 57 07 pm" src="https://user-images.githubusercontent.com/10803178/35943741-0f3ef670-0c28-11e8-9817-d8be2d2068c9.png">
<img width="235" alt="screen shot 2018-02-07 at 4 57 22 pm" src="https://user-images.githubusercontent.com/10803178/35943743-109f1d92-0c28-11e8-9196-7f27dde0c338.png">
