### PR TITLE
Fixes yarn warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,15 +28,15 @@
     "lint-js": "eslint *.js \"src/**/*.js\" --fix",
     "lint-md":
       "remark -u devtools-linters/markdown/preset -qf *.md src configs docs",
-    "lint-fix": "yarn lint-js -- --fix",
+    "lint-fix": "yarn lint-js --fix",
     "mochi":
       "mochii --mc ./firefox --interactive --default-test-path devtools/client/debugger/new",
-    "mochid": "yarn mochi -- --jsdebugger --",
-    "mochir": "yarn mochi -- --repeat 10 --",
-    "mochih": "yarn mochi -- --headless --",
+    "mochid": "yarn mochi --jsdebugger",
+    "mochir": "yarn mochi --repeat 10",
+    "mochih": "yarn mochi --headless",
     "test": "jest",
     "test:watch": "jest --watch",
-    "test-coverage": "yarn test -- --coverage",
+    "test-coverage": "yarn test --coverage",
     "test-all": "yarn test; yarn lint; yarn flow",
     "firefox":
       "start-firefox --start --location https://devtools-html.github.io/debugger-examples/",


### PR DESCRIPTION
Associated Issue: #5418

Fixes error messages while running yarn scripts.

Before fix example:
![screenshot-20180214100827-810x186](https://user-images.githubusercontent.com/23530054/36196404-e88b5bb0-1170-11e8-8651-cfc744cec7f8.png)

After fix example:
![screenshot-20180214101038-810x125](https://user-images.githubusercontent.com/23530054/36196421-f7234368-1170-11e8-94aa-7a7794c38317.png)

