### PR TITLE
change svg colors

### DIFF
--- a/src/components/shared/Svg.css
+++ b/src/components/shared/Svg.css
@@ -111,10 +111,6 @@ html .arrow.expanded svg {
   vertical-align: sub;
 }
 
-.theme-dark .webpack {
-  opacity: 0.5;
-}
-
 .function svg {
   height: 10px;
   width: 15px;
@@ -132,10 +128,16 @@ html .arrow.expanded svg {
   vertical-align: sub;
 }
 
-.source-icon svg {
-  fill: var(--theme-body-color);
+.angular,
+.webpack {
+  opacity: 0.8;
 }
 
-.theme-dark .angular {
+.theme-dark .angular,
+.theme-dark .webpack {
   opacity: 0.5;
+}
+
+.source-icon svg {
+  fill: var(--theme-comment);
 }


### PR DESCRIPTION
Associated Issue: #2545

* upped the opacity, for light theme, on the angular and webpack icons.
* change the color to --theme-comment for the JS icon (also affected , TypeScript, coffeescript, react)
* I did not make the file or folder icons bolder, once the color matched with the other icons I don't think they look too soft.

### Screenshots/Videos
before:
<img width="92" alt="screen shot 2018-02-13 at 2 47 32 pm" src="https://user-images.githubusercontent.com/10803178/36171792-f2d54b2a-10d1-11e8-89f8-0ba9c5b166c0.png">
after:
<img width="90" alt="screen shot 2018-02-13 at 2 47 24 pm" src="https://user-images.githubusercontent.com/10803178/36171793-f4bf32d4-10d1-11e8-8017-20e2d7c92584.png">

webpack before:
<img width="159" alt="screen shot 2018-02-13 at 3 25 55 pm" src="https://user-images.githubusercontent.com/10803178/36171898-40ac2e7c-10d2-11e8-900c-f5c3fa97a010.png">
after:
<img width="504" alt="screen shot 2018-02-13 at 3 03 49 pm" src="https://user-images.githubusercontent.com/10803178/36171916-52862a62-10d2-11e8-872c-791c8366aa10.png">

<img width="207" alt="screen shot 2018-02-13 at 3 30 14 pm" src="https://user-images.githubusercontent.com/10803178/36172100-d541c902-10d2-11e8-9534-6406f930470e.png">

<img width="183" alt="screen shot 2018-02-13 at 3 11 21 pm" src="https://user-images.githubusercontent.com/10803178/36172259-4ec7289e-10d3-11e8-8499-e733e14d7f55.png">

