### PR TITLE
Sync Bug 1434374 - use ChromeUtils.import instead Cu.import

### DIFF
--- a/src/actions/preview.js
+++ b/src/actions/preview.js
@@ -83,7 +83,7 @@ export function updatePreview(target: HTMLElement, editor: any) {
     const source = getSelectedSource(getState());
 
     const symbols = getSymbols(getState(), source.toJS());
-    if (symbols.identifiers.length == 0) {
+    if (!symbols || symbols.identifiers.length == 0) {
       return;
     }
 

--- a/src/test/mochitest/browser_dbg-chrome-create.js
+++ b/src/test/mochitest/browser_dbg-chrome-create.js
@@ -7,7 +7,7 @@
  * Tests that a chrome debugger can be created in a new process.
  */
 
-const { BrowserToolboxProcess } = Cu.import(
+const { BrowserToolboxProcess } = ChromeUtils.import(
   "resource://devtools/client/framework/ToolboxProcess.jsm",
   {}
 );

--- a/src/test/mochitest/browser_dbg-chrome-debugging.js
+++ b/src/test/mochitest/browser_dbg-chrome-debugging.js
@@ -11,7 +11,10 @@ var gClient, gThreadClient;
 var gNewGlobal = promise.defer();
 var gNewChromeSource = promise.defer();
 
-var { DevToolsLoader } = Cu.import("resource://devtools/shared/Loader.jsm", {});
+var { DevToolsLoader } = ChromeUtils.import(
+  "resource://devtools/shared/Loader.jsm",
+  {}
+);
 var customLoader = new DevToolsLoader();
 customLoader.invisibleToDebugger = true;
 var { DebuggerServer } = customLoader.require("devtools/server/main");


### PR DESCRIPTION
Needed for release 16

Sync changes from https://bugzilla.mozilla.org/show_bug.cgi?id=1434374