### PR TITLE
WIP: Show project root based on sources count

### DIFF
--- a/src/actions/ui.js
+++ b/src/actions/ui.js
@@ -162,11 +162,15 @@ export function clearProjectDirectoryRoot() {
 export function setProjectDirectoryRoot(newRoot: string) {
   return ({ dispatch, getState }: ThunkArgs) => {
     const curRoot = getProjectDirectoryRoot(getState());
+
+    // What is this for?  It's causing problems by appending successive root settings
+    /*
     if (newRoot && curRoot) {
       const temp = newRoot.split("/");
       temp.splice(0, 2);
       newRoot = `${curRoot}/${temp.join("/")}`;
     }
+    */
 
     dispatch({
       type: "SET_PROJECT_DIRECTORY_ROOT",

--- a/src/components/PrimaryPanes/SourcesTree.js
+++ b/src/components/PrimaryPanes/SourcesTree.js
@@ -145,20 +145,14 @@ class SourcesTree extends Component<Props, State> {
     // only when a new source is added
     if (nextProps.sources != this.props.sources) {
       this.setState(
-        /*
         updateTree({
           newSources: nextProps.sources,
           prevSources: sources,
           debuggeeUrl,
           projectRoot,
+          projectRootUsed: this.state.projectRootUsed,
           uncollapsedTree,
           sourceTree
-        })
-        */
-        createTree({
-          sources: nextProps.sources,
-          debuggeeUrl: nextProps.debuggeeUrl,
-          projectRoot: nextProps.projectRoot
         })
       );
     }
@@ -346,7 +340,6 @@ class SourcesTree extends Component<Props, State> {
 
     // The "sourceTree.contents[0]" check ensures that there are contents
     // A custom root with no existing sources will be ignored
-
     if (isCustomRoot && sourceTree.contents.length) {
       clearProjectRootButton = (
         <button

--- a/src/components/PrimaryPanes/SourcesTree.js
+++ b/src/components/PrimaryPanes/SourcesTree.js
@@ -66,6 +66,7 @@ type State = {
   parentMap: any,
   sourceTree: Object,
   projectRoot: string,
+  projectRootUsed: boolean,
   uncollapsedTree: any,
   listItems?: any,
   highlightItems?: any
@@ -85,6 +86,7 @@ class SourcesTree extends Component<Props, State> {
     super(props);
     const { debuggeeUrl, sources, projectRoot } = this.props;
 
+    console.log('constructor() createTree!');
     this.state = createTree({
       projectRoot,
       debuggeeUrl,
@@ -110,6 +112,7 @@ class SourcesTree extends Component<Props, State> {
     ) {
       // early recreate tree because of changes
       // to project root, debugee url or lack of sources
+      console.log('componentWillReceiveProps() createTree!');
       return this.setState(
         createTree({
           sources: nextProps.sources,
@@ -143,6 +146,7 @@ class SourcesTree extends Component<Props, State> {
     // NOTE: do not run this every time a source is clicked,
     // only when a new source is added
     if (nextProps.sources != this.props.sources) {
+      console.log('componentWillReceiveProps() updateTree!');
       this.setState(
         updateTree({
           newSources: nextProps.sources,
@@ -318,8 +322,12 @@ class SourcesTree extends Component<Props, State> {
       highlightItems,
       listItems,
       parentMap,
+      projectRootUsed,
       sourceTree
     } = this.state;
+
+    //console.log(sourceTree, sourceTree.contents);
+    console.log(this.state.sources, this.props.sources)
 
     const onExpand = (item, expandedState) => {
       this.props.setExpandedState(expandedState);
@@ -329,14 +337,16 @@ class SourcesTree extends Component<Props, State> {
       this.props.setExpandedState(expandedState);
     };
 
-    const isCustomRoot = projectRoot !== "";
+    const isCustomRoot = projectRoot !== "" && projectRootUsed;
     let roots = () => sourceTree.contents;
 
     let clearProjectRootButton = null;
 
     // The "sourceTree.contents[0]" check ensures that there are contents
     // A custom root with no existing sources will be ignored
-    if (isCustomRoot && sourceTree.contents[0]) {
+
+    //if (isCustomRoot && sourceTree.contents.length) {
+    if (isCustomRoot) {
       clearProjectRootButton = (
         <button
           className="sources-clear-root"

--- a/src/components/PrimaryPanes/SourcesTree.js
+++ b/src/components/PrimaryPanes/SourcesTree.js
@@ -86,7 +86,6 @@ class SourcesTree extends Component<Props, State> {
     super(props);
     const { debuggeeUrl, sources, projectRoot } = this.props;
 
-    console.log('constructor() createTree!');
     this.state = createTree({
       projectRoot,
       debuggeeUrl,
@@ -112,7 +111,6 @@ class SourcesTree extends Component<Props, State> {
     ) {
       // early recreate tree because of changes
       // to project root, debugee url or lack of sources
-      console.log('componentWillReceiveProps() createTree!');
       return this.setState(
         createTree({
           sources: nextProps.sources,
@@ -146,8 +144,8 @@ class SourcesTree extends Component<Props, State> {
     // NOTE: do not run this every time a source is clicked,
     // only when a new source is added
     if (nextProps.sources != this.props.sources) {
-      console.log('componentWillReceiveProps() updateTree!');
       this.setState(
+        /*
         updateTree({
           newSources: nextProps.sources,
           prevSources: sources,
@@ -155,6 +153,12 @@ class SourcesTree extends Component<Props, State> {
           projectRoot,
           uncollapsedTree,
           sourceTree
+        })
+        */
+        createTree({
+          sources: nextProps.sources,
+          debuggeeUrl: nextProps.debuggeeUrl,
+          projectRoot: nextProps.projectRoot
         })
       );
     }
@@ -296,6 +300,7 @@ class SourcesTree extends Component<Props, State> {
     return (
       <div
         className={classnames("node", { focused })}
+        title={item.path}
         key={item.path}
         onClick={e => {
           this.focusItem(item);
@@ -326,9 +331,6 @@ class SourcesTree extends Component<Props, State> {
       sourceTree
     } = this.state;
 
-    //console.log(sourceTree, sourceTree.contents);
-    console.log(this.state.sources, this.props.sources)
-
     const onExpand = (item, expandedState) => {
       this.props.setExpandedState(expandedState);
     };
@@ -345,8 +347,7 @@ class SourcesTree extends Component<Props, State> {
     // The "sourceTree.contents[0]" check ensures that there are contents
     // A custom root with no existing sources will be ignored
 
-    //if (isCustomRoot && sourceTree.contents.length) {
-    if (isCustomRoot) {
+    if (isCustomRoot && sourceTree.contents.length) {
       clearProjectRootButton = (
         <button
           className="sources-clear-root"

--- a/src/reducers/sources.js
+++ b/src/reducers/sources.js
@@ -376,7 +376,7 @@ export function getSourceInSources(
 
 export const getSources = createSelector(
   getSourcesState,
-  sources => { console.log(sources, sources.sources); return sources.sources; }
+  sources => sources.sources
 );
 
 export const getTabs = createSelector(getSourcesState, sources => sources.tabs);

--- a/src/reducers/sources.js
+++ b/src/reducers/sources.js
@@ -376,7 +376,7 @@ export function getSourceInSources(
 
 export const getSources = createSelector(
   getSourcesState,
-  sources => sources.sources
+  sources => { console.log(sources, sources.sources); return sources.sources; }
 );
 
 export const getTabs = createSelector(getSourcesState, sources => sources.tabs);

--- a/src/utils/sources-tree/addToTree.js
+++ b/src/utils/sources-tree/addToTree.js
@@ -175,6 +175,7 @@ export function addToTree(
   if (isInvalidUrl(url, source) || !isUnderRoot(url, projectRoot)) {
     return;
   }
+  //console.log('is under root! ', url, projectRoot)
 
   const finalNode = traverseTree(url, tree, debuggeeHost, projectRoot);
   finalNode.contents = addSourceToNode(finalNode, url, source);

--- a/src/utils/sources-tree/createTree.js
+++ b/src/utils/sources-tree/createTree.js
@@ -22,11 +22,22 @@ export function createTree({ sources, debuggeeUrl, projectRoot }: Params) {
     addToTree(uncollapsedTree, source, debuggeeUrl, projectRoot);
   }
 
+  // If a project root is set but the page does not have an sources for that root,
+  // continue to store the root but show the entire tree for the time being
+  let projectRootUsed = true;
+  if (uncollapsedTree.contents.length === 0) {
+    projectRootUsed = false;
+    for (const source of sources.valueSeq()) {
+      addToTree(uncollapsedTree, source, debuggeeUrl, "");
+    }
+  }
+
   const sourceTree = collapseTree(uncollapsedTree);
 
   return {
     uncollapsedTree,
     sourceTree,
+    projectRootUsed,
     parentMap: createParentMap(sourceTree),
     focusedItem: null
   };

--- a/src/utils/sources-tree/updateTree.js
+++ b/src/utils/sources-tree/updateTree.js
@@ -17,6 +17,10 @@ function newSourcesSet(newSources, prevSources) {
   return next.subtract(prev);
 }
 
+function allSourcesSet(newSources, prevSources) {
+  return prevSources.toSet().union(newSources.toSet());
+}
+
 type Params = {
   newSources: SourcesMap,
   prevSources: SourcesMap,
@@ -31,6 +35,7 @@ export function updateTree({
   prevSources,
   debuggeeUrl,
   projectRoot,
+  projectRootUsed,
   uncollapsedTree,
   sourceTree
 }: Params) {
@@ -42,16 +47,14 @@ export function updateTree({
 
   // If a project root is set but the page does not have an sources for that root,
   // continue to store the root but show the entire tree for the time being
-  /*
-  let projectRootUsed = true;
+  projectRootUsed = true;
   if (uncollapsedTree.contents.length === 0) {
     projectRootUsed = false;
-    for (const source of sources.valueSeq()) {
+    const allSources = allSourcesSet(newSources, prevSources);
+    for (const source of allSources) {
       addToTree(uncollapsedTree, source, debuggeeUrl, "");
     }
   }
-  */
-  let projectRootUsed = true;
 
   const newSourceTree = collapseTree(uncollapsedTree);
 

--- a/src/utils/sources-tree/updateTree.js
+++ b/src/utils/sources-tree/updateTree.js
@@ -47,11 +47,10 @@ export function updateTree({
 
   // If a project root is set but the page does not have an sources for that root,
   // continue to store the root but show the entire tree for the time being
-  projectRootUsed = true;
-  if (uncollapsedTree.contents.length === 0) {
+  if (projectRoot && uncollapsedTree.contents.length === 0) {
     projectRootUsed = false;
-    const allSources = allSourcesSet(newSources, prevSources);
-    for (const source of allSources) {
+    //const allSources = allSourcesSet(newSources, prevSources);
+    for (const source of newSet) {
       addToTree(uncollapsedTree, source, debuggeeUrl, "");
     }
   }

--- a/src/utils/sources-tree/updateTree.js
+++ b/src/utils/sources-tree/updateTree.js
@@ -40,10 +40,24 @@ export function updateTree({
     addToTree(uncollapsedTree, source, debuggeeUrl, projectRoot);
   }
 
+  // If a project root is set but the page does not have an sources for that root,
+  // continue to store the root but show the entire tree for the time being
+  /*
+  let projectRootUsed = true;
+  if (uncollapsedTree.contents.length === 0) {
+    projectRootUsed = false;
+    for (const source of sources.valueSeq()) {
+      addToTree(uncollapsedTree, source, debuggeeUrl, "");
+    }
+  }
+  */
+  let projectRootUsed = true;
+
   const newSourceTree = collapseTree(uncollapsedTree);
 
   return {
     uncollapsedTree,
+    projectRootUsed,
     sourceTree: newSourceTree,
     parentMap: createParentMap(sourceTree),
     focusedItem: null


### PR DESCRIPTION
Fixes Issue: #5447 

This is an early WIP to show progress, get feedback, and allow me to quickly check out other PRS.

## Summary
- If a custom project root is set and that root exists in the sources tree, show only sources under that root.
- If a custom project root is set and that root does *not* exist in the sources tree, show the full tree.

## ToDo
- [x] Ensure functionality works for `createTree` (initial display of the tree upon render)
- [ ] Ensure functionality works for `updateTree`
- [ ] Test(s)