### PR TITLE
Expression syntax errors are cleared on save

### DIFF
--- a/src/actions/expressions.js
+++ b/src/actions/expressions.js
@@ -32,12 +32,13 @@ export function addExpression(input: string) {
       return;
     }
 
+    const expressionError = await parser.hasSyntaxError(input);
+
     const expression = getExpression(getState(), input);
     if (expression) {
       return dispatch(evaluateExpression(expression));
     }
 
-    const expressionError = await parser.hasSyntaxError(input);
     dispatch({ type: "ADD_EXPRESSION", input, expressionError });
 
     const newExpression = getExpression(getState(), input);

--- a/src/components/SecondaryPanes/Expressions.js
+++ b/src/components/SecondaryPanes/Expressions.js
@@ -121,16 +121,22 @@ class Expressions extends Component<Props, State> {
   ) => {
     e.preventDefault();
     e.stopPropagation();
+
     this.props.updateExpression(this.state.inputValue, expression);
   };
 
   handleNewSubmit = async (e: SyntheticEvent<HTMLFormElement>) => {
     const { inputValue } = this.state;
-    this.props.clearExpressionError();
     e.preventDefault();
     e.stopPropagation();
+
+    this.props.clearExpressionError();
     await this.props.addExpression(this.state.inputValue);
-    this.setState({ editing: false, editIndex: -1, inputValue: this.props.expressionError ? inputValue : "" });
+    this.setState({
+      editing: false,
+      editIndex: -1,
+      inputValue: this.props.expressionError ? inputValue : ""
+    });
   };
 
   renderExpression = (expression: Expression, index: number) => {

--- a/src/components/SecondaryPanes/Expressions.js
+++ b/src/components/SecondaryPanes/Expressions.js
@@ -29,6 +29,7 @@ type State = {
 type Props = {
   expressions: List<Expression>,
   expressionError: boolean,
+  sintaxCheck(): boolean,
   addExpression: (input: string) => void,
   clearExpressionError: () => void,
   evaluateExpressions: () => void,
@@ -125,10 +126,16 @@ class Expressions extends Component<Props, State> {
   };
 
   handleNewSubmit = async (e: SyntheticEvent<HTMLFormElement>) => {
+    const { inputValue } = this.state;
+    this.props.clearExpressionError();
     e.preventDefault();
     e.stopPropagation();
-    this.props.addExpression(this.state.inputValue);
-    this.setState({ editing: false, editIndex: -1, inputValue: "" });
+    await this.props.addExpression(this.state.inputValue);
+    if (!this.props.expressionError) {
+      this.setState({ editing: false, editIndex: -1, inputValue: "" });
+    } else {
+      this.setState({ editing: false, editIndex: -1, inputValue: inputValue });
+    }
   };
 
   renderExpression = (expression: Expression, index: number) => {

--- a/src/components/SecondaryPanes/Expressions.js
+++ b/src/components/SecondaryPanes/Expressions.js
@@ -130,11 +130,7 @@ class Expressions extends Component<Props, State> {
     e.preventDefault();
     e.stopPropagation();
     await this.props.addExpression(this.state.inputValue);
-    if (!this.props.expressionError) {
-      this.setState({ editing: false, editIndex: -1, inputValue: "" });
-    } else {
-      this.setState({ editing: false, editIndex: -1, inputValue: inputValue });
-    }
+    this.setState({ editing: false, editIndex: -1, inputValue: this.props.expressionError ? inputValue : "" });
   };
 
   renderExpression = (expression: Expression, index: number) => {

--- a/src/components/SecondaryPanes/Expressions.js
+++ b/src/components/SecondaryPanes/Expressions.js
@@ -29,7 +29,6 @@ type State = {
 type Props = {
   expressions: List<Expression>,
   expressionError: boolean,
-  sintaxCheck(): boolean,
   addExpression: (input: string) => void,
   clearExpressionError: () => void,
   evaluateExpressions: () => void,


### PR DESCRIPTION
Fixes Issue: #5204 

Here's the Pull Request Doc
https://devtools-html.github.io/debugger.html/CONTRIBUTING.html#pull-requests

### Summary of Changes

* Now the wrong expression is not cleaned
* The red borders now are displaying only when there is an error

Here's the Debugger's Testing doc
https://docs.google.com/document/d/1oBMRxV8A2ag2t22YsQOxTdEv0mXKzIg0tggJjRkU1S0/edit#.
Feel free to improve it!

### GIF
![dpfqqfod2x](https://user-images.githubusercontent.com/36955296/37466159-5bd65932-285d-11e8-82dd-63f9a58b3e33.gif)
