### PR TITLE
Fix alignment of line numbers in quick open

### DIFF
--- a/src/components/shared/ResultList.css
+++ b/src/components/shared/ResultList.css
@@ -28,6 +28,10 @@
   border-bottom: 1px solid var(--theme-splitter-color);
 }
 
+.result-list.small li {
+  justify-content: space-between;
+}
+
 .result-list li:hover {
   background: var(--theme-tab-toolbar-background);
 }


### PR DESCRIPTION
PR https://github.com/devtools-html/debugger.html/pull/5729 introduced a bug where alignment of line numbers was no longer to the right.  This PR fixes said bug.

<img width="839" alt="smallopen" src="https://user-images.githubusercontent.com/46655/37981379-32782dfe-31b3-11e8-90b7-b93694216e53.png">
<img width="806" alt="bigopen" src="https://user-images.githubusercontent.com/46655/37981380-328ff6d2-31b3-11e8-888f-44a650e1d6cc.png">
