### PR TITLE
Lock down parser flow type exports

### DIFF
--- a/src/actions/preview.js
+++ b/src/actions/preview.js
@@ -21,7 +21,6 @@ import {
 } from "../selectors";
 
 import { getMappedExpression } from "./expressions";
-
 import { isEqual } from "lodash";
 
 import type { ThunkArgs } from "./types";
@@ -91,7 +90,6 @@ function isInvalidTarget(target: HTMLElement) {
 
 export function updatePreview(target: HTMLElement, editor: any) {
   return ({ dispatch, getState, client, sourceMaps }: ThunkArgs) => {
-    const tokenText = target.innerText ? target.innerText.trim() : "";
     const tokenPos = getTokenLocation(editor.codeMirror, target);
     const cursorPos = target.getBoundingClientRect();
     const preview = getPreview(getState());
@@ -126,9 +124,9 @@ export function updatePreview(target: HTMLElement, editor: any) {
 
     let match;
     if (!symbols || symbols.loading) {
-      match = findBestMatchExpression(symbols, tokenPos, tokenText);
-    } else {
       match = getExpressionFromCoords(editor.codeMirror, tokenPos);
+    } else {
+      match = findBestMatchExpression(symbols, tokenPos);
     }
 
     if (!match) {

--- a/src/actions/types.js
+++ b/src/actions/types.js
@@ -24,8 +24,9 @@ import type {
 } from "../reducers/ui";
 import type { MatchedLocations } from "../reducers/file-search";
 
-import type { SymbolDeclaration, AstLocation } from "../workers/parser";
+import type { AstLocation, SymbolDeclaration } from "../workers/parser";
 import type { SourceMetaDataType } from "../reducers/ast.js";
+
 /**
  * Flow types
  * @module actions/types

--- a/src/components/PrimaryPanes/Outline.js
+++ b/src/components/PrimaryPanes/Outline.js
@@ -15,9 +15,9 @@ import PreviewFunction from "../shared/PreviewFunction";
 import { uniq, sortBy } from "lodash";
 import type {
   SymbolDeclarations,
-  SymbolDeclaration
-} from "../../workers/parser/getSymbols";
-import type { AstLocation } from "../../workers/parser/types";
+  SymbolDeclaration,
+  AstLocation
+} from "../../workers/parser";
 import type { SourceRecord } from "../../reducers/sources";
 
 type Props = {

--- a/src/test/mochitest/browser_dbg-pretty-print-console.js
+++ b/src/test/mochitest/browser_dbg-pretty-print-console.js
@@ -23,6 +23,8 @@ add_task(async function() {
   info("Switch back to debugger and pretty-print");
   await toolbox.selectTool("jsdebugger");
   await selectSource(dbg, "math.min.js", 2);
+  await waitForSelectedSource(dbg, "math.min.js");
+
   clickElement(dbg, "prettyPrintButton");
 
   await waitForSource(dbg, "math.min.js:formatted");

--- a/src/test/mochitest/browser_dbg-sourcemaps2.js
+++ b/src/test/mochitest/browser_dbg-sourcemaps2.js
@@ -45,6 +45,8 @@ add_task(async function() {
   // Tests the existence of the sourcemap link in the original source.
   ok(findElement(dbg, "sourceMapLink"), "Sourcemap link in original source");
   await selectSource(dbg, "main.min.js");
+  await waitForSelectedSource(dbg, "main.min.js");
+
   ok(
     !findElement(dbg, "sourceMapLink"),
     "No Sourcemap link exists in generated source"

--- a/src/types.js
+++ b/src/types.js
@@ -327,3 +327,7 @@ export type Worker = {
   type: number,
   url: string
 };
+
+export type Position = { line: number, column: number };
+
+export type Range = { end: Position, start: Position };

--- a/src/utils/ast.js
+++ b/src/utils/ast.js
@@ -2,7 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
-export function findBestMatchExpression(symbols, tokenPos, token) {
+// @flow
+
+import type { Position } from "../types";
+import type { SymbolDeclarations } from "../workers/parser";
+
+export function findBestMatchExpression(
+  symbols: SymbolDeclarations,
+  tokenPos: Position
+) {
   const { memberExpressions, identifiers } = symbols;
   const { line, column } = tokenPos;
   return identifiers.concat(memberExpressions).reduce((found, expression) => {

--- a/src/utils/breakpoint/astBreakpointLocation.js
+++ b/src/utils/breakpoint/astBreakpointLocation.js
@@ -6,8 +6,12 @@
 
 import { getSymbols } from "../../workers/parser";
 
-import type { Scope, AstPosition } from "../../workers/parser/types";
-import type { SymbolDeclarations } from "../../workers/parser/getSymbols";
+import type {
+  Scope,
+  AstPosition,
+  SymbolDeclarations
+} from "../../workers/parser";
+
 import type { Location, Source, ASTLocation } from "../../types";
 
 export function containsPosition(a: AstPosition, b: AstPosition) {

--- a/src/utils/breakpoint/tests/astBreakpointLocation.spec.js
+++ b/src/utils/breakpoint/tests/astBreakpointLocation.spec.js
@@ -1,7 +1,7 @@
 import { getASTLocation } from "../astBreakpointLocation.js";
 import { getSource } from "../../../workers/parser/tests/helpers";
 import { setSource } from "../../../workers/parser/sources";
-import getSymbols from "../../../workers/parser/getSymbols";
+import { getSymbols } from "../../../workers/parser/getSymbols";
 import cases from "jest-in-case";
 
 async function setup({ fileName, location, functionName }) {

--- a/src/utils/editor/source-documents.js
+++ b/src/utils/editor/source-documents.js
@@ -9,7 +9,7 @@ import { getMode } from "../source";
 import type { Source } from "../../types";
 import { isWasm, getWasmLineNumberFormatter, renderWasmText } from "../wasm";
 import { resizeBreakpointGutter, resizeToggleButton } from "../ui";
-import type { SymbolDeclarations } from "../../workers/parser/getSymbols";
+import type { SymbolDeclarations } from "../../workers/parser";
 import type { SourceRecord } from "../../reducers/types";
 import SourceEditor from "./source-editor";
 

--- a/src/utils/tests/ast.spec.js
+++ b/src/utils/tests/ast.spec.js
@@ -1,6 +1,6 @@
 import { findBestMatchExpression } from "../ast";
 
-import getSymbols from "../../workers/parser/getSymbols";
+import { getSymbols } from "../../workers/parser/getSymbols";
 import { getSource } from "../../workers/parser/tests/helpers";
 import { setSource } from "../../workers/parser/sources";
 

--- a/src/utils/tests/function.spec.js
+++ b/src/utils/tests/function.spec.js
@@ -1,6 +1,6 @@
 import { findFunctionText } from "../function";
 
-import getSymbols from "../../workers/parser/getSymbols";
+import { getSymbols } from "../../workers/parser/getSymbols";
 import { getOriginalSource } from "../../workers/parser/tests/helpers";
 import { setSource } from "../../workers/parser/sources";
 

--- a/src/workers/parser/findOutOfScopeLocations.js
+++ b/src/workers/parser/findOutOfScopeLocations.js
@@ -12,7 +12,7 @@ import findLastIndex from "lodash/findLastIndex";
 
 import { containsLocation, containsPosition } from "./utils/contains";
 
-import getSymbols from "./getSymbols";
+import { getSymbols } from "./getSymbols";
 
 function findSymbols(source) {
   const { functions, comments } = getSymbols(source);

--- a/src/workers/parser/frameworks.js
+++ b/src/workers/parser/frameworks.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
-import getSymbols from "./getSymbols";
+import { getSymbols } from "./getSymbols";
 
 export function getFramework(sourceId) {
   const sourceSymbols = getSymbols(sourceId);

--- a/src/workers/parser/getSymbols.js
+++ b/src/workers/parser/getSymbols.js
@@ -7,12 +7,8 @@
 import flatten from "lodash/flatten";
 import * as t from "@babel/types";
 
-import type {
-  Node,
-  TraversalAncestors,
-  Location as BabelLocation
-} from "@babel/types";
-import createSimplePath, { type SimplePath } from "./utils/simple-path";
+import type { Node, TraversalAncestors } from "@babel/types";
+import createSimplePath from "./utils/simple-path";
 import { traverseAst } from "./utils/ast";
 import {
   isVariable,
@@ -20,43 +16,14 @@ import {
   getVariables,
   isComputedExpression
 } from "./utils/helpers";
+
 import { inferClassName } from "./utils/inferClassName";
 import getFunctionName from "./utils/getFunctionName";
 
+import type { SimplePath } from "./utils/simple-path";
+import type { SymbolDeclarations, SymbolDeclaration } from "./types";
+
 let symbolDeclarations = new Map();
-
-export type ClassDeclaration = {|
-  name: string,
-  location: BabelLocation,
-  parent?: ClassDeclaration
-|};
-
-export type SymbolDeclaration = {|
-  name: string,
-  expression?: string,
-  klass?: ?string,
-  location: BabelLocation,
-  expressionLocation?: BabelLocation,
-  parameterNames?: string[],
-  identifier?: Object,
-  computed?: Boolean,
-  values?: string[]
-|};
-
-export type FunctionDeclaration = SymbolDeclaration & {|
-  parameterNames: string[]
-|};
-
-export type SymbolDeclarations = {
-  classes: Array<ClassDeclaration>,
-  functions: Array<SymbolDeclaration>,
-  variables: Array<SymbolDeclaration>,
-  memberExpressions: Array<SymbolDeclaration>,
-  callExpressions: Array<SymbolDeclaration>,
-  objectProperties: Array<SymbolDeclaration>,
-  identifiers: Array<SymbolDeclaration>,
-  comments: Array<SymbolDeclaration>
-};
 
 function getFunctionParameterNames(path: SimplePath): string[] {
   if (path.node.params != null) {
@@ -484,7 +451,7 @@ export function clearSymbols() {
   symbolDeclarations = new Map();
 }
 
-export default function getSymbols(sourceId: string): SymbolDeclarations {
+export function getSymbols(sourceId: string): SymbolDeclarations {
   if (symbolDeclarations.has(sourceId)) {
     const symbols = symbolDeclarations.get(sourceId);
     if (symbols) {

--- a/src/workers/parser/index.js
+++ b/src/workers/parser/index.js
@@ -40,5 +40,11 @@ export type {
   BindingMetaValue,
   BindingType
 } from "./getScopes";
-export type { SymbolDeclaration, SymbolDeclarations } from "./getSymbols";
-export type { AstLocation } from "./types";
+
+export type {
+  SymbolDeclaration,
+  SymbolDeclarations,
+  AstLocation,
+  AstPosition,
+  Scope
+} from "./types";

--- a/src/workers/parser/types.js
+++ b/src/workers/parser/types.js
@@ -12,4 +12,35 @@ export type Scope = {
   bindings: Object[]
 };
 
-export type { SymbolDeclaration, SymbolDeclarations } from "./getSymbols";
+export type ClassDeclaration = {|
+  name: string,
+  location: BabelLocation,
+  parent?: ClassDeclaration
+|};
+
+export type SymbolDeclaration = {|
+  name: string,
+  expression?: string,
+  klass?: ?string,
+  location: BabelLocation,
+  expressionLocation?: BabelLocation,
+  parameterNames?: string[],
+  identifier?: Object,
+  computed?: Boolean,
+  values?: string[]
+|};
+
+export type FunctionDeclaration = SymbolDeclaration & {|
+  parameterNames: string[]
+|};
+
+export type SymbolDeclarations = {
+  classes: Array<ClassDeclaration>,
+  functions: Array<SymbolDeclaration>,
+  variables: Array<SymbolDeclaration>,
+  memberExpressions: Array<SymbolDeclaration>,
+  callExpressions: Array<SymbolDeclaration>,
+  objectProperties: Array<SymbolDeclaration>,
+  identifiers: Array<SymbolDeclaration>,
+  comments: Array<SymbolDeclaration>
+};

--- a/src/workers/parser/utils/formatSymbols.js
+++ b/src/workers/parser/utils/formatSymbols.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
-import getSymbols from "../getSymbols";
+import { getSymbols } from "../getSymbols";
 import { setSource } from "../sources";
 
 function formatLocation(loc) {

--- a/src/workers/parser/worker.js
+++ b/src/workers/parser/worker.js
@@ -2,8 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
+// @flow
+
 import { getClosestExpression } from "./utils/closest";
-import getSymbols, { clearSymbols } from "./getSymbols";
+import { getSymbols, clearSymbols } from "./getSymbols";
 import { clearASTs } from "./utils/ast";
 import getScopes, { clearScopes } from "./getScopes";
 import { hasSource, setSource, clearSources } from "./sources";


### PR DESCRIPTION
### Summary of Changes

* adds flow types for utils/ast
* exports types from parser/index
* fixes a recursion issue caused by defining types in getSymbols
