### PR TITLE
Prevent items[selectedIndex] error

### DIFF
--- a/src/components/QuickOpenModal.js
+++ b/src/components/QuickOpenModal.js
@@ -392,7 +392,9 @@ export class QuickOpenModal extends Component<Props, State> {
           handleClose={this.closeModal}
           hasPrefix={this.hasPrefix()}
           expanded={expanded}
-          selectedItemId={expanded ? items[selectedIndex].id : ""}
+          selectedItemId={
+            expanded && items[selectedIndex] ? items[selectedIndex].id : ""
+          }
         />
         {newResults && (
           <ResultList


### PR DESCRIPTION
If you do `Command+P`, the type `@`, then use your arrow keys, you get a `items[selectedIndex] is undefined` error.  Let's prevent that.