### PR TITLE
QuickOpen File Search rows can be quite tall

### DIFF
--- a/src/components/QuickOpenModal.js
+++ b/src/components/QuickOpenModal.js
@@ -335,16 +335,7 @@ export class QuickOpenModal extends Component<Props, State> {
     return results.map(result => {
       return {
         ...result,
-        title: this.renderHighlight(result.title, basename(newQuery), "title"),
-        ...(result.subtitle != null && !this.isSymbolSearch()
-          ? {
-              subtitle: this.renderHighlight(
-                result.subtitle,
-                newQuery,
-                "subtitle"
-              )
-            }
-          : null)
+        title: this.renderHighlight(result.title, basename(newQuery), "title")
       };
     });
   };

--- a/src/components/shared/ResultList.css
+++ b/src/components/shared/ResultList.css
@@ -59,7 +59,6 @@
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;
-  max-width: 50%;
 }
 
 .result-list li.selected .title {
@@ -77,7 +76,6 @@
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;
-  max-width: 50%;
 }
 
 .result-list.big li .subtitle {

--- a/src/components/shared/ResultList.css
+++ b/src/components/shared/ResultList.css
@@ -72,10 +72,7 @@
 .result-list.big li .subtitle {
   word-break: break-all;
   color: var(--theme-body-color-inactive);
-  margin-left: 5px;
-  text-overflow: ellipsis;
-  overflow: hidden;
-  white-space: nowrap;
+  margin-left: 15px;
 }
 
 .result-list.big li .subtitle {

--- a/src/components/shared/ResultList.css
+++ b/src/components/shared/ResultList.css
@@ -73,6 +73,9 @@
   word-break: break-all;
   color: var(--theme-body-color-inactive);
   margin-left: 15px;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
 }
 
 .result-list.big li .subtitle {

--- a/src/components/shared/ResultList.css
+++ b/src/components/shared/ResultList.css
@@ -20,12 +20,11 @@
   color: var(--theme-body-color);
   padding: 4px 13px;
   display: flex;
-  justify-content: space-between;
 }
 
 .result-list.big li {
   padding: 10px;
-  flex-direction: column;
+  flex-direction: row;
   border-bottom: 1px solid var(--theme-splitter-color);
 }
 
@@ -57,6 +56,10 @@
 .result-list li .title {
   line-height: 1.5em;
   word-break: break-all;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+  max-width: 50%;
 }
 
 .result-list li.selected .title {
@@ -70,6 +73,11 @@
 .result-list.big li .subtitle {
   word-break: break-all;
   color: var(--theme-body-color-inactive);
+  margin-left: 5px;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+  max-width: 50%;
 }
 
 .result-list.big li .subtitle {

--- a/src/utils/quick-open.js
+++ b/src/utils/quick-open.js
@@ -118,7 +118,10 @@ export function formatSources(sources: SourcesMap): Array<QuickOpenResult> {
       const sourcePath = getSourcePath(source.get("url"));
       return {
         value: sourcePath,
-        title: sourcePath.split("/").pop(),
+        title: sourcePath
+          .split("/")
+          .pop()
+          .split("?")[0],
         subtitle: endTruncateStr(sourcePath, 100)
           .replace(sourcePath.split("/").pop(), "")
           .slice(1, -1),

--- a/src/utils/quick-open.js
+++ b/src/utils/quick-open.js
@@ -119,10 +119,9 @@ export function formatSources(sources: SourcesMap): Array<QuickOpenResult> {
       return {
         value: sourcePath,
         title: sourcePath.split("/").pop(),
-        subtitle: endTruncateStr(sourcePath, 100).replace(
-          sourcePath.split("/").pop(),
-          ""
-        ),
+        subtitle: endTruncateStr(sourcePath, 100)
+          .replace(sourcePath.split("/").pop(), "")
+          .slice(1, -1),
         id: source.get("id"),
         url: source.get("url")
       };

--- a/src/utils/quick-open.js
+++ b/src/utils/quick-open.js
@@ -119,7 +119,10 @@ export function formatSources(sources: SourcesMap): Array<QuickOpenResult> {
       return {
         value: sourcePath,
         title: sourcePath.split("/").pop(),
-        subtitle: endTruncateStr(sourcePath, 100).replace(sourcePath.split("/").pop(), ""),
+        subtitle: endTruncateStr(sourcePath, 100).replace(
+          sourcePath.split("/").pop(),
+          ""
+        ),
         id: source.get("id"),
         url: source.get("url")
       };

--- a/src/utils/quick-open.js
+++ b/src/utils/quick-open.js
@@ -119,7 +119,7 @@ export function formatSources(sources: SourcesMap): Array<QuickOpenResult> {
       return {
         value: sourcePath,
         title: sourcePath.split("/").pop(),
-        subtitle: endTruncateStr(sourcePath, 100),
+        subtitle: endTruncateStr(sourcePath, 100).replace(sourcePath.split("/").pop(), ""),
         id: source.get("id"),
         url: source.get("url")
       };


### PR DESCRIPTION
Fixes Issue: #5630

Here's the Pull Request Doc
https://devtools-html.github.io/debugger.html/CONTRIBUTING.html#pull-requests

### Summary of Changes

* Now the path is in the same line of the filename
* Added truncation to filename and path

Here's the Debugger's Testing doc
https://docs.google.com/document/d/1oBMRxV8A2ag2t22YsQOxTdEv0mXKzIg0tggJjRkU1S0/edit#.
Feel free to improve it!

### Screenshots
![c02ca444-6b3a-4f34-8541-d21d546fe6e1](https://user-images.githubusercontent.com/36955296/37660463-cabe824a-2c52-11e8-9134-c30c035837e2.jpg)