### PR TITLE
Prevent the re-rendering of a conditional breakpoint panel (cbp) when…

### DIFF
--- a/src/components/Editor/ConditionalPanel.js
+++ b/src/components/Editor/ConditionalPanel.js
@@ -104,6 +104,13 @@ export class ConditionalPanel extends PureComponent<Props> {
   }
 
   renderToWidget(props: Props) {
+    if (this.cbPanel) {
+      if (this.props.line && this.props.line == props.line) {
+        return props.closeConditionalPanel();
+      }
+      this.clearConditionalPanel();
+    }
+
     const { selectedLocation, line, editor } = props;
     const sourceId = selectedLocation ? selectedLocation.sourceId : "";
 


### PR DESCRIPTION
Prevent the re-rendering of a conditional breakpoint panel (cbp) when opening a new cbp or removing or disabling an open cbp.

Associated Issue: #4964 

### Summary of Changes

- When rendering, if the conditional breakpoint panel is open, then close it before rendering a new instance.
- For situations where the renderToWidget is called before the closeConditionalPanel action can be sent out, send out the action before the conditional panel gets dereferenced and return. (ex. Removing or disabling a conditional breakpoint when editing)

### Screenshots/Videos

Before:
- As can be seen when adding multiple conditional panels without closing the previous instances a new panel would be made but the old panel would remain and would have no ability to clear it out.
- When editing a conditional breakpoint, if we remove or disable it the breakpoint will once again remain and be unable to be interacted with.
![beforefix](https://user-images.githubusercontent.com/14250545/36442058-bdb8f350-1631-11e8-87b4-c0a3ad12bf97.gif)

After:
- Can add conditional breakpoint panels with the prior instance being cleared.
- Can add a new conditional breakpoint panel/remove/disable the conditional breakpoint panel even while editing and it will properly be cleared out.
![afterfix](https://user-images.githubusercontent.com/14250545/36442064-c26b6cac-1631-11e8-826e-c0d7824070d2.gif)
