### PR TITLE
Avoid allow text selection in secondary panels - Fix #5762

### DIFF
--- a/src/components/SecondaryPanes/SecondaryPanes.css
+++ b/src/components/SecondaryPanes/SecondaryPanes.css
@@ -9,6 +9,8 @@
   flex: 1;
   white-space: nowrap;
   --breakpoint-expression-right-clear-space: 36px;
+  -moz-user-select: none;
+  user-select: none;
 }
 
 /*


### PR DESCRIPTION
Fixes Issue: #5762

Should not allow text selections 

Example test plan:

- add a breakpoint
- select the breakpoint and drag your mouse down
