### PR TITLE
Issue 5679:  Quick Open - style selected matches

### DIFF
--- a/src/components/QuickOpenModal.css
+++ b/src/components/QuickOpenModal.css
@@ -3,6 +3,10 @@
   background-color: transparent;
 }
 
+.selected .highlight {
+  color:white;
+}
+
 .result-item .subtitle .highlight {
   color: var(--grey-90);
   font-weight: 500;

--- a/src/components/QuickOpenModal.css
+++ b/src/components/QuickOpenModal.css
@@ -4,7 +4,7 @@
 }
 
 .selected .highlight {
-  color:white;
+  color: white;
 }
 
 .result-item .subtitle .highlight {


### PR DESCRIPTION
Fixes Issue: #5679 

### Summary of Changes
* Changed selected quick open element text be bolded white

### Test Plan

- [x] Typing in letters/text in quick open shows white bolded text against blue background for highlighted item

### Screenshot
![screen shot 2018-03-21 at 10 17 55 pm](https://user-images.githubusercontent.com/13398997/37747974-29704e30-2d58-11e8-8d74-e6b106ed2d61.png)
