### PR TITLE
Re-added changes from #5409, and added waitFor changes to test sugges…

### DIFF
--- a/src/components/Editor/ConditionalPanel.js
+++ b/src/components/Editor/ConditionalPanel.js
@@ -96,6 +96,10 @@ export class ConditionalPanel extends PureComponent<Props> {
     return this.clearConditionalPanel();
   }
 
+  componentDidUpdate(prevProps: Props) {
+    this.keepFocusOnInput();
+  }
+
   componentWillUnmount() {
     // This is called if CodeMirror is re-initializing itself before the
     // user closes the conditional panel. Clear the widget, and re-render it
@@ -140,8 +144,6 @@ export class ConditionalPanel extends PureComponent<Props> {
         this.scrollParent.addEventListener("scroll", this.repositionOnScroll);
         this.repositionOnScroll();
       }
-
-      this.input.focus();
     }
   }
 

--- a/src/test/mochitest/browser_dbg-breakpoints-cond.js
+++ b/src/test/mochitest/browser_dbg-breakpoints-cond.js
@@ -24,11 +24,23 @@ function assertEditorBreakpoint(dbg, line, shouldExist) {
   );
 }
 
+async function assertConditionalBreakpointIsFocused(dbg) {
+  const conditionalBreakpointInput = findElementWithSelector(
+    dbg,
+    ".conditional-breakpoint-panel input"
+  );
+
+  const breakpointFocused = await waitFor(() => dbg.win.document.activeElement == conditionalBreakpointInput &&
+    dbg.win.document.hasFocus());
+
+  ok(breakpointFocused, "Conditional Breakpoint Input is focused.");
+}
+
 async function setConditionalBreakpoint(dbg, index, condition) {
   rightClickElement(dbg, "gutter", index);
   selectMenuItem(dbg, 2);
   await waitForElementWithSelector(dbg, ".conditional-breakpoint-panel input");
-  findElementWithSelector(dbg, ".conditional-breakpoint-panel input").focus();
+  await assertConditionalBreakpointIsFocused(dbg);
   // Position cursor reliably at the end of the text.
   pressKey(dbg, "End");
   type(dbg, condition);


### PR DESCRIPTION
Re-added changes from #5409, and added waitFor changes to test suggested by nchevobbe.

Associated Issue: #5473 

### **From PR #5409** ---------------------------------------------
Associated Issue: #4823

### Summary of Changes

* Changed the focus of the conditional breakpoint panel's input to after the render in the componentDidUpdate instead of the renderToWidget.

### Test Plan

Added one test, browser_dbg-breakpoints-cond_focus.js, to ensure that the input does focus.

### Before: 
It can be seen that after adding a conditional breakpoint the input does not automatically focus.
![before](https://user-images.githubusercontent.com/14250545/36173564-b21be2ca-10c6-11e8-991e-0fc19dd142a6.gif)

### After: 
It can be seen now that the input box is acting as expected. Each time a conditional breakpoint is added, the input is focused.
![after](https://user-images.githubusercontent.com/14250545/36173600-cf3739d6-10c6-11e8-8b21-b82a50cc2f54.gif)
