### PR TITLE
Removes toJS from 3 files

### DIFF
--- a/src/actions/ast.js
+++ b/src/actions/ast.js
@@ -25,13 +25,8 @@ import type { ThunkArgs } from "./types";
 
 export function setSourceMetaData(sourceId: SourceId) {
   return async ({ dispatch, getState }: ThunkArgs) => {
-    const sourceRecord = getSource(getState(), sourceId);
-    if (!sourceRecord) {
-      return;
-    }
-
-    const source = sourceRecord.toJS();
-    if (!source.text || source.isWasm) {
+    const source = getSource(getState(), sourceId);
+    if (!source || !source.text || source.isWasm) {
       return;
     }
 
@@ -48,19 +43,19 @@ export function setSourceMetaData(sourceId: SourceId) {
 
 export function setSymbols(sourceId: SourceId) {
   return async ({ dispatch, getState }: ThunkArgs) => {
-    const sourceRecord = getSource(getState(), sourceId);
-    if (!sourceRecord) {
-      return;
-    }
-
-    const source = sourceRecord.toJS();
-    if (!source.text || source.isWasm || hasSymbols(getState(), source)) {
+    const source = getSource(getState(), sourceId);
+    if (
+      !source ||
+      !source.text ||
+      source.isWasm ||
+      hasSymbols(getState(), source)
+    ) {
       return;
     }
 
     await dispatch({
       type: "SET_SYMBOLS",
-      source,
+      source: source.toJS(),
       [PROMISE]: getSymbols(source.id)
     });
 
@@ -94,22 +89,17 @@ export function setOutOfScopeLocations() {
 
 export function setPausePoints(sourceId: SourceId) {
   return async ({ dispatch, getState, client }: ThunkArgs) => {
-    const sourceRecord = getSource(getState(), sourceId);
-    if (!sourceRecord) {
-      return;
-    }
-
-    const source = sourceRecord.toJS();
-    if (!source.text || source.isWasm) {
+    const source = getSource(getState(), sourceId);
+    if (!source || !source.text || source.isWasm) {
       return;
     }
 
     const pausePoints = await getPausePoints(source.id);
-    await client.setPausePoints(sourceId, pausePoints);
+    await client.setPausePoints(source.id, pausePoints);
 
     dispatch({
       type: "SET_PAUSE_POINTS",
-      source,
+      source: source.toJS(),
       pausePoints
     });
   };

--- a/src/actions/breakpoints.js
+++ b/src/actions/breakpoints.js
@@ -334,7 +334,7 @@ export function toggleBreakpoint(line: ?number, column?: number) {
     const state = getState();
     const selectedSource = getSelectedSource(state);
     const bp = getBreakpointAtLocation(state, { line, column });
-    const isEmptyLine = isEmptyLineInSource(state, line, selectedSource.toJS());
+    const isEmptyLine = isEmptyLineInSource(state, line, selectedSource);
 
     if ((!bp && isEmptyLine) || (bp && bp.loading)) {
       return;

--- a/src/actions/breakpoints/addBreakpoint.js
+++ b/src/actions/breakpoints/addBreakpoint.js
@@ -21,11 +21,10 @@ export default async function addBreakpoint(
   const state = getState();
 
   const source = getSource(state, breakpoint.location.sourceId);
-  const sourceRecord = source.toJS();
-  const location = { ...breakpoint.location, sourceUrl: source.get("url") };
+  const location = { ...breakpoint.location, sourceUrl: source.url };
   const generatedLocation = await getGeneratedLocation(
     state,
-    sourceRecord,
+    source.toJS(),
     location,
     sourceMaps
   );
@@ -50,8 +49,8 @@ export default async function addBreakpoint(
     newGeneratedLocation
   );
 
-  const symbols = getSymbols(getState(), sourceRecord);
-  const astLocation = await getASTLocation(sourceRecord, symbols, newLocation);
+  const symbols = getSymbols(getState(), source);
+  const astLocation = await getASTLocation(source, symbols, newLocation);
 
   const newBreakpoint = {
     id,


### PR DESCRIPTION
Edited 3 files to remove possible toJS calls from actions:
- ast.js,
- breakpoints.js,
- addBreakpoint.js

Investigate: `getGeneratedLocation` uses source records, so it would be nice to remove the toJS from here as well

