### PR TITLE
Prevent anonymous functions from displaying in symbol search

### DIFF
--- a/src/components/QuickOpenModal.js
+++ b/src/components/QuickOpenModal.js
@@ -128,7 +128,10 @@ export class QuickOpenModal extends Component<Props, State> {
     let results = functions;
     if (this.isVariableQuery()) {
       results = variables;
+    } else {
+      results = results.filter(result => result.title !== "anonymous");
     }
+
     if (query === "@" || query === "#") {
       return this.setState({ results });
     }

--- a/src/components/tests/QuickOpenModal.spec.js
+++ b/src/components/tests/QuickOpenModal.spec.js
@@ -66,6 +66,27 @@ describe("QuickOpenModal", () => {
     expect(wrapper).toMatchSnapshot();
   });
 
+  test("Ensure anonymous functions do not render in QuickOpenModal", () => {
+    const { wrapper } = generateModal(
+      {
+        enabled: true,
+        query: "@",
+        searchType: "functions",
+        symbols: {
+          functions: [
+            { title: "anonymous" },
+            { title: "c" },
+            { title: "anonymous" }
+          ],
+          variables: []
+        }
+      },
+      "mount"
+    );
+    expect(wrapper.find("ResultList")).toHaveLength(1);
+    expect(wrapper.find("li")).toHaveLength(1);
+  });
+
   test("Basic render with mount & searchType = variables", () => {
     const { wrapper } = generateModal(
       {


### PR DESCRIPTION
@jasonLaster mentioned that anonymous functions were being listed in the symbol search, which is undesirable.  

## Testing

1.  Open a source with anonymous functions
2.  Type `Command+Shift+O`
3.  Notice no anonymous functions are listed

<img width="840" alt="noannons" src="https://user-images.githubusercontent.com/46655/37983840-33f3664c-31ba-11e8-928c-ba92b82c61f2.png">
