### PR TITLE
Added recognition of react version 16 and greater components, and mod...

### DIFF
--- a/src/actions/preview.js
+++ b/src/actions/preview.js
@@ -28,11 +28,7 @@ import type { AstLocation } from "../workers/parser";
 
 async function getReactProps(evaluate) {
   const reactDisplayName = await evaluate(
-    "if (this._reactInternalFiber) {\n" +
-      "this._reactInternalFiber.type.name;\n" +
-      "} else {\n" +
-      "this._reactInternalInstance.getName();" +
-      "}"
+    "this.hasOwnProperty('_reactInternalFiber') ? this._reactInternalFiber.type.name : this._reactInternalInstance.getName()"
   );
 
   return {

--- a/src/actions/preview.js
+++ b/src/actions/preview.js
@@ -28,7 +28,9 @@ import type { AstLocation } from "../workers/parser";
 
 async function getReactProps(evaluate) {
   const reactDisplayName = await evaluate(
-    "this.hasOwnProperty('_reactInternalFiber') ? this._reactInternalFiber.type.name : this._reactInternalInstance.getName()"
+    "this.hasOwnProperty('_reactInternalFiber') ? " +
+      "this._reactInternalFiber.type.name : " +
+      "this._reactInternalInstance.getName()"
   );
 
   return {

--- a/src/actions/preview.js
+++ b/src/actions/preview.js
@@ -28,7 +28,11 @@ import type { AstLocation } from "../workers/parser";
 
 async function getReactProps(evaluate) {
   const reactDisplayName = await evaluate(
-    "this._reactInternalInstance.getName()"
+    "if (this._reactInternalFiber) {\n" +
+      "this._reactInternalFiber.type.name;\n" +
+      "} else {\n" +
+      "this._reactInternalInstance.getName();" +
+      "}"
   );
 
   return {

--- a/src/actions/tests/preview.spec.js
+++ b/src/actions/tests/preview.spec.js
@@ -91,10 +91,14 @@ describe("setPreview", () => {
   it("react instance", async () => {
     await setup("foo.js");
     evaluationResult = {
-      this: react,
-      "this.hasOwnProperty('_reactInternalFiber') ? this._reactInternalFiber.type.name : this._reactInternalInstance.getName()":
-        "Foo"
+      this: react
     };
+    evaluationResult[
+      "this.hasOwnProperty('_reactInternalFiber') ? " +
+        "this._reactInternalFiber.type.name : " +
+        "this._reactInternalInstance.getName()"
+    ] =
+      "Foo";
 
     await dispatch(
       actions.setPreview(

--- a/src/actions/tests/preview.spec.js
+++ b/src/actions/tests/preview.spec.js
@@ -92,7 +92,8 @@ describe("setPreview", () => {
     await setup("foo.js");
     evaluationResult = {
       this: react,
-      "this._reactInternalInstance.getName()": "Foo"
+      "this.hasOwnProperty('_reactInternalFiber') ? this._reactInternalFiber.type.name : this._reactInternalInstance.getName()":
+        "Foo"
     };
 
     await dispatch(

--- a/src/utils/preview.js
+++ b/src/utils/preview.js
@@ -33,5 +33,8 @@ export function isReactComponent(result: Grip) {
     return;
   }
 
-  return Object.keys(ownProperties).includes("_reactInternalInstance");
+  return (
+    Object.keys(ownProperties).includes("_reactInternalInstance") ||
+    Object.keys(ownProperties).includes("_reactInternalFiber")
+  );
 }


### PR DESCRIPTION
Added recognition of react version 16 and greater components, and modified getReactProps to get name of React version 16+ components.

Fixes Issue: #5732 

Here's the Pull Request Doc
https://devtools-html.github.io/debugger.html/CONTRIBUTING.html#pull-requests

### Summary of Changes

* Check properties for _internalReactFiber as well as _internalReactInstance
* Get the name of React 16+ components

### Before
![before16fix](https://user-images.githubusercontent.com/14250545/37674460-8ac6b56e-2c38-11e8-94ff-cda9b9003c15.gif)

### After
![after16fix](https://user-images.githubusercontent.com/14250545/37674464-8ee7b828-2c38-11e8-8438-bf7f694dc068.gif)
