### PR TITLE
3601 - [blackbox] sources should be persisted

### DIFF
--- a/assets/panel/prefs.js
+++ b/assets/panel/prefs.js
@@ -34,6 +34,7 @@ pref("devtools.debugger.expressions-visible", true);
 pref("devtools.debugger.start-panel-collapsed", false);
 pref("devtools.debugger.end-panel-collapsed", false);
 pref("devtools.debugger.tabs", "[]");
+pref("devtools.debugger.tabsBlackBoxed", "[]");
 pref("devtools.debugger.pending-selected-location", "{}");
 pref("devtools.debugger.pending-breakpoints", "{}");
 pref("devtools.debugger.expressions", "[]");

--- a/src/actions/sources/newSources.js
+++ b/src/actions/sources/newSources.js
@@ -133,7 +133,7 @@ function restoreBlackBoxedSources(sources: Source[]) {
     }
     for (const source of sources) {
       if (tabs.includes(source.url) && !source.isBlackBoxed) {
-        dispatch(toggleBlackBox(source))
+        dispatch(toggleBlackBox(source));
       }
     }
   };

--- a/src/actions/sources/newSources.js
+++ b/src/actions/sources/newSources.js
@@ -8,7 +8,7 @@
  * Redux actions for the sources state
  * @module actions/sources
  */
-
+import { toggleBlackBox } from "./blackbox";
 import { syncBreakpoint } from "../breakpoints";
 import { loadSourceText } from "./loadSourceText";
 import { togglePrettyPrint } from "./prettyPrint";
@@ -16,6 +16,7 @@ import { selectLocation } from "../sources";
 import { getRawSourceURL, isPrettyURL } from "../../utils/source";
 
 import {
+  getBlackBoxList,
   getSource,
   getPendingSelectedLocation,
   getPendingBreakpointsForSource
@@ -124,6 +125,20 @@ function checkPendingBreakpoints(sourceId: string) {
   };
 }
 
+function restoreBlackBoxedSources(sources: Source[]) {
+  return async ({ dispatch }: ThunkArgs) => {
+    const tabs = getBlackBoxList();
+    if (tabs.length == 0) {
+      return;
+    }
+    for (const source of sources) {
+      if (tabs.includes(source.url) && !source.isBlackBoxed) {
+        dispatch(toggleBlackBox(source))
+      }
+    }
+  };
+}
+
 /**
  * Handler for the debugger client's unsolicited newSource notification.
  * @memberof actions/sources
@@ -155,8 +170,11 @@ export function newSources(sources: Source[]) {
       dispatch(checkPendingBreakpoints(source.id));
     }
 
-    return Promise.all(
+    await Promise.all(
       filteredSources.map(source => dispatch(loadSourceMap(source)))
     );
+    // We would like to restore the blackboxed state
+    // after loading all states to make sure the correctness.
+    dispatch(restoreBlackBoxedSources(filteredSources));
   };
 }

--- a/src/reducers/sources.js
+++ b/src/reducers/sources.js
@@ -124,9 +124,12 @@ function update(
 
     case "BLACKBOX":
       if (action.status === "done") {
+        const url = action.source.url;
+        const isBlackBoxed = action.value.isBlackBoxed;
+        updateBlackBoxList(url, isBlackBoxed);
         return state.setIn(
           ["sources", action.source.id, "isBlackBoxed"],
-          action.value.isBlackBoxed
+          isBlackBoxed
         );
       }
       break;
@@ -216,6 +219,23 @@ function updateTabList(state: OuterState, url: ?string, tabIndex?: number) {
 
   prefs.tabs = tabs.toJS();
   return tabs;
+}
+
+function updateBlackBoxList(url, isBlackBoxed) {
+  let tabs = getBlackBoxList();
+  const i = tabs.indexOf(url);
+  if (i >= 0) {
+    if (!isBlackBoxed) {
+      tabs.splice(i, 1);
+    }
+  } else if (isBlackBoxed) {
+    tabs.push(url);
+  }
+  prefs.tabsBlackBoxed = tabs;
+}
+
+export function getBlackBoxList() {
+  return prefs.tabsBlackBoxed || [];
 }
 
 /**

--- a/src/reducers/sources.js
+++ b/src/reducers/sources.js
@@ -222,7 +222,7 @@ function updateTabList(state: OuterState, url: ?string, tabIndex?: number) {
 }
 
 function updateBlackBoxList(url, isBlackBoxed) {
-  let tabs = getBlackBoxList();
+  const tabs = getBlackBoxList();
   const i = tabs.indexOf(url);
   if (i >= 0) {
     if (!isBlackBoxed) {

--- a/src/utils/prefs.js
+++ b/src/utils/prefs.js
@@ -24,6 +24,7 @@ if (isDevelopment()) {
   pref("devtools.debugger.start-panel-collapsed", false);
   pref("devtools.debugger.end-panel-collapsed", false);
   pref("devtools.debugger.tabs", "[]");
+  pref("devtools.debugger.tabsBlackBoxed", "[]");
   pref("devtools.debugger.ui.framework-grouping-on", true);
   pref("devtools.debugger.pending-selected-location", "{}");
   pref("devtools.debugger.pending-breakpoints", "{}");
@@ -65,6 +66,7 @@ export const prefs = new PrefsHelper("devtools", {
   endPanelCollapsed: ["Bool", "debugger.end-panel-collapsed"],
   frameworkGroupingOn: ["Bool", "debugger.ui.framework-grouping-on"],
   tabs: ["Json", "debugger.tabs", []],
+  tabsBlackBoxed: ["Json", "debugger.tabsBlackBoxed", []],
   pendingSelectedLocation: ["Json", "debugger.pending-selected-location", {}],
   pendingBreakpoints: ["Json", "debugger.pending-breakpoints", {}],
   expressions: ["Json", "debugger.expressions", []],


### PR DESCRIPTION
Associated Issue: #3601

### Summary of Changes
Introduce "devtools.debugger.tabsBlackBoxed" pref to save the blackboxed sources and restore blackboxed states while receiving new sources.

### Screenshots/Videos 
![ljp7tknlls](https://user-images.githubusercontent.com/5627487/36886825-2b89dbac-1e29-11e8-845f-6a3b59e9a8c8.gif)

