### PR TITLE
Change 'Expand/Collapse' Rows element to <button>

### DIFF
--- a/src/components/SecondaryPanes/Frames/Frames.css
+++ b/src/components/SecondaryPanes/Frames/Frames.css
@@ -79,12 +79,18 @@
   color: white;
 }
 
+.show-more-container {
+  display: flex;
+}
+
 .show-more {
   text-align: center;
   padding: 8px 0px;
   margin: 7px 10px 7px 7px;
   border: 1px solid var(--theme-splitter-color);
   background-color: var(--theme-tab-toolbar-background);
+  width: 100%;
+  font-size: inherit;
 }
 
 .show-more:hover {

--- a/src/components/SecondaryPanes/Frames/index.js
+++ b/src/components/SecondaryPanes/Frames/index.js
@@ -166,8 +166,10 @@ class Frames extends Component<Props, State> {
     }
 
     return (
-      <div className="show-more" onClick={this.toggleFramesDisplay}>
-        {buttonMessage}
+      <div className="show-more-container">
+        <button className="show-more" onClick={this.toggleFramesDisplay}>
+          {buttonMessage}
+        </button>
       </div>
     );
   }

--- a/src/components/SecondaryPanes/Frames/tests/__snapshots__/Frames.spec.js.snap
+++ b/src/components/SecondaryPanes/Frames/tests/__snapshots__/Frames.spec.js.snap
@@ -480,10 +480,14 @@ exports[`Frames Supports different number of frames toggling the show more butto
     />
   </ul>
   <div
-    className="show-more"
-    onClick={[Function]}
+    className="show-more-container"
   >
-    Collapse rows
+    <button
+      className="show-more"
+      onClick={[Function]}
+    >
+      Collapse rows
+    </button>
   </div>
 </div>
 `;


### PR DESCRIPTION
At present it's a `<div>` but for the sake of a11y it should be a button.  I was inspired to do this because hovering over the text I saw the text cursor; I was just going to change its cursor but decided a button was best.

<img width="331" alt="expandcontractbutton" src="https://user-images.githubusercontent.com/46655/36050449-30dc4708-0dac-11e8-9487-dce73bb92d04.png">

To test, add a few breakpoints somewhere and you should see the expand/collapse button.  Should look the same as before.