### PR TITLE
Show rightmost columns of the editor.

### DIFF
--- a/src/components/Editor/ConditionalPanel.css
+++ b/src/components/Editor/ConditionalPanel.css
@@ -11,7 +11,6 @@
   background: var(--theme-toolbar-background);
   border-top: 1px solid var(--theme-splitter-color);
   border-bottom: 1px solid var(--theme-splitter-color);
-  padding-right: 16px;
 }
 
 .conditional-breakpoint-panel .prompt {

--- a/src/components/Editor/ConditionalPanel.js
+++ b/src/components/Editor/ConditionalPanel.js
@@ -157,11 +157,6 @@ export class ConditionalPanel extends PureComponent<Props> {
           onKeyDown={this.onKey}
           ref={input => (this.input = input)}
         />
-        <CloseButton
-          handleClick={this.props.closeConditionalPanel}
-          buttonClass="big"
-          tooltip={L10N.getStr("editor.conditionalPanel.close")}
-        />
       </div>,
       panel
     );

--- a/src/components/Editor/ConditionalPanel.js
+++ b/src/components/Editor/ConditionalPanel.js
@@ -6,7 +6,6 @@
 import React, { PureComponent } from "react";
 import ReactDOM from "react-dom";
 import { connect } from "react-redux";
-import CloseButton from "../shared/Button/Close";
 import "./ConditionalPanel.css";
 import { toEditorLine } from "../../utils/editor";
 import actions from "../../actions";

--- a/src/components/Editor/Editor.css
+++ b/src/components/Editor/Editor.css
@@ -19,10 +19,10 @@
 
 .editor-wrapper .CodeMirror-linewidget {
   margin-right: -7px;
-  overflow: visible;
+  overflow: hidden;
 }
 
-.editor-wrapper .CodeMirror-sizer {
+.editor-wrapper {
   min-width: 0 !important;
 }
 


### PR DESCRIPTION
Associated Issue: #5302

### Summary of Changes

* Reverted min-width: 0 for CodeMirror-sizer that modified the codemirror's fundamental behaviour, hiding the rightmost columns.
* Removed close button which was aligned with the previously moving code-mirror-sizer as it was not needed since the close conditional breakpoint panel action is also invoked onBlur.
* Switched CodeMirror-linewidget overflow to hidden to prevent infinite horizontal scrolling when repositioning the conditional breakpoint panel (when the conditional breakpoint panel is open).

### Screenshots/Videos 
Before, as can be seen in the gif below, the rightmost columns are unable to be seen when horizontally scrolling to the right.
![before](https://user-images.githubusercontent.com/14250545/36182064-0039ac94-10e5-11e8-9e28-538a1d134a0d.gif)

After, as can be seen in the gif below, the rightmost columns are now accessible when scrolling horizontally to the right.
![aftercolumns](https://user-images.githubusercontent.com/14250545/36182083-178370a6-10e5-11e8-8fd4-8318ae4e5ee6.gif)
