### PR TITLE
[Editor] [WIP] Stop highlighting the line being left when stepping

### DIFF
--- a/src/components/Editor/HighlightLine.js
+++ b/src/components/Editor/HighlightLine.js
@@ -12,13 +12,15 @@ import { connect } from "react-redux";
 import {
   getVisibleSelectedFrame,
   getSelectedLocation,
-  getSelectedSource
+  getSelectedSource,
+  getPauseCommand
 } from "../../selectors";
 
 import type { Frame, Location, SourceRecord } from "../../types";
+import type { Command } from "../../reducers/types";
 
 type Props = {
-  pauseCommand: string,
+  pauseCommand: Command,
   selectedFrame: Frame,
   selectedLocation: Location,
   selectedSource: SourceRecord
@@ -44,14 +46,8 @@ function isDocumentReady(selectedSource, selectedLocation) {
 }
 
 export class HighlightLine extends PureComponent<Props> {
-  isStepping: boolean;
-  previousEditorLine: ?number;
-
-  constructor(props: Props) {
-    super(props);
-    this.isStepping = false;
-    this.previousEditorLine = null;
-  }
+  isStepping: boolean = false;
+  previousEditorLine: ?number = null;
 
   shouldComponentUpdate(nextProps: Props) {
     const { selectedLocation, selectedSource } = nextProps;
@@ -64,12 +60,15 @@ export class HighlightLine extends PureComponent<Props> {
   ) {
     const { sourceId, line } = selectedLocation;
     const editorLine = toEditorLine(sourceId, line);
-    if (this.isStepping && editorLine === this.previousEditorLine) {
-      return false;
-    }
+
     if (!isDocumentReady(selectedSource, selectedLocation)) {
       return false;
     }
+
+    if (this.isStepping && editorLine === this.previousEditorLine) {
+      return false;
+    }
+
     return true;
   }
 
@@ -129,7 +128,7 @@ export class HighlightLine extends PureComponent<Props> {
 }
 
 export default connect(state => ({
-  pauseCommand: state.pause.command,
+  pauseCommand: getPauseCommand(state),
   selectedFrame: getVisibleSelectedFrame(state),
   selectedLocation: getSelectedLocation(state),
   selectedSource: getSelectedSource(state)


### PR DESCRIPTION
Fixes Issue: #5633

### Summary of Changes

* Stopped highlighting the line being left when using stepping functions

### Test Plan

- [x] Open http://firefox-dev.tools/debugger-examples/examples/todomvc/ as debugee
- [x] In `Sources`: open `firefox-dev.tools`, open `debugger-examples/examples/todomvc`, open `bower_components`, open `js`, open `views`, open `app-view.js`
- [x] Put a breakpoint on line 31 of `app-view.js`
- [x] Refresh http://firefox-dev.tools/debugger-examples/examples/todomvc/
- [x] In the top right of the Debugger, press any of the `Resume`, `Step over`, `Step in`, or `Step out` buttons
- [x] Notice the line being left not being highlighted in grey
- [x] Breakpoints can be clicked repeatedly and they will highlight the appropriate location in grey

## Notes
Cases this seems to fix
- Clicking `Resume`, `Step over`, `Step in`, or `Step out` buttons—removes the unwanted grey line on the previous location
- Repeatedly clicking the same breakpoint in the secondary pane—after every click, the breakpoint location is selected and highlighted in grey, as desired
- Clicking on a breakpoint in the secondary pane and then clicking a debugger button (`Step over`, `Step in`, etc.)—the breakpoint location is selected and highlighted in gray, then, when a debugger button is clicked, no line is highlighted in grey, but the new selected location is highlighted in blue as desired

Why this works: upon clicking a debugger button, `isInSteppingUpdate ` is set to `true` and no line is highlighted until the component runs through its updates. On the last one, the previous and current lines are different, so `isInSteppingUpdate` can be set to `false`. At this point, the component allows highlighting.

Repeatedly clicking a breakpoint still works because `isInSteppingUpdate ` will not be set to true.

### Videos
Before
![5633-before](https://user-images.githubusercontent.com/12681350/37233676-29427d60-23c2-11e8-90eb-4dc5a2f4902e.gif)


After
![5633-after](https://user-images.githubusercontent.com/12681350/37233680-2d0a3d3e-23c2-11e8-9c9e-905bfe8dd264.gif)
