### PR TITLE
[QuickOpen] fix for fuzzymatch

### DIFF
--- a/src/components/QuickOpenModal.js
+++ b/src/components/QuickOpenModal.js
@@ -335,7 +335,6 @@ export class QuickOpenModal extends Component<Props, State> {
     if (newQuery === "") {
       return results;
     }
-    
     newQuery = query.replace(/[@:#?]/gi, " ");
 
     return results.map(result => {

--- a/src/components/QuickOpenModal.js
+++ b/src/components/QuickOpenModal.js
@@ -335,10 +335,8 @@ export class QuickOpenModal extends Component<Props, State> {
     if (newQuery === "") {
       return results;
     }
-    newQuery = query.replace(
-      new RegExp(`[${Object.keys(MODIFIERS).join(``)}]`, "gi"),
-      " "
-    );
+    
+    newQuery = query.replace(/[@:#?]/gi, " ");
 
     return results.map(result => {
       return {

--- a/src/components/QuickOpenModal.js
+++ b/src/components/QuickOpenModal.js
@@ -22,8 +22,7 @@ import {
   formatSymbols,
   formatSources,
   parseLineColumn,
-  formatShortcutResults,
-  MODIFIERS
+  formatShortcutResults
 } from "../utils/quick-open";
 import Modal from "./shared/Modal";
 import SearchInput from "./shared/SearchInput";

--- a/src/components/QuickOpenModal.js
+++ b/src/components/QuickOpenModal.js
@@ -335,9 +335,7 @@ export class QuickOpenModal extends Component<Props, State> {
     if (newQuery === "") {
       return results;
     }
-    if (Object.keys(MODIFIERS).includes(query[0])) {
-      newQuery = query.slice(1, query.length);
-    }
+    newQuery = query.replace(/#|@|:|\?/gi, " ");
 
     return results.map(result => {
       return {

--- a/src/components/QuickOpenModal.js
+++ b/src/components/QuickOpenModal.js
@@ -335,7 +335,10 @@ export class QuickOpenModal extends Component<Props, State> {
     if (newQuery === "") {
       return results;
     }
-    newQuery = query.replace(/#|@|:|\?/gi, " ");
+    newQuery = query.replace(
+      new RegExp(`[${Object.keys(MODIFIERS).join(``)}]`, "gi"),
+      " "
+    );
 
     return results.map(result => {
       return {


### PR DESCRIPTION
Associated Issue: ##4488

### Summary of Changes

* Small fix for a bug with fuzzy match, so now when you type '@' results are shown, while still providing highlighting on every character after the modifier

Before
![image](https://user-images.githubusercontent.com/23143862/36185624-75da9fbe-10f7-11e8-8228-5b920b2c1d83.png)

After
![image](https://user-images.githubusercontent.com/23143862/36185655-9b60f512-10f7-11e8-82b0-b1875e3aca15.png)

![image](https://user-images.githubusercontent.com/23143862/36185700-ca7d7f0a-10f7-11e8-8587-6b61baf426e1.png)

