### PR TITLE
Revert 5740, which clears the root upon any navigation change

### DIFF
--- a/src/actions/navigation.js
+++ b/src/actions/navigation.js
@@ -11,7 +11,6 @@ import { waitForMs } from "../utils/utils";
 
 import { newSources } from "./sources";
 import { updateWorkers } from "./debuggee";
-import { clearProjectDirectoryRoot } from "./ui";
 
 import {
   clearASTs,
@@ -42,7 +41,6 @@ export function willNavigate(event: Object) {
     clearASTs();
     clearScopes();
     clearSources();
-    dispatch(clearProjectDirectoryRoot());
     dispatch(navigate(event.url));
   };
 }


### PR DESCRIPTION
This shouldn't go in as-is, since any nav change clears the root.  Ideally we'd only do this upon hostname change.