### PR TITLE
Disabled forward/backward stepping for a single history item

### DIFF
--- a/src/components/SecondaryPanes/CommandBar.js
+++ b/src/components/SecondaryPanes/CommandBar.js
@@ -347,7 +347,7 @@ class CommandBar extends Component<Props> {
     const { history, historyPosition, canRewind } = this.props;
     const historyLength = history.length;
 
-    if (canRewind || !historyLength || !features.replay) {
+    if (canRewind || !historyLength || historyLength <= 1 || !features.replay) {
       return null;
     }
 
@@ -366,7 +366,7 @@ class CommandBar extends Component<Props> {
     const { history, historyPosition, canRewind } = this.props;
     const historyLength = history.length;
 
-    if (canRewind || !historyLength || !features.replay) {
+    if (canRewind || !historyLength || historyLength <= 1 || !features.replay) {
       return null;
     }
 


### PR DESCRIPTION
Associated Issue: #5456

### Summary of Changes

* Disabled forward/backward stepping when history is of size 1 in the debugger's command bar. 

### Screenshots/Videos


![disabled button](https://user-images.githubusercontent.com/19397242/37065413-bbeca1aa-216e-11e8-8ddd-fa15798867bf.gif)
Example used: Debugger Statements
