### PR TITLE
Display message to indicate no selected source in Outline tab (#5266)

### DIFF
--- a/assets/panel/debugger.properties
+++ b/assets/panel/debugger.properties
@@ -555,6 +555,9 @@ outline.header=Outline
 # LOCALIZATION NOTE (outline.noFunctions): Outline text when there are no functions to display
 outline.noFunctions=No functions
 
+# LOCALIZATION NOTE (outline.noFileSelected): Outline text when there are no functions to display
+outline.noFileSelected=No file selected
+
 # LOCALIZATION NOTE (sources.search): Sources left sidebar prompt
 # e.g. Cmd+P to search. On a mac, we use the command unicode character.
 # On windows, it's ctrl.

--- a/assets/panel/debugger.properties
+++ b/assets/panel/debugger.properties
@@ -555,7 +555,7 @@ outline.header=Outline
 # LOCALIZATION NOTE (outline.noFunctions): Outline text when there are no functions to display
 outline.noFunctions=No functions
 
-# LOCALIZATION NOTE (outline.noFileSelected): Outline text when there are no functions to display
+# LOCALIZATION NOTE (outline.noFileSelected): Outline text when there are no files selected
 outline.noFileSelected=No file selected
 
 # LOCALIZATION NOTE (sources.search): Sources left sidebar prompt

--- a/src/components/PrimaryPanes/Outline.js
+++ b/src/components/PrimaryPanes/Outline.js
@@ -38,11 +38,11 @@ export class Outline extends Component<Props> {
   }
 
   renderPlaceholder() {
-    return (
-      <div className="outline-pane-info">
-        {L10N.getStr("outline.noFunctions")}
-      </div>
-    );
+    const placeholderMessage = !this.props.selectedSource
+      ? L10N.getStr("outline.noFileSelected")
+      : L10N.getStr("outline.noFunctions");
+
+    return <div className="outline-pane-info">{placeholderMessage}</div>;
   }
 
   renderFunction(func: SymbolDeclaration) {

--- a/src/components/PrimaryPanes/Outline.js
+++ b/src/components/PrimaryPanes/Outline.js
@@ -38,9 +38,9 @@ export class Outline extends Component<Props> {
   }
 
   renderPlaceholder() {
-    const placeholderMessage = !this.props.selectedSource
-      ? L10N.getStr("outline.noFileSelected")
-      : L10N.getStr("outline.noFunctions");
+    const placeholderMessage = this.props.selectedSource
+      ? L10N.getStr("outline.noFunctions")
+      : L10N.getStr("outline.noFileSelected");
 
     return <div className="outline-pane-info">{placeholderMessage}</div>;
   }


### PR DESCRIPTION
Associated Issue: #5266 

### Summary of Changes

'No file selected' message is displayed in the Outline tab when there is no source selected.
