### PR TITLE
Better tab widths & the death of endTruncateStr (3 of 3 endTruncateStr PRs)

### DIFF
--- a/src/components/Editor/Tab.js
+++ b/src/components/Editor/Tab.js
@@ -156,6 +156,12 @@ class Tab extends PureComponent<Props> {
     const isPrettyCode = isPretty(source);
     const sourceAnnotation = getSourceAnnotation(source, sourceMetaData);
 
+    const sourceTabsWidth = document.getElementsByClassName("source-tabs");
+    const tabWidth =
+      filename.length < 40
+        ? "auto"
+        : sourceTabsWidth[0].clientWidth * 0.4 + "px";
+
     function onClickClose(ev) {
       ev.stopPropagation();
       closeTab(source.get("url"));
@@ -173,6 +179,7 @@ class Tab extends PureComponent<Props> {
         onClick={() => selectSource(sourceId)}
         onContextMenu={e => this.onTabContextMenu(e, sourceId)}
         title={getFileURL(src)}
+        style={{ width: tabWidth }}
       >
         {sourceAnnotation}
         <div className="filename">{filename}</div>

--- a/src/components/Editor/Tabs.css
+++ b/src/components/Editor/Tabs.css
@@ -33,7 +33,7 @@
 }
 
 .source-tabs {
-  max-width: calc(100% - 80px);
+  width: calc(100% - 80px);
   align-self: flex-start;
 }
 
@@ -76,11 +76,12 @@
 
 .source-tab img.prettyPrint {
   mask: url(/images/prettyPrint.svg) no-repeat;
-  mask-size: 100%;
   padding-top: 12px;
   height: 12px;
   width: 12px;
   background: var(--theme-highlight-blue);
+  flex-shrink: 0;
+  mask-size: 100%;
 }
 
 .source-tab .prettyPrint path {

--- a/src/components/Editor/Tabs.js
+++ b/src/components/Editor/Tabs.js
@@ -139,11 +139,9 @@ class Tabs extends PureComponent<Props, State> {
       return;
     }
 
-    return (
-      <div className="source-tabs" ref="sourceTabs">
-        {tabSources.map((source, index) => <Tab key={index} source={source} />)}
-      </div>
-    );
+    return tabSources.map((source, index) => (
+      <Tab key={index} source={source} />
+    ));
   }
 
   renderDropdown() {
@@ -187,7 +185,7 @@ class Tabs extends PureComponent<Props, State> {
     return (
       <div className="source-header">
         {this.renderStartPanelToggleButton()}
-        {this.renderTabs()}
+        <div className="source-tabs">{this.renderTabs()}</div>
         {this.renderDropdown()}
         {this.renderEndPanelToggleButton()}
       </div>

--- a/src/components/SecondaryPanes/Breakpoints.js
+++ b/src/components/SecondaryPanes/Breakpoints.js
@@ -13,7 +13,6 @@ import { sortBy } from "lodash";
 
 import actions from "../../actions";
 import CloseButton from "../shared/Button/Close";
-import { endTruncateStr } from "../../utils/utils";
 import { features } from "../../utils/prefs";
 import { getFilename } from "../../utils/source";
 import {
@@ -80,11 +79,7 @@ function renderSourceLocation(source, line, column) {
     return null;
   }
 
-  return (
-    <div className="location">
-      {`${endTruncateStr(filename, 30)}: ${bpLocation}`}
-    </div>
-  );
+  return <div className="location">{`$filename}: ${bpLocation}`}</div>;
 }
 
 class Breakpoints extends PureComponent<Props> {

--- a/src/test/mochitest/browser_dbg-preview-module.js
+++ b/src/test/mochitest/browser_dbg-preview-module.js
@@ -10,7 +10,7 @@ add_task(async function() {
   navigate(dbg, "doc-on-load.html");
 
   // wait for `top-level.js` to load and to pause at a debugger statement
-  await waitForSelectedSource(dbg)
+  await waitForSelectedSource(dbg);
   await waitForPaused(dbg);
 
   const popupPreviewed = waitForDispatch(dbg, "SET_PREVIEW");

--- a/src/utils/frame.js
+++ b/src/utils/frame.js
@@ -4,7 +4,6 @@
 
 // @flow
 
-import { endTruncateStr } from "./utils";
 import { getFilename } from "./source";
 import { get, find, findIndex } from "lodash";
 
@@ -202,7 +201,7 @@ export function formatDisplayName(
   }
 
   displayName = simplifyDisplayName(displayName);
-  return endTruncateStr(displayName, 25);
+  return displayName;
 }
 
 export function formatCopyName(frame: LocalFrame) {

--- a/src/utils/quick-open.js
+++ b/src/utils/quick-open.js
@@ -3,7 +3,6 @@
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
 // @flow
-import { endTruncateStr } from "./utils";
 import { isPretty, getSourcePath } from "./source";
 
 import type { Location as BabelLocation } from "@babel/traverse";
@@ -119,7 +118,7 @@ export function formatSources(sources: SourcesMap): Array<QuickOpenResult> {
       return {
         value: sourcePath,
         title: sourcePath.split("/").pop(),
-        subtitle: endTruncateStr(sourcePath, 100),
+        subtitle: sourcePath,
         id: source.get("id"),
         url: source.get("url")
       };

--- a/src/utils/source.js
+++ b/src/utils/source.js
@@ -10,7 +10,6 @@
  */
 
 import { isOriginalId } from "devtools-source-map";
-import { endTruncateStr } from "./utils";
 import { basename } from "./path";
 
 import { parse as parseURL } from "url";
@@ -124,7 +123,7 @@ function resolveFileURL(
 ) {
   url = getRawSourceURL(url || "");
   const name = transformUrl(url);
-  return endTruncateStr(name, 50);
+  return name;
 }
 
 export function getFilenameFromURL(url: string) {

--- a/src/utils/tests/frame.spec.js
+++ b/src/utils/tests/frame.spec.js
@@ -72,17 +72,6 @@ describe("function names", () => {
 
       expect(formatDisplayName(frame)).toEqual("baz");
     });
-
-    it("truncates long function names", () => {
-      const frame = {
-        displayName: "bazbazbazbazbazbazbazbazbazbazbazbazbaz",
-        source: {
-          url: "assets/bar.js"
-        }
-      };
-
-      expect(formatDisplayName(frame)).toEqual("...zbazbazbazbazbazbazbazbaz");
-    });
   });
 
   describe("formatCopyName", () => {

--- a/src/utils/tests/source.spec.js
+++ b/src/utils/tests/source.spec.js
@@ -24,15 +24,6 @@ describe("sources", () => {
         })
       ).toBe("hello.html");
     });
-    it("should truncate the file name when it is more than 50 chars", () => {
-      expect(
-        getFileURL({
-          url:
-            "http://localhost/really-really-really-really-really-really-long-name.html",
-          id: ""
-        })
-      ).toBe("...-really-really-really-really-really-long-name.html");
-    });
     it("should give us the filename excluding the query strings", () => {
       expect(
         getFilename({
@@ -51,14 +42,6 @@ describe("sources", () => {
           id: ""
         })
       ).toBe("http://localhost.com:7999/increment/hello.html");
-    });
-    it("should truncate the file url when it is more than 50 chars", () => {
-      expect(
-        getFileURL({
-          url: "http://localhost-long.com:7999/increment/hello.html",
-          id: ""
-        })
-      ).toBe("...ttp://localhost-long.com:7999/increment/hello.html");
     });
   });
 

--- a/src/utils/tests/utils.spec.js
+++ b/src/utils/tests/utils.spec.js
@@ -1,4 +1,4 @@
-import { handleError, promisify, endTruncateStr, waitForMs } from "../utils";
+import { handleError, promisify, waitForMs } from "../utils";
 
 describe("handleError()", () => {
   const testErrorText = "ERROR: ";
@@ -34,27 +34,6 @@ describe("promisify()", () => {
     testPromise = promisify(testContext, testMethod, testArgs);
 
     expect(testMethod).toBeCalledWith(testArgs, expect.anything());
-  });
-});
-
-describe("endTruncateStr()", () => {
-  let testString;
-  const testSize = 11;
-
-  describe("when the string is larger than the specified size", () => {
-    it("returns an elipsis and characters at the end of the string", () => {
-      testString = "Mozilla Firefox is my favorite web browser";
-
-      expect(endTruncateStr(testString, testSize)).toBe("...web browser");
-    });
-  });
-
-  describe("when the string is not larger than the specified size", () => {
-    it("returns the string unchanged", () => {
-      testString = "Firefox";
-
-      expect(endTruncateStr(testString, testSize)).toBe(testString);
-    });
   });
 });
 

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -38,15 +38,9 @@ function promisify(context: any, method: any, ...args: any): Promise<mixed> {
  * @memberof utils/utils
  * @static
  */
-function endTruncateStr(str: any, size: number) {
-  if (str.length > size) {
-    return `...${str.slice(str.length - size)}`;
-  }
-  return str;
-}
 
 function waitForMs(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
-export { handleError, promisify, endTruncateStr, waitForMs };
+export { handleError, promisify, waitForMs };


### PR DESCRIPTION
A tab's width (if the string's length is 40 or above) is now 40% of `source-tab`'s width. `source-tab`'s width is now 100% (minus the pixels the buttons to right take up) by default, this is what allows this method of tab-sizing to work. `Tab`'s width can easily be lowered from `Tab.js`, it probably should.

`source-tabs` is rendered before a `source-tab` is rendered, so its width can be grabbed before a `source-tab` is rendered.

<img width="615" alt="screen shot 2018-03-01 at 1 13 16 pm" src="https://user-images.githubusercontent.com/24966772/36864451-5d6a8bc6-1d52-11e8-8933-7dfacfb7bf6f.png">

`endTruncateString` is no more, so some things are wonky. I also had a PR that dealt with the effects of removing `endTruncateStr` from breakpoints, but I was made aware the breakpoints are going through redesign anyway, so I'll hold off on that PR. 
