### PR TITLE
[Sources] Fixes full width for highlighted items with no root

### DIFF
--- a/src/components/PrimaryPanes/Sources.css
+++ b/src/components/PrimaryPanes/Sources.css
@@ -65,6 +65,12 @@
   overflow-y: auto;
 }
 
+.sources-list {
+  flex: 1;
+  display: flex;
+  overflow: hidden;
+}
+
 .sources-list .tree:focus {
   outline: none;
 }
@@ -219,11 +225,6 @@
 
 .sources-list-custom-root .sources-pane {
   display: block;
-}
-
-.sources-list-custom-root .sources-list {
-  flex: 1;
-  display: flex;
 }
 
 .sources-list-custom-root .sources-list,


### PR DESCRIPTION
Yesterday's fix created this small side effect:

<img width="258" alt="notfullwidth" src="https://user-images.githubusercontent.com/46655/37974389-731a6db0-31a2-11e8-83cd-a553ce1e67f8.png">

My fix should have just been the `overflow: hidden;` line.

### How to Test

1.  Go to https://davidwalsh.name/
2.  Squeeze the height and width of the left pane, ensure only one scrollbar and highighted items take up the whole line.  Opening the doubleclick.net dir, which has a few large file names, is helpful in this.
3.  Do the same with a directory root.