### PR TITLE
Fix ObjectInspector indent issue.

### DIFF
--- a/src/components/PrimaryPanes/Sources.css
+++ b/src/components/PrimaryPanes/Sources.css
@@ -163,6 +163,6 @@
   background-color: white;
 }
 
-.tree-node[data-expandable="false"] .tree-indent:last-of-type {
+.tree:not(.object-inspector) .tree-node[data-expandable="false"] .tree-indent:last-of-type {
   margin-inline-end: 4px;
 }


### PR DESCRIPTION
In #5269, we introduced an override for non-expandable nodes on the Tree component,
since we don't use the provided arrow in the project.
But, by doing that, we introduced a regression in the ObjectInspector indent,
since it also uses the Tree component.

Here we add more specificity to the overriding rule so we don't target ObjectInspector anymore.

### Screenshots

![group 3](https://user-images.githubusercontent.com/578107/36387020-fce36de8-1597-11e8-916a-2999fbdb2c12.png)

