### PR TITLE
Fix Sources.css issues.

### DIFF
--- a/src/components/PrimaryPanes/Sources.css
+++ b/src/components/PrimaryPanes/Sources.css
@@ -210,9 +210,7 @@
   background-color: white;
 }
 
-.tree:not(.object-inspector)
-  .tree-node[data-expandable="false"]
-  .tree-indent:last-of-type {
+.tree:not(.object-inspector) .tree-node[data-expandable="false"] .tree-indent:last-of-type {
   margin-inline-end: 4px;
 }
 


### PR DESCRIPTION
For some reason postCSS was breaking the CSS rule in a weird way which causes
the non-expandable node to be off in the Scopes panel.
Putting the whole selector on the same line fixes the issue.

### Screenshots/Videos 
See `ENTER_KEY` and `ESC_KEY` node in the screenshot below: 

![slice 1](https://user-images.githubusercontent.com/578107/37675489-a9bcfce8-2c75-11e8-8a06-dcee42503925.png)

