### PR TITLE
(TravisCI test) [WIP] Clear the sourceMapURL on fail to load source maps in order to enable pretty printing

### DIFF
--- a/src/actions/sources/newSources.js
+++ b/src/actions/sources/newSources.js
@@ -40,11 +40,14 @@ function createOriginalSource(
 }
 
 // TODO: It would be nice to make getOriginalURLs a safer api
-async function loadOriginalSourceUrls(sourceMaps, generatedSource) {
+async function loadOriginalSourceUrls(dispatch, sourceMaps, generatedSource) {
   try {
     return await sourceMaps.getOriginalURLs(generatedSource);
   } catch (e) {
-    console.error(e);
+    dispatch({
+      type: "UPDATE_SOURCE",
+      source: { generatedSource, sourceMapURL: "" }
+    });
     return null;
   }
 }
@@ -53,11 +56,19 @@ async function loadOriginalSourceUrls(sourceMaps, generatedSource) {
  * @memberof actions/sources
  * @static
  */
-function loadSourceMap(generatedSource) {
+export function loadSourceMap(generatedSource: Source) {
   return async function({ dispatch, getState, sourceMaps }: ThunkArgs) {
-    const urls = await loadOriginalSourceUrls(sourceMaps, generatedSource);
+    const urls = await loadOriginalSourceUrls(
+      dispatch,
+      sourceMaps,
+      generatedSource
+    );
     if (!urls) {
-      // If this source doesn't have a sourcemap, do nothing.
+      // If this source doesn't have a sourcemap, enable it for pretty printing
+      dispatch({
+        type: "UPDATE_SOURCE",
+        source: { ...generatedSource, sourceMapURL: "" }
+      });
       return;
     }
 

--- a/src/actions/sources/tests/newSources.spec.js
+++ b/src/actions/sources/tests/newSources.spec.js
@@ -10,6 +10,17 @@ const { getSource, getSources, getSelectedSource } = selectors;
 import { sourceThreadClient as threadClient } from "../../tests/helpers/threadClient.js";
 
 describe("sources - new sources", () => {
+  it(`should clear sourceMapURL on fail
+        to load original source URLs`, async () => {
+    const { dispatch, getState } = createStore(threadClient);
+    // loadSourceMap is called upon creation of the source
+    await dispatch(
+      actions.newSource(makeSource("base.js", { sourceMapURL: "base.map.js" }))
+    );
+    const base = getSource(getState(), "base.js");
+    expect(base.get("sourceMapURL")).toEqual("");
+  });
+
   it("should add sources to state", async () => {
     const { dispatch, getState } = createStore(threadClient);
     await dispatch(actions.newSource(makeSource("base.js")));

--- a/src/test/mochitest/browser_dbg-sourcemaps-reload.js
+++ b/src/test/mochitest/browser_dbg-sourcemaps-reload.js
@@ -46,7 +46,7 @@ add_task(async function() {
   is(breakpoint.generatedLocation.line, 73);
 
   await resume(dbg);
-  syncBp = waitForDispatch(dbg, "SYNC_BREAKPOINT", 2);
+  syncBp = waitForDispatch(dbg, "SYNC_BREAKPOINT", 3);
   await selectSource(dbg, "v1");
   await addBreakpoint(dbg, "v1", 13);
 


### PR DESCRIPTION
Associated Issue: #1661
Reliant on https://github.com/devtools-html/devtools-core/pull/921 so `fetchSourceMap` properly throws error

### Summary of Changes
*  Started clearing the sourceMapURL on fail to load source maps
* Added unit test to test the above

### Test Plan
Setup to get a source with a source map that fails on load:
- [x] Clone https://github.com/spotify/web-api-auth-examples
- [x] Run the following :
    $ npm install
    $ cd authorization_code
    $ node app.js
- [x] Simulate a fail to load the source map. Example method: Add `return null` to line 45 of `actions/newSources`

To test the patch
- [x] Open `code.jquery.com` folder from the sources
- [x] Click on `jquery-1.10.1.min.js`
- [x] `jquery-1.10.1.min.js` is automatically pretty printed (as opposed to being unable to pretty print before the patch)

### Screenshots
Before:
![image](https://user-images.githubusercontent.com/12681350/36043558-a7867220-0d9d-11e8-8d4d-10a790cdc101.png)

After:
![image](https://user-images.githubusercontent.com/12681350/36043272-c53f9fea-0d9c-11e8-9e49-2c5e10194124.png)