### PR TITLE
[Outline] Add "Copy Function" context menu item to functions

### DIFF
--- a/src/components/PrimaryPanes/Outline.js
+++ b/src/components/PrimaryPanes/Outline.js
@@ -6,9 +6,19 @@
 
 import React, { Component } from "react";
 import { bindActionCreators } from "redux";
+import { showMenu } from "devtools-contextmenu";
 import { connect } from "react-redux";
+
+import { copyToTheClipboard } from "../../utils/clipboard";
+import { findFunctionText } from "../../utils/function";
+import { findClosestScope } from "../../utils/breakpoint/astBreakpointLocation";
+
 import actions from "../../actions";
-import { getSelectedSource, getSymbols } from "../../selectors";
+import {
+  getSelectedSource,
+  getSymbols,
+  getSelectedLocation
+} from "../../selectors";
 
 import "./Outline.css";
 import PreviewFunction from "../shared/PreviewFunction";
@@ -25,7 +35,11 @@ type Props = {
   selectLocation: ({ sourceId: string, line: number }) => void,
   selectedSource: ?SourceRecord,
   onAlphabetizeClick: Function,
-  alphabetizeOutline: boolean
+  alphabetizeOutline: boolean,
+  getFunctionText: Function,
+  getFunctionLocation: Function,
+  flashLineRange: Function,
+  selectedLocation: any
 };
 
 export class Outline extends Component<Props> {
@@ -37,6 +51,46 @@ export class Outline extends Component<Props> {
     const selectedSourceId = selectedSource.get("id");
     const startLine = location.start.line;
     selectLocation({ sourceId: selectedSourceId, line: startLine });
+  }
+
+  onContextMenu(event: SyntheticEvent<HTMLElement>, func: SymbolDeclaration) {
+    event.stopPropagation();
+    event.preventDefault();
+
+    const {
+      selectedSource,
+      getFunctionText,
+      getFunctionLocation,
+      flashLineRange,
+      selectedLocation
+    } = this.props;
+
+    const copyFunctionKey = L10N.getStr("copyFunction.accesskey");
+    const copyFunctionLabel = L10N.getStr("copyFunction.label");
+
+    if (!selectedSource) {
+      return;
+    }
+
+    const sourceLine = func.location.start.line;
+    const functionText = getFunctionText(sourceLine);
+    const copyFunctionItem = {
+      id: "node-menu-copy-function",
+      label: copyFunctionLabel,
+      accesskey: copyFunctionKey,
+      disabled: !functionText,
+      click: () => {
+        const { location: { start, end } } = getFunctionLocation(sourceLine);
+        flashLineRange({
+          start: start.line,
+          end: end.line,
+          sourceId: selectedLocation.sourceId
+        });
+        return copyToTheClipboard(functionText);
+      }
+    };
+    const menuOptions = [copyFunctionItem];
+    showMenu(event, menuOptions);
   }
 
   renderPlaceholder() {
@@ -61,6 +115,7 @@ export class Outline extends Component<Props> {
         key={`${name}:${location.start.line}:${location.start.column}`}
         className="outline-list__element"
         onClick={() => this.selectItem(location)}
+        onContextMenu={e => this.onContextMenu(e, func)}
       >
         <span className="outline-list__element-icon">λ</span>
         <PreviewFunction func={{ name, parameterNames }} />
@@ -162,7 +217,20 @@ export default connect(
     const selectedSource = getSelectedSource(state);
     return {
       symbols: getSymbols(state, selectedSource && selectedSource.toJS()),
-      selectedSource
+      selectedSource,
+      selectedLocation: getSelectedLocation(state),
+      getFunctionText: line =>
+        findFunctionText(
+          line,
+          selectedSource.toJS(),
+          getSymbols(state, selectedSource.toJS())
+        ),
+      getFunctionLocation: line =>
+        findClosestScope(getSymbols(state, selectedSource.toJS()).functions, {
+          line,
+          column: Infinity,
+          sourceId: selectedSource.get("id")
+        })
     };
   },
   dispatch => bindActionCreators(actions, dispatch)


### PR DESCRIPTION
Fixes Issue: #5352

### Summary of Changes

* Add "Copy Function" context menu item to functions in Outline tab

### Test Plan

- [x] Open any source contains functions
- [x] Open Outline tab
- [x] Open context menu on any function
- [x] Clicking "copy function" copies function body
