### PR TITLE
Added page visibility and observer to refresh CodeMirror editor after…

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
   "dependencies": {
     "@babel/types": "^7.0.0-beta.39",
     "babylon": "^7.0.0-beta.39",
-    "codemirror": "^5.28.0",
+    "codemirror": "^5.34.0",
     "devtools-launchpad": "^0.0.117",
     "devtools-linters": "^0.0.4",
     "devtools-reps": "^0.20.0",

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -128,21 +128,25 @@ class Editor extends PureComponent<Props, State> {
   }
 
   initPageVisibility = () => {
-    window.addEventListener("visibilitychange", () => {
-      if (document.visibilityState == "visible") {
-        const boxEl = window.parent.document.getElementById("toolbox-deck");
+    window.addEventListener(
+      "visibilitychange",
+      () => {
+        if (document.visibilityState == "hidden") {
+          const vBoxEl = window.parent.document.getElementById("toolbox-panel-jsdebugger");
 
-        if (boxEl) {
-          const observer = new MutationObserver((mutationsList) => {
-            if (isEditorVisible(mutationsList)) {
-              this.state.editor.codeMirror.refresh();
-              observer.disconnect();
-            }
-          });
-          observer.observe(boxEl, { attributes: true });
+          if (vBoxEl) {
+            const observer = new MutationObserver(mutationsList => {
+              if (isEditorVisible(mutationsList)) {
+                this.state.editor.codeMirror.refresh();
+                observer.disconnect();
+              }
+            });
+            observer.observe(vBoxEl, { attributes: true });
+          }
         }
-      }
-    }, false);
+      },
+      false
+    );
   };
 
   setupEditor() {
@@ -160,7 +164,6 @@ class Editor extends PureComponent<Props, State> {
     const { codeMirror } = editor;
     const codeMirrorWrapper = codeMirror.getWrapperElement();
 
-    this.initPageVisibility.bind(this);
     this.initPageVisibility();
 
     resizeBreakpointGutter(codeMirror);

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -126,6 +126,34 @@ class Editor extends PureComponent<Props, State> {
     this.scrollToLocation(nextProps);
   }
 
+  initPageVisibility = () => {
+    function changeHandler() {
+      if (document.visibilityState == "visible") {
+        const boxEl = window.parent.document.getElementById("toolbox-deck");
+        const config = { attributes: true };
+        const callback = function(mutationsList) {
+          for (const mutation of mutationsList) {
+            if (
+              mutation.type == "attributes" &&
+              mutation.attributeName == "collapsed" &&
+              mutation.target.collapsed == false
+            ) {
+              this.state.editor.codeMirror.refresh();
+              observer.disconnect();
+            }
+          }
+        };
+
+        const observer = new MutationObserver(callback.bind(this));
+        observer.observe(boxEl, config);
+      }
+    }
+
+    const visibilityChange = "visibilitychange";
+    window.addEventListener(visibilityChange, changeHandler.bind(this), false);
+  };
+    
+
   setupEditor() {
     const editor = createEditor();
 
@@ -140,6 +168,9 @@ class Editor extends PureComponent<Props, State> {
 
     const { codeMirror } = editor;
     const codeMirrorWrapper = codeMirror.getWrapperElement();
+
+    this.initPageVisibility.bind(this);
+    this.initPageVisibility();
 
     resizeBreakpointGutter(codeMirror);
     resizeToggleButton(codeMirror);

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -57,7 +57,8 @@ import {
   scrollToColumn,
   toEditorPosition,
   getSourceLocationFromMouseEvent,
-  hasDocument
+  hasDocument,
+  isEditorVisible
 } from "../../utils/editor";
 
 import { resizeToggleButton, resizeBreakpointGutter } from "../../utils/ui";
@@ -127,32 +128,22 @@ class Editor extends PureComponent<Props, State> {
   }
 
   initPageVisibility = () => {
-    function changeHandler() {
+    window.addEventListener("visibilitychange", () => {
       if (document.visibilityState == "visible") {
         const boxEl = window.parent.document.getElementById("toolbox-deck");
-        const config = { attributes: true };
-        const callback = function(mutationsList) {
-          for (const mutation of mutationsList) {
-            if (
-              mutation.type == "attributes" &&
-              mutation.attributeName == "collapsed" &&
-              mutation.target.collapsed == false
-            ) {
+
+        if (boxEl) {
+          const observer = new MutationObserver((mutationsList) => {
+            if (isEditorVisible(mutationsList)) {
               this.state.editor.codeMirror.refresh();
               observer.disconnect();
             }
-          }
-        };
-
-        const observer = new MutationObserver(callback.bind(this));
-        observer.observe(boxEl, config);
+          });
+          observer.observe(boxEl, { attributes: true });
+        }
       }
-    }
-
-    const visibilityChange = "visibilitychange";
-    window.addEventListener(visibilityChange, changeHandler.bind(this), false);
+    }, false);
   };
-    
 
   setupEditor() {
     const editor = createEditor();

--- a/src/utils/editor/index.js
+++ b/src/utils/editor/index.js
@@ -185,8 +185,10 @@ export function isEditorVisible(mutationsList) {
   for (const mutation of mutationsList) {
     if (
       mutation.type == "attributes" &&
-      mutation.attributeName == "collapsed" &&
-      mutation.target.collapsed == false
+      mutation.attributeName == "selected" &&
+      mutation.target.attributes.getNamedItem("id").value ==
+        "toolbox-panel-jsdebugger" &&
+      mutation.target.attributes.getNamedItem("selected").value == "true"
     ) {
       return true;
     }

--- a/src/utils/editor/index.js
+++ b/src/utils/editor/index.js
@@ -180,3 +180,16 @@ export function getTextForLine(codeMirror, line) {
 export function getCursorLine(codeMirror) {
   return codeMirror.getCursor().line;
 }
+
+export function isEditorVisible(mutationsList) {
+  for (const mutation of mutationsList) {
+    if (
+      mutation.type == "attributes" &&
+      mutation.attributeName == "collapsed" &&
+      mutation.target.collapsed == false
+    ) {
+      return true;
+    }
+  }
+  return false;
+}


### PR DESCRIPTION
Added page visibility and observer to refresh CodeMirror editor after tab is visible.

Fixes Issue: #4852 

### Summary of Changes

1. Upgraded CodeMirror to the latest version 5.34.
2. Added a visibilitychange event listener to detect when the debugger tab in the panel is visible.
3. Added a mutationObserver to call a CodeMirror `refresh()` after tab is fully visible and not collapsed.

### Screenshots/Videos

- Before: 
After scrolling down the document and switching tabs elsewhere and back to the debugger tab. If the user is to click to make a new breakpoint, the breakpoint will appear on a line much higher up than selected. If the user is to click in the text portion of the editor, the editor will re-focus on a line much higher up than selected.
![beforefixjumping](https://user-images.githubusercontent.com/14250545/37176004-5d396b46-22d8-11e8-92f7-6e0ed588ca3d.gif)

- After:
![afterfixjump](https://user-images.githubusercontent.com/14250545/37176102-95032b8e-22d8-11e8-8fdd-4d7d71ae71e9.gif)

### Alternative approaches that were also explored

1. [~Worked] Scrolling to the location upon receiving the specific CodeMirror `signal(...)` to the location that was properly stored in the instance, just not updated to. -- This approach was passed on as it wasn't very generic. For each breaking case you would have to have this event handler, possibly missing some cases. For example, the breakpoint would be firing this handler upon a `"gutterclick"` signal and for the click in the text of the editor we would fire upon a `"focus"` signal. 

2. [Failed] Sending different CodeMirror signals, `"refresh"`, `"update"`, `"scroll"`, `"focus"`, `"viewportChange"`, etc.

3. [Failed] Throwing a CodeMirror `refresh()` upon the change in visibility of the page.

4. [Failed] Forcing an update with `forceUpdate()`, using an instance variable, `this.visibilityChange = true`, to track if the update was just forced from the visibilityChange, then doing a CodeMirror `refresh()` in `componentDidUpdate()`.

5. [Failed] Using React's `ref` in hopes that it will only be called back when the actual DOM has been flushed out. Then trying to do a refresh, but this is called before `componentDidMount` and `componentDidUpdate`.

6. [Failed] Spawning an event handler when the tab is visible, to listen for some HTML DOM events such as `"load"`.

- 3, 4, 5, and 6, all failed because the refresh is called while the tab is collapsed.

6. [Worked] Forcing an update and in componentDidUpdate doing a CodeMirror `refresh()` (allowing the `refresh()` on every update). This worked.. but because the original `refresh()` spawned two more update cycles, in which the third one, or last one occurred after the tab is visible again or no longer collapsed. 

7. [Worked] Method proposed in this PR.
