### PR TITLE
Externalize lodash

### DIFF
--- a/webpack-loaders/rewrite-lodash-imports.js
+++ b/webpack-loaders/rewrite-lodash-imports.js
@@ -1,0 +1,16 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/*
+ * Rewrite all the require("lodash/foo") to require("lodash").foo
+ *
+ * This will allow to reuse the vendored lodash package from mozilla-central
+ * when running in Firefox.
+ */
+module.exports = function(content) {
+  this.cacheable && this.cacheable();
+
+  const lodashRequireRegexp = /require\("lodash\/([a-zA-Z]+)"\)/g;
+  return content.replace(lodashRequireRegexp, 'require("lodash").$1');
+};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,7 +2,7 @@ const toolbox = require("./node_modules/devtools-launchpad/index");
 
 const getConfig = require("./bin/getConfig");
 const { isDevelopment, isFirefoxPanel } = require("devtools-config");
-const { NormalModuleReplacementPlugin } = require("webpack");
+const { BannerPlugin, NormalModuleReplacementPlugin } = require("webpack");
 const path = require("path");
 const projectPath = path.join(__dirname, "src");
 var Visualizer = require("webpack-visualizer-plugin");
@@ -71,6 +71,22 @@ function buildConfig(envConfig) {
     mappings.forEach(([regex, res]) => {
       webpackConfig.plugins.push(new NormalModuleReplacementPlugin(regex, res));
     });
+
+    // On worker bundles lodash cannot be required as in modules.
+    // In this context, `exports` is not defined, consequently, the webpack
+    // module definition will call:
+    //   `factory(root["devtools/client/shared/vendor/lodash"]);`
+    // We manually map self["devtools/client/shared/vendor/lodash"] to the
+    // vendored lodash.js so that this external import can work.
+    webpackConfig.plugins.push(
+      new BannerPlugin({
+        banner:
+          'importScripts("resource://gre/modules/workers/require.js");\n' +
+          'self["devtools/client/shared/vendor/lodash"] = require("resource://devtools/client/shared/vendor/lodash.js");',
+        raw: true,
+        test: ["parser-worker", "search-worker", "pretty-print-worker"]
+      })
+    );
   }
 
   // TODO: It would be nice to stop bundling `devtools-source-map` entirely for

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -68,6 +68,27 @@ function buildConfig(envConfig) {
       "chrome-remote-interface": "devtools/shared/flags"
     };
 
+    // Safely get or create webpackConfig.resolveLoader.modules
+    webpackConfig.resolveLoader = webpackConfig.resolveLoader || {};
+    webpackConfig.resolveLoader.modules =
+      webpackConfig.resolveLoader.modules || [];
+    // "node_modules" needs to be explicitely added in order to find
+    // babel-loader.
+    webpackConfig.resolveLoader.modules.push("node_modules");
+    // Add the "webpack-loaders" directory where our custom loaders are located
+    webpackConfig.resolveLoader.modules.push(
+      path.join(__dirname, "webpack-loaders")
+    );
+
+    // Safely get or create webpackConfig.module.rules
+    webpackConfig.module = webpackConfig.module || {};
+    webpackConfig.module.rules = webpackConfig.module.rules || [];
+    // Add a loader to rewrite lodash imports.
+    webpackConfig.module.rules.push({
+      test: /\.js$/,
+      loaders: ["rewrite-lodash-imports"]
+    });
+
     mappings.forEach(([regex, res]) => {
       webpackConfig.plugins.push(new NormalModuleReplacementPlugin(regex, res));
     });


### PR DESCRIPTION
The changes here allow to use the vendored lodash for all lodash imports. It rewrites all the require("lodash/foo") to require("lodash").foo, which allows to leverage our existing external rule for lodash. 

On top of that we import lodash via importScript ([example](https://searchfox.org/mozilla-central/rev/61d400da1c692453c2dc2c1cf37b616ce13dea5b/devtools/client/shared/widgets/GraphsWorker.js#11)) as a Banner inside of the worker bundles.

On my computer the size of the bundles evolve as follows:
- debugger.js: 1 656 738 -> 1 612 925 (-40k)
- parser-worker.js: 1 529 483 -> 1 361 640 (-160k)
- search-worker.js: 22 600 -> 13 517 (-10k)

Overall this leads to a 200k win in the bundle size here.