### PR TITLE
Fix #5353 - Don't show 'close tabs to the right' context menu item when there's only one source open

### DIFF
--- a/src/components/Editor/Tab.js
+++ b/src/components/Editor/Tab.js
@@ -94,6 +94,7 @@ class Tab extends PureComponent<Props> {
           }
         },
         hidden: () =>
+          tabSources.size === 1 ||
           tabSources.some((t, i) => t === tab && tabSources.size - 1 === i)
       },
       {


### PR DESCRIPTION
Tiny nit