### PR TITLE
[Parser] Remove reference to babel-types

### DIFF
--- a/src/workers/parser/getSymbols.js
+++ b/src/workers/parser/getSymbols.js
@@ -5,7 +5,7 @@
 // @flow
 
 import flatten from "lodash/flatten";
-import * as t from "babel-types";
+import * as t from "@babel/types";
 
 import { traverseAst } from "./utils/ast";
 import { isVariable, isFunction, getVariables } from "./utils/helpers";


### PR DESCRIPTION
#5557 

### Summary of Changes

Removes last reference to babel-types. This saves 200KB


#### Before
![screen shot 2018-03-01 at 1 53 35 pm](https://user-images.githubusercontent.com/254562/36863585-18f6f898-1d58-11e8-8428-4ef4b1d44d78.png)

#### After

![screen shot 2018-03-01 at 1 53 21 pm](https://user-images.githubusercontent.com/254562/36863581-176fb71c-1d58-11e8-9e3b-2a6dfa6fd758.png)
