### PR TITLE
Avoid listing workers if connected to Fennec v59

### DIFF
--- a/src/client/firefox/commands.js
+++ b/src/client/firefox/commands.js
@@ -322,9 +322,9 @@ async function fetchSources() {
 
 /**
  * Temporary helper to check if the current server will support a call to
- * listWorkers. On Fennec 59 or older, the call will silently crash and prevent
+ * listWorkers. On Fennec 60 or older, the call will silently crash and prevent
  * the client from resuming.
- * XXX: Remove when FF59 for Android is no longer used or available.
+ * XXX: Remove when FF60 for Android is no longer used or available.
  *
  * See https://bugzilla.mozilla.org/show_bug.cgi?id=1443550 for more details.
  */
@@ -342,16 +342,14 @@ async function checkServerSupportsListWorkers() {
   }
 
   // We are only interested in Fennec release versions here.
-  // We assume that the server fix for Bug 1443550 will be uplifted to FF60.
-  // This means that we will not attempt to fetch workers for any early 60
-  // version such as 60.0b6.
+  // We assume that the server fix for Bug 1443550 will land in FF61.
   const version = description.platformversion;
-  return Services.vc.compare(version, "60.0") >= 0;
+  return Services.vc.compare(version, "61.0") >= 0;
 }
 
 async function fetchWorkers(): Promise<{ workers: Worker[] }> {
   // Temporary workaround for Bug 1443550
-  // XXX: Remove when FF59 for Android is no longer used or available.
+  // XXX: Remove when FF60 for Android is no longer used or available.
   const supportsListWorkers = await checkServerSupportsListWorkers();
 
   // NOTE: The Worker and Browser Content toolboxes do not have a parent

--- a/src/client/firefox/commands.js
+++ b/src/client/firefox/commands.js
@@ -31,6 +31,9 @@ import { makePendingLocationId } from "../../utils/breakpoint";
 
 import { createSource, createBreakpointLocation } from "./create";
 
+import { getDeviceFront } from "./fronts-device";
+import { Services } from "devtools-modules";
+
 let bpClients: BPClients;
 let threadClient: ThreadClient;
 let tabTarget: TabTarget;
@@ -317,14 +320,48 @@ async function fetchSources() {
   return sources.map(source => createSource(source, { supportsWasm }));
 }
 
+/**
+ * Temporary helper to check if the current server will support a call to
+ * listWorkers. On Fennec 59 or older, the call will silently crash and prevent
+ * the client from resuming.
+ * XXX: Remove when FF59 for Android is no longer used or available.
+ *
+ * See https://bugzilla.mozilla.org/show_bug.cgi?id=1443550 for more details.
+ */
+async function checkServerSupportsListWorkers() {
+  const root = await tabTarget.root;
+  const deviceFront = await getDeviceFront(debuggerClient, root);
+  const description = await deviceFront.getDescription();
+
+  const isFennec = description.apptype === "mobile/android";
+  if (!isFennec) {
+    // Explicitly return true early to avoid calling Services.vs.compare.
+    // This would force us to extent the Services shim provided by
+    // devtools-modules, used when this code runs in a tab.
+    return true;
+  }
+
+  // We are only interested in Fennec release versions here.
+  // We assume that the server fix for Bug 1443550 will be uplifted to FF60.
+  // This means that we will not attempt to fetch workers for any early 60
+  // version such as 60.0b6.
+  const version = description.platformversion;
+  return Services.vc.compare(version, "60.0") >= 0;
+}
+
 async function fetchWorkers(): Promise<{ workers: Worker[] }> {
+  // Temporary workaround for Bug 1443550
+  // XXX: Remove when FF59 for Android is no longer used or available.
+  const supportsListWorkers = await checkServerSupportsListWorkers();
+
   // NOTE: The Worker and Browser Content toolboxes do not have a parent
   // with a listWorkers function
   // TODO: there is a listWorkers property, but it is not a function on the
   // parent. Investigate what it is
   if (
     !threadClient._parent ||
-    typeof threadClient._parent.listWorkers != "function"
+    typeof threadClient._parent.listWorkers != "function" ||
+    !supportsListWorkers
   ) {
     return Promise.resolve({ workers: [] });
   }

--- a/src/client/firefox/fronts-device.js
+++ b/src/client/firefox/fronts-device.js
@@ -1,0 +1,15 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
+export function getDeviceFront() {
+  return {
+    getDescription: function() {
+      return {
+        // Return anything that will not match Fennec v59
+        apptype: "apptype",
+        version: "version"
+      };
+    }
+  };
+}

--- a/src/client/firefox/types.js
+++ b/src/client/firefox/types.js
@@ -241,6 +241,7 @@ export type TabTarget = {
     ) => void
   },
   form: { consoleActor: any },
+  root: any,
   activeTab: {
     navigateTo: string => Promise<*>,
     reload: () => Promise<*>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -58,6 +58,7 @@ function buildConfig(envConfig) {
     extra.excludeMap = {
       "./source-editor": "devtools/client/sourceeditor/editor",
       "./test-flag": "devtools/shared/flags",
+      "./fronts-device": "devtools/shared/fronts/device",
       react: "devtools/client/shared/vendor/react",
       redux: "devtools/client/shared/vendor/redux",
       "react-dom": "devtools/client/shared/vendor/react-dom",


### PR DESCRIPTION
This is a client side workaround for fixing connection to Fennec v59, for the issue mentioned on [Bug 1443550](https://bugzilla.mozilla.org/show_bug.cgi?id=1443550)

It assumes that the root issue will be fixed after 59. We get device information and check the application type and the version. If we are on Fennec 59, we do not attempt to fetch workers.

Another possible workaround is to use Promise.race to timeout the listWorkers call after N seconds. I will submit another PR for this second approach and we can decide which one we like best.
