### PR TITLE
Ensure the source tree highlights the correct item, regardless of pretty or original print

### DIFF
--- a/src/components/PrimaryPanes/SourcesTree.js
+++ b/src/components/PrimaryPanes/SourcesTree.js
@@ -124,11 +124,15 @@ class SourcesTree extends Component<Props, State> {
     }
 
     if (nextProps.selectedSource) {
-      const highlightItems = getDirectories(
-        getRawSourceURL(nextProps.selectedSource.get("url")),
-        sourceTree
-      );
-      return this.setState({ highlightItems });
+      const highlightUrl = nextProps.selectedSource.get("url");
+
+      if (highlightUrl) {
+        const highlightItems = getDirectories(
+          getRawSourceURL(highlightUrl),
+          sourceTree
+        );
+        return this.setState({ highlightItems });
+      }
     }
 
     // NOTE: do not run this every time a source is clicked,

--- a/src/components/PrimaryPanes/SourcesTree.js
+++ b/src/components/PrimaryPanes/SourcesTree.js
@@ -42,6 +42,8 @@ import {
   getExtension
 } from "../../utils/sources-tree";
 
+import { getRawSourceURL } from "../../utils/source";
+
 import { copyToTheClipboard } from "../../utils/clipboard";
 import { features } from "../../utils/prefs";
 
@@ -92,13 +94,7 @@ class SourcesTree extends Component<Props, State> {
   }
 
   componentWillReceiveProps(nextProps) {
-    const {
-      projectRoot,
-      debuggeeUrl,
-      sources,
-      shownSource,
-      selectedSource
-    } = this.props;
+    const { projectRoot, debuggeeUrl, sources, shownSource } = this.props;
 
     const { uncollapsedTree, sourceTree } = this.state;
 
@@ -127,15 +123,11 @@ class SourcesTree extends Component<Props, State> {
       return this.setState({ listItems });
     }
 
-    if (
-      nextProps.selectedSource &&
-      nextProps.selectedSource != selectedSource
-    ) {
+    if (nextProps.selectedSource) {
       const highlightItems = getDirectories(
-        nextProps.selectedSource.get("url"),
+        getRawSourceURL(nextProps.selectedSource.get("url")),
         sourceTree
       );
-
       return this.setState({ highlightItems });
     }
 


### PR DESCRIPTION
So this has been really bugging me, had to fix it.

At present, if you open a pretty print tab (which now happens automagically when selecting a source from tree), the file is no longer highlighted in the tree.  This is because we were comparing sources; since PP and Original are different sources, and the pretty print URL was requested to highlight, but doesn't exit in the tree, nothing would be highlighted.

Additionally, I tried using an additional check:

```js
!selectedSource || selectedSource.get("url") != nextProps.selectedSource.get("url")
```

... but if you clicked on the tab you were already looking at, the highlight would go away.

In the end, I get why we did the checks we did but they have side effects.  I think simplifying this highlight check will do us wonders!