### PR TITLE
Changes highlight from <strong> to <mark>

### DIFF
--- a/src/components/QuickOpenModal.css
+++ b/src/components/QuickOpenModal.css
@@ -1,10 +1,12 @@
 .result-item .title .highlight {
   font-weight: bold;
+  background-color: transparent;
 }
 
 .result-item .subtitle .highlight {
   color: var(--grey-90);
   font-weight: 500;
+  background-color: transparent;
 }
 
 .theme-dark .result-item .title .highlight,

--- a/src/components/QuickOpenModal.js
+++ b/src/components/QuickOpenModal.js
@@ -320,8 +320,13 @@ export class QuickOpenModal extends Component<Props, State> {
 
   /* eslint-disable react/no-danger */
   renderHighlight = (candidateString: string, query: string, name: string) => {
-    const html = fuzzyAldrin.wrap(candidateString, query);
-
+    const options = {
+      wrap: {
+        tagOpen: '<mark class="highlight">',
+        tagClose: "</mark>"
+      }
+    };
+    const html = fuzzyAldrin.wrap(candidateString, query, options);
     return <div dangerouslySetInnerHTML={{ __html: html }} />;
   };
 


### PR DESCRIPTION
Fixes Issue: #5584

Replaces `<strong>` in highlights with `<mark>`

## Vid:
![mark_instead_of_strong](https://user-images.githubusercontent.com/23530054/37193139-06e11fa0-2369-11e8-922f-0331974f2559.gif)



