### PR TITLE
Provide Tab Keyboard Navigation

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -132,8 +132,8 @@ class App extends Component<Props, State> {
     shortcuts.on("Escape", this.onEscape);
     shortcuts.on("Cmd+/", this.onCommandSlash);
 
-    shortcuts.on("Command+Left", this.goToPreviousTab);
-    shortcuts.on("Command+Right", this.goToNextTab);
+    shortcuts.on("CmdOrCtrl+Left", this.goToPreviousTab);
+    shortcuts.on("CmdOrCtrl+Right", this.goToNextTab);
   }
 
   componentWillUnmount() {
@@ -154,8 +154,8 @@ class App extends Component<Props, State> {
 
     shortcuts.off("Escape", this.onEscape);
 
-    shortcuts.off("Command+Left", this.goToPreviousTab);
-    shortcuts.off("Command+Right", this.goToNextTab);
+    shortcuts.off("CmdOrCtrl+Left", this.goToPreviousTab);
+    shortcuts.off("CmdOrCtrl+Right", this.goToNextTab);
   }
 
   goToNextOrPreviousTab(e, goNext) {

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -90,6 +90,9 @@ class App extends Component<Props, State> {
   toggleQuickOpenModal: Function;
   onEscape: Function;
   onCommandSlash: Function;
+  goToPreviousTab: Function;
+  goToNextTab: Function;
+  goToNextOrPreviousTab: Function;
 
   constructor(props) {
     super(props);

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -59,10 +59,6 @@ import EditorTabs from "./Editor/Tabs";
 
 import QuickOpenModal from "./QuickOpenModal";
 
-function tabToNextOrPreviousTab(e, offset) {
-
-}
-
 type Props = {
   selectedSource: SourceRecord,
   selectSpecificSource: Object => void,
@@ -130,31 +126,43 @@ class App extends Component<Props, State> {
     shortcuts.on("Escape", this.onEscape);
     shortcuts.on("Cmd+/", this.onCommandSlash);
 
-    shortcuts.on("Command+Left", (_, e) => {
-      e.preventDefault();
+    shortcuts.on("Command+Left", (_, e) =>
+      this.goToNextOrPreviousTab(e, false)
+    );
+    shortcuts.on("Command+Right", (_, e) =>
+      this.goToNextOrPreviousTab(e, true)
+    );
+  }
 
-      const { selectedSource, tabSources, selectSpecificSource } = this.props;
+  goToNextOrPreviousTab(e, offset) {
+    e.preventDefault();
 
-      window.tabSources = tabSources;
+    const { selectedSource, tabSources, selectSpecificSource } = this.props;
 
-      // There needs to be multiple sources for any action to be taken
-      if (!selectedSource || this.props.tabSources.size < 2) {
-        return;
-      }
+    // There needs to be multiple sources for any action to be taken
+    if (!selectedSource || this.props.tabSources.size < 2) {
+      return;
+    }
 
-      // Get the index of the source to be selected
-      const currentIndex = tabSources.indexOf(this.props.selectedSource);
-      if (currentIndex < 0) {
-        return;
-      }
+    // Get the index of the source to be selected
+    const currentIndex = tabSources.indexOf(this.props.selectedSource);
+    if (currentIndex < 0) {
+      return;
+    }
 
-      // Calculate the next index
-      const nextIndex =
-        currentIndex === 0 ? tabSources.size - 1 : currentIndex - 1;
+    // Calculate the next index
+    let nextIndex = 0;
 
-      // Focus on the next source tab
-      selectSpecificSource(tabSources.get(nextIndex).id);
-    });
+    // Next
+    if (offset) {
+      nextIndex = currentIndex === tabSources.size - 1 ? 0 : currentIndex + 1;
+    } else {
+      // Previous
+      nextIndex = currentIndex === 0 ? tabSources.size - 1 : currentIndex - 1;
+    }
+
+    // Focus on the next source tab
+    selectSpecificSource(tabSources.get(nextIndex).id);
   }
 
   componentWillUnmount() {

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -98,6 +98,9 @@ class App extends Component<Props, State> {
       startPanelSize: 0,
       endPanelSize: 0
     };
+
+    this.goToPreviousTab = (_, e) => this.goToNextOrPreviousTab(e, false);
+    this.goToNextTab = (_, e) => this.goToNextOrPreviousTab(e, true);
   }
 
   getChildContext = () => {
@@ -126,12 +129,30 @@ class App extends Component<Props, State> {
     shortcuts.on("Escape", this.onEscape);
     shortcuts.on("Cmd+/", this.onCommandSlash);
 
-    shortcuts.on("Command+Left", (_, e) =>
-      this.goToNextOrPreviousTab(e, false)
+    shortcuts.on("Command+Left", this.goToPreviousTab);
+    shortcuts.on("Command+Right", this.goToNextTab);
+  }
+
+  componentWillUnmount() {
+    horizontalLayoutBreakpoint.removeListener(this.onLayoutChange);
+    verticalLayoutBreakpoint.removeListener(this.onLayoutChange);
+    shortcuts.off(
+      L10N.getStr("symbolSearch.search.key2"),
+      this.toggleQuickOpenModal
     );
-    shortcuts.on("Command+Right", (_, e) =>
-      this.goToNextOrPreviousTab(e, true)
-    );
+
+    const searchKeys = [
+      L10N.getStr("sources.search.key2"),
+      L10N.getStr("sources.search.alt.key")
+    ];
+    searchKeys.forEach(key => shortcuts.off(key, this.toggleQuickOpenModal));
+
+    shortcuts.off(L10N.getStr("gotoLineModal.key2"), this.toggleQuickOpenModal);
+
+    shortcuts.off("Escape", this.onEscape);
+
+    shortcuts.off("Command+Left", this.goToPreviousTab);
+    shortcuts.off("Command+Right", this.goToNextTab);
   }
 
   goToNextOrPreviousTab(e, offset) {
@@ -163,25 +184,6 @@ class App extends Component<Props, State> {
 
     // Focus on the next source tab
     selectSpecificSource(tabSources.get(nextIndex).id);
-  }
-
-  componentWillUnmount() {
-    horizontalLayoutBreakpoint.removeListener(this.onLayoutChange);
-    verticalLayoutBreakpoint.removeListener(this.onLayoutChange);
-    shortcuts.off(
-      L10N.getStr("symbolSearch.search.key2"),
-      this.toggleQuickOpenModal
-    );
-
-    const searchKeys = [
-      L10N.getStr("sources.search.key2"),
-      L10N.getStr("sources.search.alt.key")
-    ];
-    searchKeys.forEach(key => shortcuts.off(key, this.toggleQuickOpenModal));
-
-    shortcuts.off(L10N.getStr("gotoLineModal.key2"), this.toggleQuickOpenModal);
-
-    shortcuts.off("Escape", this.onEscape);
   }
 
   onEscape = (_, e) => {

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -155,7 +155,7 @@ class App extends Component<Props, State> {
     shortcuts.off("Command+Right", this.goToNextTab);
   }
 
-  goToNextOrPreviousTab(e, offset) {
+  goToNextOrPreviousTab(e, goNext) {
     e.preventDefault();
 
     const { selectedSource, tabSources, selectSpecificSource } = this.props;
@@ -175,7 +175,7 @@ class App extends Component<Props, State> {
     let nextIndex = 0;
 
     // Next
-    if (offset) {
+    if (goNext) {
       nextIndex = currentIndex === tabSources.size - 1 ? 0 : currentIndex + 1;
     } else {
       // Previous

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -17,7 +17,8 @@ import {
   getPaneCollapse,
   getActiveSearch,
   getQuickOpenEnabled,
-  getOrientation
+  getOrientation,
+  getSourcesForTabs
 } from "../selectors";
 
 import type { OrientationType } from "../reducers/types";
@@ -58,8 +59,13 @@ import EditorTabs from "./Editor/Tabs";
 
 import QuickOpenModal from "./QuickOpenModal";
 
+function tabToNextOrPreviousTab(e, offset) {
+
+}
+
 type Props = {
   selectedSource: SourceRecord,
+  selectSpecificSource: Object => void,
   orientation: OrientationType,
   startPanelCollapsed: boolean,
   endPanelCollapsed: boolean,
@@ -70,7 +76,8 @@ type Props = {
   closeProjectSearch: () => void,
   openQuickOpen: (query?: string) => void,
   closeQuickOpen: () => void,
-  setOrientation: OrientationType => void
+  setOrientation: OrientationType => void,
+  tabSources: SourcesList
 };
 
 type State = {
@@ -122,6 +129,32 @@ class App extends Component<Props, State> {
 
     shortcuts.on("Escape", this.onEscape);
     shortcuts.on("Cmd+/", this.onCommandSlash);
+
+    shortcuts.on("Command+Left", (_, e) => {
+      e.preventDefault();
+
+      const { selectedSource, tabSources, selectSpecificSource } = this.props;
+
+      window.tabSources = tabSources;
+
+      // There needs to be multiple sources for any action to be taken
+      if (!selectedSource || this.props.tabSources.size < 2) {
+        return;
+      }
+
+      // Get the index of the source to be selected
+      const currentIndex = tabSources.indexOf(this.props.selectedSource);
+      if (currentIndex < 0) {
+        return;
+      }
+
+      // Calculate the next index
+      const nextIndex =
+        currentIndex === 0 ? tabSources.size - 1 : currentIndex - 1;
+
+      // Focus on the next source tab
+      selectSpecificSource(tabSources.get(nextIndex).id);
+    });
   }
 
   componentWillUnmount() {
@@ -326,7 +359,8 @@ function mapStateToProps(state) {
     endPanelCollapsed: getPaneCollapse(state, "end"),
     activeSearch: getActiveSearch(state),
     quickOpenEnabled: getQuickOpenEnabled(state),
-    orientation: getOrientation(state)
+    orientation: getOrientation(state),
+    tabSources: getSourcesForTabs(state)
   };
 }
 

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -23,6 +23,7 @@ import {
 
 import type { OrientationType } from "../reducers/types";
 import type { SourceRecord } from "../types";
+import type { SourcesList } from "../utils/tabs";
 
 import { KeyShortcuts, Services } from "devtools-modules";
 const shortcuts = new KeyShortcuts({ window });

--- a/src/utils/tabs.js
+++ b/src/utils/tabs.js
@@ -11,7 +11,7 @@ import type { SourceRecord } from "../types";
 import type { SourceMetaDataType } from "../reducers/ast";
 import { isPretty } from "./source";
 
-type SourcesList = List<SourceRecord>;
+export type SourcesList = List<SourceRecord>;
 /*
  * Finds the hidden tabs by comparing the tabs' top offset.
  * hidden tabs will have a great top offset.


### PR DESCRIPTION
Making source tabs navigatable by key is important for usability and accessibility.  This is my prototype code.

![keyboardnavigation](https://user-images.githubusercontent.com/46655/38005247-9864143c-3205-11e8-9ffc-42a23d37f20d.gif)

## ToDo
- [x] Comment cleanup
- [x] `shortcuts.off` for both events in `componentWillUnmount`
- [x] Windows support - `CommandorControl` most likely
