### PR TITLE
Allow dbg in the browser toolbox

### DIFF
--- a/src/client/index.js
+++ b/src/client/index.js
@@ -10,7 +10,6 @@ import * as chrome from "./chrome";
 import { prefs } from "../utils/prefs";
 import { setupHelper } from "../utils/dbg";
 
-import { isFirefoxPanel } from "devtools-config";
 import {
   bootstrapApp,
   bootstrapStore,
@@ -49,14 +48,12 @@ async function onConnect(
   await client.onConnect(connection, actions);
   await loadFromPrefs(actions);
 
-  if (!isFirefoxPanel()) {
-    setupHelper({
-      store,
-      actions,
-      selectors,
-      client: client.clientCommands
-    });
-  }
+  setupHelper({
+    store,
+    actions,
+    selectors,
+    client: client.clientCommands
+  });
 
   bootstrapApp(store);
   return { store, actions, selectors, client: commands };

--- a/src/utils/dbg.js
+++ b/src/utils/dbg.js
@@ -1,6 +1,7 @@
 import { bindActionCreators } from "redux";
 import * as timings from "./timings";
 import { prefs, features } from "./prefs";
+import { isDevelopment } from "devtools-config";
 
 function findSource(dbg, url) {
   const sources = dbg.selectors.getSources();
@@ -56,10 +57,12 @@ export function setupHelper(obj) {
 
   window.dbg = dbg;
 
-  console.group("Development Notes");
-  const baseUrl = "https://devtools-html.github.io/debugger.html";
-  const localDevelopmentUrl = `${baseUrl}/docs/dbg.html`;
-  console.log("Debugging Tips", localDevelopmentUrl);
-  console.log("dbg", window.dbg);
-  console.groupEnd();
+  if (isDevelopment()) {
+    console.group("Development Notes");
+    const baseUrl = "https://devtools-html.github.io/debugger.html";
+    const localDevelopmentUrl = `${baseUrl}/docs/dbg.html`;
+    console.log("Debugging Tips", localDevelopmentUrl);
+    console.log("dbg", window.dbg);
+    console.groupEnd();
+  }
 }


### PR DESCRIPTION
### Summary of Changes

This lets us use `dbg` in the browser toolbox, which is fine because it is not a performance cost