### PR TITLE
Fix re-evaluate on resume

### DIFF
--- a/src/actions/pause/resumed.js
+++ b/src/actions/pause/resumed.js
@@ -20,13 +20,12 @@ export function resumed() {
   return async ({ dispatch, client, getState }: ThunkArgs) => {
     const why = getPauseReason(getState());
     const wasPausedInEval = inDebuggerEval(why);
+    const wasStepping = isStepping(getState());
 
-    if (!isStepping(getState()) && !wasPausedInEval) {
+    dispatch({ type: "RESUME" });
+
+    if (!wasStepping && !wasPausedInEval) {
       await dispatch(evaluateExpressions());
     }
-
-    dispatch({
-      type: "RESUME"
-    });
   };
 }

--- a/src/reducers/pause.js
+++ b/src/reducers/pause.js
@@ -69,7 +69,6 @@ export const createPauseState = (): PauseState => ({
 });
 
 const emptyPauseState = {
-  pause: null,
   frames: null,
   frameScopes: {
     generated: {},
@@ -77,7 +76,8 @@ const emptyPauseState = {
   },
   selectedFrameId: null,
   loadedObjects: {},
-  previousLocation: null
+  previousLocation: null,
+  why: null
 };
 
 function update(
@@ -208,9 +208,7 @@ function update(
     }
 
     case "RESUME":
-      // We clear why on resume because we need it to decide if
-      // we shoul re-evaluate watch expressions.
-      return { ...state, why: null };
+      return { ...state, ...emptyPauseState };
 
     case "EVALUATE_EXPRESSION":
       return {

--- a/src/test/mochitest/browser.ini
+++ b/src/test/mochitest/browser.ini
@@ -81,6 +81,7 @@ support-files =
   examples/doc-babel.html
   examples/doc-content-script-sources.html
   examples/doc-scripts.html
+  examples/doc-scripts-debugger.html
   examples/doc-script-mutate.html
   examples/doc-script-switching.html
   examples/doc-exceptions.html
@@ -153,6 +154,7 @@ skip-if = os == "linux" # bug 1351952
 skip-if = os == "win"
 [browser_dbg-navigation.js]
 [browser_dbg-minified.js]
+[browser_dbg-pause-on-navigate.js]
 [browser_dbg-pretty-print.js]
 [browser_dbg-pretty-print-console.js]
 [browser_dbg-pretty-print-paused.js]

--- a/src/test/mochitest/browser_dbg-pause-on-navigate.js
+++ b/src/test/mochitest/browser_dbg-pause-on-navigate.js
@@ -1,0 +1,39 @@
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
+
+async function addExpression(dbg, input) {
+  info("Adding an expression");
+  findElement(dbg, "expressionInput").focus();
+  type(dbg, input);
+  pressKey(dbg, "Enter");
+
+  await waitForDispatch(dbg, "EVALUATE_EXPRESSION");
+}
+
+function getLabel(dbg, index) {
+  return findElement(dbg, "expressionNode", index).innerText;
+}
+
+function getValue(dbg, index) {
+  return findElement(dbg, "expressionValue", index)
+    .innerText
+    .replace(/\r?\n|\r/g, '')
+    .replace(/^[\s\u200b]*/g, "");
+}
+
+add_task(async function() {
+  const dbg = await initDebugger("doc-scripts.html");
+
+  await addExpression(dbg, "location.hostname");
+
+  navigate(dbg, "doc-scripts-debugger.html");
+  const expressionEvaluated = waitForDispatch(dbg, "EVALUATE_EXPRESSION")
+  await waitForPaused(dbg);
+  await expressionEvaluated;
+
+  assertDebugLine(dbg, 13);
+  is(getLabel(dbg, 1), "location.hostname", "Expression label is 'location'");
+  is("example.com", "example.com",  "Expression value is set");
+
+  navigate(dbg, "doc-scripts.html");
+});

--- a/src/test/mochitest/examples/doc-scripts-debugger.html
+++ b/src/test/mochitest/examples/doc-scripts-debugger.html
@@ -1,0 +1,20 @@
+ <!-- This Source Code Form is subject to the terms of the Mozilla Public
+    - License, v. 2.0. If a copy of the MPL was not distributed with this
+    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8"/>
+    <title>Debugger test page</title>
+  </head>
+
+  <body>
+    <script>
+      debugger;
+      // This inline script allows this HTML page to show up as a
+      // source. It also needs to introduce a new global variable so
+      // it's not immediately garbage collected.
+      inline_script = function () { var x = 5; };
+    </script>
+  </body>
+</html>

--- a/src/test/mochitest/head.js
+++ b/src/test/mochitest/head.js
@@ -685,7 +685,7 @@ function reload(dbg, ...sources) {
  */
 function navigate(dbg, url, ...sources) {
   dbg.client.navigate(url);
-  return waitForSources(dbg, ...sources);
+  return waitForSources(dbg, url, ...sources);
 }
 
 /**
@@ -912,6 +912,7 @@ const selectors = {
     `.expressions-list .expression-container:nth-child(${i}) .object-delimiter + *`,
   expressionClose: i =>
     `.expressions-list .expression-container:nth-child(${i}) .close`,
+  expressionInput: '.expressions-list  input.input-expression',
   expressionNodes: ".expressions-list .tree-node",
   scopesHeader: ".scopes-pane ._header",
   breakpointItem: i => `.breakpoints-list .breakpoint:nth-child(${i})`,


### PR DESCRIPTION
Fixes #5509

### Summary of Changes

The issue was that we were only clearing the pause state when the debugger would fire a command like step or resume. Another time we resume is when we navigate. In this case there is a navigate event and resumed event. We should also make sure we clear the pause state when we were resumed by the server.


