### PR TITLE
Fix message and formatting of Outline when no functions

### DIFF
--- a/src/components/PrimaryPanes/Outline.css
+++ b/src/components/PrimaryPanes/Outline.css
@@ -11,7 +11,7 @@
   position: relative;
 }
 
-.outline .outline-pane-info {
+.outline-pane-info {
   width: 100%;
   font-style: italic;
   text-align: center;

--- a/src/components/PrimaryPanes/Outline.js
+++ b/src/components/PrimaryPanes/Outline.js
@@ -137,7 +137,10 @@ export class Outline extends Component<Props> {
   }
 
   render() {
-    const { symbols } = this.props;
+    const { symbols, selectedSource } = this.props;
+    if (!selectedSource) {
+      return this.renderPlaceholder();
+    }
     if (!symbols || symbols.loading) {
       return this.renderLoading();
     }


### PR DESCRIPTION
At present, if no source is selected, the Outline tab shows `Loading...`, which is not good.  The formatting was also off, so I fixed that.