### PR TITLE
Remove special selector to see if tests pass on CI

### DIFF
--- a/src/test/mochitest/browser_dbg-sources.js
+++ b/src/test/mochitest/browser_dbg-sources.js
@@ -33,7 +33,7 @@ add_task(async function() {
   await clickElement(dbg, "sourceArrow", 2);
 
   await assertSourceCount(dbg, 7);
-  await clickElement(dbg, "sourceDirectory", 3);
+  await clickElement(dbg, "sourceArrow", 3);
   await assertSourceCount(dbg, 8);
 
   // Select a source

--- a/src/test/mochitest/head.js
+++ b/src/test/mochitest/head.js
@@ -940,7 +940,6 @@ const selectors = {
   sourceNode: i => `.sources-list .tree-node:nth-child(${i}) .node`,
   sourceNodes: ".sources-list .tree-node",
   sourceArrow: i => `.sources-list .tree-node:nth-child(${i}) .arrow`,
-  sourceDirectory: i => `.sources-list .tree-node:nth-child(${i})`,
   resultItems: ".result-list .result-item",
   fileMatch: ".managed-tree .result",
   popup: ".popover",


### PR DESCRIPTION
Stepping backward, short of a full revert, to see the easiest way to fix this test issue.