### PR TITLE
Issue 5324

### DIFF
--- a/src/components/ProjectSearch.css
+++ b/src/components/ProjectSearch.css
@@ -66,7 +66,6 @@
   color: var(--theme-body-color-inactive);
   font-size: 24px;
   padding: 4px;
-  word-break: break-all;
 }
 
 .project-text-search .file-result {

--- a/src/components/ProjectSearch.css
+++ b/src/components/ProjectSearch.css
@@ -65,7 +65,10 @@
 .project-text-search .no-result-msg {
   color: var(--theme-body-color-inactive);
   font-size: 24px;
-  padding: 4px;
+  padding: 4px 15px;
+  max-width: 100%;
+  overflow-wrap: break-word;
+  hyphens: auto;
 }
 
 .project-text-search .file-result {

--- a/src/components/SecondaryPanes/Frames/Frame.js
+++ b/src/components/SecondaryPanes/Frames/Frame.js
@@ -87,7 +87,7 @@ export default class FrameComponent extends Component<FrameComponentProps> {
     frame: Frame,
     selectedFrame: Frame
   ) {
-    if (e.nativeEvent.which == 3 || selectedFrame.id === frame.id) {
+    if (e.nativeEvent.which == 3) {
       return;
     }
     this.props.selectFrame(frame);
@@ -98,7 +98,7 @@ export default class FrameComponent extends Component<FrameComponentProps> {
     frame: Frame,
     selectedFrame: Frame
   ) {
-    if (event.key != "Enter" || selectedFrame.id == frame.id) {
+    if (event.key != "Enter") {
       return;
     }
     this.props.selectFrame(frame);


### PR DESCRIPTION
Associated Issue: #5324

### Summary of Changes

* removed the word-break property from `no-result-msg` css class in `ProjectSearch.css` file
* added `overflow-wrap` to break word if it exceed the parent (`max-width: 100%`)
* `hyphens: auto` to insert hyphens when word break on letters

### Screenshots/Videos (OPTIONAL)

#### before 
![before](https://user-images.githubusercontent.com/17466642/35984796-2cc94562-0d1b-11e8-967f-0a02ed1954a3.gif)

#### after
![after](https://user-images.githubusercontent.com/17466642/35984838-4326bd12-0d1b-11e8-8396-b6a7fec5518f.gif)



