### PR TITLE
Fix warning about PureComponent & shouldComponentUpdate

### DIFF
--- a/src/components/Editor/EditorMenu.js
+++ b/src/components/Editor/EditorMenu.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
-import { PureComponent } from "react";
+import { Component } from "react";
 import { connect } from "react-redux";
 import { showMenu } from "devtools-launchpad";
 import { isOriginalId } from "devtools-source-map";
@@ -185,7 +185,7 @@ function getMenuItems(
   return menuItems;
 }
 
-class EditorMenu extends PureComponent {
+class EditorMenu extends Component {
   props: Props;
 
   constructor() {

--- a/src/components/Editor/GutterMenu.js
+++ b/src/components/Editor/GutterMenu.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
-import { PureComponent } from "react";
+import { Component } from "react";
 import { showMenu } from "devtools-contextmenu";
 import { bindActionCreators } from "redux";
 import { connect } from "react-redux";
@@ -116,7 +116,7 @@ export function gutterMenu({
   showMenu(event, items);
 }
 
-class GutterContextMenuComponent extends PureComponent {
+class GutterContextMenuComponent extends Component {
   props: Props;
 
   constructor() {

--- a/src/components/SecondaryPanes/Breakpoints.js
+++ b/src/components/SecondaryPanes/Breakpoints.js
@@ -3,7 +3,7 @@
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
 // @flow
-import React, { PureComponent } from "react";
+import React, { Component } from "react";
 import { bindActionCreators } from "redux";
 import { connect } from "react-redux";
 import * as I from "immutable";
@@ -87,7 +87,7 @@ function renderSourceLocation(source, line, column) {
   );
 }
 
-class Breakpoints extends PureComponent<Props> {
+class Breakpoints extends Component<Props> {
   shouldComponentUpdate(nextProps, nextState) {
     const { breakpoints } = this.props;
     return breakpoints !== nextProps.breakpoints;

--- a/src/components/SecondaryPanes/Expressions.js
+++ b/src/components/SecondaryPanes/Expressions.js
@@ -3,7 +3,7 @@
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
 // @flow
-import React, { PureComponent } from "react";
+import React, { Component } from "react";
 import { connect } from "react-redux";
 import classnames from "classnames";
 import { ObjectInspector } from "devtools-reps";
@@ -37,7 +37,7 @@ type Props = {
   openLink: (url: string) => void
 };
 
-class Expressions extends PureComponent<Props, State> {
+class Expressions extends Component<Props, State> {
   _input: ?HTMLInputElement;
   renderExpression: (
     expression: Expression,


### PR DESCRIPTION
Associated Issue: #5589 

It seems that react 16 has a new useful warning about using shouldComponentUpdate inside a PureComponent.