### PR TITLE
add function to check for console object or props

### DIFF
--- a/src/actions/preview.js
+++ b/src/actions/preview.js
@@ -6,7 +6,7 @@
 
 import { findBestMatchExpression } from "../utils/ast";
 import { getTokenLocation } from "../utils/editor";
-import { isReactComponent, isImmutable } from "../utils/preview";
+import { isReactComponent, isImmutable, isConsole } from "../utils/preview";
 import { isGeneratedId } from "devtools-source-map";
 import { PROMISE } from "./utils/middleware/promise";
 import { getExpressionFromCoords } from "../utils/editor/get-expression";
@@ -136,6 +136,11 @@ export function updatePreview(target: HTMLElement, editor: any) {
     }
 
     const { expression, location } = match;
+
+    if (isConsole(expression)) {
+      return;
+    }
+
     dispatch(setPreview(expression, location, tokenPos, cursorPos));
   };
 }

--- a/src/utils/preview.js
+++ b/src/utils/preview.js
@@ -38,3 +38,7 @@ export function isReactComponent(result: Grip) {
     Object.keys(ownProperties).includes("_reactInternalFiber")
   );
 }
+
+export function isConsole(expression: String) {
+  return /^console/.test(expression);
+}

--- a/src/utils/preview.js
+++ b/src/utils/preview.js
@@ -39,6 +39,6 @@ export function isReactComponent(result: Grip) {
   );
 }
 
-export function isConsole(expression: String) {
+export function isConsole(expression: string) {
   return /^console/.test(expression);
 }


### PR DESCRIPTION
Fixes Issue: #5695

### Summary of Changes

* added `isConsole` function
* hide

### Test Plan

Tell us a little a bit about how you tested your patch.

Example test plan:

- [x] debug https://loud-bowl.glitch.me/
- [x] set breakpoint on line 26
- [x] refresh debuggee
- [x] hover over all `console`, `log`, `warn` and `group`
