### PR TITLE
Provide a method for Alphabetizing the outline functions and classes

### DIFF
--- a/assets/panel/debugger.properties
+++ b/assets/panel/debugger.properties
@@ -552,6 +552,9 @@ sources.header=Sources
 # LOCALIZATION NOTE (outline.header): Outline left sidebar header
 outline.header=Outline
 
+# LOCALIZATION NOTE (outline.sortLabel): Label for the sort button
+outline.sortLabel=Sort by name
+
 # LOCALIZATION NOTE (outline.noFunctions): Outline text when there are no functions to display
 outline.noFunctions=No functions
 

--- a/assets/panel/prefs.js
+++ b/assets/panel/prefs.js
@@ -13,6 +13,7 @@ pref("devtools.debugger.pause-on-exceptions", false);
 pref("devtools.debugger.ignore-caught-exceptions", false);
 pref("devtools.debugger.source-maps-enabled", true);
 pref("devtools.debugger.pretty-print-enabled", true);
+pref("devtools.debugger.alphabetize-outline", false);
 pref("devtools.debugger.auto-pretty-print", false);
 pref("devtools.debugger.auto-black-box", true);
 pref("devtools.debugger.workers", false);

--- a/src/components/PrimaryPanes/Outline.css
+++ b/src/components/PrimaryPanes/Outline.css
@@ -3,7 +3,12 @@
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
 .outline {
-  overflow-y: auto;
+  overflow-y: hidden;
+}
+
+.outline > div {
+  width: 100%;
+  position: relative;
 }
 
 .outline .outline-pane-info {
@@ -13,14 +18,20 @@
   padding: 0.5em;
   user-select: none;
   font-size: 12px;
+  overflow: hidden;
 }
 
 .outline-list {
   list-style-type: none;
-  flex: 1 0 100%;
-  padding: 10px 0px;
+  padding: 10px 0;
   margin: 0;
   font-family: var(--monospace-font-family);
+  overflow: auto;
+  position: absolute;
+  top: 0;
+  right: 0;
+  left: 0;
+  bottom: 25px;
 }
 
 .outline-list__class-list {
@@ -69,4 +80,25 @@
 
 .outline-list__element:hover {
   background: var(--theme-toolbar-background-hover);
+}
+
+.outline-footer {
+  background: var(--theme-body-background);
+  border-top: 1px solid var(--theme-splitter-color);
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  opacity: 1;
+  z-index: 1;
+  -moz-user-select: none;
+  user-select: none;
+  height: 25px;
+  box-sizing: border-box;
+  display: flex;
+}
+
+.outline-footer button.active {
+  background: var(--theme-highlight-blue);
+  color: #ffffff;
 }

--- a/src/components/PrimaryPanes/Outline.js
+++ b/src/components/PrimaryPanes/Outline.js
@@ -25,7 +25,7 @@ type Props = {
   selectLocation: ({ sourceId: string, line: number }) => void,
   selectedSource: ?SourceRecord,
   onAlphabetizeClick: Function,
-  alphabetizeOutline: Boolean
+  alphabetizeOutline: boolean
 };
 
 export class Outline extends Component<Props> {

--- a/src/components/PrimaryPanes/Outline.js
+++ b/src/components/PrimaryPanes/Outline.js
@@ -12,7 +12,7 @@ import { getSelectedSource, getSymbols } from "../../selectors";
 
 import "./Outline.css";
 import PreviewFunction from "../shared/PreviewFunction";
-import { uniq } from "lodash";
+import { uniq, sortBy } from "lodash";
 import type {
   SymbolDeclarations,
   SymbolDeclaration
@@ -23,7 +23,9 @@ import type { SourceRecord } from "../../reducers/sources";
 type Props = {
   symbols: SymbolDeclarations,
   selectLocation: ({ sourceId: string, line: number }) => void,
-  selectedSource: ?SourceRecord
+  selectedSource: ?SourceRecord,
+  onAlphabetizeClick: Function,
+  alphabetizeOutline: Boolean
 };
 
 export class Outline extends Component<Props> {
@@ -90,21 +92,41 @@ export class Outline extends Component<Props> {
   }
 
   renderFunctions(functions: Array<SymbolDeclaration>) {
-    const classes = uniq(functions.map(func => func.klass));
-    const namedFunctions = functions.filter(
+    let classes = uniq(functions.map(func => func.klass));
+    let namedFunctions = functions.filter(
       func =>
         func.name != "anonymous" && !func.klass && !classes.includes(func.name)
     );
 
-    const classFunctions = functions.filter(
+    let classFunctions = functions.filter(
       func => func.name != "anonymous" && !!func.klass
     );
 
+    if (this.props.alphabetizeOutline) {
+      namedFunctions = sortBy(namedFunctions, "name");
+      classes = sortBy(classes, "klass");
+      classFunctions = sortBy(classFunctions, "name");
+    }
+
     return (
-      <ul className="outline-list">
-        {namedFunctions.map(func => this.renderFunction(func))}
-        {classes.map(klass => this.renderClassFunctions(klass, classFunctions))}
-      </ul>
+      <div>
+        <ul className="outline-list">
+          {namedFunctions.map(func => this.renderFunction(func))}
+          {classes.map(klass =>
+            this.renderClassFunctions(klass, classFunctions)
+          )}
+        </ul>
+        <div className="outline-footer bottom">
+          <button
+            onClick={() => {
+              this.props.onAlphabetizeClick();
+            }}
+            className={this.props.alphabetizeOutline ? "active" : ""}
+          >
+            {L10N.getStr("outline.sortLabel")}
+          </button>
+        </div>
+      </div>
     );
   }
 

--- a/src/components/PrimaryPanes/index.js
+++ b/src/components/PrimaryPanes/index.js
@@ -14,7 +14,7 @@ import {
   getActiveSearch,
   getSelectedPrimaryPaneTab
 } from "../../selectors";
-import { features } from "../../utils/prefs";
+import { features, prefs } from "../../utils/prefs";
 import "./Sources.css";
 import classnames from "classnames";
 
@@ -22,6 +22,10 @@ import Outline from "./Outline";
 import SourcesTree from "./SourcesTree";
 
 import type { SourcesMap } from "../../reducers/types";
+
+type State = {
+  alphabetizeOutline: boolean
+};
 
 type Props = {
   selectedTab: string,
@@ -31,22 +35,34 @@ type Props = {
   horizontal: boolean,
   setActiveSearch: string => void,
   closeActiveSearch: () => void,
-  sourceSearchOn: boolean
+  sourceSearchOn: boolean,
+  alphabetizeOutline: boolean
 };
 
-class PrimaryPanes extends Component<Props> {
+class PrimaryPanes extends Component<Props, State> {
   renderShortcut: Function;
   selectedPane: String;
   showPane: Function;
   renderTabs: Function;
   renderChildren: Function;
+  onAlphabetizeClick: Function;
 
   constructor(props: Props) {
     super(props);
+
+    this.state = {
+      alphabetizeOutline: prefs.alphabetizeOutline
+    };
   }
 
   showPane = (selectedPane: string) => {
     this.props.setPrimaryPaneTab(selectedPane);
+  };
+
+  onAlphabetizeClick = () => {
+    const alphabetizeOutline = !prefs.alphabetizeOutline;
+    prefs.alphabetizeOutline = alphabetizeOutline;
+    this.setState({ alphabetizeOutline });
   };
 
   renderOutlineTabs() {
@@ -111,7 +127,14 @@ class PrimaryPanes extends Component<Props> {
     return (
       <div className="sources-panel">
         {this.renderTabs()}
-        {selectedTab === "sources" ? <SourcesTree /> : <Outline />}
+        {selectedTab === "sources" ? (
+          <SourcesTree />
+        ) : (
+          <Outline
+            alphabetizeOutline={this.state.alphabetizeOutline}
+            onAlphabetizeClick={this.onAlphabetizeClick}
+          />
+        )}
       </div>
     );
   }

--- a/src/components/PrimaryPanes/index.js
+++ b/src/components/PrimaryPanes/index.js
@@ -119,7 +119,7 @@ class PrimaryPanes extends Component<Props, State> {
         </span>
       );
     }
-  }
+  };
 
   render() {
     const { selectedTab } = this.props;

--- a/src/components/tests/__snapshots__/Outline.spec.js.snap
+++ b/src/components/tests/__snapshots__/Outline.spec.js.snap
@@ -4,48 +4,60 @@ exports[`Outline should render a list of functions when properties change 1`] = 
 <div
   className="outline"
 >
-  <ul
-    className="outline-list"
-  >
-    <li
-      className="outline-list__element"
-      key="my_example_function1:21:undefined"
-      onClick={[Function]}
+  <div>
+    <ul
+      className="outline-list"
     >
-      <span
-        className="outline-list__element-icon"
+      <li
+        className="outline-list__element"
+        key="my_example_function1:21:undefined"
+        onClick={[Function]}
       >
-        λ
-      </span>
-      <PreviewFunction
-        func={
-          Object {
-            "name": "my_example_function1",
-            "parameterNames": undefined,
+        <span
+          className="outline-list__element-icon"
+        >
+          λ
+        </span>
+        <PreviewFunction
+          func={
+            Object {
+              "name": "my_example_function1",
+              "parameterNames": undefined,
+            }
           }
-        }
-      />
-    </li>
-    <li
-      className="outline-list__element"
-      key="my_example_function2:22:undefined"
-      onClick={[Function]}
+        />
+      </li>
+      <li
+        className="outline-list__element"
+        key="my_example_function2:22:undefined"
+        onClick={[Function]}
+      >
+        <span
+          className="outline-list__element-icon"
+        >
+          λ
+        </span>
+        <PreviewFunction
+          func={
+            Object {
+              "name": "my_example_function2",
+              "parameterNames": undefined,
+            }
+          }
+        />
+      </li>
+    </ul>
+    <div
+      className="outline-footer bottom"
     >
-      <span
-        className="outline-list__element-icon"
+      <button
+        className=""
+        onClick={[Function]}
       >
-        λ
-      </span>
-      <PreviewFunction
-        func={
-          Object {
-            "name": "my_example_function2",
-            "parameterNames": undefined,
-          }
-        }
-      />
-    </li>
-  </ul>
+        Sort by name
+      </button>
+    </div>
+  </div>
 </div>
 `;
 
@@ -53,28 +65,40 @@ exports[`Outline should render ignore anonimous functions 1`] = `
 <div
   className="outline"
 >
-  <ul
-    className="outline-list"
-  >
-    <li
-      className="outline-list__element"
-      key="my_example_function1:21:undefined"
-      onClick={[Function]}
+  <div>
+    <ul
+      className="outline-list"
     >
-      <span
-        className="outline-list__element-icon"
+      <li
+        className="outline-list__element"
+        key="my_example_function1:21:undefined"
+        onClick={[Function]}
       >
-        λ
-      </span>
-      <PreviewFunction
-        func={
-          Object {
-            "name": "my_example_function1",
-            "parameterNames": undefined,
+        <span
+          className="outline-list__element-icon"
+        >
+          λ
+        </span>
+        <PreviewFunction
+          func={
+            Object {
+              "name": "my_example_function1",
+              "parameterNames": undefined,
+            }
           }
-        }
-      />
-    </li>
-  </ul>
+        />
+      </li>
+    </ul>
+    <div
+      className="outline-footer bottom"
+    >
+      <button
+        className=""
+        onClick={[Function]}
+      >
+        Sort by name
+      </button>
+    </div>
+  </div>
 </div>
 `;

--- a/src/test/mochitest/browser_dbg-outline.js
+++ b/src/test/mochitest/browser_dbg-outline.js
@@ -27,4 +27,15 @@ add_task(async function() {
   is(item.innerText, "evaledFunc()", "got evaled func");
   item.click();
   assertHighlightLocation(dbg, "simple1", 15);
+
+  // Ensure "main()" is the first function listed
+  const functions = getElementsWithSelector('.outline-list__class-list li');
+  is(functions[0].innerText, "main()", "Natural first function is first listed");
+  // Sort the list
+  findElementWithSelector(dbg, ".outline-footer button").click();
+  // Button becomes active to show alphabetization
+  is(findElementWithSelector(dbg, ".outline-footer .active").length, 1);
+  // Ensure "doEval()" is the first function listed after alphabetization
+  const alphaFunctions = getElementsWithSelector('.outline-list__class-list li');
+  is(alphaFunctions[0].innerText, "doEval()", "Alphabetized first function is correct");
 });

--- a/src/test/mochitest/browser_dbg-outline.js
+++ b/src/test/mochitest/browser_dbg-outline.js
@@ -29,13 +29,13 @@ add_task(async function() {
   assertHighlightLocation(dbg, "simple1", 15);
 
   // Ensure "main()" is the first function listed
-  const functions = getElementsWithSelector('.outline-list__class-list li');
-  is(functions[0].innerText, "main()", "Natural first function is first listed");
+  const firstFunction = findElementWithSelector(dbg, '.outline-list__element .function-signature');
+  is(firstFunction.innerText, "main()", "Natural first function is first listed");
   // Sort the list
   findElementWithSelector(dbg, ".outline-footer button").click();
   // Button becomes active to show alphabetization
-  is(findElementWithSelector(dbg, ".outline-footer .active").length, 1);
+  is(findElementWithSelector(dbg, ".outline-footer button").className, "active", "Alphabetize button is highlighted when active");
   // Ensure "doEval()" is the first function listed after alphabetization
-  const alphaFunctions = getElementsWithSelector('.outline-list__class-list li');
-  is(alphaFunctions[0].innerText, "doEval()", "Alphabetized first function is correct");
+  const firstAlphaFunction = findElementWithSelector(dbg, '.outline-list__element .function-signature');
+  is(firstAlphaFunction.innerText.replace("λ", ""), "doEval()", "Alphabetized first function is correct");
 });

--- a/src/utils/prefs.js
+++ b/src/utils/prefs.js
@@ -12,6 +12,7 @@ const prefsSchemaVersion = "1.0.3";
 const pref = Services.pref;
 
 if (isDevelopment()) {
+  pref("devtools.debugger.alphabetize-outline", false);
   pref("devtools.debugger.auto-pretty-print", true);
   pref("devtools.source-map.client-service.enabled", true);
   pref("devtools.debugger.pause-on-exceptions", false);
@@ -52,6 +53,7 @@ if (isDevelopment()) {
 }
 
 export const prefs = new PrefsHelper("devtools", {
+  alphabetizeOutline: ["Bool", "debugger.alphabetize-outline"],
   autoPrettyPrint: ["Bool", "debugger.auto-pretty-print"],
   clientSourceMapsEnabled: ["Bool", "source-map.client-service.enabled"],
   pauseOnExceptions: ["Bool", "debugger.pause-on-exceptions"],


### PR DESCRIPTION
I find the Outline pane much easier to use when the functions are in alphabetical order.  This PR provides a place for discussion about a feature for alphabetizing and restoring original order:

<img width="248" alt="outlinealphabetize" src="https://user-images.githubusercontent.com/46655/36518031-5a3fc352-174a-11e8-91e7-601c939b28ff.png">

## ToDo:

- [x] Use variable (not hardcoded) height for the Outline footer and its styles
- [x] Add a "toggled" UI state for the "Az" button so it's clear whether the current state is set to alphabetize or not
- [x] Sort classes as well
- [x] Make the alphabetize setting persist (?) so that moving between sources keeps the alphabetized state
- [x] Tests
