### PR TITLE
[WIP] Fix 5341 - Add 'copy text' menu item to source tree context menu

### DIFF
--- a/assets/panel/debugger.properties
+++ b/assets/panel/debugger.properties
@@ -24,6 +24,11 @@ copySource.accesskey=y
 copySourceUri2=Copy source URI
 copySourceUri2.accesskey=u
 
+# LOCALIZATION NOTE (copySourceText): This is the text that appears in the
+# context menu to copy the source text of file open.
+copySourceText=Copy source code
+copySourceText.accesskey=s
+
 # LOCALIZATION NOTE (setDirectoryRoot.label): This is the text that appears in the
 # context menu to set a directory as root directory
 setDirectoryRoot.label=Set directory root

--- a/src/components/PrimaryPanes/SourcesTree.js
+++ b/src/components/PrimaryPanes/SourcesTree.js
@@ -248,6 +248,8 @@ class SourcesTree extends Component<Props, State> {
   onContextMenu = (event, item) => {
     const copySourceUri2Label = L10N.getStr("copySourceUri2");
     const copySourceUri2Key = L10N.getStr("copySourceUri2.accesskey");
+    const copySourceTextLabel = L10N.getStr("copySourceText");
+    const copySourceTextKey = L10N.getStr("copySourceText.accesskey");
     const setDirectoryRootLabel = L10N.getStr("setDirectoryRoot.label");
     const setDirectoryRootKey = L10N.getStr("setDirectoryRoot.accesskey");
     const removeDirectoryRootLabel = L10N.getStr("removeDirectoryRoot.label");
@@ -267,7 +269,15 @@ class SourcesTree extends Component<Props, State> {
         click: () => copyToTheClipboard(source)
       };
 
-      menuOptions.push(copySourceUri2);
+      const copyText = {
+        id: "node-menu-copy-text",
+        label: copySourceTextLabel,
+        accesskey: copySourceTextKey,
+        disabled: false,
+        click: () => copyToTheClipboard(item.contents.get("text"))
+      };
+
+      menuOptions.push(copySourceUri2, copyText);
     }
 
     if (isDirectory(item) && features.root) {


### PR DESCRIPTION
This is more of a conversation starter.  

## ToDo
- [ ] Do we want this functionality?
- [ ] If so, do we also want this as a tab context menu item? (probably)
- [ ] What would be a good access key?
- [ ] Add a test
- [ ] Figure out the case where "undefined" is returned