### PR TITLE
Revert "Ensure the source tree highlights the correct item, regardless of pretty or original print (#5455)"

### DIFF
--- a/src/components/PrimaryPanes/SourcesTree.js
+++ b/src/components/PrimaryPanes/SourcesTree.js
@@ -42,8 +42,6 @@ import {
   getExtension
 } from "../../utils/sources-tree";
 
-import { getRawSourceURL } from "../../utils/source";
-
 import { copyToTheClipboard } from "../../utils/clipboard";
 import { features } from "../../utils/prefs";
 
@@ -94,7 +92,13 @@ class SourcesTree extends Component<Props, State> {
   }
 
   componentWillReceiveProps(nextProps) {
-    const { projectRoot, debuggeeUrl, sources, shownSource } = this.props;
+    const {
+      projectRoot,
+      debuggeeUrl,
+      sources,
+      shownSource,
+      selectedSource
+    } = this.props;
 
     const { uncollapsedTree, sourceTree } = this.state;
 
@@ -123,16 +127,16 @@ class SourcesTree extends Component<Props, State> {
       return this.setState({ listItems });
     }
 
-    if (nextProps.selectedSource) {
-      const highlightUrl = nextProps.selectedSource.get("url");
+    if (
+      nextProps.selectedSource &&
+      nextProps.selectedSource != selectedSource
+    ) {
+      const highlightItems = getDirectories(
+        nextProps.selectedSource.get("url"),
+        sourceTree
+      );
 
-      if (highlightUrl) {
-        const highlightItems = getDirectories(
-          getRawSourceURL(highlightUrl),
-          sourceTree
-        );
-        return this.setState({ highlightItems });
-      }
+      return this.setState({ highlightItems });
     }
 
     // NOTE: do not run this every time a source is clicked,


### PR DESCRIPTION
For some reason this commit breaks the last test in dbg-sources:

```js
// Make sure new sources appear in the list.
  ContentTask.spawn(gBrowser.selectedBrowser, null, function() {
    const script = content.document.createElement("script");
    script.src = "math.min.js";
    content.document.body.appendChild(script);
  });

  await waitForSourceCount(dbg, 9);
  is(
    getLabel(dbg, 7),
    "math.min.js",
    "math.min.js - The dynamic script exists"
  );
```

While this makes absolutely no sense to me as to why this test could time out, the problem started with this commit and reverting will hopefully turn the candle green again.