### PR TITLE
Fix #5366 - Prevent multiple search boxes from opening on Windows

### DIFF
--- a/src/utils/editor/create-editor.js
+++ b/src/utils/editor/create-editor.js
@@ -31,7 +31,9 @@ export function createEditor() {
       // Override code mirror keymap to avoid conflicts with split console.
       Esc: false,
       "Cmd-F": false,
-      "Cmd-G": false
+      "Ctrl-F": false,
+      "Cmd-G": false,
+      "Ctrl-G": false
     }
   });
 }

--- a/src/utils/editor/tests/__snapshots__/create-editor.spec.js.snap
+++ b/src/utils/editor/tests/__snapshots__/create-editor.spec.js.snap
@@ -6,6 +6,8 @@ Object {
   "extraKeys": Object {
     "Cmd-F": false,
     "Cmd-G": false,
+    "Ctrl-F": false,
+    "Ctrl-G": false,
     "Esc": false,
   },
   "foldGutter": true,
@@ -33,6 +35,8 @@ Object {
   "extraKeys": Object {
     "Cmd-F": false,
     "Cmd-G": false,
+    "Ctrl-F": false,
+    "Ctrl-G": false,
     "Esc": false,
   },
   "foldGutter": false,


### PR DESCRIPTION
Associated Issue: #5366 

By adding the "Ctrl-F" key override we no longer see the double search box issue.