### PR TITLE
Fix double scrollbar issue in SourcesTree

### DIFF
--- a/src/components/PrimaryPanes/Sources.css
+++ b/src/components/PrimaryPanes/Sources.css
@@ -65,11 +65,6 @@
   overflow-y: auto;
 }
 
-.sources-list {
-  flex: 1;
-  display: flex;
-}
-
 .sources-list .tree:focus {
   outline: none;
 }
@@ -224,6 +219,11 @@
 
 .sources-list-custom-root .sources-pane {
   display: block;
+}
+
+.sources-list-custom-root .sources-list {
+  flex: 1;
+  display: flex;
 }
 
 .sources-list-custom-root .sources-list,


### PR DESCRIPTION
@jasonLaster discovered a double scrollbar in the Sources Tree.  I couldn't spot it on Mac but Windows made the problem more visible.

After testing things out, I found what I consider to be the issue: I'm applying CSS code to the `sources-list` at all states when it only needs to be applied when the custom root is showing.

The sources tree layout stuff got complicated when we switched to the directory root button/layout because we always wanted that clear button on top, and so we had to go with absolute positioning and so on, thus the scrollbar situation got complicated.

## Testing
1.  Go to https://davidwalsh.name
2.  Expand all of the items, toggle the width and height of the sources tree pane, ensure that only one horizontal and vertical scrollbar displays and is on screen at all times (i.e. doesn't get pushed to the right, hidden due to parent overflow)
3.  Set `pagead2.googlesyndication.com` as the root directory
4.  Repeat step 2, ensuring that the scrollbars display as you'd expect

This is easier to test on windows since the scrollbars are always there and don't overlay the content.