### PR TITLE
Fixes ? in QOM needing a space to show results

### DIFF
--- a/src/components/QuickOpenModal.js
+++ b/src/components/QuickOpenModal.js
@@ -164,7 +164,7 @@ export class QuickOpenModal extends Component<Props, State> {
       return;
     }
 
-    if (query == "") {
+    if (query == "" && !this.isShortcutQuery()) {
       return this.showTopSources();
     }
 


### PR DESCRIPTION
Associated Issue: #5373

### Before: 
STR:
- press `ctrl+;`
- remove character
- type `?`
- notice result count = 3
- type `[space]`

ER:
- suggestions show up immediately after typing `?`

AR:
- suggestions require `? ` being typed to show up

### After
![qom-space](https://user-images.githubusercontent.com/23530054/36548103-b5d50628-17ef-11e8-9a60-45ac490f8266.gif)
