### PR TITLE
[QuickOpen] Fix loading for searching symbols

### DIFF
--- a/src/components/QuickOpenModal.js
+++ b/src/components/QuickOpenModal.js
@@ -362,6 +362,21 @@ export class QuickOpenModal extends Component<Props, State> {
     return !this.getResultCount() && !!query;
   }
 
+  
+  renderSymLoading = (symbols: FormattedSymbolDeclarations, selectedSource: any, 
+    isSymbolSearch: boolean ) => {
+
+    if(isSymbolSearch && selectedSource) {
+      if(!symbols || symbols.functions.length == 0) {      
+        return(
+          <div className="loading-indicator">
+            {L10N.getStr("loadingText")}
+          </div>
+        )
+      }
+    }
+  }
+
   render() {
     const { enabled, query, symbols, selectedSource } = this.props;
     const { selectedIndex, results } = this.state;
@@ -388,14 +403,8 @@ export class QuickOpenModal extends Component<Props, State> {
             expanded && items[selectedIndex] ? items[selectedIndex].id : ""
           }
         />
-        {this.isSymbolSearch() &&
-          selectedSource &&
-          (!symbols ||
-          (symbols.functions.length == 0 && (
-            <div className="loading-indicator">
-              {L10N.getStr("loadingText")}
-            </div>
-          )))}
+
+        {this.renderSymLoading(symbols, selectedSource, this.isSymbolSearch())}
         {newResults && (
           <ResultList
             key="results"

--- a/src/components/QuickOpenModal.js
+++ b/src/components/QuickOpenModal.js
@@ -362,23 +362,20 @@ export class QuickOpenModal extends Component<Props, State> {
     return !this.getResultCount() && !!query;
   }
 
-  
-  renderSymLoading = (symbols: FormattedSymbolDeclarations, selectedSource: any, 
-    isSymbolSearch: boolean ) => {
+  renderLoading = (isSymbolSearch: boolean) => {
+    const { symbols, selectedSource } = this.props;
 
-    if(isSymbolSearch && selectedSource) {
-      if(!symbols || symbols.functions.length == 0) {      
-        return(
-          <div className="loading-indicator">
-            {L10N.getStr("loadingText")}
-          </div>
-        )
+    if (isSymbolSearch && selectedSource) {
+      if (!symbols || symbols.functions.length == 0) {
+        return (
+          <div className="loading-indicator">{L10N.getStr("loadingText")}</div>
+        );
       }
     }
-  }
+  };
 
   render() {
-    const { enabled, query, symbols, selectedSource } = this.props;
+    const { enabled, query } = this.props;
     const { selectedIndex, results } = this.state;
 
     if (!enabled) {
@@ -404,7 +401,7 @@ export class QuickOpenModal extends Component<Props, State> {
           }
         />
 
-        {this.renderSymLoading(symbols, selectedSource, this.isSymbolSearch())}
+        {this.renderLoading(this.isSymbolSearch())}
         {newResults && (
           <ResultList
             key="results"

--- a/src/components/QuickOpenModal.js
+++ b/src/components/QuickOpenModal.js
@@ -362,10 +362,10 @@ export class QuickOpenModal extends Component<Props, State> {
     return !this.getResultCount() && !!query;
   }
 
-  renderLoading = (isSymbolSearch: boolean) => {
+  renderLoading = () => {
     const { symbols, selectedSource } = this.props;
 
-    if (isSymbolSearch && selectedSource) {
+    if (selectedSource) {
       if (!symbols || symbols.functions.length == 0) {
         return (
           <div className="loading-indicator">{L10N.getStr("loadingText")}</div>
@@ -400,8 +400,7 @@ export class QuickOpenModal extends Component<Props, State> {
             expanded && items[selectedIndex] ? items[selectedIndex].id : ""
           }
         />
-
-        {this.renderLoading(this.isSymbolSearch())}
+        {this.isSymbolSearch() && this.renderLoading()}
         {newResults && (
           <ResultList
             key="results"

--- a/src/components/QuickOpenModal.js
+++ b/src/components/QuickOpenModal.js
@@ -15,7 +15,8 @@ import {
   getQuickOpenType,
   getSelectedSource,
   getSymbols,
-  getTabs
+  getTabs,
+  isSymbolsLoading
 } from "../selectors";
 import { scrollList } from "../utils/result-list";
 import {
@@ -46,6 +47,7 @@ type Props = {
   query: string,
   searchType: QuickOpenType,
   symbols: FormattedSymbolDeclarations,
+  symbolsLoading: boolean,
   tabs: string[],
   selectLocation: Location => void,
   setQuickOpenQuery: (query: string) => void,
@@ -363,14 +365,12 @@ export class QuickOpenModal extends Component<Props, State> {
   }
 
   renderLoading = () => {
-    const { symbols, selectedSource } = this.props;
+    const { symbolsLoading } = this.props;
 
-    if ((this.isFunctionQuery() || this.isVariableQuery()) && selectedSource) {
-      if (!symbols || symbols.functions.length == 0) {
-        return (
-          <div className="loading-indicator">{L10N.getStr("loadingText")}</div>
-        );
-      }
+    if ((this.isFunctionQuery() || this.isVariableQuery()) && symbolsLoading) {
+      return (
+        <div className="loading-indicator">{L10N.getStr("loadingText")}</div>
+      );
     }
   };
 
@@ -420,16 +420,13 @@ export class QuickOpenModal extends Component<Props, State> {
 /* istanbul ignore next: ignoring testing of redux connection stuff */
 function mapStateToProps(state) {
   const selectedSource = getSelectedSource(state);
-  let symbols = null;
-  if (selectedSource != null) {
-    symbols = getSymbols(state, selectedSource.toJS());
-  }
 
   return {
     enabled: getQuickOpenEnabled(state),
     sources: formatSources(getSources(state)),
     selectedSource,
-    symbols: formatSymbols(symbols),
+    symbols: formatSymbols(getSymbols(state, selectedSource)),
+    symbolsLoading: isSymbolsLoading(state, selectedSource),
     query: getQuickOpenQuery(state),
     searchType: getQuickOpenType(state),
     tabs: getTabs(state).toArray()

--- a/src/components/QuickOpenModal.js
+++ b/src/components/QuickOpenModal.js
@@ -365,7 +365,7 @@ export class QuickOpenModal extends Component<Props, State> {
   renderLoading = () => {
     const { symbols, selectedSource } = this.props;
 
-    if (selectedSource) {
+    if ((this.isFunctionQuery() || this.isVariableQuery()) && selectedSource) {
       if (!symbols || symbols.functions.length == 0) {
         return (
           <div className="loading-indicator">{L10N.getStr("loadingText")}</div>
@@ -400,7 +400,7 @@ export class QuickOpenModal extends Component<Props, State> {
             expanded && items[selectedIndex] ? items[selectedIndex].id : ""
           }
         />
-        {this.isSymbolSearch() && this.renderLoading()}
+        {this.renderLoading()}
         {newResults && (
           <ResultList
             key="results"

--- a/src/components/QuickOpenModal.js
+++ b/src/components/QuickOpenModal.js
@@ -363,7 +363,7 @@ export class QuickOpenModal extends Component<Props, State> {
   }
 
   render() {
-    const { enabled, query, symbols } = this.props;
+    const { enabled, query, symbols, selectedSource } = this.props;
     const { selectedIndex, results } = this.state;
 
     if (!enabled) {
@@ -388,12 +388,14 @@ export class QuickOpenModal extends Component<Props, State> {
             expanded && items[selectedIndex] ? items[selectedIndex].id : ""
           }
         />
-        {!symbols ||
+        {this.isSymbolSearch() &&
+          selectedSource &&
+          (!symbols ||
           (symbols.functions.length == 0 && (
             <div className="loading-indicator">
               {L10N.getStr("loadingText")}
             </div>
-          ))}
+          )))}
         {newResults && (
           <ResultList
             key="results"

--- a/src/components/tests/__snapshots__/QuickOpenModal.spec.js.snap
+++ b/src/components/tests/__snapshots__/QuickOpenModal.spec.js.snap
@@ -117,11 +117,6 @@ exports[`QuickOpenModal Basic render with mount & searchType = functions 1`] = `
                 </CloseButton>
               </div>
             </SearchInput>
-            <div
-              className="loading-indicator"
-            >
-              Loading…
-            </div>
             <ResultList
               expanded={false}
               items={Array []}
@@ -263,11 +258,6 @@ exports[`QuickOpenModal Basic render with mount & searchType = variables 1`] = `
                 </CloseButton>
               </div>
             </SearchInput>
-            <div
-              className="loading-indicator"
-            >
-              Loading…
-            </div>
             <ResultList
               expanded={false}
               items={Array []}
@@ -577,11 +567,6 @@ exports[`QuickOpenModal Simple goto search query = :abc & searchType = goto 1`] 
                 </CloseButton>
               </div>
             </SearchInput>
-            <div
-              className="loading-indicator"
-            >
-              Loading…
-            </div>
           </div>
         </div>
       </Modal>


### PR DESCRIPTION
Fixes Issue: #5623 

### Summary of Changes

* Loading indicator to show only when searching up symbols, and only with a source tab selected
* update snapshot



### Test Plan
- [x] cntrl + shift + o with no tabs open (Shouln't show)
- [x] cntrl + shift + o with tabs(source) open (Should Show)

### Screenshots/Videos
![loadingindicator](https://user-images.githubusercontent.com/23143862/37255763-9e1dd6b6-2516-11e8-984f-619340629fa4.gif)