### PR TITLE
Ensure correct URL copied from tab context menu

### DIFF
--- a/src/components/Editor/EditorMenu.js
+++ b/src/components/Editor/EditorMenu.js
@@ -14,7 +14,7 @@ import {
   getSourceLocationFromMouseEvent,
   toSourceLine
 } from "../../utils/editor";
-import { isPretty } from "../../utils/source";
+import { isPretty, getRawSourceURL } from "../../utils/source";
 import {
   getContextMenu,
   getPrettySource,
@@ -103,7 +103,7 @@ function getMenuItems(
     label: copySourceUri2Label,
     accesskey: copySourceUri2Key,
     disabled: false,
-    click: () => copyToTheClipboard(selectedSource.get("url"))
+    click: () => copyToTheClipboard(getRawSourceURL(selectedSource.get("url")))
   };
 
   const sourceId = selectedSource.get("id");

--- a/src/components/Editor/Tab.js
+++ b/src/components/Editor/Tab.js
@@ -17,7 +17,12 @@ import type { SourceRecord } from "../../reducers/sources";
 
 import actions from "../../actions";
 
-import { getFilename, getFileURL, isPretty } from "../../utils/source";
+import {
+  getFilename,
+  getFileURL,
+  getRawSourceURL,
+  isPretty
+} from "../../utils/source";
 import { copyToTheClipboard } from "../../utils/clipboard";
 import { getSourceAnnotation, getTabMenuItems } from "../../utils/tabs";
 
@@ -104,7 +109,7 @@ class Tab extends PureComponent<Props> {
       {
         item: {
           ...tabMenuItems.copySourceUri2,
-          click: () => copyToTheClipboard(sourceTab.get("url"))
+          click: () => copyToTheClipboard(getRawSourceURL(sourceTab.get("url")))
         }
       }
     ];


### PR DESCRIPTION
The context menu's "Copy Source URI" menu item for pretty tabs is outputting the `:formatted` URL; let's remote that internal `:formatted` signifier from the source.