### PR TITLE
Fix permanent loading state

### DIFF
--- a/src/actions/sources/tests/newSources.spec.js
+++ b/src/actions/sources/tests/newSources.spec.js
@@ -40,4 +40,31 @@ describe("sources - new sources", () => {
     await dispatch(actions.newSource(baseSource));
     expect(getSelectedSource(getState()).get("url")).toBe(baseSource.url);
   });
+
+  it("should add original sources", async () => {
+    const { dispatch, getState } = createStore(
+      threadClient,
+      {},
+      {
+        getOriginalURLs: () => Promise.resolve(["magic.js"]),
+        generatedToOriginalId: (a, b) => `${a}/${b}`
+      }
+    );
+
+    await dispatch(
+      actions.newSource(makeSource("base.js", { sourceMapURL: "base.js.map" }))
+    );
+
+    const magic = getSource(getState(), "base.js/magic.js");
+    expect(magic.get("url")).toEqual("magic.js");
+  });
+
+  // eslint-disable-next-line
+  it("should no attempt to fetch original sources if it's missing a source map url", async () => {
+    const getOriginalURLs = jest.fn();
+    const { dispatch } = createStore(threadClient, {}, { getOriginalURLs });
+
+    await dispatch(actions.newSource(makeSource("base.js")));
+    expect(getOriginalURLs).not.toHaveBeenCalled();
+  });
 });

--- a/src/reducers/sources.js
+++ b/src/reducers/sources.js
@@ -170,6 +170,7 @@ function getTextPropsFromAction(action: any) {
   } else if (action.status === "error") {
     return { id: sourceId, error: action.error, loadedState: "loaded" };
   }
+
   return {
     text: value.text,
     id: sourceId,
@@ -191,12 +192,14 @@ function updateSource(state: Record<SourcesState>, source: Source | Object) {
   if (!source.id) {
     return state;
   }
+
   const existingSource = state.getIn(["sources", source.id]);
 
   if (existingSource) {
     const updatedSource = existingSource.merge(source);
     return state.setIn(["sources", source.id], updatedSource);
   }
+
   return state.setIn(["sources", source.id], new SourceRecordClass(source));
 }
 


### PR DESCRIPTION
Fixes Issue: #5639

### Summary of Changes

This PR #5296 started updating every source that did not have a generatedSourceURL, the effect was that sources would go from being loaded to unloaded. This fixes that and cleans up loadSourceMap a bit.

Another nice effect is that it cleaned up our redux actions quite a bit

### Testing

Given that this was a race condition it is difficult to have a mochitest for it. I'll investigate some options tomorrow.
