### PR TITLE
Use babel7 imports

### DIFF
--- a/src/test/mochitest/browser_dbg-preview-module.js
+++ b/src/test/mochitest/browser_dbg-preview-module.js
@@ -10,7 +10,7 @@ add_task(async function() {
   navigate(dbg, "doc-on-load.html");
 
   // wait for `top-level.js` to load and to pause at a debugger statement
-  await waitForSelectedSource(dbg)
+  await waitForSelectedSource(dbg);
   await waitForPaused(dbg);
 
   const popupPreviewed = waitForDispatch(dbg, "SET_PREVIEW");

--- a/src/test/mochitest/browser_dbg-quick-open.js
+++ b/src/test/mochitest/browser_dbg-quick-open.js
@@ -95,7 +95,7 @@ add_task(async function() {
   quickOpen(dbg, "#");
   is(resultCount(dbg), 1, "one variable result");
   const results = findAllElements(dbg, "resultItems");
-  results.forEach(result => is(result.textContent, "13"));
+  results.forEach(result => is(result.textContent, "x13"));
   await waitToClose(dbg);
 
   info("Testing goto line:column");

--- a/src/workers/parser/utils/ast.js
+++ b/src/workers/parser/utils/ast.js
@@ -21,9 +21,12 @@ function _parse(code, opts) {
 }
 
 const sourceOptions = {
-  generated: {},
+  generated: {
+    tokens: true
+  },
   original: {
     sourceType: "unambiguous",
+    tokens: true,
     plugins: [
       "jsx",
       "flow",


### PR DESCRIPTION
this reduces the parser worker bundle from 60K to 54K

dropping babel-traverse will bring us down to 30K...

<img width="1085" alt="screen shot 2018-02-15 at 6 35 57 pm" src="https://user-images.githubusercontent.com/254562/36286808-56eace9c-127f-11e8-895e-d805fc214817.png">
<img width="1026" alt="screen shot 2018-02-15 at 6 35 49 pm" src="https://user-images.githubusercontent.com/254562/36286809-56f4e800-127f-11e8-84dc-cace3a820594.png">
