### PR TITLE
Send pause points to the server

### DIFF
--- a/src/actions/ast.js
+++ b/src/actions/ast.js
@@ -93,7 +93,7 @@ export function setOutOfScopeLocations() {
 }
 
 export function setPausePoints(sourceId: SourceId) {
-  return async ({ dispatch, getState }: ThunkArgs) => {
+  return async ({ dispatch, getState, client }: ThunkArgs) => {
     const sourceRecord = getSource(getState(), sourceId);
     if (!sourceRecord) {
       return;
@@ -105,6 +105,8 @@ export function setPausePoints(sourceId: SourceId) {
     }
 
     const pausePoints = await getPausePoints(source.id);
+    await client.setPausePoints(sourceId, pausePoints);
+
     dispatch({
       type: "SET_PAUSE_POINTS",
       source,

--- a/src/actions/tests/ast.spec.js
+++ b/src/actions/tests/ast.spec.js
@@ -32,9 +32,8 @@ const threadClient = {
       })
     );
   },
-  getFrameScopes: function() {
-    return Promise.resolve({});
-  },
+  setPausePoints: async () => {},
+  getFrameScopes: async () => {},
   evaluate: function(expression) {
     return new Promise((resolve, reject) =>
       resolve({ result: evaluationResult[expression] })

--- a/src/actions/tests/helpers/threadClient.js
+++ b/src/actions/tests/helpers/threadClient.js
@@ -34,7 +34,7 @@ export const simpleMockThreadClient = {
 
   setBreakpointCondition: (_id, _location, _condition, _noSliding) =>
     Promise.resolve({ sourceId: "a", line: 5 }),
-
+  setPausePoints: () => Promise.resolve({}),
   sourceContents: sourceId =>
     new Promise((resolve, reject) => {
       if (sources.includes(sourceId)) {
@@ -85,5 +85,6 @@ export const sourceThreadClient = {
       reject(`unknown source: ${sourceId}`);
     });
   },
+  threadClient: async () => {},
   getFrameScopes: async () => {}
 };

--- a/src/actions/tests/preview.spec.js
+++ b/src/actions/tests/preview.spec.js
@@ -17,9 +17,8 @@ const threadClient = {
       })
     );
   },
-  getFrameScopes: function() {
-    return Promise.resolve({});
-  },
+  setPausePoints: async () => {},
+  getFrameScopes: async () => {},
   evaluate: function(expression) {
     return new Promise((resolve, reject) =>
       resolve({ result: evaluationResult[expression] })

--- a/src/client/firefox/commands.js
+++ b/src/client/firefox/commands.js
@@ -25,6 +25,8 @@ import type {
   BPClients
 } from "./types";
 
+import type { PausePoint } from "../../workers/parser";
+
 import { makePendingLocationId } from "../../utils/breakpoint";
 
 import { createSource, createBreakpointLocation } from "./create";
@@ -50,6 +52,10 @@ function setupCommands(dependencies: Dependencies): { bpClients: BPClients } {
   bpClients = {};
 
   return { bpClients };
+}
+
+function sendPacket(packet: Object, callback?: Function) {
+  debuggerClient.request(packet).then(callback);
 }
 
 function resume(): Promise<*> {
@@ -290,6 +296,10 @@ function disablePrettyPrint(sourceId: SourceId): Promise<*> {
   return sourceClient.disablePrettyPrint();
 }
 
+async function setPausePoints(sourceId: SourceId, pausePoints: PausePoint[]) {
+  return sendPacket({ to: sourceId, type: "setPausePoints", pausePoints });
+}
+
 function interrupt(): Promise<*> {
   return threadClient.interrupt();
 }
@@ -352,7 +362,9 @@ const clientCommands = {
   prettyPrint,
   disablePrettyPrint,
   fetchSources,
-  fetchWorkers
+  fetchWorkers,
+  sendPacket,
+  setPausePoints
 };
 
 export { setupCommands, clientCommands };

--- a/src/client/firefox/types.js
+++ b/src/client/firefox/types.js
@@ -268,7 +268,8 @@ export type DebuggerClient = {
     traits: any
   },
   connect: () => Promise<*>,
-  listTabs: () => Promise<*>
+  listTabs: () => Promise<*>,
+  request: (packet: Object) => Promise<*>
 };
 
 export type TabClient = {

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -52,6 +52,7 @@ async function onConnect(
     store,
     actions,
     selectors,
+    connection,
     client: client.clientCommands
   });
 

--- a/src/reducers/ast.js
+++ b/src/reducers/ast.js
@@ -14,7 +14,11 @@ import * as I from "immutable";
 import makeRecord from "../utils/makeRecord";
 import { findEmptyLines } from "../utils/ast";
 
-import type { SymbolDeclarations, AstLocation } from "../workers/parser/types";
+import type {
+  SymbolDeclarations,
+  AstLocation,
+  PausePoint
+} from "../workers/parser";
 
 import type { Map } from "immutable";
 import type { Source } from "../types";
@@ -31,7 +35,7 @@ export type SourceMetaDataType = {
 };
 
 export type SourceMetaDataMap = Map<string, SourceMetaDataType>;
-export type PausePointsMap = Map<string, any>;
+export type PausePointsMap = Map<string, PausePoint>;
 
 export type Preview =
   | {| updating: true |}

--- a/src/utils/dbg.js
+++ b/src/utils/dbg.js
@@ -17,9 +17,6 @@ function findSource(dbg, url) {
 
 function sendPacket(dbg, packet, callback) {
   dbg.client.sendPacket(packet, callback || console.log);
-  // dbg.connection.tabConnection.debuggerClient
-  //   .request(packet)
-  //   .then(callback || console.log);
 }
 
 function sendPacketToThread(dbg, packet, callback) {

--- a/src/utils/dbg.js
+++ b/src/utils/dbg.js
@@ -2,6 +2,7 @@ import { bindActionCreators } from "redux";
 import * as timings from "./timings";
 import { prefs, features } from "./prefs";
 import { isDevelopment } from "devtools-config";
+import { formatPausePoints } from "./pause/pausePoints";
 
 function findSource(dbg, url) {
   const sources = dbg.selectors.getSources();
@@ -15,9 +16,18 @@ function findSource(dbg, url) {
 }
 
 function sendPacket(dbg, packet, callback) {
-  dbg.connection.tabConnection.debuggerClient
-    .request(packet)
-    .then(callback || console.log);
+  dbg.client.sendPacket(packet, callback || console.log);
+  // dbg.connection.tabConnection.debuggerClient
+  //   .request(packet)
+  //   .then(callback || console.log);
+}
+
+function sendPacketToThread(dbg, packet, callback) {
+  sendPacket(
+    dbg,
+    { to: dbg.connection.tabConnection.threadClient.actor, ...packet },
+    callback
+  );
 }
 
 function evaluate(dbg, expression, callback) {
@@ -37,6 +47,12 @@ function getCM() {
   return cm && cm.CodeMirror;
 }
 
+function _formatPausePoints(dbg, url) {
+  const source = dbg.helpers.findSource(url);
+  const pausePoints = dbg.selectors.getPausePoints(source);
+  console.log(formatPausePoints(source.text, pausePoints));
+}
+
 export function setupHelper(obj) {
   const selectors = bindSelectors(obj);
   const actions = bindActionCreators(obj.actions, obj.store.dispatch);
@@ -51,7 +67,11 @@ export function setupHelper(obj) {
     helpers: {
       findSource: url => findSource(dbg, url),
       evaluate: (expression, cbk) => evaluate(dbg, expression, cbk),
+      sendPacketToThread: (packet, cbk) => sendPacketToThread(dbg, packet, cbk),
       sendPacket: (packet, cbk) => sendPacket(dbg, packet, cbk)
+    },
+    formatters: {
+      pausePoints: url => _formatPausePoints(dbg, url)
     }
   };
 

--- a/src/utils/pause/pausePoints.js
+++ b/src/utils/pause/pausePoints.js
@@ -1,0 +1,24 @@
+import { reverse, sortBy } from "lodash";
+function insertStrtAt(string, index, newString) {
+  const start = string.slice(0, index);
+  const end = string.slice(index);
+  return `${start}${newString}${end}`;
+}
+
+export function formatPausePoints(text, nodes) {
+  nodes = reverse(sortBy(nodes, ["location.line", "location.column"]));
+  const lines = text.split("\n");
+  nodes.forEach((node, index) => {
+    const { line, column } = node.location;
+    const { breakpoint, stepOver } = node.types;
+    const num = nodes.length - index;
+    const types = `${breakpoint ? "b" : ""}${stepOver ? "s" : ""}`;
+    lines[line - 1] = insertStrtAt(
+      lines[line - 1],
+      column,
+      `/*${types} ${num}*/`
+    );
+  });
+
+  return lines.join("\n");
+}

--- a/src/workers/parser/pausePoints.js
+++ b/src/workers/parser/pausePoints.js
@@ -13,14 +13,15 @@ const isControlFlow = node =>
   t.isForStatement(node) || t.isWhileStatement(node) || t.isIfStatement(node);
 
 const isAssignment = node =>
-  t.isVariableDeclaration(node) || t.isAssignmentExpression(node);
+  t.isVariableDeclarator(node) || t.isAssignmentExpression(node);
 
 const isImport = node => t.isImport(node) || t.isImportDeclaration(node);
 const isReturn = node => t.isReturnStatement(node);
 const inExpression = parent =>
   t.isArrayExpression(parent.node) ||
   t.isObjectProperty(parent.node) ||
-  t.isCallExpression(parent.node);
+  t.isCallExpression(parent.node) ||
+  t.isTemplateLiteral(parent.node);
 
 export function getPausePoints(sourceId) {
   const state = [];
@@ -71,6 +72,13 @@ function onEnter(node, ancestors, state) {
         { line, column: column - 1 },
         { breakpoint: true, stepOver: true }
       )
+    );
+  }
+
+  if (t.isProgram(node)) {
+    const lastStatement = node.body[node.body.length - 1];
+    state.push(
+      formatNode(lastStatement.loc.end, { breakpoint: true, stepOver: true })
     );
   }
 }

--- a/src/workers/parser/tests/__snapshots__/pausePoints.spec.js.snap
+++ b/src/workers/parser/tests/__snapshots__/pausePoints.spec.js.snap
@@ -3,13 +3,13 @@
 exports[`Parser.pausePoints pause-points 1`] = `
 "/*bs 1*/import {x} from \\"y\\"
 
-/*bs 2*/const arr = [
+const /*bs 2*/arr = [
   '1',
   2,
   /*b 3*/foo()
 ]
 
-/*bs 4*/const obj = {
+const /*bs 4*/obj = {
   a: '1',
   b: 2,
   c: /*b 5*/foo(),
@@ -21,9 +21,9 @@ exports[`Parser.pausePoints pause-points 1`] = `
 /*bs 10*/foo(1, '2', /*b 11*/bar())
 
 /*b 12*/function func() {
-  /*bs 14*/console.log(\\"...\\")
-  /*bs 15*/return \\"ret\\"
-/*bs 13*/}
+  /*bs 13*/console.log(\\"...\\")
+  /*bs 14*/return \\"ret\\"
+/*bs 15*/}
 
 /*bs 16*/this.x = 3;
 
@@ -36,12 +36,13 @@ else /*bs 18*/if (y) {
 else {
 
 }
-/*bs 19*/for (/*bs 20*/var i=0; i< 5; i++ ) {
+/*bs 19*/for (var /*bs 20*/i=0; i< 5; i++ ) {
 
 }
 
 /*bs 21*/while (x) {
 
 }
+var /*bs 22*/a = 3;/*bs 23*/
 "
 `;

--- a/src/workers/parser/tests/fixtures/pause-points.js
+++ b/src/workers/parser/tests/fixtures/pause-points.js
@@ -40,3 +40,4 @@ for (var i=0; i< 5; i++ ) {
 while (x) {
 
 }
+var a = 3;

--- a/src/workers/parser/tests/pausePoints.spec.js
+++ b/src/workers/parser/tests/pausePoints.spec.js
@@ -1,39 +1,15 @@
 /* eslint max-nested-callbacks: ["error", 4]*/
+import { formatPausePoints } from "../../../utils/pause/pausePoints";
 
 import { getPausePoints } from "../pausePoints";
 import { setSource } from "../sources";
 import { getOriginalSource } from "./helpers";
-import { reverse } from "lodash";
-
-function insertStrtAt(string, index, newString) {
-  const start = string.slice(0, index);
-  const end = string.slice(index);
-  return `${start}${newString}${end}`;
-}
-
-function formatText(text, nodes) {
-  nodes = reverse(nodes);
-  const lines = text.split("\n");
-  nodes.forEach((node, index) => {
-    const { line, column } = node.location;
-    const { breakpoint, stepOver } = node.types;
-    const num = nodes.length - index;
-    const types = `${breakpoint ? "b" : ""}${stepOver ? "s" : ""}`;
-    lines[line - 1] = insertStrtAt(
-      lines[line - 1],
-      column,
-      `/*${types} ${num}*/`
-    );
-  });
-
-  return lines.join("\n");
-}
 
 describe("Parser.pausePoints", () => {
   it("pause-points", () => {
     const source = getOriginalSource("pause-points");
     setSource(source);
     const nodes = getPausePoints(source.id);
-    expect(formatText(source.text, nodes)).toMatchSnapshot();
+    expect(formatPausePoints(source.text, nodes)).toMatchSnapshot();
   });
 });

--- a/src/workers/parser/utils/simple-path.js
+++ b/src/workers/parser/utils/simple-path.js
@@ -122,6 +122,7 @@ class SimplePath {
     }
     return null;
   }
+
   findParent(predicate: SimplePath => boolean): SimplePath | null {
     if (!this.parentPath) {
       throw new Error("Cannot use findParent on root path");


### PR DESCRIPTION
Fixes #4013

### Summary of Changes

1. adds a `setPausePoints` client command
2. adds a `sendPacket` helper for simple protocol calls
3. moves `formatPausePoints` to a helper so that it can be used in `dbg`
4. tweak pause points for some cases