### PR TITLE
Use original scope mappings to rewrite preview and watch expressions

### DIFF
--- a/src/actions/pause/fetchScopes.js
+++ b/src/actions/pause/fetchScopes.js
@@ -23,6 +23,6 @@ export function fetchScopes() {
       [PROMISE]: client.getFrameScopes(frame)
     });
 
-    dispatch(mapScopes(scopes, frame));
+    await dispatch(mapScopes(scopes, frame));
   };
 }

--- a/src/actions/pause/paused.js
+++ b/src/actions/pause/paused.js
@@ -70,10 +70,6 @@ export function paused(pauseInfo: Pause) {
       dispatch(removeBreakpoint(hiddenBreakpointLocation));
     }
 
-    if (!isEvaluatingExpression(getState())) {
-      dispatch(evaluateExpressions());
-    }
-
     await dispatch(mapFrames());
     const selectedFrame = getSelectedFrame(getState());
 
@@ -86,6 +82,12 @@ export function paused(pauseInfo: Pause) {
     }
 
     dispatch(togglePaneCollapse("end", false));
-    dispatch(fetchScopes());
+    await dispatch(fetchScopes());
+
+    // Run after fetching scoping data so that it may make use of the sourcemap
+    // expression mappings for local variables.
+    if (!isEvaluatingExpression(getState())) {
+      dispatch(evaluateExpressions());
+    }
   };
 }

--- a/src/actions/preview.js
+++ b/src/actions/preview.js
@@ -158,7 +158,7 @@ export function setPreview(
           );
 
           expression = await getMappedExpression(
-            { sourceMaps },
+            { sourceMaps, getState },
             generatedLocation,
             expression
           );

--- a/src/actions/types.js
+++ b/src/actions/types.js
@@ -300,7 +300,12 @@ type PauseAction =
       type: "MAP_SCOPES",
       frame: Frame,
       status: AsyncStatus,
-      value: Scope
+      value: {
+        scope: Scope,
+        mappings: {
+          [string]: string | null
+        }
+      }
     }
   | {
       type: "MAP_FRAMES",

--- a/src/reducers/pause.js
+++ b/src/reducers/pause.js
@@ -35,6 +35,11 @@ export type PauseState = {
         pending: boolean,
         scope: OriginalScope
       }
+    },
+    mappings: {
+      [FrameId]: {
+        [string]: string | null
+      }
     }
   },
   selectedFrameId: ?string,
@@ -57,7 +62,8 @@ export const createPauseState = (): PauseState => ({
   selectedFrameId: undefined,
   frameScopes: {
     generated: {},
-    original: {}
+    original: {},
+    mappings: {}
   },
   loadedObjects: {},
   shouldPauseOnExceptions: prefs.pauseOnExceptions,
@@ -73,7 +79,8 @@ const emptyPauseState = {
   frames: null,
   frameScopes: {
     generated: {},
-    original: {}
+    original: {},
+    mappings: {}
   },
   selectedFrameId: null,
   loadedObjects: {},
@@ -143,14 +150,20 @@ function update(
         ...state.frameScopes.original,
         [selectedFrameId]: {
           pending: status !== "done",
-          scope: value
+          scope: value && value.scope
         }
+      };
+
+      const mappings = {
+        ...state.frameScopes.mappings,
+        [selectedFrameId]: value && value.mappings
       };
       return {
         ...state,
         frameScopes: {
           ...state.frameScopes,
-          original
+          original,
+          mappings
         }
       };
     }
@@ -345,6 +358,19 @@ export function getSelectedScope(state: OuterState) {
   const { scope } =
     getFrameScope(state, sourceRecord && sourceRecord.get("id"), frameId) || {};
   return scope || null;
+}
+
+export function getSelectedScopeMappings(
+  state: OuterState
+): {
+  [string]: string | null
+} | null {
+  const frameId = getSelectedFrameId(state);
+  if (!frameId) {
+    return null;
+  }
+
+  return getFrameScopes(state).mappings[frameId];
 }
 
 export function getSelectedFrameId(state: OuterState) {

--- a/src/test/mochitest/browser.ini
+++ b/src/test/mochitest/browser.ini
@@ -126,6 +126,7 @@ support-files =
 [browser_dbg-async-stepping.js]
 [browser_dbg-babel-scopes.js]
 [browser_dbg-babel-stepping.js]
+[browser_dbg-babel-preview.js]
 [browser_dbg-breaking.js]
 [browser_dbg-breaking-from-console.js]
 [browser_dbg-breakpoints.js]

--- a/src/test/mochitest/browser_dbg-babel-preview.js
+++ b/src/test/mochitest/browser_dbg-babel-preview.js
@@ -1,0 +1,236 @@
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
+
+function getCoordsFromPosition(cm, { line, ch }) {
+  return cm.charCoords({ line: ~~line, ch: ~~ch });
+}
+
+async function assertPreviews(dbg, previews) {
+  for (const { line, column, expression, result, fields } of previews) {
+    hoverAtPos(dbg, { line, ch: column });
+
+    if (fields && result) {
+      throw new Error("Invalid test fixture");
+    }
+
+    if (fields) {
+      for (const [field, value] of fields) {
+        await assertPreviewPopup(dbg, { expression, field, value });
+      }
+    } else {
+      await assertPreviewTextValue(dbg, { expression, text: result });
+    }
+
+    // Move to column 0 after to make sure that the preview created by this
+    // test does not affect later attempts to hover and preview.
+    hoverAtPos(dbg, { line: line - 1, ch: 0 });
+  }
+}
+
+async function breakpointPreviews(dbg, fixture, { line, column }, previews) {
+  const { selectors: { getBreakpoint, getBreakpoints }, getState } = dbg;
+
+  const filename = `fixtures/${fixture}/input.js`;
+  await waitForSources(dbg, filename);
+
+  ok(true, "Original sources exist");
+  const source = findSource(dbg, filename);
+
+  await selectSource(dbg, source);
+
+  // Test that breakpoint is not off by a line.
+  await addBreakpoint(dbg, source, line);
+
+  is(getBreakpoints(getState()).size, 1, "One breakpoint exists");
+  ok(
+    getBreakpoint(getState(), { sourceId: source.id, line, column }),
+    "Breakpoint has correct line"
+  );
+
+  const fnName = fixture.replace(/-([a-z])/g, (s, c) => c.toUpperCase());
+
+  const invokeResult = invokeInTab(fnName);
+
+  let invokeFailed = await Promise.race([
+    waitForPaused(dbg),
+    invokeResult.then(() => new Promise(() => {}), () => true)
+  ]);
+
+  if (invokeFailed) {
+    return invokeResult;
+  }
+
+  assertPausedLocation(dbg);
+
+  await assertPreviews(dbg, previews);
+
+  await removeBreakpoint(dbg, source.id, line, column);
+
+  is(getBreakpoints(getState()).size, 0, "Breakpoint reverted");
+
+  await resume(dbg);
+
+  // If the invoke errored later somehow, capture here so the error is reported nicely.
+  await invokeResult;
+
+  ok(true, `Ran tests for ${fixture} at line ${line} column ${column}`);
+}
+
+add_task(async function() {
+  await pushPref("devtools.debugger.features.map-scopes", true);
+
+  const dbg = await initDebugger("doc-babel.html");
+
+  await breakpointPreviews(dbg, "for-of", { line: 5, column: 4 }, [
+    {
+      line: 5,
+      column: 7,
+      expression: "doThing;",
+      result: "doThing(arg)",
+    },
+    {
+      line: 5,
+      column: 12,
+      expression: "x;",
+      result: "1",
+    },
+    {
+      line: 8,
+      column: 16,
+      expression: "doThing;",
+      result: "doThing(arg)",
+    },
+  ]);
+
+  await breakpointPreviews(dbg, "shadowed-vars", { line: 18, column: 6 }, [
+    // These aren't what the user would expect, but we test them anyway since
+    // they reflect what this actually returns. These shadowed bindings read
+    // the binding closest to the current frame's scope even though their
+    // actual value is different.
+    {
+      line: 2,
+      column: 9,
+      expression: "aVar;",
+      result: '"var3"',
+    },
+    {
+      line: 3,
+      column: 9,
+      expression: "_aLet2;",
+      result: '"let3"',
+    },
+    {
+      line: 4,
+      column: 11,
+      expression: "_aConst2;",
+      result: '"const3"',
+    },
+    {
+      line: 10,
+      column: 11,
+      expression: "aVar;",
+      result: '"var3"',
+    },
+    {
+      line: 11,
+      column: 11,
+      expression: "_aLet2;",
+      result: '"let3"',
+    },
+    {
+      line: 12,
+      column: 13,
+      expression: "_aConst2;",
+      result: '"const3"',
+    },
+
+    // These actually result in the values the user would expect.
+    {
+      line: 14,
+      column: 13,
+      expression: "aVar;",
+      result: '"var3"',
+    },
+    {
+      line: 15,
+      column: 13,
+      expression: "_aLet2;",
+      result: '"let3"',
+    },
+    {
+      line: 16,
+      column: 13,
+      expression: "_aConst2;",
+      result: '"const3"',
+    },
+  ]);
+
+  await breakpointPreviews(dbg, "imported-bindings", { line: 17, column: 2 }, [
+    {
+      line: 19,
+      column: 16,
+      expression: "_mod2.default;",
+      result: '"a-default"',
+    },
+    {
+      line: 20,
+      column: 16,
+      expression: "_mod4.original;",
+      result: '"an-original"',
+    },
+    {
+      line: 21,
+      column: 16,
+      expression: "_mod3.aNamed;",
+      result: '"a-named"',
+    },
+    {
+      line: 22,
+      column: 16,
+      expression: "_mod4.original;",
+      result: '"an-original"',
+    },
+    {
+      line: 23,
+      column: 16,
+      expression: "aNamespace;",
+      fields: [
+        ['aNamed', 'a-named'],
+        ['default', 'a-default'],
+      ],
+    },
+    {
+      line: 28,
+      column: 20,
+      expression: "_mod7.default;",
+      result: '"a-default2"',
+    },
+    {
+      line: 29,
+      column: 20,
+      expression: "_mod9.original;",
+      result: '"an-original2"',
+    },
+    {
+      line: 30,
+      column: 20,
+      expression: "_mod8.aNamed2;",
+      result: '"a-named2"',
+    },
+    {
+      line: 31,
+      column: 20,
+      expression: "_mod9.original;",
+      result: '"an-original2"',
+    },
+    {
+      line: 32,
+      column: 20,
+      expression: "aNamespace2;",
+      fields: [
+        ['aNamed', 'a-named2'],
+        ['default', 'a-default2'],
+      ],
+    },
+  ]);
+});

--- a/src/test/mochitest/head.js
+++ b/src/test/mochitest/head.js
@@ -1096,6 +1096,12 @@ function getCoordsFromPosition(cm, { line, ch }) {
 
 function hoverAtPos(dbg, { line, ch }) {
   const cm = getCM(dbg);
+
+  // Ensure the line is visible with margin because the bar at the bottom of
+  // the editor overlaps into what the editor things is its own space, blocking
+  // the click event below.
+  cm.scrollIntoView({ line: line - 1, ch  }, 100);
+
   const coords = getCoordsFromPosition(cm, { line: line - 1, ch });
   const tokenEl = dbg.win.document.elementFromPoint(coords.left, coords.top);
   tokenEl.dispatchEvent(
@@ -1105,6 +1111,21 @@ function hoverAtPos(dbg, { line, ch }) {
       view: dbg.win
     })
   );
+}
+
+async function assertPreviewTextValue(dbg, { text, expression }) {
+  const previewElPromise = await Promise.race([
+    waitForElement(dbg, "tooltip"),
+    waitForElement(dbg, "popup"),
+  ]);
+
+  const previewEl = await previewElPromise;
+
+  is(previewEl.innerText, text, "Preview text shown to user");
+
+  const preview = dbg.selectors.getPreview(dbg.getState());
+  is(preview.updating, false, "Preview.updating");
+  is(preview.expression, expression, "Preview.expression");
 }
 
 async function assertPreviewTooltip(dbg, { result, expression }) {

--- a/src/utils/pause/mapScopes/findGeneratedBindingFromPosition.js
+++ b/src/utils/pause/mapScopes/findGeneratedBindingFromPosition.js
@@ -19,7 +19,9 @@ type GeneratedDescriptor = {
   // Falsy if the binding itself matched a location, but the location didn't
   // have a value descriptor attached. Happens if the binding was 'this'
   // or if there was a mismatch between client and generated scopes.
-  desc: ?BindingContents
+  desc: ?BindingContents,
+
+  expression: string
 };
 
 export async function findGeneratedBindingFromPosition(
@@ -148,7 +150,8 @@ async function mapBindingReferenceToDescriptor(
   ) {
     return {
       name: binding.name,
-      desc: binding.desc
+      desc: binding.desc,
+      expression: binding.name
     };
   }
 
@@ -176,6 +179,8 @@ async function mapImportDeclarationToDescriptor(
     return null;
   }
 
+  let expression = binding.name;
+
   let desc = binding.desc;
   if (desc && typeof desc.value === "object") {
     if (desc.value.optimizedOut) {
@@ -199,12 +204,15 @@ async function mapImportDeclarationToDescriptor(
 
     const objectClient = createObjectClient(desc.value);
     desc = (await objectClient.getProperty(mapped.importName)).descriptor;
+
+    expression += `.${mapped.importName}`;
   }
 
   return desc
     ? {
         name: binding.name,
-        desc
+        desc,
+        expression
       }
     : null;
 }
@@ -257,6 +265,7 @@ async function mapImportReferenceToDescriptor(
     return null;
   }
 
+  let expression = binding.name;
   let desc = binding.desc;
 
   if (binding.loc.type === "ref") {
@@ -283,13 +292,16 @@ async function mapImportReferenceToDescriptor(
 
       const objectClient = createObjectClient(desc.value);
       desc = (await objectClient.getProperty(op.property)).descriptor;
+
+      expression += `.${op.property}`;
     }
   }
 
   return desc
     ? {
         name: binding.name,
-        desc
+        desc,
+        expression
       }
     : null;
 }

--- a/src/workers/parser/index.js
+++ b/src/workers/parser/index.js
@@ -26,6 +26,7 @@ export const hasSource = dispatcher.task("hasSource");
 export const setSource = dispatcher.task("setSource");
 export const clearSources = dispatcher.task("clearSources");
 export const hasSyntaxError = dispatcher.task("hasSyntaxError");
+export const mapOriginalExpression = dispatcher.task("mapOriginalExpression");
 export const getFramework = dispatcher.task("getFramework");
 export const getPausePoints = dispatcher.task("getPausePoints");
 export const replaceOriginalVariableName = dispatcher.task(

--- a/src/workers/parser/mapOriginalExpression.js
+++ b/src/workers/parser/mapOriginalExpression.js
@@ -1,0 +1,54 @@
+// @flow
+
+import { parseScript } from "./utils/ast";
+import generate from "@babel/generator";
+import * as t from "@babel/types";
+
+// NOTE: this will only work if we are replacing an original identifier
+function replaceNode(ancestors, node) {
+  const ancestor = ancestors[ancestors.length - 1];
+
+  if (typeof ancestor.index === "number") {
+    ancestor.node[ancestor.key][ancestor.index] = node;
+  } else {
+    ancestor.node[ancestor.key] = node;
+  }
+}
+
+function getFirstExpression(ast) {
+  const statements = ast.program.body;
+  if (statements.length == 0) {
+    return null;
+  }
+
+  return statements[0].expression;
+}
+
+export default function mapOriginalExpression(
+  expression: string,
+  mappings: {
+    [string]: string | null
+  }
+): string {
+  const ast = parseScript(expression);
+  t.traverse(ast, (node, ancestors) => {
+    const parent = ancestors[ancestors.length - 1];
+    if (!parent) {
+      return;
+    }
+
+    const parentNode = parent.node;
+    if (t.isIdentifier(node) && t.isReferenced(node, parentNode)) {
+      if (mappings.hasOwnProperty(node.name)) {
+        const mapping = mappings[node.name];
+        if (mapping) {
+          const mappingNode = getFirstExpression(parseScript(mapping));
+
+          replaceNode(ancestors, mappingNode);
+        }
+      }
+    }
+  });
+
+  return generate(ast, { concise: true }).code;
+}

--- a/src/workers/parser/tests/mapOriginalExpression.spec.js
+++ b/src/workers/parser/tests/mapOriginalExpression.spec.js
@@ -1,0 +1,28 @@
+import mapOriginalExpression from "../mapOriginalExpression";
+
+describe("mapOriginalExpression", () => {
+  it("simple", () => {
+    const generatedExpression = mapOriginalExpression("a + b;", {
+      a: "foo",
+      b: "bar"
+    });
+    expect(generatedExpression).toEqual("foo + bar;");
+  });
+
+  it("member expressions", () => {
+    const generatedExpression = mapOriginalExpression("a + b", {
+      a: "_mod.foo",
+      b: "_mod.bar"
+    });
+    expect(generatedExpression).toEqual("_mod.foo + _mod.bar;");
+  });
+
+  it("block", () => {
+    // todo: maybe wrap with parens ()
+    const generatedExpression = mapOriginalExpression("{a}", {
+      a: "_mod.foo",
+      b: "_mod.bar"
+    });
+    expect(generatedExpression).toEqual("{ _mod.foo; }");
+  });
+});

--- a/src/workers/parser/worker.js
+++ b/src/workers/parser/worker.js
@@ -15,6 +15,7 @@ import { hasSyntaxError } from "./validate";
 import { getFramework } from "./frameworks";
 import { isInvalidPauseLocation } from "./pauseLocation";
 import { getPausePoints } from "./pausePoints";
+import mapOriginalExpression from "./mapOriginalExpression";
 
 import { workerUtils } from "devtools-utils";
 const { workerHandler } = workerUtils;
@@ -34,5 +35,6 @@ self.onmessage = workerHandler({
   getNextStep,
   hasSyntaxError,
   getFramework,
-  getPausePoints
+  getPausePoints,
+  mapOriginalExpression
 });


### PR DESCRIPTION
Related Issue: #5561

### Summary of Changes

* Adds expression-mapping logic to scope mappings
* Uses expression mappings to process watch and preview expressions

