### PR TITLE
Remove functions we no longer use

### DIFF
--- a/src/components/PrimaryPanes/index.js
+++ b/src/components/PrimaryPanes/index.js
@@ -109,21 +109,6 @@ class PrimaryPanes extends Component<Props> {
     }
   }
 
-  renderOutline() {
-    const { selectLocation } = this.props;
-
-    const outlineComp = features.outline ? (
-      <Outline selectLocation={selectLocation} />
-    ) : null;
-
-    return outlineComp;
-  }
-
-  renderSources() {
-    const { sources, selectLocation } = this.props;
-    return <SourcesTree sources={sources} selectLocation={selectLocation} />;
-  }
-
   render() {
     const { selectedTab } = this.props;
 


### PR DESCRIPTION
These aren't used anymore, thanks to:

```
{selectedTab === "sources" ? <SourcesTree /> : <Outline />}
```

https://github.com/devtools-html/debugger.html/commit/22dd6f73257bee91a2c2372c03395937b9737ea3