### PR TITLE
Revert using Flow to type context

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -3,7 +3,7 @@
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
 // @flow
-
+import PropTypes from "prop-types";
 import React, { Component } from "react";
 import { connect } from "react-redux";
 import { bindActionCreators } from "redux";
@@ -311,7 +311,7 @@ class App extends Component<Props, State> {
   }
 }
 
-App.childContextTypes = { shortcuts: Object };
+App.childContextTypes = { shortcuts: PropTypes.object };
 
 function mapStateToProps(state) {
   return {

--- a/src/components/Editor/SearchBar.js
+++ b/src/components/Editor/SearchBar.js
@@ -4,6 +4,7 @@
 
 // @flow
 
+import PropTypes from "prop-types";
 import React, { Component } from "react";
 import { connect } from "react-redux";
 import { bindActionCreators } from "redux";
@@ -322,7 +323,7 @@ class SearchBar extends Component<Props, State> {
 }
 
 SearchBar.contextTypes = {
-  shortcuts: Object
+  shortcuts: PropTypes.object
 };
 
 export default connect(

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -3,6 +3,8 @@
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
 // @flow
+
+import PropTypes from "prop-types";
 import React, { PureComponent } from "react";
 import ReactDOM from "react-dom";
 import { connect } from "react-redux";
@@ -592,7 +594,7 @@ class Editor extends PureComponent<Props, State> {
 }
 
 Editor.contextTypes = {
-  shortcuts: Object
+  shortcuts: PropTypes.object
 };
 
 const mapStateToProps = state => {

--- a/src/components/ProjectSearch.js
+++ b/src/components/ProjectSearch.js
@@ -4,6 +4,7 @@
 
 // @flow
 
+import PropTypes from "prop-types";
 import React, { Component } from "react";
 import { connect } from "react-redux";
 import classnames from "classnames";
@@ -316,7 +317,7 @@ export class ProjectSearch extends Component<Props, State> {
   }
 }
 ProjectSearch.contextTypes = {
-  shortcuts: Object
+  shortcuts: PropTypes.object
 };
 
 export default connect(

--- a/src/components/SecondaryPanes/CommandBar.js
+++ b/src/components/SecondaryPanes/CommandBar.js
@@ -4,6 +4,8 @@
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
 // @flow
+
+import PropTypes from "prop-types";
 import React, { Component } from "react";
 import { connect } from "react-redux";
 import { bindActionCreators } from "redux";
@@ -390,7 +392,7 @@ class CommandBar extends Component<Props> {
 }
 
 CommandBar.contextTypes = {
-  shortcuts: Object
+  shortcuts: PropTypes.object
 };
 
 export default connect(

--- a/src/components/SecondaryPanes/index.js
+++ b/src/components/SecondaryPanes/index.js
@@ -4,6 +4,7 @@
 
 // @flow
 
+import PropTypes from "prop-types";
 import React, { Component } from "react";
 import { connect } from "react-redux";
 import { bindActionCreators } from "redux";
@@ -326,7 +327,7 @@ class SecondaryPanes extends Component<Props> {
 }
 
 SecondaryPanes.contextTypes = {
-  shortcuts: Object
+  shortcuts: PropTypes.object
 };
 
 export default connect(

--- a/src/components/shared/Modal.js
+++ b/src/components/shared/Modal.js
@@ -4,6 +4,7 @@
 
 // @flow
 
+import PropTypes from "prop-types";
 import React from "react";
 import type { Node as ReactNode } from "react";
 import classnames from "classnames";
@@ -43,7 +44,7 @@ export class Modal extends React.Component<ModalProps> {
 }
 
 Modal.contextTypes = {
-  shortcuts: Object
+  shortcuts: PropTypes.object
 };
 
 type SlideProps = {


### PR DESCRIPTION
Associated Issue: #5587 

Reverts #5579  as it it not possible to statically type context