### PR TITLE
Ensure sort by name button is visible in dark theme

### DIFF
--- a/src/components/PrimaryPanes/Outline.css
+++ b/src/components/PrimaryPanes/Outline.css
@@ -98,6 +98,10 @@
   display: flex;
 }
 
+.theme-dark .outline-footer button {
+    color: var(--theme-body-color);
+}
+
 .outline-footer button.active {
   background: var(--theme-highlight-blue);
   color: #ffffff;


### PR DESCRIPTION
The "Sort by name" button to alphabetize the outline isn't visible in the dark theme because the button text is dark.  This fixes the issue:

<img width="193" alt="yay" src="https://user-images.githubusercontent.com/46655/37372064-835743d8-26df-11e8-9971-f50c08f0a61c.png">
