### PR TITLE
Fix previewing a file w/ no functions

### DIFF
--- a/src/actions/preview.js
+++ b/src/actions/preview.js
@@ -83,7 +83,8 @@ export function updatePreview(target: HTMLElement, editor: any) {
     const source = getSelectedSource(getState());
 
     const symbols = getSymbols(getState(), source.toJS());
-    if (symbols.functions.length == 0) {
+
+    if (symbols.identifiers.length == 0) {
       return;
     }
 

--- a/src/actions/preview.js
+++ b/src/actions/preview.js
@@ -83,7 +83,6 @@ export function updatePreview(target: HTMLElement, editor: any) {
     const source = getSelectedSource(getState());
 
     const symbols = getSymbols(getState(), source.toJS());
-
     if (symbols.identifiers.length == 0) {
       return;
     }

--- a/src/test/mochitest/browser.ini
+++ b/src/test/mochitest/browser.ini
@@ -72,6 +72,7 @@ support-files =
   examples/doc-debugger-statements.html
   examples/doc-minified.html
   examples/doc-minified2.html
+  examples/doc-on-load.html
   examples/doc-sourcemaps.html
   examples/doc-sourcemaps2.html
   examples/doc-sourcemaps3.html
@@ -87,6 +88,7 @@ support-files =
   examples/long.js
   examples/math.min.js
   examples/nested/nested-source.js
+  examples/top-level.js
   examples/opts.js
   examples/output.js
   examples/simple1.js
@@ -137,6 +139,8 @@ skip-if = os == "win"
 [browser_dbg-pretty-print-console.js]
 [browser_dbg-pretty-print-paused.js]
 [browser_dbg-preview.js]
+skip-if = os == "win"
+[browser_dbg-preview-module.js]
 skip-if = os == "win"
 [browser_dbg-preview-source-maps.js]
 skip-if = os == "win"

--- a/src/test/mochitest/browser_dbg-preview-module.js
+++ b/src/test/mochitest/browser_dbg-preview-module.js
@@ -1,28 +1,27 @@
 /* Any copyright is dedicated to the Public Domain.
  * http://creativecommons.org/publicdomain/zero/1.0/ */
 
-// Test hovering on an object, which will show a popup and on a
-// simple value, which will show a tooltip.
+// Test hovering in a script that is paused on load
+// and doesn't have functions.
 add_task(async function() {
   const dbg = await initDebugger("doc-scripts.html");
   const { selectors: { getSelectedSource }, getState } = dbg;
-  const simple3 = findSource(dbg, "simple3.js");
 
-  await selectSource(dbg, "simple3");
+  navigate(dbg, "doc-on-load.html")
 
-  await addBreakpoint(dbg, simple3, 5);
-
-  invokeInTab("simple");
   await waitForPaused(dbg);
 
-  const tooltipPreviewed = waitForDispatch(dbg, "SET_PREVIEW");
-  hoverAtPos(dbg, { line: 5, ch: 12 });
-  await tooltipPreviewed;
-  await assertTooltip(dbg, { result: "3", expression: "result" });
-
   const popupPreviewed = waitForDispatch(dbg, "SET_PREVIEW");
-  hoverAtPos(dbg, { line: 2, ch: 10 });
+  hoverAtPos(dbg, { line: 1, ch: 6 });
   await popupPreviewed;
   await assertPopup(dbg, { field: "foo", value: "1", expression: "obj" });
   await assertPopup(dbg, { field: "bar", value: "2", expression: "obj" });
+
+  // hover over an empty position
+  hoverAtPos(dbg, { line: 1, ch: 47 });
+
+  const tooltipPreviewed = waitForDispatch(dbg, "SET_PREVIEW");
+  hoverAtPos(dbg, { line: 2, ch: 7 });
+  await tooltipPreviewed;
+  await assertTooltip(dbg, { result: "3", expression: "func" });
 });

--- a/src/test/mochitest/browser_dbg-preview-module.js
+++ b/src/test/mochitest/browser_dbg-preview-module.js
@@ -9,19 +9,20 @@ add_task(async function() {
 
   navigate(dbg, "doc-on-load.html")
 
+  // wait for `top-level.js` to load and to pause at a debugger statement
   await waitForPaused(dbg);
 
   const popupPreviewed = waitForDispatch(dbg, "SET_PREVIEW");
   hoverAtPos(dbg, { line: 1, ch: 6 });
   await popupPreviewed;
-  await assertPopup(dbg, { field: "foo", value: "1", expression: "obj" });
-  await assertPopup(dbg, { field: "bar", value: "2", expression: "obj" });
+  await assertPreviewPopup(dbg, { field: "foo", value: "1", expression: "obj" });
+  await assertPreviewPopup(dbg, { field: "bar", value: "2", expression: "obj" });
 
-  // hover over an empty position
+  // hover over an empty position so that the popup closes
   hoverAtPos(dbg, { line: 1, ch: 47 });
 
   const tooltipPreviewed = waitForDispatch(dbg, "SET_PREVIEW");
   hoverAtPos(dbg, { line: 2, ch: 7 });
   await tooltipPreviewed;
-  await assertTooltip(dbg, { result: "3", expression: "func" });
+  await assertPreviewTooltip(dbg, { result: "3", expression: "func" });
 });

--- a/src/test/mochitest/browser_dbg-preview-source-maps.js
+++ b/src/test/mochitest/browser_dbg-preview-source-maps.js
@@ -18,7 +18,7 @@ function hoverAtPos(dbg, { line, ch }) {
   );
 }
 
-function assertTooltip(dbg, { result, expression }) {
+function assertPreviewTooltip(dbg, { result, expression }) {
   const previewEl = findElement(dbg, "tooltip");
   is(previewEl.innerText, result, "Preview text shown to user");
 
@@ -28,7 +28,7 @@ function assertTooltip(dbg, { result, expression }) {
   is(preview.expression, expression, "Preview.expression");
 }
 
-function assertPopup(dbg, { field, value, expression }) {
+function assertPreviewPopup(dbg, { field, value, expression }) {
   const previewEl = findElement(dbg, "popup");
   is(previewEl.innerText, "", "Preview text shown to user");
 
@@ -59,5 +59,5 @@ add_task(async function() {
   hoverAtPos(dbg, { line: 2, ch: 9 });
 
   await tooltipPreviewed;
-  assertTooltip(dbg, { result: 4, expression: "x" });
+  assertPreviewTooltip(dbg, { result: 4, expression: "x" });
 });

--- a/src/test/mochitest/browser_dbg-preview.js
+++ b/src/test/mochitest/browser_dbg-preview.js
@@ -18,11 +18,11 @@ add_task(async function() {
   const tooltipPreviewed = waitForDispatch(dbg, "SET_PREVIEW");
   hoverAtPos(dbg, { line: 5, ch: 12 });
   await tooltipPreviewed;
-  await assertTooltip(dbg, { result: "3", expression: "result" });
+  await assertPreviewTooltip(dbg, { result: "3", expression: "result" });
 
   const popupPreviewed = waitForDispatch(dbg, "SET_PREVIEW");
   hoverAtPos(dbg, { line: 2, ch: 10 });
   await popupPreviewed;
-  await assertPopup(dbg, { field: "foo", value: "1", expression: "obj" });
-  await assertPopup(dbg, { field: "bar", value: "2", expression: "obj" });
+  await assertPreviewPopup(dbg, { field: "foo", value: "1", expression: "obj" });
+  await assertPreviewPopup(dbg, { field: "bar", value: "2", expression: "obj" });
 });

--- a/src/test/mochitest/examples/doc-on-load.html
+++ b/src/test/mochitest/examples/doc-on-load.html
@@ -1,0 +1,21 @@
+ <!-- This Source Code Form is subject to the terms of the Mozilla Public
+    - License, v. 2.0. If a copy of the MPL was not distributed with this
+    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8"/>
+    <title>Debugger test page</title>
+  </head>
+
+  <body>
+
+    <script src="top-level.js"></script>
+    <script>
+      // This inline script allows this HTML page to show up as a
+      // source. It also needs to introduce a new global variable so
+      // it's not immediately garbage collected.
+      inline_script = function () { var x = 5; };
+    </script>
+  </body>
+</html>

--- a/src/test/mochitest/examples/top-level.js
+++ b/src/test/mochitest/examples/top-level.js
@@ -1,0 +1,3 @@
+var obj = { foo: 1, bar: 2 };
+var func = 3;
+debugger;

--- a/src/test/mochitest/head.js
+++ b/src/test/mochitest/head.js
@@ -1102,7 +1102,7 @@ function hoverAtPos(dbg, { line, ch }) {
   );
 }
 
-async function assertTooltip(dbg, { result, expression }) {
+async function assertPreviewTooltip(dbg, { result, expression }) {
   const previewEl = await waitForElement(dbg, "tooltip");
   is(previewEl.innerText, result, "Preview text shown to user");
 
@@ -1112,7 +1112,7 @@ async function assertTooltip(dbg, { result, expression }) {
   is(preview.expression, expression, "Preview.expression");
 }
 
-async function assertPopup(dbg, { field, value, expression }) {
+async function assertPreviewPopup(dbg, { field, value, expression }) {
   const previewEl = await waitForElement(dbg, "popup");
   const preview = dbg.selectors.getPreview(dbg.getState());
 

--- a/src/test/mochitest/head.js
+++ b/src/test/mochitest/head.js
@@ -1084,6 +1084,47 @@ function getCM(dbg) {
   return el.CodeMirror;
 }
 
+
+function getCoordsFromPosition(cm, { line, ch }) {
+  return cm.charCoords({ line: ~~line, ch: ~~ch });
+}
+
+function hoverAtPos(dbg, { line, ch }) {
+  const cm = getCM(dbg);
+  const coords = getCoordsFromPosition(cm, { line: line - 1, ch });
+  const tokenEl = dbg.win.document.elementFromPoint(coords.left, coords.top);
+  tokenEl.dispatchEvent(
+    new MouseEvent("mouseover", {
+      bubbles: true,
+      cancelable: true,
+      view: dbg.win
+    })
+  );
+}
+
+async function assertTooltip(dbg, { result, expression }) {
+  const previewEl = await waitForElement(dbg, "tooltip");
+  is(previewEl.innerText, result, "Preview text shown to user");
+
+  const preview = dbg.selectors.getPreview(dbg.getState());
+  is(`${preview.result}`, result, "Preview.result");
+  is(preview.updating, false, "Preview.updating");
+  is(preview.expression, expression, "Preview.expression");
+}
+
+async function assertPopup(dbg, { field, value, expression }) {
+  const previewEl = await waitForElement(dbg, "popup");
+  const preview = dbg.selectors.getPreview(dbg.getState());
+
+  is(
+    `${preview.result.preview.ownProperties[field].value}`,
+    value,
+    "Preview.result"
+  );
+  is(preview.updating, false, "Preview.updating");
+  is(preview.expression, expression, "Preview.expression");
+}
+
 // NOTE: still experimental, the screenshots might not be exactly correct
 async function takeScreenshot(dbg) {
   let canvas = dbg.win.document.createElementNS(


### PR DESCRIPTION
### Summary of Changes

- Previously we assumed files would always have one function if we wanted to preview them.
- now we check for atleast one identifier, which is more general.