### PR TITLE
Enable original-file Typescript parsing via Babylon.

### DIFF
--- a/src/workers/parser/getScopes/visitor.js
+++ b/src/workers/parser/getScopes/visitor.js
@@ -570,7 +570,28 @@ const scopeCollectionVisitor = {
           };
         }
       });
-    } else if (t.isIdentifier(node) && t.isReferenced(node, parentNode)) {
+    } else if (t.isTSEnumDeclaration(node)) {
+      state.scope.bindings[node.id.name] = {
+        type: "const",
+        refs: [
+          {
+            type: "decl",
+            start: fromBabelLocation(node.id.loc.start, state.sourceId),
+            end: fromBabelLocation(node.id.loc.end, state.sourceId),
+            declaration: {
+              start: fromBabelLocation(node.loc.start, state.sourceId),
+              end: fromBabelLocation(node.loc.end, state.sourceId)
+            }
+          }
+        ]
+      };
+    } else if (
+      t.isIdentifier(node) &&
+      t.isReferenced(node, parentNode) &&
+      // Babel doesn't cover this in 'isReferenced' yet, but it should
+      // eventually.
+      !t.isTSEnumMember(parentNode, { id: node })
+    ) {
       let freeVariables = state.freeVariables.get(node.name);
       if (!freeVariables) {
         freeVariables = [];

--- a/src/workers/parser/tests/__snapshots__/getScopes.spec.js.snap
+++ b/src/workers/parser/tests/__snapshots__/getScopes.spec.js.snap
@@ -12068,6 +12068,344 @@ Array [
 ]
 `;
 
+exports[`getScopes finds scope bindings in a typescript file at line 3 column 0 1`] = `
+Array [
+  Object {
+    "bindings": Object {
+      "Color": Object {
+        "refs": Array [
+          Object {
+            "declaration": Object {
+              "end": Object {
+                "column": 29,
+                "line": 2,
+                "sourceId": "scopes/ts-sample/originalSource-1",
+              },
+              "start": Object {
+                "column": 0,
+                "line": 2,
+                "sourceId": "scopes/ts-sample/originalSource-1",
+              },
+            },
+            "end": Object {
+              "column": 10,
+              "line": 2,
+              "sourceId": "scopes/ts-sample/originalSource-1",
+            },
+            "start": Object {
+              "column": 5,
+              "line": 2,
+              "sourceId": "scopes/ts-sample/originalSource-1",
+            },
+            "type": "decl",
+          },
+          Object {
+            "end": Object {
+              "column": 10,
+              "line": 2,
+              "sourceId": "scopes/ts-sample/originalSource-1",
+            },
+            "meta": null,
+            "start": Object {
+              "column": 5,
+              "line": 2,
+              "sourceId": "scopes/ts-sample/originalSource-1",
+            },
+            "type": "ref",
+          },
+        ],
+        "type": "const",
+      },
+      "Example": Object {
+        "refs": Array [
+          Object {
+            "declaration": Object {
+              "end": Object {
+                "column": 1,
+                "line": 8,
+                "sourceId": "scopes/ts-sample/originalSource-1",
+              },
+              "start": Object {
+                "column": 0,
+                "line": 4,
+                "sourceId": "scopes/ts-sample/originalSource-1",
+              },
+            },
+            "end": Object {
+              "column": 13,
+              "line": 4,
+              "sourceId": "scopes/ts-sample/originalSource-1",
+            },
+            "start": Object {
+              "column": 6,
+              "line": 4,
+              "sourceId": "scopes/ts-sample/originalSource-1",
+            },
+            "type": "decl",
+          },
+        ],
+        "type": "let",
+      },
+    },
+    "displayName": "Lexical Global",
+    "end": Object {
+      "column": 0,
+      "line": 9,
+      "sourceId": "scopes/ts-sample/originalSource-1",
+    },
+    "start": Object {
+      "column": 0,
+      "line": 1,
+      "sourceId": "scopes/ts-sample/originalSource-1",
+    },
+    "type": "block",
+  },
+  Object {
+    "bindings": Object {
+      "Error": Object {
+        "refs": Array [
+          Object {
+            "end": Object {
+              "column": 19,
+              "line": 6,
+              "sourceId": "scopes/ts-sample/originalSource-1",
+            },
+            "meta": null,
+            "start": Object {
+              "column": 14,
+              "line": 6,
+              "sourceId": "scopes/ts-sample/originalSource-1",
+            },
+            "type": "ref",
+          },
+        ],
+        "type": "global",
+      },
+      "this": Object {
+        "refs": Array [],
+        "type": "implicit",
+      },
+    },
+    "displayName": "Global",
+    "end": Object {
+      "column": 0,
+      "line": 9,
+      "sourceId": "scopes/ts-sample/originalSource-1",
+    },
+    "start": Object {
+      "column": 0,
+      "line": 1,
+      "sourceId": "scopes/ts-sample/originalSource-1",
+    },
+    "type": "object",
+  },
+]
+`;
+
+exports[`getScopes finds scope bindings in a typescript file at line 6 column 4 1`] = `
+Array [
+  Object {
+    "bindings": Object {
+      "arguments": Object {
+        "refs": Array [],
+        "type": "implicit",
+      },
+      "this": Object {
+        "refs": Array [],
+        "type": "implicit",
+      },
+    },
+    "displayName": "method",
+    "end": Object {
+      "column": 3,
+      "line": 7,
+      "sourceId": "scopes/ts-sample/originalSource-1",
+    },
+    "start": Object {
+      "column": 2,
+      "line": 5,
+      "sourceId": "scopes/ts-sample/originalSource-1",
+    },
+    "type": "function",
+  },
+  Object {
+    "bindings": Object {
+      "Example": Object {
+        "refs": Array [
+          Object {
+            "declaration": Object {
+              "end": Object {
+                "column": 1,
+                "line": 8,
+                "sourceId": "scopes/ts-sample/originalSource-1",
+              },
+              "start": Object {
+                "column": 0,
+                "line": 4,
+                "sourceId": "scopes/ts-sample/originalSource-1",
+              },
+            },
+            "end": Object {
+              "column": 13,
+              "line": 4,
+              "sourceId": "scopes/ts-sample/originalSource-1",
+            },
+            "start": Object {
+              "column": 6,
+              "line": 4,
+              "sourceId": "scopes/ts-sample/originalSource-1",
+            },
+            "type": "decl",
+          },
+        ],
+        "type": "const",
+      },
+    },
+    "displayName": "Class",
+    "end": Object {
+      "column": 1,
+      "line": 8,
+      "sourceId": "scopes/ts-sample/originalSource-1",
+    },
+    "start": Object {
+      "column": 0,
+      "line": 4,
+      "sourceId": "scopes/ts-sample/originalSource-1",
+    },
+    "type": "block",
+  },
+  Object {
+    "bindings": Object {
+      "Color": Object {
+        "refs": Array [
+          Object {
+            "declaration": Object {
+              "end": Object {
+                "column": 29,
+                "line": 2,
+                "sourceId": "scopes/ts-sample/originalSource-1",
+              },
+              "start": Object {
+                "column": 0,
+                "line": 2,
+                "sourceId": "scopes/ts-sample/originalSource-1",
+              },
+            },
+            "end": Object {
+              "column": 10,
+              "line": 2,
+              "sourceId": "scopes/ts-sample/originalSource-1",
+            },
+            "start": Object {
+              "column": 5,
+              "line": 2,
+              "sourceId": "scopes/ts-sample/originalSource-1",
+            },
+            "type": "decl",
+          },
+          Object {
+            "end": Object {
+              "column": 10,
+              "line": 2,
+              "sourceId": "scopes/ts-sample/originalSource-1",
+            },
+            "meta": null,
+            "start": Object {
+              "column": 5,
+              "line": 2,
+              "sourceId": "scopes/ts-sample/originalSource-1",
+            },
+            "type": "ref",
+          },
+        ],
+        "type": "const",
+      },
+      "Example": Object {
+        "refs": Array [
+          Object {
+            "declaration": Object {
+              "end": Object {
+                "column": 1,
+                "line": 8,
+                "sourceId": "scopes/ts-sample/originalSource-1",
+              },
+              "start": Object {
+                "column": 0,
+                "line": 4,
+                "sourceId": "scopes/ts-sample/originalSource-1",
+              },
+            },
+            "end": Object {
+              "column": 13,
+              "line": 4,
+              "sourceId": "scopes/ts-sample/originalSource-1",
+            },
+            "start": Object {
+              "column": 6,
+              "line": 4,
+              "sourceId": "scopes/ts-sample/originalSource-1",
+            },
+            "type": "decl",
+          },
+        ],
+        "type": "let",
+      },
+    },
+    "displayName": "Lexical Global",
+    "end": Object {
+      "column": 0,
+      "line": 9,
+      "sourceId": "scopes/ts-sample/originalSource-1",
+    },
+    "start": Object {
+      "column": 0,
+      "line": 1,
+      "sourceId": "scopes/ts-sample/originalSource-1",
+    },
+    "type": "block",
+  },
+  Object {
+    "bindings": Object {
+      "Error": Object {
+        "refs": Array [
+          Object {
+            "end": Object {
+              "column": 19,
+              "line": 6,
+              "sourceId": "scopes/ts-sample/originalSource-1",
+            },
+            "meta": null,
+            "start": Object {
+              "column": 14,
+              "line": 6,
+              "sourceId": "scopes/ts-sample/originalSource-1",
+            },
+            "type": "ref",
+          },
+        ],
+        "type": "global",
+      },
+      "this": Object {
+        "refs": Array [],
+        "type": "implicit",
+      },
+    },
+    "displayName": "Global",
+    "end": Object {
+      "column": 0,
+      "line": 9,
+      "sourceId": "scopes/ts-sample/originalSource-1",
+    },
+    "start": Object {
+      "column": 0,
+      "line": 1,
+      "sourceId": "scopes/ts-sample/originalSource-1",
+    },
+    "type": "object",
+  },
+]
+`;
+
 exports[`getScopes finds scope bindings with expression metadata at line 2 column 0 1`] = `
 Array [
   Object {

--- a/src/workers/parser/tests/fixtures/scopes/ts-sample.ts
+++ b/src/workers/parser/tests/fixtures/scopes/ts-sample.ts
@@ -1,0 +1,8 @@
+
+enum Color {Red, Green, Blue}
+
+class Example<T> {
+  method(): never {
+    throw new Error();
+  }
+}

--- a/src/workers/parser/tests/getScopes.spec.js
+++ b/src/workers/parser/tests/getScopes.spec.js
@@ -7,8 +7,8 @@ import cases from "jest-in-case";
 
 cases(
   "Parser.getScopes",
-  ({ name, file, locations }) => {
-    const source = getOriginalSource(file);
+  ({ name, file, type, locations }) => {
+    const source = getOriginalSource(file, type);
     setSource(source);
 
     locations.forEach(([line, column]) => {
@@ -24,6 +24,12 @@ cases(
     });
   },
   [
+    {
+      name: "finds scope bindings in a typescript file",
+      file: "scopes/ts-sample",
+      type: "ts",
+      locations: [[3, 0], [6, 4]]
+    },
     {
       name: "finds scope bindings in a module",
       file: "scopes/simple-module",

--- a/src/workers/parser/tests/helpers/index.js
+++ b/src/workers/parser/tests/helpers/index.js
@@ -6,7 +6,13 @@ export function getSource(name, type = "js") {
     path.join(__dirname, `../fixtures/${name}.${type}`),
     "utf8"
   );
-  const contentType = type === "html" ? "text/html" : "text/javascript";
+  let contentType = "text/javascript";
+  if (type === "html") {
+    contentType = "text/html";
+  } else if (type === "ts") {
+    contentType = "text/typescript";
+  }
+
   return {
     id: name,
     text,

--- a/src/workers/parser/utils/ast.js
+++ b/src/workers/parser/utils/ast.js
@@ -82,6 +82,18 @@ export function getAst(sourceId: string) {
     const type = source.id.includes("original") ? "original" : "generated";
     const options = sourceOptions[type];
     ast = parse(source.text, options);
+  } else if (contentType && contentType.match(/typescript/)) {
+    const options = {
+      ...sourceOptions.original,
+      plugins: [
+        ...sourceOptions.original.plugins.filter(
+          p => p !== "flow" && p !== "decorators" && p !== "decorators2"
+        ),
+        "decorators",
+        "typescript"
+      ]
+    };
+    ast = parse(source.text, options);
   }
 
   ASTs.set(source.id, ast);


### PR DESCRIPTION
Refs Issue: #5561

### Summary of Changes

* Parse Typescript files with Babylon to expand the original-scope debugging work to TS files
