### PR TITLE
Change shortcuts modal cursor to default for consistency

### DIFF
--- a/src/components/ShortcutsModal.css
+++ b/src/components/ShortcutsModal.css
@@ -7,6 +7,7 @@
   -moz-column-width: 250px;
   -webkit-column-width: 250px;
   column-width: 250px;
+  cursor: default;
 }
 
 .shortcuts-content h2 {


### PR DESCRIPTION
This is super minor but for consistency we should remove the text cursor upon hover since this isn't text anyone interacts with (i.e. copies)