### PR TITLE
Removes sad face when source+goto

### DIFF
--- a/src/components/QuickOpenModal.js
+++ b/src/components/QuickOpenModal.js
@@ -110,10 +110,14 @@ export class QuickOpenModal extends Component<Props, State> {
     this.props.closeQuickOpen();
   };
 
+  dropGoto = (query: string) => {
+    return query.split(":")[0];
+  };
+
   searchSources = (query: string) => {
     const { sources } = this.props;
     const results =
-      query == "" ? sources : filter(sources, query.split(":")[0]);
+      query == "" ? sources : filter(sources, this.dropGoto(query));
     return this.setState({ results });
   };
 

--- a/src/components/QuickOpenModal.js
+++ b/src/components/QuickOpenModal.js
@@ -111,18 +111,10 @@ export class QuickOpenModal extends Component<Props, State> {
   };
 
   searchSources = (query: string) => {
-    if (query == "") {
-      const results = this.props.sources;
-      return this.setState({ results });
-    }
-    if (this.isGotoSourceQuery()) {
-      const [baseQuery] = query.split(":");
-      const results = filter(this.props.sources, baseQuery);
-      this.setState({ results });
-    } else {
-      const results = filter(this.props.sources, query);
-      this.setState({ results });
-    }
+    const { sources } = this.props;
+    const results =
+      query == "" ? sources : filter(sources, query.split(":")[0]);
+    return this.setState({ results });
   };
 
   searchSymbols = (query: string) => {


### PR DESCRIPTION
Associated Issue: #5428

- Removes sad face when using source+goto queries in QOM search
- handles source goto queries

Vid:
![removes-sad-goto](https://user-images.githubusercontent.com/23530054/36551637-5d77725a-17f8-11e8-8907-6a0564421e71.gif)


