### PR TITLE
Use Pretty Printed Tab when Available

### DIFF
--- a/src/actions/sources/prettyPrint.js
+++ b/src/actions/sources/prettyPrint.js
@@ -12,7 +12,7 @@ import { prettyPrint } from "../../workers/pretty-print";
 import { setSource } from "../../workers/parser";
 import { getPrettySourceURL, isLoaded } from "../../utils/source";
 import { loadSourceText } from "./loadSourceText";
-import { selectLocation } from "../sources";
+import { selectLocation, selectSpecificLocation } from "../sources";
 import { mapFrames } from "../pause";
 
 import {
@@ -95,7 +95,7 @@ export function togglePrettyPrint(sourceId: string) {
     if (prettySource) {
       const _sourceId = prettySource.get("id");
       return dispatch(
-        selectLocation({ ...options.location, sourceId: _sourceId })
+        selectSpecificLocation({ ...options.location, sourceId: _sourceId })
       );
     }
 
@@ -107,7 +107,7 @@ export function togglePrettyPrint(sourceId: string) {
     await dispatch(setSymbols(newPrettySource.id));
 
     return dispatch(
-      selectLocation({ ...options.location, sourceId: newPrettySource.id })
+      selectSpecificLocation({ ...options.location, sourceId: newPrettySource.id })
     );
   };
 }

--- a/src/actions/sources/prettyPrint.js
+++ b/src/actions/sources/prettyPrint.js
@@ -12,7 +12,7 @@ import { prettyPrint } from "../../workers/pretty-print";
 import { setSource } from "../../workers/parser";
 import { getPrettySourceURL, isLoaded } from "../../utils/source";
 import { loadSourceText } from "./loadSourceText";
-import { selectLocation, selectSpecificLocation } from "../sources";
+import { selectSpecificLocation } from "../sources";
 import { mapFrames } from "../pause";
 
 import {
@@ -107,7 +107,10 @@ export function togglePrettyPrint(sourceId: string) {
     await dispatch(setSymbols(newPrettySource.id));
 
     return dispatch(
-      selectSpecificLocation({ ...options.location, sourceId: newPrettySource.id })
+      selectSpecificLocation({
+        ...options.location,
+        sourceId: newPrettySource.id
+      })
     );
   };
 }

--- a/src/actions/sources/select.js
+++ b/src/actions/sources/select.js
@@ -110,11 +110,11 @@ export function selectLocation(location: Location) {
     }
 
     // If this source has a pretty-printed tab open, focus on that
-    if (/* prefs.autoPrettyPrint && */getPrettySource(getState(), source.get("id"))) {
+    if (getPrettySource(getState(), source.get("id"))) {
       await dispatch(togglePrettyPrint(source.get("id")));
       dispatch(setSymbols(source.get("id")));
       dispatch(setOutOfScopeLocations());
-      console.log('bailing because pretty tab is already open');
+      console.log("bailing because pretty tab is already open");
       return;
     }
 

--- a/src/actions/sources/select.js
+++ b/src/actions/sources/select.js
@@ -117,7 +117,6 @@ export function selectLocation(location: Location) {
       await dispatch(togglePrettyPrint(source.get("id")));
       dispatch(setSymbols(source.get("id")));
       dispatch(setOutOfScopeLocations());
-      console.log("bailing because pretty tab is already open");
       return;
     }
 

--- a/src/actions/sources/select.js
+++ b/src/actions/sources/select.js
@@ -109,6 +109,15 @@ export function selectLocation(location: Location) {
       dispatch(closeActiveSearch());
     }
 
+    // If this source has a pretty-printed tab open, focus on that
+    if (/* prefs.autoPrettyPrint && */getPrettySource(getState(), source.get("id"))) {
+      await dispatch(togglePrettyPrint(source.get("id")));
+      dispatch(setSymbols(source.get("id")));
+      dispatch(setOutOfScopeLocations());
+      console.log('bailing because pretty tab is already open');
+      return;
+    }
+
     dispatch(addTab(source.toJS(), 0));
 
     dispatch({
@@ -219,7 +228,7 @@ export function jumpToMappedLocation(location: Location) {
       );
     }
 
-    return dispatch(selectLocation({ ...pairedLocation }));
+    return dispatch(selectSpecificLocation({ ...pairedLocation }));
   };
 }
 

--- a/src/actions/sources/select.js
+++ b/src/actions/sources/select.js
@@ -110,7 +110,10 @@ export function selectLocation(location: Location) {
     }
 
     // If this source has a pretty-printed tab open, focus on that
-    if (getPrettySource(getState(), source.get("id"))) {
+    if (
+      prefs.autoPrettyPrint &&
+      getPrettySource(getState(), source.get("id"))
+    ) {
       await dispatch(togglePrettyPrint(source.get("id")));
       dispatch(setSymbols(source.get("id")));
       dispatch(setOutOfScopeLocations());


### PR DESCRIPTION
One side effect of `selectLocation` is that if you click on an item in the source tree for which a pretty tab is already open for it, the original source tab also opens.  That's an undesirable eyesore.

WIP'ing as a discussion point.