### PR TITLE
Map frame display names

### DIFF
--- a/src/actions/ast.js
+++ b/src/actions/ast.js
@@ -11,6 +11,7 @@ import {
   isPaused
 } from "../selectors";
 
+import { mapFrames } from "./pause";
 import { setInScopeLines } from "./ast/setInScopeLines";
 import {
   getSymbols,
@@ -58,6 +59,10 @@ export function setSymbols(sourceId: SourceId) {
       source: source.toJS(),
       [PROMISE]: getSymbols(source.id)
     });
+
+    if (isPaused(getState())) {
+      await dispatch(mapFrames());
+    }
 
     await dispatch(setPausePoints(sourceId));
     await dispatch(setSourceMetaData(sourceId));

--- a/src/actions/pause/mapFrames.js
+++ b/src/actions/pause/mapFrames.js
@@ -36,13 +36,16 @@ export function mapDisplayNames(frames: Frame[], getState: () => State) {
     if (!symbols || !symbols.functions) {
       return frame;
     }
+
     const originalFunction = findClosestFunction(
       symbols.functions,
       frame.location
     );
+
     if (!originalFunction) {
       return frame;
     }
+
     const originalDisplayName = originalFunction.name;
     return { ...frame, originalDisplayName };
   });

--- a/src/actions/tests/pause.spec.js
+++ b/src/actions/tests/pause.spec.js
@@ -4,6 +4,7 @@ import {
   createStore,
   waitForState,
   makeSource,
+  makeOriginalSource,
   makeFrame
 } from "../../utils/test-head";
 
@@ -40,6 +41,11 @@ const mockThreadClient = {
         case "foo":
           return resolve({
             source: "function foo() {\n  return -5;\n}",
+            contentType: "text/javascript"
+          });
+        case "foo-original":
+          return resolve({
+            source: "\n\nfunction fooOriginal() {\n  return -5;\n}",
             contentType: "text/javascript"
           });
       }
@@ -144,6 +150,44 @@ describe("pause", () => {
       dispatch(actions.stepOver());
       expect(getNextStepSpy).toBeCalled();
       getNextStepSpy.mockRestore();
+    });
+
+    describe("pausing in a generated location", () => {
+      it("maps frame locations and names to original source", async () => {
+        const generatedLocation = {
+          sourceId: "foo",
+          line: 1,
+          column: 0
+        };
+        const originalLocation = {
+          sourceId: "foo-original",
+          line: 3,
+          column: 0
+        };
+        const sourceMapsMock = {
+          getOriginalLocation: () => Promise.resolve(originalLocation)
+        };
+        const store = createStore(mockThreadClient, {}, sourceMapsMock);
+        const { dispatch, getState } = store;
+        const mockPauseInfo = createPauseInfo(generatedLocation);
+
+        await dispatch(actions.newSource(makeSource("foo")));
+        await dispatch(actions.newSource(makeOriginalSource("foo")));
+        await dispatch(actions.loadSourceText(I.Map({ id: "foo" })));
+        await dispatch(actions.loadSourceText(I.Map({ id: "foo-original" })));
+        await dispatch(actions.setSymbols("foo-original"));
+
+        await dispatch(actions.paused(mockPauseInfo));
+        expect(selectors.getFrames(getState())).toEqual([
+          {
+            id: 1,
+            scope: [],
+            location: originalLocation,
+            generatedLocation,
+            originalDisplayName: "fooOriginal"
+          }
+        ]);
+      });
     });
   });
 

--- a/src/selectors/test/getCallStackFrames.spec.js
+++ b/src/selectors/test/getCallStackFrames.spec.js
@@ -47,7 +47,7 @@ describe("getCallStackFrames selector", () => {
     it("annotates frames related to Babel async transforms", () => {
       const preAwaitGroup = [
         {
-          displayName: "_callee$",
+          displayName: "asyncAppFunction",
           location: { sourceId: "bundle" }
         },
         {
@@ -86,7 +86,7 @@ describe("getCallStackFrames selector", () => {
 
       const postAwaitGroup = [
         {
-          displayName: "_callee$",
+          displayName: "asyncAppFunction",
           location: { sourceId: "bundle" }
         },
         {
@@ -160,6 +160,7 @@ describe("getCallStackFrames selector", () => {
         5,
         6,
         7,
+        8,
         10,
         11,
         12,

--- a/src/utils/pause/frames/displayName.js
+++ b/src/utils/pause/frames/displayName.js
@@ -79,7 +79,8 @@ export function formatDisplayName(
   frame: LocalFrame,
   { shouldMapDisplayName = true }: formatDisplayNameParams = {}
 ) {
-  let { displayName, library } = frame;
+  let { displayName, originalDisplayName, library } = frame;
+  displayName = originalDisplayName || displayName;
   if (library && shouldMapDisplayName) {
     displayName = mapDisplayNames(frame, library);
   }

--- a/src/utils/pause/frames/tests/displayName.spec.js
+++ b/src/utils/pause/frames/tests/displayName.spec.js
@@ -54,6 +54,18 @@ describe("formatting display names", () => {
 
     expect(formatDisplayName(frame)).toEqual("...zbazbazbazbazbazbazbazbaz");
   });
+
+  it("returns the original function name when present", () => {
+    const frame = {
+      originalDisplayName: "originalFn",
+      displayName: "fn",
+      source: {
+        url: "entry.js"
+      }
+    };
+
+    expect(formatDisplayName(frame)).toEqual("originalFn");
+  });
 });
 
 describe("simplifying display names", () => {


### PR DESCRIPTION
Fixes Issue: #5659

### Summary of Changes

* 756fedb8955a002bb2b11cb5750dd62d598fea05: When pausing in a generated source, map call stack frame names to the closest corresponding function in the original source. This gets rid of cryptic function names that show up in generated source.
* c418541a45c7743f95baf3b423ae1c6c072889fe Slight update to the Babel async grouping to make things a little easier to read than this  (see how `slowest` and `slower` appear twice): 
![image](https://user-images.githubusercontent.com/7321311/37939740-88a177ca-3132-11e8-9681-aa5e9090a84c.png)


### Test Plan
1. Go to http://firefox-dev.tools/debugger-examples/examples/babel/
2. Set breakpoint at entry.js:23
3. Click "asyncExample" button. 
4. Expect second screenshot below

### Screenshots
![image](https://user-images.githubusercontent.com/7321311/37939776-c6355bd8-3132-11e8-8452-0f0003192f24.png)

![image](https://user-images.githubusercontent.com/7321311/37939703-504ee682-3132-11e8-98b1-6cc693e21905.png)

