### PR TITLE
Ignore node_modules in flow

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,8 +1,5 @@
 [ignore]
-.*node_modules/documentation.*
-.*node_modules/devtools-reps/src/object-inspector/index.js
-.*node_modules/devtools-mc-assets/.*
-.*node_modules/immutable/dist/immutable.js.flow
+.*node_modules/.*
 <PROJECT_ROOT>/firefox/.*
 .*mozilla-central/.*
 .*flow-coverage-report/.*


### PR DESCRIPTION

### Summary of Changes

Follows perf.html's lead - https://github.com/devtools-html/perf.html/pull/810/files
This should help the memory and local perf usage for the debugger