### PR TITLE
Pause points tweaks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
   global:
     - DISPLAY=':99.0'
     - YARN_VERSION='0.24.5'
-    - MC_COMMIT='0b997836c7cf' # https://hg.mozilla.org/mozilla-central/shortlog
+    - MC_COMMIT='5bc910c1f477' # https://hg.mozilla.org/mozilla-central/shortlog
 
 notifications:
   slack:

--- a/src/test/mochitest/browser_dbg-editor-select.js
+++ b/src/test/mochitest/browser_dbg-editor-select.js
@@ -26,6 +26,7 @@ add_task(async function() {
 
   // Step through to another file and make sure it's paused in the
   // right place.
+  await stepOver(dbg);
   await stepIn(dbg);
   await waitForSelectedSource(dbg, "simple2");
   assertPausedLocation(dbg);

--- a/src/test/mochitest/browser_dbg-sourcemaps.js
+++ b/src/test/mochitest/browser_dbg-sourcemaps.js
@@ -61,21 +61,16 @@ add_task(async function() {
     "Original source text loaded correctly"
   );
 
-  // Test that breakpoint sliding is not attempted. The breakpoint
-  // should not move anywhere.
-  await addBreakpoint(dbg, entrySrc, 13);
-  is(getBreakpoints(getState()).size, 1, "One breakpoint exists");
-  assertBreakpointExists(dbg, entrySrc, 13);
-
   // Test breaking on a breakpoint
   await addBreakpoint(dbg, "entry.js", 15);
-  is(getBreakpoints(getState()).size, 2, "Two breakpoints exist");
+  is(getBreakpoints(getState()).size, 1, "One breakpoint exists");
   assertBreakpointExists(dbg, entrySrc, 15);
 
   invokeInTab("keepMeAlive");
   await waitForPaused(dbg);
   assertPausedLocation(dbg);
 
+  await stepIn(dbg);
   await stepIn(dbg);
   assertPausedLocation(dbg);
 

--- a/src/test/mochitest/browser_dbg-stepping.js
+++ b/src/test/mochitest/browser_dbg-stepping.js
@@ -32,6 +32,6 @@ add_task(async function test() {
   await stepIn(dbg);
 
   assertSelectedFile(dbg, "bundle.js");
-  assertDebugLine(dbg, 42309);
+  assertDebugLine(dbg, 42264);
   assertPausedLocation(dbg);
 });

--- a/src/workers/parser/pausePoints.js
+++ b/src/workers/parser/pausePoints.js
@@ -1,5 +1,22 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
+// @flow
+
 import { traverseAst } from "./utils/ast";
 import * as t from "@babel/types";
+
+import type { AstLocation } from "./types";
+import type { BabelNode } from "@babel/types";
+import type { SimplePath } from "./utils/simple-path";
+
+export type PausePoint = {|
+  location: AstLocation,
+  types: {| breakpoint: boolean, stepOver: boolean |}
+|};
+
+export type PausePoints = PausePoint[];
 
 const isControlFlow = node =>
   t.isForStatement(node) || t.isWhileStatement(node) || t.isIfStatement(node);
@@ -15,62 +32,69 @@ const inExpression = parent =>
   t.isCallExpression(parent.node) ||
   t.isTemplateLiteral(parent.node);
 
-export function getPausePoints(sourceId) {
+export function getPausePoints(sourceId: string) {
   const state = [];
   traverseAst(sourceId, { enter: onEnter }, state);
   return state;
 }
 
-function formatNode(location, types) {
-  return { location, types };
-}
-
-function onEnter(node, ancestors, state) {
+function onEnter(node: BabelNode, ancestors: SimplePath[], state) {
   const parent = ancestors[ancestors.length - 1];
 
   if (
     isAssignment(node) ||
     isImport(node) ||
     isControlFlow(node) ||
-    isReturn(node)
+    t.isDebuggerStatement(node)
   ) {
-    state.push(
-      formatNode(node.loc.start, { breakpoint: true, stepOver: true })
-    );
+    addPoint(state, node.loc.start);
+  }
+
+  if (isReturn(node)) {
+    if (t.isCallExpression(node.argument)) {
+      addEmptyPoint(state, node.loc.start);
+    } else {
+      addPoint(state, node.loc.start);
+    }
   }
 
   if (t.isCallExpression(node)) {
-    state.push(
-      formatNode(node.loc.start, {
-        breakpoint: true,
+    addPoint(state, node.loc.start, {
+      breakpoint: true,
 
-        // NOTE: we do not want to land inside an expression e.g. [], {}, call
-        stepOver: !inExpression(parent)
-      })
-    );
-  }
-
-  if (t.isDebuggerStatement(node)) {
-    state.push(
-      formatNode(node.loc.start, { breakpoint: true, stepOver: true })
-    );
+      // NOTE: we do not want to land inside an expression e.g. [], {}, call
+      stepOver: !inExpression(parent)
+    });
   }
 
   if (t.isFunction(node)) {
     const { line, column } = node.loc.end;
-    state.push(formatNode(node.loc.start, { breakpoint: true }));
-    state.push(
-      formatNode(
-        { line, column: column - 1 },
-        { breakpoint: true, stepOver: true }
-      )
-    );
+    addBreakPoint(state, node.loc.start);
+    addPoint(state, { line, column: column - 1 });
   }
 
   if (t.isProgram(node)) {
     const lastStatement = node.body[node.body.length - 1];
-    state.push(
-      formatNode(lastStatement.loc.end, { breakpoint: true, stepOver: true })
-    );
+    addPoint(state, lastStatement.loc.end);
   }
+}
+
+function formatNode(location, types) {
+  return { location, types };
+}
+
+function addPoint(
+  state,
+  location,
+  types = { breakpoint: true, stepOver: true }
+) {
+  state.push(formatNode(location, types));
+}
+
+function addEmptyPoint(state, location) {
+  addPoint(state, location, { breakpoint: false, stepOver: false });
+}
+
+function addBreakPoint(state, location) {
+  addPoint(state, location, { breakpoint: true, stepOver: false });
 }

--- a/src/workers/parser/tests/__snapshots__/pausePoints.spec.js.snap
+++ b/src/workers/parser/tests/__snapshots__/pausePoints.spec.js.snap
@@ -43,6 +43,13 @@ else {
 /*bs 21*/while (x) {
 
 }
-var /*bs 22*/a = 3;/*bs 23*/
+
+/*b 22*/function ret() {
+  /*bs 23*/console.log(\\"...\\")
+  /* 24*/return /*bs 25*/func()
+/*bs 26*/}
+
+
+var /*bs 27*/a = 3;/*bs 28*/
 "
 `;

--- a/src/workers/parser/tests/fixtures/pause-points.js
+++ b/src/workers/parser/tests/fixtures/pause-points.js
@@ -40,4 +40,11 @@ for (var i=0; i< 5; i++ ) {
 while (x) {
 
 }
+
+function ret() {
+  console.log("...")
+  return func()
+}
+
+
 var a = 3;


### PR DESCRIPTION
### Summary of Changes

* fixes up two tests whose behavior changed (largely) for the better
* removes a check about adding a breakpoint w/ sliding bc pausepoints prevents users from adding bps in that spot
* added a `return foo()` check in pause points to prevent pausing at a return when there is a subsequent call
