### PR TITLE
fix tabs using the selected source

### DIFF
--- a/src/actions/types.js
+++ b/src/actions/types.js
@@ -25,7 +25,7 @@ import type {
 import type { MatchedLocations } from "../reducers/file-search";
 
 import type { SymbolDeclaration, AstLocation } from "../workers/parser";
-
+import type { SourceMetaDataType } from "../reducers/ast.js";
 /**
  * Flow types
  * @module actions/types
@@ -342,9 +342,7 @@ type ASTAction =
   | {
       type: "SET_SOURCE_METADATA",
       sourceId: string,
-      sourceMetaData: {
-        framework: ?string
-      }
+      sourceMetaData: SourceMetaDataType
     }
   | {
       type: "CLEAR_SELECTION"

--- a/src/components/Editor/Tab.js
+++ b/src/components/Editor/Tab.js
@@ -47,7 +47,7 @@ type Props = {
   showSource: string => void,
   source: SourceRecord,
   activeSearch: string,
-  sourceMetaData: string => any
+  getMetaData: string => any
 };
 
 class Tab extends PureComponent<Props> {
@@ -144,7 +144,7 @@ class Tab extends PureComponent<Props> {
       selectSource,
       closeTab,
       source,
-      sourceMetaData
+      getMetaData
     } = this.props;
     const src = source.toJS();
     const filename = getFilename(src);
@@ -154,7 +154,7 @@ class Tab extends PureComponent<Props> {
       sourceId == selectedSource.get("id") &&
       (!this.isProjectSearchEnabled() && !this.isSourceSearchEnabled());
     const isPrettyCode = isPretty(source);
-    const sourceAnnotation = getSourceAnnotation(source, sourceMetaData);
+    const sourceAnnotation = getSourceAnnotation(source, getMetaData(sourceId));
 
     function onClickClose(e) {
       e.stopPropagation();
@@ -202,10 +202,7 @@ export default connect(
     return {
       tabSources: getSourcesForTabs(state),
       selectedSource: selectedSource,
-      sourceMetaData: getSourceMetaData(
-        state,
-        selectedSource && selectedSource.get("id")
-      ),
+      getMetaData: sourceId => getSourceMetaData(state, sourceId),
       activeSearch: getActiveSearch(state)
     };
   },

--- a/src/components/Editor/Tab.js
+++ b/src/components/Editor/Tab.js
@@ -198,9 +198,9 @@ class Tab extends PureComponent<Props> {
   }
 }
 export default connect(
-  (state, ownProps) => {
+  (state, props) => {
     const selectedSource = getSelectedSource(state);
-    const { source } = ownProps;
+    const { source } = props;
     return {
       tabSources: getSourcesForTabs(state),
       selectedSource: selectedSource,

--- a/src/components/Editor/Tab.js
+++ b/src/components/Editor/Tab.js
@@ -14,6 +14,7 @@ import CloseButton from "../shared/Button/Close";
 
 import type { List } from "immutable";
 import type { SourceRecord } from "../../reducers/sources";
+import type { SourceMetaDataType } from "../../reducers/ast";
 
 import actions from "../../actions";
 
@@ -47,7 +48,7 @@ type Props = {
   showSource: string => void,
   source: SourceRecord,
   activeSearch: string,
-  getMetaData: string => any
+  sourceMetaData: SourceMetaDataType
 };
 
 class Tab extends PureComponent<Props> {
@@ -144,7 +145,7 @@ class Tab extends PureComponent<Props> {
       selectSource,
       closeTab,
       source,
-      getMetaData
+      sourceMetaData
     } = this.props;
     const src = source.toJS();
     const filename = getFilename(src);
@@ -154,7 +155,7 @@ class Tab extends PureComponent<Props> {
       sourceId == selectedSource.get("id") &&
       (!this.isProjectSearchEnabled() && !this.isSourceSearchEnabled());
     const isPrettyCode = isPretty(source);
-    const sourceAnnotation = getSourceAnnotation(source, getMetaData(sourceId));
+    const sourceAnnotation = getSourceAnnotation(source, sourceMetaData);
 
     function onClickClose(e) {
       e.stopPropagation();
@@ -197,12 +198,13 @@ class Tab extends PureComponent<Props> {
   }
 }
 export default connect(
-  state => {
+  (state, ownProps) => {
     const selectedSource = getSelectedSource(state);
+    const { source } = ownProps;
     return {
       tabSources: getSourcesForTabs(state),
       selectedSource: selectedSource,
-      getMetaData: sourceId => getSourceMetaData(state, sourceId),
+      sourceMetaData: getSourceMetaData(state, source.get("id")),
       activeSearch: getActiveSearch(state)
     };
   },

--- a/src/reducers/ast.js
+++ b/src/reducers/ast.js
@@ -24,7 +24,7 @@ export type SymbolsMap = Map<string, SymbolDeclarations>;
 export type EmptyLinesMap = Map<string, EmptyLinesType>;
 
 export type SourceMetaDataType = {
-  getFramework: ?string
+  framework: ?string
 };
 
 export type SourceMetaDataMap = Map<string, SourceMetaDataType>;

--- a/src/utils/tabs.js
+++ b/src/utils/tabs.js
@@ -8,6 +8,7 @@ import React from "react";
 
 import type { List } from "immutable";
 import type { SourceRecord } from "../reducers/sources";
+import type { SourceMetaDataType } from "../reducers/ast";
 import { isPretty } from "./source";
 
 type SourcesList = List<SourceRecord>;
@@ -46,7 +47,7 @@ export function getHiddenTabs(
 
 export function getSourceAnnotation(
   source: SourceRecord,
-  sourceMetaData: Object
+  sourceMetaData: SourceMetaDataType
 ) {
   const framework =
     sourceMetaData && sourceMetaData.framework


### PR DESCRIPTION
Associated Issue: #4773

Here's the Pull Request Doc
https://devtools-html.github.io/debugger.html/CONTRIBUTING.html#pull-requests

### Summary of Changes

* remove `sourceMetaData` which uses the selectedSource
* added a `getMetaData` function which would take the current source id

### Test Plan

Tell us a little a bit about how you tested your patch.

Example test plan:

- [x] Select react tab
- [x] Switch between other tabs and react tab


### Screenshots/Videos (OPTIONAL)
![](http://g.recordit.co/IVc1h9hiDw.gif)