### PR TITLE
Fix project directory root

### DIFF
--- a/src/utils/prefs.js
+++ b/src/utils/prefs.js
@@ -72,7 +72,7 @@ export const prefs = new PrefsHelper("devtools", {
   fileSearchWholeWord: ["Bool", "debugger.file-search-whole-word"],
   fileSearchRegexMatch: ["Bool", "debugger.file-search-regex-match"],
   debuggerPrefsSchemaVersion: ["Char", "debugger.prefs-schema-version"],
-  projectDirectoryRoot: ["Char", "project-directory-root", ""]
+  projectDirectoryRoot: ["Char", "debugger.project-directory-root", ""]
 });
 
 export const features = new PrefsHelper("devtools.debugger.features", {


### PR DESCRIPTION
### Summary of Changes

I noticed in about:config that i couldnt reset the directory root. Turns out that the prefhelper was pointing to the wrong pref field