### PR TITLE
Remove double tilde

### DIFF
--- a/src/test/mochitest/head.js
+++ b/src/test/mochitest/head.js
@@ -1085,7 +1085,7 @@ function getCM(dbg) {
 }
 
 function getCoordsFromPosition(cm, { line, ch }) {
-  return cm.charCoords({ line: ~~line, ch: ~~ch });
+  return cm.charCoords({ line, ch });
 }
 
 function hoverAtPos(dbg, { line, ch }) {


### PR DESCRIPTION
Drops the double tilde from the mochitest because its unnecessary in this context.