### PR TITLE
Remove tabIndex field

### DIFF
--- a/src/actions/sources/select.js
+++ b/src/actions/sources/select.js
@@ -79,10 +79,10 @@ export function selectSourceURL(
  * @memberof actions/sources
  * @static
  */
-export function selectSource(sourceId: string, tabIndex: string = "") {
+export function selectSource(sourceId: string) {
   return async ({ dispatch }: ThunkArgs) => {
     const location = createLocation({ sourceId });
-    return await dispatch(selectLocation(location, tabIndex));
+    return await dispatch(selectLocation(location));
   };
 }
 
@@ -90,7 +90,7 @@ export function selectSource(sourceId: string, tabIndex: string = "") {
  * @memberof actions/sources
  * @static
  */
-export function selectLocation(location: Location, tabIndex: string = "") {
+export function selectLocation(location: Location) {
   return async ({ dispatch, getState, client }: ThunkArgs) => {
     if (!client) {
       // No connection, do nothing. This happens when the debugger is
@@ -114,7 +114,6 @@ export function selectLocation(location: Location, tabIndex: string = "") {
     dispatch({
       type: "SELECT_SOURCE",
       source: source.toJS(),
-      tabIndex,
       location
     });
 

--- a/src/actions/types.js
+++ b/src/actions/types.js
@@ -142,8 +142,7 @@ type SourceAction =
   | {
       type: "SELECT_SOURCE",
       source: Source,
-      location?: { line?: number, column?: number },
-      tabIndex?: number
+      location?: { line?: number, column?: number }
     }
   | { type: "SELECT_SOURCE_URL", url: string, line?: number }
   | {


### PR DESCRIPTION
### Summary of Changes

The `tabIndex` field is no longer needed because we use `moveTab`. I believe we could have removed it then.