### PR TITLE
Enhancement add contenxt menu copy to clipboard

### DIFF
--- a/assets/panel/debugger.properties
+++ b/assets/panel/debugger.properties
@@ -15,8 +15,8 @@
 collapsePanes=Collapse panes
 
 # LOCALIZATION NOTE (copyToClipboard): This is the text that appears in the
-# context menu to copy the complete source of file open.
-copyToClipboard=Copy to clipboard
+# context menu to copy the complete source of the open file.
+copyToClipboard.label=Copy to clipboard
 copyToClipboard.accesskey=C
 
 # LOCALIZATION NOTE (copySource): This is the text that appears in the

--- a/assets/panel/debugger.properties
+++ b/assets/panel/debugger.properties
@@ -14,7 +14,7 @@
 # that collapses the left and right panes in the debugger UI.
 collapsePanes=Collapse panes
 
-# LOCALIZATION NOTE (copyToClipboard): This is the text that appears in the
+# LOCALIZATION NOTE (copyToClipboard.label): This is the text that appears in the
 # context menu to copy the complete source of the open file.
 copyToClipboard.label=Copy to clipboard
 copyToClipboard.accesskey=C

--- a/assets/panel/debugger.properties
+++ b/assets/panel/debugger.properties
@@ -14,6 +14,11 @@
 # that collapses the left and right panes in the debugger UI.
 collapsePanes=Collapse panes
 
+# LOCALIZATION NOTE (copyToClipboard): This is the text that appears in the
+# context menu to copy the complete source of file open.
+copyToClipboard=Copy to Clipboard
+copyToClipboard.accesskey=null
+
 # LOCALIZATION NOTE (copySource): This is the text that appears in the
 # context menu to copy the selected source of file open.
 copySource=Copy

--- a/assets/panel/debugger.properties
+++ b/assets/panel/debugger.properties
@@ -16,8 +16,8 @@ collapsePanes=Collapse panes
 
 # LOCALIZATION NOTE (copyToClipboard): This is the text that appears in the
 # context menu to copy the complete source of file open.
-copyToClipboard=Copy to Clipboard
-copyToClipboard.accesskey=null
+copyToClipboard=Copy to clipboard
+copyToClipboard.accesskey=C
 
 # LOCALIZATION NOTE (copySource): This is the text that appears in the
 # context menu to copy the selected source of file open.

--- a/src/components/Editor/EditorMenu.js
+++ b/src/components/Editor/EditorMenu.js
@@ -77,6 +77,8 @@ function getMenuItems(
   const copyFunctionLabel = L10N.getStr("copyFunction.label");
   const copySourceKey = L10N.getStr("copySource.accesskey");
   const copySourceLabel = L10N.getStr("copySource");
+  const copyToClipboardKey = L10N.getStr("copyToClipboard.accesskey");
+  const copyToClipboardLabel = L10N.getStr("copyToClipboard");
   const copySourceUri2Key = L10N.getStr("copySourceUri2.accesskey");
   const copySourceUri2Label = L10N.getStr("copySourceUri2");
   const evaluateInConsoleLabel = L10N.getStr("evaluateInConsole.label");
@@ -93,6 +95,15 @@ function getMenuItems(
   const watchExpressionLabel = L10N.getStr("expressions.label");
 
   // menu items
+
+  const copyToClipboardItem = {
+    id: "node-menu-copy-to-clipboard",
+    label: copyToClipboardLabel,
+    accesskey: copyToClipboardKey,
+    disabled: false,
+    click: () => copyToTheClipboard(getRawSourceURL(selectedSource.get("text")))
+  };
+
   const copySourceItem = {
     id: "node-menu-copy-source",
     label: copySourceLabel,
@@ -168,6 +179,7 @@ function getMenuItems(
 
   // construct menu
   const menuItems = [
+    copyToClipboardItem,
     copySourceItem,
     copySourceUri2Item,
     copyFunctionItem,

--- a/src/components/Editor/EditorMenu.js
+++ b/src/components/Editor/EditorMenu.js
@@ -78,7 +78,7 @@ function getMenuItems(
   const copySourceKey = L10N.getStr("copySource.accesskey");
   const copySourceLabel = L10N.getStr("copySource");
   const copyToClipboardKey = L10N.getStr("copyToClipboard.accesskey");
-  const copyToClipboardLabel = L10N.getStr("copyToClipboard");
+  const copyToClipboardLabel = L10N.getStr("copyToClipboard.label");
   const copySourceUri2Key = L10N.getStr("copySourceUri2.accesskey");
   const copySourceUri2Label = L10N.getStr("copySourceUri2");
   const evaluateInConsoleLabel = L10N.getStr("evaluateInConsole.label");

--- a/src/components/Editor/EditorMenu.js
+++ b/src/components/Editor/EditorMenu.js
@@ -101,7 +101,7 @@ function getMenuItems(
     label: copyToClipboardLabel,
     accesskey: copyToClipboardKey,
     disabled: false,
-    click: () => copyToTheClipboard(getRawSourceURL(selectedSource.get("text")))
+    click: () => copyToTheClipboard(selectedSource.get("text"))
   };
 
   const copySourceItem = {

--- a/src/components/Editor/Tab.js
+++ b/src/components/Editor/Tab.js
@@ -63,7 +63,8 @@ class Tab extends PureComponent<Props> {
       closeTabs,
       tabSources,
       showSource,
-      togglePrettyPrint
+      togglePrettyPrint,
+      selectedSource
     } = this.props;
 
     const otherTabs = tabSources.filter(t => t.get("id") !== tab);
@@ -107,6 +108,13 @@ class Tab extends PureComponent<Props> {
         item: { ...tabMenuItems.closeAllTabs, click: () => closeTabs(tabURLs) }
       },
       { item: { type: "separator" } },
+      {
+        item: {
+          ...tabMenuItems.copyToClipboard,
+          disabled: selectedSource.get("id") !== tab,
+          click: () => copyToTheClipboard(getRawSourceURL(sourceTab.get("text")))
+        }
+      },
       {
         item: {
           ...tabMenuItems.copySourceUri2,

--- a/src/components/Editor/Tab.js
+++ b/src/components/Editor/Tab.js
@@ -112,7 +112,7 @@ class Tab extends PureComponent<Props> {
         item: {
           ...tabMenuItems.copyToClipboard,
           disabled: selectedSource.get("id") !== tab,
-          click: () => copyToTheClipboard(getRawSourceURL(sourceTab.get("text")))
+          click: () => copyToTheClipboard(sourceTab.get("text"))
         }
       },
       {

--- a/src/utils/tabs.js
+++ b/src/utils/tabs.js
@@ -98,6 +98,12 @@ export function getTabMenuItems() {
       accesskey: L10N.getStr("sourceTabs.revealInTree.accesskey"),
       disabled: false
     },
+    copyToClipboard: {
+      id: "node-menu-copy-to-clipboard",
+      label: L10N.getStr("copyToClipboard"),
+      accesskey: L10N.getStr("copyToClipboard.accesskey"),
+      disabled: false
+    },
     copySourceUri2: {
       id: "node-menu-copy-source-url",
       label: L10N.getStr("copySourceUri2"),

--- a/src/utils/tabs.js
+++ b/src/utils/tabs.js
@@ -100,7 +100,7 @@ export function getTabMenuItems() {
     },
     copyToClipboard: {
       id: "node-menu-copy-to-clipboard",
-      label: L10N.getStr("copyToClipboard"),
+      label: L10N.getStr("copyToClipboard.label"),
       accesskey: L10N.getStr("copyToClipboard.accesskey"),
       disabled: false
     },


### PR DESCRIPTION
Fixes Issue: #5341

### Summary of Changes

* Add item "Copy to clipboard" to editor context menu
* Add item "Copy to clipboard" to source tab context menu

### Test Plan

- [x] Open any source using Command + P
- [x] Go to Editor and open context menu (right+click)
- [x] Clicking on "Copy to clipboard" copies current source to clipboard
- [x] Try to paste to copied source somewhere else. It should match currently open editor source.

- [x] Right click on source tab panel
- [x] Context menu is expected to show item "Copy to clipboard"
- [x] If you have open context menu on tab of currently selected source, then "Copy to clipboard" should be in enabled state.
- [x] Click on "Copy to clipboard" item, it should have copied currently open source to clipboard.
- [x] Try pasting copied source somewhere else.



### Screenshots/Videos (OPTIONAL)
![mar-17-2018 16-46-47](https://user-images.githubusercontent.com/26451940/37554772-5401dfd6-2a03-11e8-82d3-00c001471416.gif)
