### PR TITLE
Request longer timeout for dbg-sources tests

### DIFF
--- a/src/test/mochitest/browser_dbg-sources.js
+++ b/src/test/mochitest/browser_dbg-sources.js
@@ -23,6 +23,8 @@ function getLabel(dbg, index) {
 }
 
 add_task(async function() {
+  requestLongerTimeout(5);
+
   const dbg = await initDebugger("doc-sources.html");
   const { selectors: { getSelectedSource }, getState } = dbg;
 


### PR DESCRIPTION
The test that fails *appears to be* the test that adds the dynamic source; let's up the timeout to see if that's the issue.