### PR TITLE
Restore throttling of SourceTree

### DIFF
--- a/src/components/PrimaryPanes/SourcesTree.js
+++ b/src/components/PrimaryPanes/SourcesTree.js
@@ -43,6 +43,7 @@ import {
 } from "../../utils/sources-tree";
 
 import { copyToTheClipboard } from "../../utils/clipboard";
+import { throttle } from "../../utils/utils";
 import { features } from "../../utils/prefs";
 
 import type { SourcesMap, SourceRecord } from "../../reducers/types";
@@ -89,6 +90,19 @@ class SourcesTree extends Component<Props, State> {
       debuggeeUrl,
       sources
     });
+  }
+
+  componentDidMount() {
+    this.mounted = true;
+  }
+
+  componentWillUnMount() {
+    this.mounted = false;
+  }
+
+  shouldComponentUpdate() {
+    this.queueUpdate();
+    return false;
   }
 
   componentWillReceiveProps(nextProps) {
@@ -154,6 +168,14 @@ class SourcesTree extends Component<Props, State> {
       );
     }
   }
+
+  queueUpdate = throttle(function() {
+    if (!this.mounted) {
+      return;
+    }
+
+    this.forceUpdate();
+  }, 50);
 
   focusItem = item => {
     this.setState({ focusedItem: item });

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -45,8 +45,29 @@ function endTruncateStr(str: any, size: number) {
   return str;
 }
 
+/**
+ * @memberof utils/utils
+ * @static
+ */
+/**
+ * @memberof utils/utils
+ * @static
+ */
+function throttle(func: any, ms: number) {
+  let timeout, _this;
+  return function(...args: any) {
+    _this = this;
+    if (!timeout) {
+      timeout = setTimeout(() => {
+        func.apply(_this, ...args);
+        timeout = null;
+      }, ms);
+    }
+  };
+}
+
 function waitForMs(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
-export { handleError, promisify, endTruncateStr, waitForMs };
+export { handleError, promisify, endTruncateStr, throttle, waitForMs };


### PR DESCRIPTION
@jasonLaster suspect our https://github.com/devtools-html/debugger.html/pull/5345 refactor may have caused an issue with sources in Firefox.  This restores the throttle.

If it turns out this does avoid an issue in Firefox but not launchpad, we should definitely document the issue in a comment above the `queueUpdate` function as to why it would be needed.