### PR TITLE
Remove references to `listTabs` API

### DIFF
--- a/src/client/firefox/types.js
+++ b/src/client/firefox/types.js
@@ -197,23 +197,6 @@ export type TabPayload = {
 };
 
 /**
- * Response from the `listTabs` function call
- * @memberof firefox
- * @static
- */
-export type ListTabsResponse = {
-  actorRegistryActor: ActorId,
-  addonsActor: ActorId,
-  deviceActor: ActorId,
-  directorRegistryActor: ActorId,
-  from: string,
-  heapSnapshotFileActor: ActorId,
-  preferenceActor: ActorId,
-  selected: number,
-  tabs: TabPayload[]
-};
-
-/**
  * Actions
  * @memberof firefox
  * @static
@@ -268,7 +251,6 @@ export type DebuggerClient = {
     traits: any
   },
   connect: () => Promise<*>,
-  listTabs: () => Promise<*>,
   request: (packet: Object) => Promise<*>
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3309,7 +3309,7 @@ eslint-plugin-jest@^21.5.0:
   version "21.15.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-21.15.0.tgz#645a3f560d3e61d99611b215adc80b4f31e6d896"
 
-eslint-plugin-mozilla@0.10.0:
+eslint-plugin-mozilla@^0.10.0:
   version "0.10.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-mozilla/-/eslint-plugin-mozilla-0.10.0.tgz#a3918efcc19405459cb605ebafc535eef4d600de"
   dependencies:


### PR DESCRIPTION
`listTabs` is bad for performance and should be avoided where possible.  In most
cases of interest to the debugger, a `target` is already prepared by the toolbox
with all data it would need.

The debugger doesn't actually seem to use `listTabs` currently, so we should
remove these types as well to avoid the suggestion that it's a good idea to use.