### PR TITLE
Update timeout in browser_dbg-babel.js (sync m-c bug 1440102)

### DIFF
--- a/src/test/mochitest/browser_dbg-babel-scopes.js
+++ b/src/test/mochitest/browser_dbg-babel-scopes.js
@@ -1,6 +1,9 @@
 /* Any copyright is dedicated to the Public Domain.
  * http://creativecommons.org/publicdomain/zero/1.0/ */
 
+// This test can be really slow on debug platforms and should be split.
+requestLongerTimeout(4);
+
 // Tests loading sourcemapped sources for Babel's compile output.
 
 async function breakpointScopes(dbg, fixture, { line, column }, scopes) {
@@ -86,8 +89,6 @@ async function assertScopes(dbg, items) {
 }
 
 add_task(async function() {
-  requestLongerTimeout(2);
-
   await pushPref("devtools.debugger.features.map-scopes", true);
 
   const dbg = await initDebugger("doc-babel.html");


### PR DESCRIPTION
Synchronizing changes from https://bugzilla.mozilla.org/show_bug.cgi?id=1440102 

I haven't changed the browser.ini in the sync since the previous m-c change (skip on win + ccov) had not been synchronized here.