### PR TITLE
Highlight original source for sources tree

### DIFF
--- a/src/components/PrimaryPanes/SourcesTree.js
+++ b/src/components/PrimaryPanes/SourcesTree.js
@@ -42,6 +42,7 @@ import {
   getExtension
 } from "../../utils/sources-tree";
 
+import { getRawSourceURL } from "../../utils/source";
 import { copyToTheClipboard } from "../../utils/clipboard";
 import { features } from "../../utils/prefs";
 
@@ -132,7 +133,7 @@ class SourcesTree extends Component<Props, State> {
       nextProps.selectedSource != selectedSource
     ) {
       const highlightItems = getDirectories(
-        nextProps.selectedSource.get("url"),
+        getRawSourceURL(nextProps.selectedSource.get("url")),
         sourceTree
       );
 

--- a/src/utils/source.js
+++ b/src/utils/source.js
@@ -115,7 +115,7 @@ export function getPrettySourceURL(url: ?string): string {
  * @static
  */
 export function getRawSourceURL(url: string): string {
-  return url.replace(/:formatted$/, "");
+  return url ? url.replace(/:formatted$/, "") : url;
 }
 
 function resolveFileURL(


### PR DESCRIPTION
More updates are needed to make the source tree behave but this should be fairly easy:  don't try to highlight pretty-printed `:formatted` addresses that don't exist in the tree.  Instead highlight its original counterpart.