### PR TITLE
Added VisibilityHandler to handle the mounting and unmounting of child components of App when changing panel tabs.

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -100,10 +100,6 @@ class App extends Component<Props, State> {
     return { shortcuts };
   };
 
-  componentDidUnmount() {
-    console.log("Unmounting App.");
-  }
-
   componentDidMount() {
     horizontalLayoutBreakpoint.addListener(this.onLayoutChange);
     verticalLayoutBreakpoint.addListener(this.onLayoutChange);

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -10,6 +10,7 @@ import { bindActionCreators } from "redux";
 import { features } from "../utils/prefs";
 import actions from "../actions";
 import { ShortcutsModal } from "./ShortcutsModal";
+import VisibilityHandler from "./shared/VisibilityHandler";
 
 import {
   getSelectedSource,
@@ -98,6 +99,10 @@ class App extends Component<Props, State> {
   getChildContext = () => {
     return { shortcuts };
   };
+
+  componentDidUnmount() {
+    console.log("Unmounting App.");
+  }
 
   componentDidMount() {
     horizontalLayoutBreakpoint.addListener(this.onLayoutChange);
@@ -299,16 +304,18 @@ class App extends Component<Props, State> {
   render() {
     const { quickOpenEnabled } = this.props;
     return (
-      <div className="debugger">
-        {this.renderLayout()}
-        {quickOpenEnabled === true && (
-          <QuickOpenModal
-            shortcutsModalEnabled={this.state.shortcutsModalEnabled}
-            toggleShortcutsModal={() => this.toggleShortcutsModal()}
-          />
-        )}
-        {this.renderShortcutsModal()}
-      </div>
+      <VisibilityHandler>
+        <div className="debugger">
+          {this.renderLayout()}
+          {quickOpenEnabled === true && (
+            <QuickOpenModal
+              shortcutsModalEnabled={this.state.shortcutsModalEnabled}
+              toggleShortcutsModal={() => this.toggleShortcutsModal()}
+            />
+          )}
+          {this.renderShortcutsModal()}
+        </div>
+      </VisibilityHandler>
     );
   }
 }

--- a/src/components/shared/VisibilityHandler.js
+++ b/src/components/shared/VisibilityHandler.js
@@ -1,0 +1,55 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Helper class to disable panel rendering when it is in background.
+ *
+ * Toolbox code hides the iframes when switching to another panel
+ * and triggers `visibilitychange` events.
+ *
+ * See devtools/client/framework/toolbox.js:setIframeVisible().
+ */
+
+import PropTypes from "prop-types";
+import { Component } from "react";
+
+class VisibilityHandler extends Component {
+  static get propTypes() {
+    return {
+      children: PropTypes.element.isRequired
+    };
+  }
+
+  constructor(props) {
+    super(props);
+    this.isVisible = true;
+    this.onVisibilityChange = this.onVisibilityChange.bind(this);
+  }
+
+  componentDidMount() {
+    window.addEventListener("visibilitychange", this.onVisibilityChange);
+  }
+
+  shouldComponentUpdate() {
+    return document.visibilityState == "visible";
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener("visibilitychange", this.onVisibilityChange);
+  }
+
+  onVisibilityChange() {
+    this.isVisible = false;
+    if (document.visibilityState == "visible") {
+      this.isVisible = true;
+    }
+    this.forceUpdate();
+  }
+
+  render() {
+    return this.isVisible ? this.props.children : null;
+  }
+}
+
+module.exports = VisibilityHandler;


### PR DESCRIPTION
Added VisibilityHandler to handle the mounting and unmounting of child components of App when changing panel tabs.

Fixes Issue: #4852 -- Does not address the scrolling issue directly. The fix will unmount the child components of App when the visibility of the tab is hidden, and mount the components of App when the tab is visible. Therefore the previous position in the editor is ignored, and is reloaded to the top of the editor. 

### Summary of Changes

- Addition of the VisibilityHandler from [here](https://hg.mozilla.org/mozilla-central/raw-file/tip/devtools/client/shared/components/VisibilityHandler.js). (With a slight modification to only render the children when the tab is visible.)

- Wrap the contents of the App component in the modified VisibilityHandler.

### Screenshots/Videos
Before:
![beforefixjumping](https://user-images.githubusercontent.com/14250545/37176004-5d396b46-22d8-11e8-92f7-6e0ed588ca3d.gif)

After:
Just showing how the editor is reloaded, loses the scroll position, and is reloaded at the top of the document.
![aftertoday](https://user-images.githubusercontent.com/14250545/37488408-1f14a36c-285a-11e8-86c6-073693e9a725.gif)
