### PR TITLE
Revert "Clear the directory root when navigating domains"

### DIFF
--- a/src/actions/navigation.js
+++ b/src/actions/navigation.js
@@ -11,7 +11,6 @@ import { waitForMs } from "../utils/utils";
 
 import { newSources } from "./sources";
 import { updateWorkers } from "./debuggee";
-import { clearProjectDirectoryRoot } from "./ui";
 
 import {
   clearASTs,
@@ -42,7 +41,6 @@ export function willNavigate(event: Object) {
     clearASTs();
     clearScopes();
     clearSources();
-    dispatch(clearProjectDirectoryRoot());
     dispatch(navigate(event.url));
   };
 }


### PR DESCRIPTION
Reverts devtools-html/debugger.html#5740

We may need to remove this, as it clears upon refresh, not domain change;  we'll need to add a domain change check to ensure we clear only when we want to.