### PR TITLE
Exclude flow annotations from symbol identifiers

### DIFF
--- a/src/workers/parser/getSymbols.js
+++ b/src/workers/parser/getSymbols.js
@@ -214,7 +214,8 @@ function extractSymbol(path, symbols) {
   if (t.isIdentifier(path) && !t.isGenericTypeAnnotation(path.parent)) {
     let { start, end } = path.node.loc;
 
-    if (t.isClassMethod(path.parent)) {
+    // We want to include function params, but exclude the function name
+    if (t.isClassMethod(path.parent) && !path.inList) {
       return;
     }
 

--- a/src/workers/parser/getSymbols.js
+++ b/src/workers/parser/getSymbols.js
@@ -211,7 +211,7 @@ function extractSymbol(path, symbols) {
     }
   }
 
-  if (t.isIdentifier(path)) {
+  if (t.isIdentifier(path) && !t.isGenericTypeAnnotation(path.parent)) {
     let { start, end } = path.node.loc;
 
     if (t.isClassMethod(path.parent)) {
@@ -250,7 +250,6 @@ function extractSymbol(path, symbols) {
     if (t.isArrayPattern(node)) {
       return;
     }
-
     symbols.identifiers.push({
       name: node.name,
       expression: node.name,

--- a/src/workers/parser/tests/__snapshots__/getSymbols.spec.js.snap
+++ b/src/workers/parser/tests/__snapshots__/getSymbols.spec.js.snap
@@ -70,6 +70,7 @@ identifiers:
 [(23, 6), (23, 11)]  Ultra Ultra
 [(25, 4), (25, 8)] [(25, 4), (25, 8)] this this
 [(25, 9), (25, 16)]  awesome awesome
+[(28, 12), (28, 18)]  person person
 [(29, 4), (29, 11)]  console console
 [(29, 12), (29, 15)]  log log
 [(29, 19), (29, 25)]  person person
@@ -159,6 +160,7 @@ identifiers:
 [(1, 6), (1, 10)]  Test Test
 [(3, 4), (3, 8)] [(3, 4), (3, 8)] this this
 [(3, 9), (3, 12)]  foo foo
+[(6, 6), (6, 7)]  a a
 [(7, 4), (7, 11)]  console console
 [(7, 12), (7, 15)]  log log
 [(7, 23), (7, 24)]  a a
@@ -254,6 +256,7 @@ comments:
 
 identifiers:
 [(5, 6), (5, 11)]  Punny Punny
+[(6, 14), (6, 19)]  props props
 [(8, 4), (8, 8)] [(8, 4), (8, 8)] this this
 [(8, 9), (8, 16)]  onClick onClick
 [(8, 19), (8, 23)] [(8, 19), (8, 23)] this this
@@ -702,11 +705,8 @@ comments:
 
 identifiers:
 [(1, 6), (1, 9)]  App App
-[(2, 2), (2, 13)]  renderHello renderHello
 [(2, 14), (2, 18)]  name name
 [(2, 28), (2, 34)]  action action
-[(2, 51), (2, 56)]  todos todos
-[(2, 51), (2, 56)]  todos todos
 [(3, 20), (3, 24)]  name name
 [(1, 18), (1, 27)]  Component Component
 

--- a/src/workers/parser/tests/__snapshots__/getSymbols.spec.js.snap
+++ b/src/workers/parser/tests/__snapshots__/getSymbols.spec.js.snap
@@ -680,10 +680,13 @@ hasJsx: false"
 
 exports[`Parser.getSymbols flow 1`] = `
 "functions:
-[(2, 2), (4, 3)]   renderHello(name) App
+[(2, 2), (4, 3)]   renderHello(name, action, ) App
 
 variables:
 [(2, 14), (2, 26)]   name
+[(2, 28), (2, 47)]   action
+[(2, 49), (2, 65)]
+[(2, 51), (2, 56)]   todos
 
 callExpressions:
 
@@ -692,13 +695,18 @@ memberExpressions:
 
 
 objectProperties:
-
+[(2, 51), (2, 56)]  todos todos
 
 comments:
 
 
 identifiers:
 [(1, 6), (1, 9)]  App App
+[(2, 2), (2, 13)]  renderHello renderHello
+[(2, 14), (2, 18)]  name name
+[(2, 28), (2, 34)]  action action
+[(2, 51), (2, 56)]  todos todos
+[(2, 51), (2, 56)]  todos todos
 [(3, 20), (3, 24)]  name name
 [(1, 18), (1, 27)]  Component Component
 

--- a/src/workers/parser/tests/fixtures/flow.js
+++ b/src/workers/parser/tests/fixtures/flow.js
@@ -1,5 +1,5 @@
 class App extends Component {
-  renderHello(name: string) {
+  renderHello(name: string, action: ReduxAction, { todos }: Props) {
     return `howdy ${name}`;
   }
 }

--- a/src/workers/parser/tests/getSymbols.spec.js
+++ b/src/workers/parser/tests/getSymbols.spec.js
@@ -7,10 +7,11 @@ import cases from "jest-in-case";
 cases(
   "Parser.getSymbols",
   ({ name, file, original, type }) => {
-    // console.log(formatSymbols(getSource(file, type)));
     const source = original
       ? getOriginalSource(file, type)
       : getSource(file, type);
+
+    // console.log(formatSymbols(source));
     expect(formatSymbols(source)).toMatchSnapshot();
   },
   [


### PR DESCRIPTION
Associated Issue: #5482 

### Summary of Changes

* Exclude identifier from symbols if it's a type annotation

### Test Plan

- [x] Updated `getSymbols` test to incorporate this change

### Screenshots/Videos (OPTIONAL)

![a](https://user-images.githubusercontent.com/7821757/36467741-1ebec1fa-1706-11e8-80c7-ebc7be26c6db.gif)

