### PR TITLE
Give command bar buttons full background on hover

### DIFF
--- a/src/components/SecondaryPanes/CommandBar.css
+++ b/src/components/SecondaryPanes/CommandBar.css
@@ -113,7 +113,8 @@ img.resume {
 
 .command-bar .step-position {
   color: var(--theme-comment-alt);
-  margin-inline-end: 1em;
+  padding-top: 8px;
+  margin-inline-end: 4px;
 }
 
 .command-bar .replay-active {

--- a/src/components/SecondaryPanes/CommandBar.css
+++ b/src/components/SecondaryPanes/CommandBar.css
@@ -9,7 +9,6 @@
   overflow: hidden;
   z-index: 1;
   background-color: var(--theme-toolbar-background);
-  align-items: center;
 }
 
 html[dir="rtl"] .command-bar {

--- a/src/components/shared/Button/CommandBarButton.css
+++ b/src/components/shared/Button/CommandBarButton.css
@@ -6,7 +6,6 @@
   text-align: center;
   position: relative;
   padding: 0px 5px;
-  margin-inline-end: 0.3em;
   fill: currentColor;
 }
 


### PR DESCRIPTION
Associated Issue: #5534

### Summary of Changes

* Changed the flexbox alignment as it was preventing buttons from reaching full height and has no visible effect on icons being centered
* Also removed the margin-inline-end property as it was separating the buttons from one another on hover, if that is the intended effect while keeping the button height full on hover, I can put it back :)

### Test Plan

- [x] Opened a few projects and hovered and clicked on the command bar icons

### Screenshots/Videos 

![full-background-on-hover](https://user-images.githubusercontent.com/6593585/36753552-869488a8-1c17-11e8-8f12-68ed72345acd.gif)


