### PR TITLE
Improve evaluating expressions when pausing

### DIFF
--- a/src/actions/expressions.js
+++ b/src/actions/expressions.js
@@ -96,10 +96,11 @@ export function deleteExpression(expression: Expression) {
  */
 export function evaluateExpressions() {
   return async function({ dispatch, getState, client }: ThunkArgs) {
-    const expressions = getExpressions(getState());
-    for (const expression of expressions) {
-      await dispatch(evaluateExpression(expression));
-    }
+    const expressions = getExpressions(getState()).toJS();
+    const inputs = expressions.map(({ input }) => input);
+    const frameId = getSelectedFrameId(getState());
+    const results = await client.evaluateExpressions(inputs, frameId);
+    dispatch({ type: "EVALUATE_EXPRESSIONS", inputs, results });
   };
 }
 
@@ -134,7 +135,7 @@ function evaluateExpression(expression: Expression) {
     return dispatch({
       type: "EVALUATE_EXPRESSION",
       input: expression.input,
-      [PROMISE]: client.evaluate(wrapExpression(input), { frameId })
+      [PROMISE]: client.evaluateInFrame(wrapExpression(input), frameId)
     });
   };
 }

--- a/src/actions/pause/fetchExtra.js
+++ b/src/actions/pause/fetchExtra.js
@@ -11,11 +11,7 @@ import type { ThunkArgs } from "../types";
 export function fetchExtra() {
   return async function({ dispatch, getState }: ThunkArgs) {
     const frame = getSelectedFrame(getState());
-    if (!frame) {
-      return;
-    }
-
-    const extra = await dispatch(getExtra("this;", frame.this, frame));
+    const extra = await dispatch(getExtra("this;", frame.this));
     dispatch({
       type: "ADD_EXTRA",
       extra: extra

--- a/src/actions/pause/paused.js
+++ b/src/actions/pause/paused.js
@@ -87,8 +87,9 @@ export function paused(pauseInfo: Pause) {
 
     // Run after fetching scoping data so that it may make use of the sourcemap
     // expression mappings for local variables.
-    if (!isEvaluatingExpression(getState())) {
-      dispatch(evaluateExpressions());
+    const atException = why.type == "exception";
+    if (!atException || !isEvaluatingExpression(getState())) {
+      await dispatch(evaluateExpressions());
     }
   };
 }

--- a/src/actions/pause/resumed.js
+++ b/src/actions/pause/resumed.js
@@ -20,13 +20,12 @@ export function resumed() {
   return async ({ dispatch, client, getState }: ThunkArgs) => {
     const why = getPauseReason(getState());
     const wasPausedInEval = inDebuggerEval(why);
+    const wasStepping = isStepping(getState());
 
-    if (!isStepping(getState()) && !wasPausedInEval) {
+    dispatch({ type: "RESUME" });
+
+    if (!wasStepping && !wasPausedInEval) {
       await dispatch(evaluateExpressions());
     }
-
-    dispatch({
-      type: "RESUME"
-    });
   };
 }

--- a/src/actions/sources/tests/select.spec.js
+++ b/src/actions/sources/tests/select.spec.js
@@ -29,7 +29,10 @@ describe("sources", () => {
 
     await dispatch(actions.newSource(makeSource("foo1")));
     await dispatch(
-      actions.paused({ frames: [makeFrame({ id: 1, sourceId: "foo1" })] })
+      actions.paused({
+        why: { type: "debuggerStatement" },
+        frames: [makeFrame({ id: 1, sourceId: "foo1" })]
+      })
     );
 
     await dispatch(

--- a/src/actions/tests/ast.spec.js
+++ b/src/actions/tests/ast.spec.js
@@ -38,6 +38,15 @@ const threadClient = {
     return new Promise((resolve, reject) =>
       resolve({ result: evaluationResult[expression] })
     );
+  },
+  evaluateExpressions: function(expressions) {
+    return new Promise((resolve, reject) =>
+      resolve(
+        expressions.map(expression => ({
+          result: evaluationResult[expression]
+        }))
+      )
+    );
   }
 };
 
@@ -158,6 +167,7 @@ describe("ast", () => {
 
       await dispatch(
         actions.paused({
+          why: { type: "debuggerStatement" },
           frames: [makeFrame({ id: 1, sourceId: "scopes.js" })]
         })
       );

--- a/src/actions/tests/expressions.spec.js
+++ b/src/actions/tests/expressions.spec.js
@@ -1,15 +1,27 @@
 import { actions, selectors, createStore } from "../../utils/test-head";
 
 const mockThreadClient = {
-  evaluate: (script, { frameId }) => {
-    return new Promise((resolve, reject) => {
+  evaluateInFrame: (script, frameId) =>
+    new Promise((resolve, reject) => {
       if (!frameId) {
         resolve("bla");
       } else {
         resolve("boo");
       }
-    });
-  },
+    }),
+  evaluateExpressions: (inputs, frameId) =>
+    Promise.all(
+      inputs.map(
+        input =>
+          new Promise((resolve, reject) => {
+            if (!frameId) {
+              resolve("bla");
+            } else {
+              resolve("boo");
+            }
+          })
+      )
+    ),
   getFrameScopes: async () => {},
   sourceContents: () => ({})
 };
@@ -19,7 +31,6 @@ describe("expressions", () => {
     const { dispatch, getState } = createStore(mockThreadClient);
 
     await dispatch(actions.addExpression("foo"));
-
     expect(selectors.getExpressions(getState()).size).toBe(1);
   });
 

--- a/src/actions/tests/helpers/threadClient.js
+++ b/src/actions/tests/helpers/threadClient.js
@@ -88,5 +88,6 @@ export const sourceThreadClient = {
   },
   threadClient: async () => {},
   getFrameScopes: async () => {},
-  setPausePoints: async () => {}
+  setPausePoints: async () => {},
+  evaluateExpressions: async () => {}
 };

--- a/src/actions/tests/pause.spec.js
+++ b/src/actions/tests/pause.spec.js
@@ -21,6 +21,9 @@ const mockThreadClient = {
     }),
   stepOver: () => new Promise(_resolve => _resolve),
   evaluate: async () => {},
+  evaluateInFrame: async () => {},
+  evaluateExpressions: async () => {},
+
   getFrameScopes: async frame => frame.scope,
   setPausePoints: async () => {},
   setBreakpoint: () => new Promise(_resolve => {}),
@@ -193,12 +196,12 @@ describe("pause", () => {
 
   describe("resumed", () => {
     it("should not evaluate expression while stepping", async () => {
-      const client = { evaluate: jest.fn() };
+      const client = { evaluateExpressions: jest.fn() };
       const { dispatch } = createStore(client);
 
       dispatch(actions.stepIn());
       await dispatch(actions.resumed());
-      expect(client.evaluate.mock.calls).toHaveLength(0);
+      expect(client.evaluateExpressions.mock.calls).toHaveLength(1);
     });
 
     it("resuming - will re-evaluate watch expressions", async () => {
@@ -211,7 +214,7 @@ describe("pause", () => {
       dispatch(actions.addExpression("foo"));
       await waitForState(store, state => selectors.getExpression(state, "foo"));
 
-      mockThreadClient.evaluate = () => new Promise(r => r("YAY"));
+      mockThreadClient.evaluateExpressions = () => new Promise(r => r(["YAY"]));
       await dispatch(actions.paused(mockPauseInfo));
 
       await dispatch(actions.resumed());

--- a/src/actions/tests/preview.spec.js
+++ b/src/actions/tests/preview.spec.js
@@ -19,14 +19,18 @@ const threadClient = {
   },
   setPausePoints: async () => {},
   getFrameScopes: async () => {},
-  evaluate: function(expression) {
+  evaluateInFrame: function(expression, frameId) {
     return new Promise((resolve, reject) =>
       resolve({ result: evaluationResult[expression] })
     );
   },
-  evaluateInFrame: function(frameId, expression) {
+  evaluateExpressions: function(expressions, frameId) {
     return new Promise((resolve, reject) =>
-      resolve({ result: evaluationResult[expression] })
+      resolve(
+        expressions.map(expression => ({
+          result: evaluationResult[expression]
+        }))
+      )
     );
   }
 };

--- a/src/actions/types.js
+++ b/src/actions/types.js
@@ -291,6 +291,12 @@ type PauseAction =
       "@@dispatch/promise": any
     |}
   | {|
+      type: "EVALUATE_EXPRESSIONS",
+      results: Expression[],
+      inputs: string[],
+      "@@dispatch/promise": any
+    |}
+  | {|
       type: "UPDATE_EXPRESSION",
       expression: Expression,
       input: string,

--- a/src/client/firefox/commands.js
+++ b/src/client/firefox/commands.js
@@ -198,13 +198,15 @@ function setBreakpointCondition(
     });
 }
 
-type EvaluateParam = {
-  frameId?: FrameId
-};
-
-function evaluateInFrame(frameId: string, script: Script) {
+async function evaluateInFrame(script: Script, frameId: string) {
   return evaluate(script, { frameId });
 }
+
+async function evaluateExpressions(scripts: Script[], frameId?: string) {
+  return Promise.all(scripts.map(script => evaluate(script, { frameId })));
+}
+
+type EvaluateParam = { frameId?: FrameId };
 
 function evaluate(
   script: ?Script,
@@ -212,11 +214,11 @@ function evaluate(
 ): Promise<mixed> {
   const params = frameId ? { frameActor: frameId } : {};
   if (!tabTarget || !tabTarget.activeConsole || !script) {
-    return Promise.resolve();
+    return Promise.resolve({});
   }
 
   return new Promise(resolve => {
-    tabTarget.activeConsole.evaluateJS(
+    tabTarget.activeConsole.evaluateJSAsync(
       script,
       result => resolve(result),
       params
@@ -388,6 +390,7 @@ const clientCommands = {
   setBreakpointCondition,
   evaluate,
   evaluateInFrame,
+  evaluateExpressions,
   debuggeeCommand,
   navigate,
   reload,

--- a/src/client/firefox/types.js
+++ b/src/client/firefox/types.js
@@ -221,6 +221,11 @@ export type TabTarget = {
       script: Script,
       func: Function,
       params?: { frameActor?: FrameId }
+    ) => void,
+    evaluateJSAsync: (
+      script: Script,
+      func: Function,
+      params?: { frameActor?: FrameId }
     ) => void
   },
   form: { consoleActor: any },

--- a/src/reducers/expressions.js
+++ b/src/reducers/expressions.js
@@ -11,7 +11,8 @@
 
 import makeRecord from "../utils/makeRecord";
 import { List } from "immutable";
-import { omit } from "lodash";
+import { omit, zip } from "lodash";
+
 import { createSelector } from "reselect";
 import { prefs } from "../utils/prefs";
 
@@ -45,6 +46,7 @@ function update(
         value: null,
         updating: true
       });
+
     case "UPDATE_EXPRESSION":
       const key = action.expression.input;
       return updateExpressionInList(state, key, {
@@ -52,14 +54,30 @@ function update(
         value: null,
         updating: true
       }).set("expressionError", !!action.expressionError);
+
     case "EVALUATE_EXPRESSION":
       return updateExpressionInList(state, action.input, {
         input: action.input,
         value: action.value,
         updating: false
       });
+
+    case "EVALUATE_EXPRESSIONS":
+      const { inputs, results } = action;
+
+      return zip(inputs, results).reduce(
+        (newState, [input, result]) =>
+          updateExpressionInList(newState, input, {
+            input: input,
+            value: result,
+            updating: false
+          }),
+        state
+      );
+
     case "DELETE_EXPRESSION":
       return deleteExpression(state, action.input);
+
     case "CLEAR_EXPRESSION_ERROR":
       return state.set("expressionError", false);
 

--- a/src/reducers/pause.js
+++ b/src/reducers/pause.js
@@ -89,7 +89,6 @@ export const createPauseState = (): PauseState => ({
 });
 
 const emptyPauseState = {
-  pause: null,
   frames: null,
   frameScopes: {
     generated: {},
@@ -98,7 +97,7 @@ const emptyPauseState = {
   },
   selectedFrameId: null,
   loadedObjects: {},
-  previousLocation: null
+  why: null
 };
 
 function update(
@@ -239,9 +238,7 @@ function update(
     }
 
     case "RESUME":
-      // We clear why on resume because we need it to decide if
-      // we shoul re-evaluate watch expressions.
-      return { ...state, why: null };
+      return { ...state, ...emptyPauseState };
 
     case "EVALUATE_EXPRESSION":
       return {

--- a/src/test/mochitest/browser.ini
+++ b/src/test/mochitest/browser.ini
@@ -91,6 +91,7 @@ support-files =
   examples/doc-babel.html
   examples/doc-content-script-sources.html
   examples/doc-scripts.html
+  examples/doc-scripts-debugger.html
   examples/doc-script-mutate.html
   examples/doc-script-switching.html
   examples/doc-exceptions.html

--- a/src/test/mochitest/browser_dbg-expressions-error.js
+++ b/src/test/mochitest/browser_dbg-expressions-error.js
@@ -35,11 +35,11 @@ add_task(async function() {
   await togglePauseOnExceptions(dbg, true, false);
 
   // add a good expression, 2 bad expressions, and another good one
+  log(`Adding location`);
   await addExpression(dbg, "location");
   await addExpression(dbg, "foo.bar");
   await addExpression(dbg, "foo.batt");
   await addExpression(dbg, "2");
-
   // check the value of
   is(getValue(dbg, 2), "(unavailable)");
   is(getValue(dbg, 3), "(unavailable)");

--- a/src/test/mochitest/browser_dbg-expressions.js
+++ b/src/test/mochitest/browser_dbg-expressions.js
@@ -46,8 +46,9 @@ async function editExpression(dbg, input) {
   // Position cursor reliably at the end of the text.
   pressKey(dbg, "End");
   type(dbg, input);
+  const evaluated = waitForDispatch(dbg, "EVALUATE_EXPRESSIONS");
   pressKey(dbg, "Enter");
-  await waitForDispatch(dbg, "EVALUATE_EXPRESSION");
+  await evaluated;
 }
 
 add_task(async function() {

--- a/src/test/mochitest/browser_dbg-navigation.js
+++ b/src/test/mochitest/browser_dbg-navigation.js
@@ -6,6 +6,14 @@ function countSources(dbg) {
   return sources.size;
 }
 
+const sources = [
+  "simple1.js",
+  "simple2.js",
+  "simple3.js",
+  "long.js",
+  "scripts.html"
+];
+
 /**
  * Test navigating
  * navigating while paused will reset the pause state and sources
@@ -27,21 +35,11 @@ add_task(async function() {
   assertPausedLocation(dbg);
   is(countSources(dbg), 5, "5 sources are loaded.");
 
-  await navigate(dbg, "about:blank");
-  await waitForDispatch(dbg, "NAVIGATE");
-  is(countSources(dbg), 0, "0 sources are loaded.");
+  await navigate(dbg, "doc-scripts.html", ...sources);
+  is(countSources(dbg), 5, "5 sources are loaded.");
   ok(!isPaused(getState()), "Is not paused");
 
-  await navigate(
-    dbg,
-    "doc-scripts.html",
-    "simple1.js",
-    "simple2.js",
-    "simple3.js",
-    "long.js",
-    "scripts.html"
-  );
-
+  await navigate(dbg, "doc-scripts.html", ...sources);
   is(countSources(dbg), 5, "5 sources are loaded.");
 
   // Test that the current select source persists across reloads
@@ -50,9 +48,7 @@ add_task(async function() {
   await waitForSelectedSource(dbg, "long.js");
 
   ok(
-    getSelectedSource(getState())
-      .get("url")
-      .includes("long.js"),
+    getSelectedSource(getState()).url.includes("long.js"),
     "Selected source is long.js"
   );
 });

--- a/src/test/mochitest/browser_dbg-sourcemaps-reload.js
+++ b/src/test/mochitest/browser_dbg-sourcemaps-reload.js
@@ -25,11 +25,12 @@ function getBreakpoints(dbg) {
 add_task(async function() {
   const dbg = await initDebugger("doc-minified.html");
 
+  dump(`>> meh`)
+
   await navigate(dbg, "sourcemaps-reload/doc-sourcemaps-reload.html", "v1");
 
-  await waitForSource(dbg, "v1");
+  dump(`>> select v1`)
   await selectSource(dbg, "v1");
-
   await addBreakpoint(dbg, "v1", 6);
   let breakpoint = getBreakpoints(dbg)[0];
   is(breakpoint.location.line, 6);

--- a/src/test/mochitest/examples/doc-scripts-debugger.html
+++ b/src/test/mochitest/examples/doc-scripts-debugger.html
@@ -1,0 +1,20 @@
+ <!-- This Source Code Form is subject to the terms of the Mozilla Public
+    - License, v. 2.0. If a copy of the MPL was not distributed with this
+    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8"/>
+    <title>Debugger test page</title>
+  </head>
+
+  <body>
+    <script>
+      debugger;
+      // This inline script allows this HTML page to show up as a
+      // source. It also needs to introduce a new global variable so
+      // it's not immediately garbage collected.
+      inline_script = function () { var x = 5; };
+    </script>
+  </body>
+</html>

--- a/src/test/mochitest/head.js
+++ b/src/test/mochitest/head.js
@@ -252,6 +252,7 @@ function waitForSelectedSource(dbg, url) {
   return waitForState(
     dbg,
     state => {
+
       const source = dbg.selectors.getSelectedSource(state);
       const isLoaded = source && sourceUtils.isLoaded(source);
       if (!isLoaded) {
@@ -713,7 +714,10 @@ async function reload(dbg, ...sources) {
  * @static
  */
 async function navigate(dbg, url, ...sources) {
+  info(`Navigating to ${url}`)
+  const navigated =  waitForDispatch(dbg, "NAVIGATE");
   await dbg.client.navigate(url);
+  await navigated;
   return waitForSources(dbg, ...sources);
 }
 
@@ -941,6 +945,7 @@ const selectors = {
     `.expressions-list .expression-container:nth-child(${i}) .object-delimiter + *`,
   expressionClose: i =>
     `.expressions-list .expression-container:nth-child(${i}) .close`,
+  expressionInput: '.expressions-list  input.input-expression',
   expressionNodes: ".expressions-list .tree-node",
   scopesHeader: ".scopes-pane ._header",
   breakpointItem: i => `.breakpoints-list .breakpoint:nth-of-type(${i})`,
@@ -1103,8 +1108,11 @@ function getScopeValue(dbg, index) {
 }
 
 function toggleObjectInspectorNode(node) {
+
   const objectInspector = node.closest(".object-inspector");
   const properties = objectInspector.querySelectorAll(".node").length;
+
+  log(`Toggling node ${node.innerText}`)
   node.click();
   return waitUntil(
     () => objectInspector.querySelectorAll(".node").length !== properties


### PR DESCRIPTION
Fixes Issue: #5509

### Summary of Changes

This is a bunch of improvements to how we think about console evaluations and pause timing. I don't know how much of this we'll want to include in the final version

- clears the frames when we resume
- adds a new `evaluateMessages` helpers
- adds a new `waitForEvaluations` helpers

