### PR TITLE
Make SourceRecord fields Read-Only

### DIFF
--- a/src/actions/sources/loadSourceText.js
+++ b/src/actions/sources/loadSourceText.js
@@ -12,7 +12,7 @@ import { isLoaded } from "../../utils/source";
 
 import defer from "../../utils/defer";
 import type { ThunkArgs } from "../types";
-import type { SourceRecord } from "../../reducers/types";
+import type { SourceRecord } from "../../types";
 
 const requests = new Map();
 import { Services } from "devtools-modules";

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -20,7 +20,8 @@ import {
   getOrientation
 } from "../selectors";
 
-import type { SourceRecord, OrientationType } from "../reducers/types";
+import type { OrientationType } from "../reducers/types";
+import type { SourceRecord } from "../types";
 
 import { KeyShortcuts, Services } from "devtools-modules";
 const shortcuts = new KeyShortcuts({ window });

--- a/src/components/Editor/Breakpoints.js
+++ b/src/components/Editor/Breakpoints.js
@@ -12,7 +12,8 @@ import { getSelectedSource, getVisibleBreakpoints } from "../../selectors";
 import { makeLocationId } from "../../utils/breakpoint";
 import { isLoaded } from "../../utils/source";
 
-import type { SourceRecord, BreakpointsMap } from "../../reducers/types";
+import type { BreakpointsMap } from "../../reducers/types";
+import type { SourceRecord } from "../../types";
 
 type Props = {
   selectedSource: SourceRecord,

--- a/src/components/Editor/DebugLine.js
+++ b/src/components/Editor/DebugLine.js
@@ -15,8 +15,7 @@ import {
   getSelectedSource
 } from "../../selectors";
 
-import type { Frame, Why } from "../../types";
-import type { SourceRecord } from "../../reducers/types";
+import type { Frame, Why, SourceRecord } from "../../types";
 
 type Props = {
   selectedFrame: Frame,

--- a/src/components/Editor/EmptyLines.js
+++ b/src/components/Editor/EmptyLines.js
@@ -5,7 +5,7 @@
 import { connect } from "react-redux";
 import { Component } from "react";
 import { getSelectedSource, getEmptyLines } from "../../selectors";
-import type { SourceRecord } from "../../reducers/types";
+import type { SourceRecord } from "../../types";
 import { toEditorLine } from "../../utils/editor";
 
 import "./EmptyLines.css";

--- a/src/components/Editor/Footer.js
+++ b/src/components/Editor/Footer.js
@@ -21,7 +21,7 @@ import { shouldShowFooter, shouldShowPrettyPrint } from "../../utils/editor";
 
 import PaneToggleButton from "../shared/Button/PaneToggle";
 
-import type { SourceRecord } from "../../reducers/sources";
+import type { SourceRecord } from "../../types";
 
 import "./Footer.css";
 

--- a/src/components/Editor/HighlightLine.js
+++ b/src/components/Editor/HighlightLine.js
@@ -15,8 +15,7 @@ import {
   getSelectedSource
 } from "../../selectors";
 
-import type { SourceRecord } from "../../reducers/types";
-import type { Frame, Location } from "../../types";
+import type { Frame, Location, SourceRecord } from "../../types";
 
 type Props = {
   selectedFrame: Frame,

--- a/src/components/Editor/Preview/index.js
+++ b/src/components/Editor/Preview/index.js
@@ -18,7 +18,9 @@ import {
 import actions from "../../../actions";
 import { toEditorRange } from "../../../utils/editor";
 
-import type { SelectedLocation, SourceRecord } from "../../../reducers/types";
+import type { SelectedLocation } from "../../../reducers/types";
+import type { SourceRecord } from "../../../types";
+
 import type { Preview as PreviewType } from "../../../reducers/ast";
 
 type Props = {

--- a/src/components/Editor/SearchBar.js
+++ b/src/components/Editor/SearchBar.js
@@ -25,7 +25,7 @@ import { removeOverlay } from "../../utils/editor";
 import { scrollList } from "../../utils/result-list";
 import classnames from "classnames";
 
-import type { SourceRecord } from "../../reducers/sources";
+import type { SourceRecord } from "../../types";
 import type { ActiveSearchType } from "../../reducers/ui";
 import type { Modifiers, SearchResults } from "../../reducers/file-search";
 

--- a/src/components/Editor/Tab.js
+++ b/src/components/Editor/Tab.js
@@ -13,7 +13,7 @@ import { showMenu, buildMenu } from "devtools-contextmenu";
 import CloseButton from "../shared/Button/Close";
 
 import type { List } from "immutable";
-import type { SourceRecord } from "../../reducers/sources";
+import type { SourceRecord } from "../../types";
 import type { SourceMetaDataType } from "../../reducers/ast";
 
 import actions from "../../actions";

--- a/src/components/Editor/Tabs.js
+++ b/src/components/Editor/Tabs.js
@@ -24,7 +24,7 @@ import PaneToggleButton from "../shared/Button/PaneToggle";
 import Dropdown from "../shared/Dropdown";
 
 import type { List } from "immutable";
-import type { SourceRecord } from "../../reducers/sources";
+import type { SourceRecord } from "../../types";
 
 type SourcesList = List<SourceRecord>;
 

--- a/src/components/PrimaryPanes/Outline.js
+++ b/src/components/PrimaryPanes/Outline.js
@@ -18,7 +18,7 @@ import type {
   SymbolDeclaration,
   AstLocation
 } from "../../workers/parser";
-import type { SourceRecord } from "../../reducers/sources";
+import type { SourceRecord } from "../../types";
 
 type Props = {
   symbols: SymbolDeclarations,

--- a/src/components/PrimaryPanes/SourcesTree.js
+++ b/src/components/PrimaryPanes/SourcesTree.js
@@ -46,7 +46,8 @@ import { getRawSourceURL } from "../../utils/source";
 import { copyToTheClipboard } from "../../utils/clipboard";
 import { features } from "../../utils/prefs";
 
-import type { SourcesMap, SourceRecord } from "../../reducers/types";
+import type { SourcesMap } from "../../reducers/types";
+import type { SourceRecord } from "../../types";
 
 type Props = {
   selectLocation: Object => void,

--- a/src/components/QuickOpenModal.js
+++ b/src/components/QuickOpenModal.js
@@ -34,8 +34,7 @@ import type {
   QuickOpenResult
 } from "../utils/quick-open";
 
-import type { Location } from "../types";
-import type { SourceRecord } from "../reducers/sources";
+import type { Location, SourceRecord } from "../types";
 import type { QuickOpenType } from "../reducers/quick-open";
 
 import "./QuickOpenModal.css";

--- a/src/components/SecondaryPanes/CommandBar.js
+++ b/src/components/SecondaryPanes/CommandBar.js
@@ -29,7 +29,8 @@ import "./CommandBar.css";
 import { Services } from "devtools-modules";
 const { appinfo } = Services;
 
-import type { SourceRecord, SourcesMap } from "../../reducers/sources";
+import type { SourcesMap } from "../../reducers/sources";
+import type { SourceRecord } from "../../types";
 
 const isMacOS = appinfo.OS === "Darwin";
 

--- a/src/reducers/sources.js
+++ b/src/reducers/sources.js
@@ -17,13 +17,12 @@ import { originalToGeneratedId, isOriginalId } from "devtools-source-map";
 import { prefs } from "../utils/prefs";
 
 import type { Map, List } from "immutable";
-import type { Source, Location } from "../types";
+import type { Source, Location, SourceRecord } from "../types";
 import type { SelectedLocation, PendingSelectedLocation } from "./types";
 import type { Action } from "../actions/types";
 import type { Record } from "../utils/makeRecord";
 
 type Tab = string;
-export type SourceRecord = Record<Source>;
 export type SourcesMap = Map<string, SourceRecord>;
 type TabList = List<Tab>;
 

--- a/src/reducers/types.js
+++ b/src/reducers/types.js
@@ -31,7 +31,7 @@ export type PendingSelectedLocation = {
   column?: number
 };
 
-export type { SourceRecord, SourcesMap } from "./sources";
+export type { SourcesMap } from "./sources";
 export type { ActiveSearchType, OrientationType } from "./ui";
 export type { BreakpointsMap } from "./breakpoints";
 export type { WorkersList } from "./debuggee";

--- a/src/types.js
+++ b/src/types.js
@@ -4,6 +4,8 @@
 
 // @flow
 
+import { RecordOf } from "immutable";
+
 export type SearchModifiers = {
   caseSensitive: boolean,
   wholeWord: boolean,
@@ -262,17 +264,20 @@ export type Grip = {
  * @memberof types
  * @static
  */
+
+export type SourceRecord = RecordOf<Source>;
+
 export type Source = {
-  id: SourceId,
-  url: string,
-  sourceMapURL?: string,
-  isBlackBoxed: boolean,
-  isPrettyPrinted: boolean,
-  isWasm: boolean,
-  text?: string,
-  contentType?: string,
-  error?: string,
-  loadedState: "unloaded" | "loading" | "loaded"
+  +id: SourceId,
+  +url: string,
+  +sourceMapURL?: string,
+  +isBlackBoxed: boolean,
+  +isPrettyPrinted: boolean,
+  +isWasm: boolean,
+  +text?: string,
+  +contentType?: string,
+  +error?: string,
+  +loadedState: "unloaded" | "loading" | "loaded"
 };
 
 /**

--- a/src/utils/editor/source-documents.js
+++ b/src/utils/editor/source-documents.js
@@ -6,11 +6,10 @@
 
 import { getMode } from "../source";
 
-import type { Source } from "../../types";
+import type { Source, SourceRecord } from "../../types";
 import { isWasm, getWasmLineNumberFormatter, renderWasmText } from "../wasm";
 import { resizeBreakpointGutter, resizeToggleButton } from "../ui";
 import type { SymbolDeclarations } from "../../workers/parser";
-import type { SourceRecord } from "../../reducers/types";
 import SourceEditor from "./source-editor";
 
 let sourceDocs = {};

--- a/src/utils/isMinified.js
+++ b/src/utils/isMinified.js
@@ -4,7 +4,7 @@
 
 // @flow
 
-import type { SourceRecord } from "../reducers/types";
+import type { SourceRecord } from "../types";
 
 // Used to detect minification for automatic pretty printing
 const SAMPLE_SIZE = 50;

--- a/src/utils/source.js
+++ b/src/utils/source.js
@@ -16,8 +16,7 @@ import { basename } from "./path";
 import { parse as parseURL } from "url";
 export { isMinified } from "./isMinified";
 
-import type { Source } from "../types";
-import type { SourceRecord } from "../reducers/types";
+import type { Source, SourceRecord } from "../types";
 import type { SymbolDeclarations } from "../workers/parser/types";
 
 type transformUrlCallback = string => string;

--- a/src/utils/sources-tree/addToTree.js
+++ b/src/utils/sources-tree/addToTree.js
@@ -20,7 +20,7 @@ import { getURL } from "./getURL";
 
 import type { ParsedURL } from "./getURL";
 import type { Node } from "./types";
-import type { SourceRecord } from "../../reducers/types";
+import type { SourceRecord } from "../../types";
 
 function isUnderRoot(url, projectRoot) {
   if (!projectRoot) {

--- a/src/utils/sources-tree/types.js
+++ b/src/utils/sources-tree/types.js
@@ -4,7 +4,7 @@
 
 // @flow
 
-import type { SourceRecord } from "../../reducers/types";
+import type { SourceRecord } from "../../types";
 
 /**
  * TODO: createNode is exported so this type could be useful to other modules

--- a/src/utils/sources-tree/utils.js
+++ b/src/utils/sources-tree/utils.js
@@ -7,7 +7,7 @@
 import { parse } from "url";
 
 import type { Node } from "./types";
-import type { SourceRecord } from "../../reducers/types";
+import type { SourceRecord } from "../../types";
 import { isPretty } from "../source";
 const IGNORED_URLS = ["debugger eval code", "XStringBundle"];
 

--- a/src/utils/tabs.js
+++ b/src/utils/tabs.js
@@ -7,7 +7,7 @@
 import React from "react";
 
 import type { List } from "immutable";
-import type { SourceRecord } from "../reducers/sources";
+import type { SourceRecord } from "../types";
 import type { SourceMetaDataType } from "../reducers/ast";
 import { isPretty } from "./source";
 

--- a/src/workers/pretty-print/index.js
+++ b/src/workers/pretty-print/index.js
@@ -9,7 +9,7 @@ const { WorkerDispatcher } = workerUtils;
 import { isJavaScript } from "../../utils/source";
 import assert from "../../utils/assert";
 
-import type { SourceRecord } from "../../reducers/types";
+import type { SourceRecord } from "../../types";
 
 const dispatcher = new WorkerDispatcher();
 export const startPrettyPrintWorker = dispatcher.start.bind(dispatcher);


### PR DESCRIPTION
Fixes: #5657 

### Summary of Changes

* Make source record fields read-only

### Test Plan

- [x] `yarn flow`
- [x] `source.id = "asdf"` throws error, saying id is read only property :)