### PR TITLE
Revert "Fixes yarn warnings (#5419)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,15 +28,15 @@
     "lint-js": "eslint *.js \"src/**/*.js\" --fix",
     "lint-md":
       "remark -u devtools-linters/markdown/preset -qf *.md src configs docs",
-    "lint-fix": "yarn lint-js --fix",
+    "lint-fix": "yarn lint-js -- --fix",
     "mochi":
       "mochii --mc ./firefox --interactive --default-test-path devtools/client/debugger/new",
-    "mochid": "yarn mochi --jsdebugger",
-    "mochir": "yarn mochi --repeat 10",
-    "mochih": "yarn mochi --headless",
+    "mochid": "yarn mochi -- --jsdebugger --",
+    "mochir": "yarn mochi -- --repeat 10 --",
+    "mochih": "yarn mochi -- --headless --",
     "test": "jest",
     "test:watch": "jest --watch",
-    "test-coverage": "yarn test --coverage",
+    "test-coverage": "yarn test -- --coverage",
     "test-all": "yarn test; yarn lint; yarn flow",
     "firefox":
       "start-firefox --start --location https://devtools-html.github.io/debugger-examples/",


### PR DESCRIPTION
This reverts commit 8b930f56f7460000f06090f1324e5f86443586a0.
For some reason we need the dashes so that `yarn mochih dbg-sources` only runs the sources tests