### PR TITLE
update file icons to use img instead of svg

### DIFF
--- a/src/components/PrimaryPanes/SourcesTree.js
+++ b/src/components/PrimaryPanes/SourcesTree.js
@@ -216,7 +216,7 @@ class SourcesTree extends Component<Props, State> {
         ts: "typescript"
       }[getExtension(source)];
       return sourceType ? (
-        <Svg className="source-icon" name={sourceType} />
+        <img className={sourceType} />
       ) : (
         <img className="file" />
       );


### PR DESCRIPTION
Fixes Issue: #5658

Here's the Pull Request Doc
https://devtools-html.github.io/debugger.html/CONTRIBUTING.html#pull-requests

### Summary of Changes

* changing `svg` icons for multiple files into `img` tags to help with performance gains

### Test Plan

Tell us a little a bit about how you tested your patch.

Example test plan:

- [x] Command-P opens the panel
- [x] Clicking “+” opens the panel
- [x] Clicking a source navigates to the source
- [x] Clicking "x" closes the panel

Here's the Debugger's Testing doc
https://docs.google.com/document/d/1oBMRxV8A2ag2t22YsQOxTdEv0mXKzIg0tggJjRkU1S0/edit#.
Feel free to improve it!