### PR TITLE
Fix #5358 - SourcesTree directory focus/highlight

### DIFF
--- a/src/components/PrimaryPanes/SourcesTree.js
+++ b/src/components/PrimaryPanes/SourcesTree.js
@@ -280,10 +280,6 @@ class SourcesTree extends Component<Props, State> {
         className={classnames("arrow", {
           expanded: expanded
         })}
-        onClick={e => {
-          e.stopPropagation();
-          setExpanded(item, !expanded, e.altKey);
-        }}
       />
     ) : (
       <i className="no-arrow" />
@@ -296,11 +292,10 @@ class SourcesTree extends Component<Props, State> {
         className={classnames("node", { focused })}
         key={item.path}
         onClick={e => {
-          e.stopPropagation();
           this.focusItem(item);
 
           if (isDirectory(item)) {
-            setExpanded(item, !expanded, e.altKey);
+            setExpanded(item, !!expanded, e.altKey);
           } else {
             this.selectItem(item);
           }

--- a/src/test/mochitest/browser_dbg-asm.js
+++ b/src/test/mochitest/browser_dbg-asm.js
@@ -12,7 +12,7 @@ add_task(async function() {
   // Expand nodes and make sure more sources appear.
   is(findAllElements(dbg, "sourceNodes").length, 2);
 
-  await clickElement(dbg, "sourceArrow", 2);
+  await clickElement(dbg, "sourceDirectoryLabel", 2);
   is(findAllElements(dbg, "sourceNodes").length, 4);
 
   await selectSource(dbg, "asm.js");

--- a/src/test/mochitest/browser_dbg-sources.js
+++ b/src/test/mochitest/browser_dbg-sources.js
@@ -44,23 +44,18 @@ add_task(async function() {
   // Ensure the source file clicked is now focused
   await waitForElementWithSelector(dbg, ".sources-list .focused")
 
+  const focusedNode = findElementWithSelector(dbg, ".sources-list .focused").textContent.trim()
+  const fourthNode = findElement(dbg, "sourceNode", 4).textContent.trim();
+  const selectedSource = getSelectedSource(getState()).get("url");
+
   console.log(
-      findElementWithSelector(dbg, ".sources-list .focused").textContent.trim(),
-      findElement(dbg, "sourceNode", 4).textContent.trim()
+    focusedNode,
+    fourthNode,
+    focusedNode == fourthNode ? "equal" : "wtf "
   );
 
-  is(
-    findElementWithSelector(dbg, ".sources-list .focused").textContent.trim(),
-    "nested-source.js",
-    "Clicked source is focused"
-  );
-
-  ok(
-    getSelectedSource(getState())
-      .get("url")
-      .includes("nested-source.js"),
-    "The right source is selected"
-  );
+  ok(fourthNode.classList.contains("focused"), '4th node is focused');
+  ok(selectedSource.includes("nested-source.js"), "The right source is selected");
 
   // Make sure new sources appear in the list.
   ContentTask.spawn(gBrowser.selectedBrowser, null, function() {

--- a/src/test/mochitest/browser_dbg-sources.js
+++ b/src/test/mochitest/browser_dbg-sources.js
@@ -30,27 +30,25 @@ add_task(async function() {
 
   // Expand nodes and make sure more sources appear.
   await assertSourceCount(dbg, 2);
-  await clickElement(dbg, "sourceArrow", 2);
+  await clickElement(dbg, "sourceDirectoryLabel", 2);
 
   await assertSourceCount(dbg, 7);
-  await clickElement(dbg, "sourceArrow", 3);
+  await clickElement(dbg, "sourceDirectoryLabel", 3);
   await assertSourceCount(dbg, 8);
-
-  // Select a source
-  ok(
-    !findElementWithSelector(dbg, ".sources-list .focused"),
-    "Source is not focused"
-  );
 
   const selected = waitForDispatch(dbg, "SELECT_SOURCE");
   await clickElement(dbg, "sourceNode", 4);
   await selected;
   await waitForSelectedSource(dbg);
 
-  ok(
-    findElementWithSelector(dbg, ".sources-list .focused"),
-    "Source is focused"
+  // Ensure the source file clicked is now focused
+  await waitForElementWithSelector(dbg, ".sources-list .focused")
+  is(
+    findElementWithSelector(dbg, ".sources-list .focused").textContent.trim(),
+    findElement(dbg, "sourceNode", 4).textContent.trim(),
+    "Clicked source is focused"
   );
+
   ok(
     getSelectedSource(getState())
       .get("url")

--- a/src/test/mochitest/browser_dbg-sources.js
+++ b/src/test/mochitest/browser_dbg-sources.js
@@ -44,17 +44,17 @@ add_task(async function() {
   // Ensure the source file clicked is now focused
   await waitForElementWithSelector(dbg, ".sources-list .focused")
 
-  const focusedNode = findElementWithSelector(dbg, ".sources-list .focused").textContent.trim()
-  const fourthNode = findElement(dbg, "sourceNode", 4).textContent.trim();
+  const focusedNode = findElementWithSelector(dbg, ".sources-list .focused")
+  const fourthNode = findElement(dbg, "sourceNode", 4);
   const selectedSource = getSelectedSource(getState()).get("url");
 
   console.log(
-    focusedNode,
-    fourthNode,
-    focusedNode == fourthNode ? "equal" : "wtf "
+    focusedNode.textContent.trim(),
+    fourthNode.textContent.trim(),
+    focusedNode.textContent.trim() == fourthNode.textContent.trim() ? "equal" : "wtf"
   );
 
-  ok(fourthNode.classList.contains("focused"), '4th node is focused');
+  ok(fourthNode.classList.contains("focused"), "4th node is focused");
   ok(selectedSource.includes("nested-source.js"), "The right source is selected");
 
   // Make sure new sources appear in the list.

--- a/src/test/mochitest/browser_dbg-sources.js
+++ b/src/test/mochitest/browser_dbg-sources.js
@@ -48,12 +48,6 @@ add_task(async function() {
   const fourthNode = findElement(dbg, "sourceNode", 4);
   const selectedSource = getSelectedSource(getState()).get("url");
 
-  console.log(
-    focusedNode.textContent.trim(),
-    fourthNode.textContent.trim(),
-    focusedNode.textContent.trim() == fourthNode.textContent.trim() ? "equal" : "wtf"
-  );
-
   ok(fourthNode.classList.contains("focused"), "4th node is focused");
   ok(selectedSource.includes("nested-source.js"), "The right source is selected");
 

--- a/src/test/mochitest/browser_dbg-sources.js
+++ b/src/test/mochitest/browser_dbg-sources.js
@@ -49,6 +49,11 @@ add_task(async function() {
     "Clicked source is focused"
   );
 
+  console.log(
+      findElementWithSelector(dbg, ".sources-list .focused").textContent.trim(),
+      findElement(dbg, "sourceNode", 4).textContent.trim()
+  );
+
   ok(
     getSelectedSource(getState())
       .get("url")

--- a/src/test/mochitest/browser_dbg-sources.js
+++ b/src/test/mochitest/browser_dbg-sources.js
@@ -43,15 +43,16 @@ add_task(async function() {
 
   // Ensure the source file clicked is now focused
   await waitForElementWithSelector(dbg, ".sources-list .focused")
-  is(
-    findElementWithSelector(dbg, ".sources-list .focused").textContent.trim(),
-    findElement(dbg, "sourceNode", 4).textContent.trim(),
-    "Clicked source is focused"
-  );
 
   console.log(
       findElementWithSelector(dbg, ".sources-list .focused").textContent.trim(),
       findElement(dbg, "sourceNode", 4).textContent.trim()
+  );
+
+  is(
+    findElementWithSelector(dbg, ".sources-list .focused").textContent.trim(),
+    "nested-source.js",
+    "Clicked source is focused"
   );
 
   ok(

--- a/src/test/mochitest/head.js
+++ b/src/test/mochitest/head.js
@@ -943,7 +943,7 @@ const selectors = {
   editorFooter: ".editor-pane .source-footer",
   sourceNode: i => `.sources-list .tree-node:nth-child(${i}) .node`,
   sourceNodes: ".sources-list .tree-node",
-  sourceArrow: i => `.sources-list .tree-node:nth-child(${i}) .arrow`,
+  sourceDirectoryLabel: i => `.sources-list .tree-node:nth-child(${i}) .label`,
   resultItems: ".result-list .result-item",
   fileMatch: ".managed-tree .result",
   popup: ".popover",


### PR DESCRIPTION
Associated Issue: #5358 

### Thoughts

* Since clicking the entire directory node is meant to toggle its expanded state, the arrow `onClick` should be irrelevant
* The functionality was broken in (https://github.com/devtools-html/debugger.html/commit/d7d1bae3374f45deca7203753e9646a8d53ac8b0), not with the reps upgrade.

### ToDo

- [ ]  Update `dbg-sources` test again for a broader click (not `.arrow`).  This should be fun since we finally fixed that test.
- [ ]  Figure out why `!!expanded` is working properly when it's been `!expanded` this whole time
- [ ]  Figure out why pressing the left key on sources loses focus

### In Action

![directorymovement](https://user-images.githubusercontent.com/46655/36005674-616563ea-0cfe-11e8-84aa-c2c4c5ae4597.gif)

### Testing
- Click the different directories, ensure they open and close properly.
- Navigate directories and sources with keyboard
