### PR TITLE
Backport changes from MC

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,3 +58,4 @@ script:
     browser_webconsole_eval_in_debugger_stackframe2.js
     browser_webconsole_location_debugger_link.js
     browser_webconsole_stacktrace_location_debugger_link.js
+    browser_browser_toolbox_debugger.js

--- a/src/test/mochitest/browser.ini
+++ b/src/test/mochitest/browser.ini
@@ -188,6 +188,7 @@ skip-if = os == "win" # Bug 1434792
 [browser_dbg-sources.js]
 [browser_dbg-sources-named-eval.js]
 [browser_dbg-stepping.js]
+skip-if = debug
 [browser_dbg-tabs.js]
 [browser_dbg-tabs-pretty-print.js]
 [browser_dbg-toggling-tools.js]

--- a/src/test/mochitest/browser_dbg-chrome-create.js
+++ b/src/test/mochitest/browser_dbg-chrome-create.js
@@ -6,6 +6,13 @@
 /**
  * Tests that a chrome debugger can be created in a new process.
  */
+
+// There are shutdown issues for which multiple rejections are left uncaught.
+// See bug 1018184 for resolving these issues.
+const { PromiseTestUtils } = scopedCuImport("resource://testing-common/PromiseTestUtils.jsm");
+PromiseTestUtils.whitelistRejectionsGlobally(/File closed/);
+PromiseTestUtils.whitelistRejectionsGlobally(/NS_ERROR_FAILURE/);
+
 requestLongerTimeout(5);
 
 const { BrowserToolboxProcess } = ChromeUtils.import(

--- a/src/test/mochitest/head.js
+++ b/src/test/mochitest/head.js
@@ -39,6 +39,8 @@ Services.scriptloader.loadSubScript(
 );
 
 var { Toolbox } = require("devtools/client/framework/toolbox");
+var { Task } = require("devtools/shared/task");
+
 const sourceUtils = {
   isLoaded: source => source.get("loadedState") === "loaded"
 };


### PR DESCRIPTION
+ Backport Bug 1442312 - Stop using deprecated-sync-thenables in DebuggerServerConnection._queueResponse
+ Backport - Bug 1440321 - Convert Task.jsm to async/await in devtools/client. r=jryans
+ Add toolbox test
+ backport browser.ini
