### PR TITLE
Allow 'Reveal in Tree' for pretty tabs

### DIFF
--- a/src/actions/ui.js
+++ b/src/actions/ui.js
@@ -7,6 +7,7 @@
 import { getSource, getActiveSearch, getPaneCollapse } from "../selectors";
 import { getProjectDirectoryRoot } from "../reducers/ui";
 import type { ThunkArgs, panelPositionType } from "./types";
+import { getRawSourceURL } from "../utils/source";
 
 import type {
   ActiveSearchType,
@@ -66,7 +67,7 @@ export function showSource(sourceId: string) {
 
     dispatch({
       type: "SHOW_SOURCE",
-      sourceUrl: source.get("url")
+      sourceUrl: getRawSourceURL(source.get("url"))
     });
   };
 }

--- a/src/components/Editor/EditorMenu.js
+++ b/src/components/Editor/EditorMenu.js
@@ -140,7 +140,7 @@ function getMenuItems(
     id: "node-menu-show-source",
     label: revealInTreeLabel,
     accesskey: revealInTreeKey,
-    disabled: isPrettyPrinted,
+    disabled: false,
     click: () => showSource(sourceId)
   };
 

--- a/src/components/Editor/Tab.js
+++ b/src/components/Editor/Tab.js
@@ -114,11 +114,11 @@ class Tab extends PureComponent<Props> {
       }
     ];
 
-    if (!isPrettySource) {
-      items.push({
-        item: { ...tabMenuItems.showSource, click: () => showSource(tab) }
-      });
+    items.push({
+      item: { ...tabMenuItems.showSource, click: () => showSource(tab) }
+    });
 
+    if (!isPrettySource) {
       items.push({
         item: {
           ...tabMenuItems.prettyPrint,


### PR DESCRIPTION
"Reveal in Tree" context menu items should be globally available regardless of pretty or not.