### PR TITLE
Removes unused modifiers reference

### DIFF
--- a/src/actions/file-search.js
+++ b/src/actions/file-search.js
@@ -133,12 +133,11 @@ export function traverseResults(rev: boolean, editor: Editor) {
 
 export function closeFileSearch(editor: Editor) {
   return ({ getState, dispatch }: ThunkArgs) => {
-    const modifiers = getFileSearchModifiers(getState());
     const query = getFileSearchQuery(getState());
 
-    if (editor && modifiers) {
+    if (editor) {
       const ctx = { ed: editor, cm: editor.codeMirror };
-      removeOverlay(ctx, query, modifiers.toJS());
+      removeOverlay(ctx, query);
     }
 
     dispatch(setFileSearchQuery(""));

--- a/src/components/Editor/SearchBar.js
+++ b/src/components/Editor/SearchBar.js
@@ -129,10 +129,10 @@ class SearchBar extends Component<Props, State> {
   };
 
   clearSearch = () => {
-    const { editor: ed, query, modifiers } = this.props;
-    if (ed && modifiers) {
+    const { editor: ed, query } = this.props;
+    if (ed) {
       const ctx = { ed, cm: ed.codeMirror };
-      removeOverlay(ctx, query, modifiers.toJS());
+      removeOverlay(ctx, query);
     }
   };
 

--- a/src/utils/editor/source-search.js
+++ b/src/utils/editor/source-search.js
@@ -31,7 +31,7 @@ function SearchState() {
  * @memberof utils/source-search
  * @static
  */
-function getSearchState(cm: any, query, modifiers) {
+function getSearchState(cm: any, query) {
   const state = cm.state.search || (cm.state.search = new SearchState());
   return state;
 }
@@ -141,11 +141,11 @@ function doSearch(ctx, rev, query, keepSelection, modifiers: SearchModifiers) {
 
   return cm.operation(function() {
     if (!query || isWhitespace(query)) {
-      clearSearch(cm, query, modifiers);
+      clearSearch(cm, query);
       return;
     }
 
-    const state = getSearchState(cm, query, modifiers);
+    const state = getSearchState(cm, query);
     const isNewQuery = state.query !== query;
     state.query = query;
 
@@ -175,7 +175,7 @@ function searchNext(ctx, rev, query, newQuery, modifiers) {
   const { cm, ed } = ctx;
   let nextMatch;
   cm.operation(function() {
-    const state = getSearchState(cm, query, modifiers);
+    const state = getSearchState(cm, query);
     const pos = getCursorPos(newQuery, rev, state);
 
     if (!state.query) {
@@ -214,12 +214,8 @@ function searchNext(ctx, rev, query, newQuery, modifiers) {
  * @memberof utils/source-search
  * @static
  */
-export function removeOverlay(
-  ctx: any,
-  query: string,
-  modifiers: SearchModifiers
-) {
-  const state = getSearchState(ctx.cm, query, modifiers);
+export function removeOverlay(ctx: any, query: string) {
+  const state = getSearchState(ctx.cm, query);
   ctx.cm.removeOverlay(state.overlay);
   const { line, ch } = ctx.cm.getCursor();
   ctx.cm.doc.setSelection({ line, ch }, { line, ch }, { scroll: false });
@@ -231,8 +227,8 @@ export function removeOverlay(
  * @memberof utils/source-search
  * @static
  */
-function clearSearch(cm, query: string, modifiers: SearchModifiers) {
-  const state = getSearchState(cm, query, modifiers);
+function clearSearch(cm, query: string) {
+  const state = getSearchState(cm, query);
 
   state.results = [];
 
@@ -255,7 +251,7 @@ export function find(
   keepSelection: boolean,
   modifiers: SearchModifiers
 ) {
-  clearSearch(ctx.cm, query, modifiers);
+  clearSearch(ctx.cm, query);
   return doSearch(ctx, false, query, keepSelection, modifiers);
 }
 

--- a/src/utils/editor/tests/source-search.spec.js
+++ b/src/utils/editor/tests/source-search.spec.js
@@ -127,7 +127,7 @@ describe("source-search", () => {
           }
         }
       };
-      removeOverlay(ctx, "test", modifiers);
+      removeOverlay(ctx, "test");
       expect(ctx.cm.removeOverlay).toHaveBeenCalled();
       expect(ctx.cm.getCursor).toHaveBeenCalled();
       expect(ctx.cm.doc.setSelection).toHaveBeenCalledWith(


### PR DESCRIPTION
part of the toJS removal:

getSearchState is not using modifiers, so they can be removed from a series of functions including:
- getSearchState
- removeOverlay
- clearSearch
- closeFileSearch
