### PR TITLE
[QuickOpen] Remove timer from test

### DIFF
--- a/src/test/mochitest/browser_dbg-quick-open.js
+++ b/src/test/mochitest/browser_dbg-quick-open.js
@@ -82,7 +82,6 @@ add_task(async function() {
   is(resultCount(dbg), 2, "two function results");
 
   type(dbg, "@x");
-  await waitForTime(1000);
   is(resultCount(dbg), 0, "no functions with 'x' in name");
 
   pressKey(dbg, "Escape");


### PR DESCRIPTION
I accidentally left a spurious timer in the test