### PR TITLE
Apply monospace font only to lists, not to 'No functions' text

### DIFF
--- a/src/components/PrimaryPanes/Outline.css
+++ b/src/components/PrimaryPanes/Outline.css
@@ -4,7 +4,6 @@
 
 .outline {
   overflow-y: auto;
-  font-family: var(--monospace-font-family);
 }
 
 .outline .outline-pane-info {
@@ -21,6 +20,7 @@
   flex: 1 0 100%;
   padding: 10px 0px;
   margin: 0;
+  font-family: var(--monospace-font-family);
 }
 
 .outline-list__class-list {


### PR DESCRIPTION
This is just a nit.  The "No functions" text should display with the basic text font, not monospace.  Moving the font declaration to the list fixes this issue.