### PR TITLE
Add method to select a specific source or location without attempting to detect pretty print

### DIFF
--- a/src/components/Editor/Tab.js
+++ b/src/components/Editor/Tab.js
@@ -40,7 +40,7 @@ type SourcesList = List<SourceRecord>;
 
 type Props = {
   tabSources: SourcesList,
-  selectSource: Object => void,
+  selectSpecificSource: Object => void,
   selectedSource: SourceRecord,
   closeTab: string => void,
   closeTabs: (List<string>) => void,
@@ -150,7 +150,7 @@ class Tab extends PureComponent<Props> {
   render() {
     const {
       selectedSource,
-      selectSource,
+      selectSpecificSource,
       closeTab,
       source,
       sourceMetaData
@@ -179,7 +179,7 @@ class Tab extends PureComponent<Props> {
         return closeTab(source.get("url"));
       }
 
-      return selectSource(sourceId);
+      return selectSpecificSource(sourceId);
     }
 
     const className = classnames("source-tab", {

--- a/src/components/Editor/Tabs.js
+++ b/src/components/Editor/Tabs.js
@@ -31,7 +31,7 @@ type SourcesList = List<SourceRecord>;
 type Props = {
   tabSources: SourcesList,
   selectedSource: SourceRecord,
-  selectSource: Object => void,
+  selectSpecificSource: Object => void,
   moveTab: (string, number) => void,
   closeTab: string => void,
   togglePaneCollapse: () => void,
@@ -121,10 +121,10 @@ class Tabs extends PureComponent<Props, State> {
   }
 
   renderDropdownSource = (source: SourceRecord) => {
-    const { selectSource } = this.props;
+    const { selectSpecificSource } = this.props;
     const filename = getFilename(source.toJS());
 
-    const onClick = () => selectSource(source.get("id"));
+    const onClick = () => selectSpecificSource(source.get("id"));
     return (
       <li key={source.get("id")} onClick={onClick}>
         <img className={`dropdown-icon ${this.getIconClass(source)}`} />


### PR DESCRIPTION
This PR provides a method for selecting a source without the pretty print logic dance.  This is a good first step in avoiding the side effects of pretty print.