### PR TITLE
Replace endTruncateStr with CSS 

### DIFF
--- a/src/components/Editor/Footer.css
+++ b/src/components/Editor/Footer.css
@@ -16,9 +16,9 @@
   user-select: none;
   height: var(--editor-footer-height);
   box-sizing: border-box;
-  white-space: nowrap; 
-  overflow: hidden; 
-  text-overflow: ellipsis; 
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .source-footer .commands {

--- a/src/components/Editor/Footer.css
+++ b/src/components/Editor/Footer.css
@@ -16,6 +16,9 @@
   user-select: none;
   height: var(--editor-footer-height);
   box-sizing: border-box;
+  white-space: nowrap; 
+  overflow: hidden; 
+  text-overflow: ellipsis; 
 }
 
 .source-footer .commands {

--- a/src/components/SecondaryPanes/Breakpoints.js
+++ b/src/components/SecondaryPanes/Breakpoints.js
@@ -13,7 +13,6 @@ import { sortBy } from "lodash";
 
 import actions from "../../actions";
 import CloseButton from "../shared/Button/Close";
-import { endTruncateStr } from "../../utils/utils";
 import { features } from "../../utils/prefs";
 import { getFilename } from "../../utils/source";
 import {
@@ -80,11 +79,7 @@ function renderSourceLocation(source, line, column) {
     return null;
   }
 
-  return (
-    <div className="location">
-      {`${endTruncateStr(filename, 30)}: ${bpLocation}`}
-    </div>
-  );
+  return <div className="location">{`${filename}: ${bpLocation}`}</div>;
 }
 
 class Breakpoints extends PureComponent<Props> {

--- a/src/components/SecondaryPanes/Frames/Frame.js
+++ b/src/components/SecondaryPanes/Frames/Frame.js
@@ -112,6 +112,8 @@ export default class FrameComponent extends Component<FrameComponentProps> {
       shouldMapDisplayName
     } = this.props;
 
+    const filename = getFilename(frame.source);
+
     const className = classNames("frame", {
       selected: selectedFrame && selectedFrame.id === frame.id
     });
@@ -119,6 +121,7 @@ export default class FrameComponent extends Component<FrameComponentProps> {
       <li
         key={frame.id}
         className={className}
+        title={filename}
         onMouseDown={e => this.onMouseDown(e, frame, selectedFrame)}
         onKeyUp={e => this.onKeyUp(e, frame, selectedFrame)}
         onContextMenu={e => this.onContextMenu(e)}

--- a/src/components/SecondaryPanes/Frames/Frames.css
+++ b/src/components/SecondaryPanes/Frames/Frames.css
@@ -36,7 +36,7 @@
   align-items: center;
   white-space: nowrap;
   overflow: hidden;
-  text-overflow: ellipsis; 
+  text-overflow: ellipsis;
   margin: 0;
 }
 
@@ -54,7 +54,7 @@
   text-overflow: ellipsis;
   overflow: hidden;
   margin: 7px 0.5em 7px 0;
-  flex-shrink: 0; 
+  flex-shrink: 0;
 }
 
 .frames ul li:hover,

--- a/src/components/SecondaryPanes/Frames/Frames.css
+++ b/src/components/SecondaryPanes/Frames/Frames.css
@@ -34,8 +34,10 @@
   justify-content: space-between;
   flex-direction: row;
   align-items: center;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis; 
   margin: 0;
-  flex-shrink: 0;
 }
 
 .theme-light .frames .location,
@@ -52,6 +54,7 @@
   text-overflow: ellipsis;
   overflow: hidden;
   margin: 7px 0.5em 7px 0;
+  flex-shrink: 0; 
 }
 
 .frames ul li:hover,

--- a/src/components/SecondaryPanes/Frames/tests/__snapshots__/Frame.spec.js.snap
+++ b/src/components/SecondaryPanes/Frames/tests/__snapshots__/Frame.spec.js.snap
@@ -8,6 +8,7 @@ exports[`Frame library frame 1`] = `
   onKeyUp={[Function]}
   onMouseDown={[Function]}
   tabIndex={0}
+  title="backbone.js"
 >
   <FrameTitle
     frame={
@@ -59,6 +60,7 @@ exports[`Frame user frame (not selected) 1`] = `
   onKeyUp={[Function]}
   onMouseDown={[Function]}
   tabIndex={0}
+  title="foo-view.js"
 >
   <FrameTitle
     frame={
@@ -112,6 +114,7 @@ exports[`Frame user frame 1`] = `
   onKeyUp={[Function]}
   onMouseDown={[Function]}
   tabIndex={0}
+  title="foo-view.js"
 >
   <FrameTitle
     frame={

--- a/src/test/mochitest/browser_dbg-preview-module.js
+++ b/src/test/mochitest/browser_dbg-preview-module.js
@@ -7,7 +7,7 @@ add_task(async function() {
   const dbg = await initDebugger("doc-scripts.html");
   const { selectors: { getSelectedSource }, getState } = dbg;
 
-  navigate(dbg, "doc-on-load.html")
+  navigate(dbg, "doc-on-load.html");
 
   // wait for `top-level.js` to load and to pause at a debugger statement
   await waitForPaused(dbg);
@@ -15,8 +15,16 @@ add_task(async function() {
   const popupPreviewed = waitForDispatch(dbg, "SET_PREVIEW");
   hoverAtPos(dbg, { line: 1, ch: 6 });
   await popupPreviewed;
-  await assertPreviewPopup(dbg, { field: "foo", value: "1", expression: "obj" });
-  await assertPreviewPopup(dbg, { field: "bar", value: "2", expression: "obj" });
+  await assertPreviewPopup(dbg, {
+    field: "foo",
+    value: "1",
+    expression: "obj"
+  });
+  await assertPreviewPopup(dbg, {
+    field: "bar",
+    value: "2",
+    expression: "obj"
+  });
 
   // hover over an empty position so that the popup closes
   hoverAtPos(dbg, { line: 1, ch: 47 });

--- a/src/test/mochitest/browser_dbg-preview.js
+++ b/src/test/mochitest/browser_dbg-preview.js
@@ -23,6 +23,14 @@ add_task(async function() {
   const popupPreviewed = waitForDispatch(dbg, "SET_PREVIEW");
   hoverAtPos(dbg, { line: 2, ch: 10 });
   await popupPreviewed;
-  await assertPreviewPopup(dbg, { field: "foo", value: "1", expression: "obj" });
-  await assertPreviewPopup(dbg, { field: "bar", value: "2", expression: "obj" });
+  await assertPreviewPopup(dbg, {
+    field: "foo",
+    value: "1",
+    expression: "obj"
+  });
+  await assertPreviewPopup(dbg, {
+    field: "bar",
+    value: "2",
+    expression: "obj"
+  });
 });

--- a/src/test/mochitest/browser_dbg-sources.js
+++ b/src/test/mochitest/browser_dbg-sources.js
@@ -42,14 +42,17 @@ add_task(async function() {
   await waitForSelectedSource(dbg);
 
   // Ensure the source file clicked is now focused
-  await waitForElementWithSelector(dbg, ".sources-list .focused")
+  await waitForElementWithSelector(dbg, ".sources-list .focused");
 
-  const focusedNode = findElementWithSelector(dbg, ".sources-list .focused")
+  const focusedNode = findElementWithSelector(dbg, ".sources-list .focused");
   const fourthNode = findElement(dbg, "sourceNode", 4);
   const selectedSource = getSelectedSource(getState()).get("url");
 
   ok(fourthNode.classList.contains("focused"), "4th node is focused");
-  ok(selectedSource.includes("nested-source.js"), "The right source is selected");
+  ok(
+    selectedSource.includes("nested-source.js"),
+    "The right source is selected"
+  );
 
   // Make sure new sources appear in the list.
   ContentTask.spawn(gBrowser.selectedBrowser, null, function() {

--- a/src/test/mochitest/head.js
+++ b/src/test/mochitest/head.js
@@ -1084,7 +1084,6 @@ function getCM(dbg) {
   return el.CodeMirror;
 }
 
-
 function getCoordsFromPosition(cm, { line, ch }) {
   return cm.charCoords({ line: ~~line, ch: ~~ch });
 }

--- a/src/utils/frame.js
+++ b/src/utils/frame.js
@@ -4,7 +4,6 @@
 
 // @flow
 
-import { endTruncateStr } from "./utils";
 import { getFilename } from "./source";
 import { get, find, findIndex } from "lodash";
 
@@ -202,7 +201,7 @@ export function formatDisplayName(
   }
 
   displayName = simplifyDisplayName(displayName);
-  return endTruncateStr(displayName, 25);
+  return displayName;
 }
 
 export function formatCopyName(frame: LocalFrame) {

--- a/src/utils/quick-open.js
+++ b/src/utils/quick-open.js
@@ -3,7 +3,6 @@
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
 // @flow
-import { endTruncateStr } from "./utils";
 import { isPretty, getSourcePath } from "./source";
 
 import type { Location as BabelLocation } from "@babel/traverse";
@@ -119,7 +118,7 @@ export function formatSources(sources: SourcesMap): Array<QuickOpenResult> {
       return {
         value: sourcePath,
         title: sourcePath.split("/").pop(),
-        subtitle: endTruncateStr(sourcePath, 100),
+        subtitle: sourcePath,
         id: source.get("id"),
         url: source.get("url")
       };

--- a/src/utils/source.js
+++ b/src/utils/source.js
@@ -10,7 +10,6 @@
  */
 
 import { isOriginalId } from "devtools-source-map";
-import { endTruncateStr } from "./utils";
 import { basename } from "./path";
 
 import { parse as parseURL } from "url";
@@ -124,7 +123,7 @@ function resolveFileURL(
 ) {
   url = getRawSourceURL(url || "");
   const name = transformUrl(url);
-  return endTruncateStr(name, 50);
+  return name;
 }
 
 export function getFilenameFromURL(url: string) {

--- a/src/utils/tests/frame.spec.js
+++ b/src/utils/tests/frame.spec.js
@@ -72,17 +72,6 @@ describe("function names", () => {
 
       expect(formatDisplayName(frame)).toEqual("baz");
     });
-
-    it("truncates long function names", () => {
-      const frame = {
-        displayName: "bazbazbazbazbazbazbazbazbazbazbazbazbaz",
-        source: {
-          url: "assets/bar.js"
-        }
-      };
-
-      expect(formatDisplayName(frame)).toEqual("...zbazbazbazbazbazbazbazbaz");
-    });
   });
 
   describe("formatCopyName", () => {

--- a/src/utils/tests/source.spec.js
+++ b/src/utils/tests/source.spec.js
@@ -24,23 +24,6 @@ describe("sources", () => {
         })
       ).toBe("hello.html");
     });
-    it("should truncate the file name when it is more than 50 chars", () => {
-      expect(
-        getFileURL({
-          url:
-            "http://localhost/really-really-really-really-really-really-long-name.html",
-          id: ""
-        })
-      ).toBe("...-really-really-really-really-really-long-name.html");
-    });
-    it("should give us the filename excluding the query strings", () => {
-      expect(
-        getFilename({
-          url: "http://localhost.com:7999/increment/hello.html?query_strings",
-          id: ""
-        })
-      ).toBe("hello.html");
-    });
   });
 
   describe("getFileURL", () => {
@@ -51,14 +34,6 @@ describe("sources", () => {
           id: ""
         })
       ).toBe("http://localhost.com:7999/increment/hello.html");
-    });
-    it("should truncate the file url when it is more than 50 chars", () => {
-      expect(
-        getFileURL({
-          url: "http://localhost-long.com:7999/increment/hello.html",
-          id: ""
-        })
-      ).toBe("...ttp://localhost-long.com:7999/increment/hello.html");
     });
   });
 

--- a/src/utils/tests/utils.spec.js
+++ b/src/utils/tests/utils.spec.js
@@ -1,4 +1,4 @@
-import { handleError, promisify, endTruncateStr, waitForMs } from "../utils";
+import { handleError, promisify, waitForMs } from "../utils";
 
 describe("handleError()", () => {
   const testErrorText = "ERROR: ";
@@ -34,27 +34,6 @@ describe("promisify()", () => {
     testPromise = promisify(testContext, testMethod, testArgs);
 
     expect(testMethod).toBeCalledWith(testArgs, expect.anything());
-  });
-});
-
-describe("endTruncateStr()", () => {
-  let testString;
-  const testSize = 11;
-
-  describe("when the string is larger than the specified size", () => {
-    it("returns an elipsis and characters at the end of the string", () => {
-      testString = "Mozilla Firefox is my favorite web browser";
-
-      expect(endTruncateStr(testString, testSize)).toBe("...web browser");
-    });
-  });
-
-  describe("when the string is not larger than the specified size", () => {
-    it("returns the string unchanged", () => {
-      testString = "Firefox";
-
-      expect(endTruncateStr(testString, testSize)).toBe(testString);
-    });
   });
 });
 

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -38,15 +38,9 @@ function promisify(context: any, method: any, ...args: any): Promise<mixed> {
  * @memberof utils/utils
  * @static
  */
-function endTruncateStr(str: any, size: number) {
-  if (str.length > size) {
-    return `...${str.slice(str.length - size)}`;
-  }
-  return str;
-}
 
 function waitForMs(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
-export { handleError, promisify, endTruncateStr, waitForMs };
+export { handleError, promisify, waitForMs };

--- a/yarn.lock
+++ b/yarn.lock
@@ -3850,7 +3850,7 @@ eslint-plugin-jest@^21.5.0:
   version "21.7.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-21.7.0.tgz#651f1c6ce999af3ac59ab8bf8a376d742fd0fc23"
 
-eslint-plugin-mozilla@0.8.1:
+eslint-plugin-mozilla@^0.8.1:
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-mozilla/-/eslint-plugin-mozilla-0.8.1.tgz#623b031b14e901999110c60ce17d0aad67cbba83"
   dependencies:


### PR DESCRIPTION
endTruncateStr is unnecessary, and may hamper future development. This PR replaces that function with css `overflow: hidden` `text-overflow:ellipsis`. 