### PR TITLE
(WIP) [travis] Switch to a virtualized container

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ cache:
   - pip
   - yarn
 
+sudo: required
 
 env:
   global:


### PR DESCRIPTION
### Summary of Changes

Mariá, a travis support team lead, suggested we try making the environment fully virtualized.

--- 
Your builds are currently running in our container-based environment, which has very speedy boot times and is recommended for lightweight testing as it runs on containers.

Something that could help is using our `sudo: required`, fully virtualized environment which also has 7.5GB of RAM instead of 4. Could you add `sudo: required` to your .travis.yml file, run a test build and let us know how it goes? You should be able to identify the infra in which your build has run by looking at the worker line on the top of the log:

* https://travis-ci.org/devtools-html/debugger.html/jobs/356803997#L2 in which ec2 means container-based and gce means fully virtualized.

Here's also some details on our different build environments: https://docs.travis-ci.com/user/reference/overview/#Virtualisation-Environment-vs-Operating-System
