### PR TITLE
Bugfix watch expression hover

### DIFF
--- a/src/components/SecondaryPanes/Expressions.css
+++ b/src/components/SecondaryPanes/Expressions.css
@@ -72,11 +72,11 @@
 }
 
 :root.theme-light .expression-container:hover {
-  background-color: var(--theme-tab-toolbar-background);
+  background-color: var(--theme-selection-background-hover);
 }
 
 :root.theme-dark .expression-container:hover {
-  background-color: var(--search-overlays-semitransparent);
+  background-color: var(--theme-selection-background-hover);
 }
 
 .expression-container__close-btn {

--- a/src/components/SecondaryPanes/Expressions.css
+++ b/src/components/SecondaryPanes/Expressions.css
@@ -79,6 +79,14 @@
   background-color: var(--theme-selection-background-hover);
 }
 
+:root.theme-firebug .expression-container:hover {
+  background-color: var(--theme-selection-background-hover);
+}
+
+.tree  .tree-node:not(.focused):hover {
+  background-color: transparent;
+}
+
 .expression-container__close-btn {
   position: absolute;
   offset-inline-end: 0px;

--- a/src/components/SecondaryPanes/Expressions.js
+++ b/src/components/SecondaryPanes/Expressions.js
@@ -88,14 +88,7 @@ class Expressions extends PureComponent<Props, State> {
     }
   }
 
-  editExpression(
-    expression: Expression,
-    index: number,
-    { depth }: { depth: number }
-  ) {
-    if (depth > 0) {
-      return;
-    }
+  editExpression(expression: Expression, index: number) {
     this.setState({
       inputValue: expression.input,
       editing: true,
@@ -160,16 +153,19 @@ class Expressions extends PureComponent<Props, State> {
     };
 
     return (
-      <li className="expression-container" key={input}>
+      <li
+        className="expression-container"
+        key={input}
+        onDoubleClick={(items, options) =>
+          this.editExpression(expression, index)
+        }
+      >
         <div className="expression-content">
           <ObjectInspector
             roots={[root]}
             autoExpandDepth={0}
             disableWrap={true}
             disabledFocus={true}
-            onDoubleClick={(items, options) =>
-              this.editExpression(expression, index, options)
-            }
             openLink={openLink}
             createObjectClient={grip => createObjectClient(grip)}
           />

--- a/src/components/SecondaryPanes/tests/__snapshots__/Expressions.spec.js.snap
+++ b/src/components/SecondaryPanes/tests/__snapshots__/Expressions.spec.js.snap
@@ -7,6 +7,7 @@ exports[`Expressions should always have unique keys 1`] = `
   <li
     className="expression-container"
     key="expression1"
+    onDoubleClick={[Function]}
   >
     <div
       className="expression-content"
@@ -16,7 +17,6 @@ exports[`Expressions should always have unique keys 1`] = `
         createObjectClient={[Function]}
         disableWrap={true}
         disabledFocus={true}
-        onDoubleClick={[Function]}
         roots={
           Array [
             Object {
@@ -44,6 +44,7 @@ exports[`Expressions should always have unique keys 1`] = `
   <li
     className="expression-container"
     key="expression2"
+    onDoubleClick={[Function]}
   >
     <div
       className="expression-content"
@@ -53,7 +54,6 @@ exports[`Expressions should always have unique keys 1`] = `
         createObjectClient={[Function]}
         disableWrap={true}
         disabledFocus={true}
-        onDoubleClick={[Function]}
         roots={
           Array [
             Object {
@@ -114,6 +114,7 @@ exports[`Expressions should render 1`] = `
   <li
     className="expression-container"
     key="expression1"
+    onDoubleClick={[Function]}
   >
     <div
       className="expression-content"
@@ -123,7 +124,6 @@ exports[`Expressions should render 1`] = `
         createObjectClient={[Function]}
         disableWrap={true}
         disabledFocus={true}
-        onDoubleClick={[Function]}
         roots={
           Array [
             Object {
@@ -151,6 +151,7 @@ exports[`Expressions should render 1`] = `
   <li
     className="expression-container"
     key="expression2"
+    onDoubleClick={[Function]}
   >
     <div
       className="expression-content"
@@ -160,7 +161,6 @@ exports[`Expressions should render 1`] = `
         createObjectClient={[Function]}
         disableWrap={true}
         disabledFocus={true}
-        onDoubleClick={[Function]}
         roots={
           Array [
             Object {


### PR DESCRIPTION
Associated Issue: 5500


### Summary of Changes

* Change in Expressions.css: onHover background-color of expression-container changes to blue( --theme-selection-background-hover). Earlier it used change only for expression text.

* Change in Expressions.js: Add doubleClick listener to expression container instead of expression text. 

### Test Plan

Tell us a little a bit about how you tested your patch.

Example test plan:

- [x] Add new watch expression
- [x] On mouse hover background-color of entire row should change to blue(--theme-selection-background-hover)
- [x] Add one more watch expression and try hovering over it.
- [x] Double click on the expression row even on white space should allow user to edit watch expression.
- [x] Click on close icon should remove the watch expression.
![watch-expression](https://user-images.githubusercontent.com/26451940/36920188-e3e5d6e0-1e85-11e8-9abe-76fad5c94d8d.gif)


### Screenshots/Videos (OPTIONAL)