### PR TITLE
Add a proper type to  scopes Block nodes

### DIFF
--- a/src/utils/pause/scopes/getScope.js
+++ b/src/utils/pause/scopes/getScope.js
@@ -3,6 +3,7 @@
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
 // @flow
+import { ObjectInspectorUtils } from "devtools-reps";
 import { getBindingVariables } from "./getVariables";
 import { getFramePopVariables, getThisVariable } from "./utils";
 import { simplifyDisplayName } from "../../pause/frames";
@@ -81,7 +82,8 @@ export function getScope(
       return {
         name: title,
         path: key,
-        contents: vars
+        contents: vars,
+        type: ObjectInspectorUtils.node.NODE_TYPES.BLOCK
       };
     }
   } else if (type === "object" && scope.object) {


### PR DESCRIPTION
Now that Reps 0.21.0 landed, we can use the BLOCK node type to style scopes block.

Here's how it looks: 

<img width="570" alt="image" src="https://user-images.githubusercontent.com/578107/37674408-21128bda-2c73-11e8-90ba-1d04afb3b7ec.png">

Fixes #5426
