### PR TITLE
Make getMappedExpression a real action and fix double-binding action creators

### DIFF
--- a/src/actions/preview.js
+++ b/src/actions/preview.js
@@ -159,16 +159,7 @@ export function setPreview(
 
         const sourceId = source.get("id");
         if (location && !isGeneratedId(sourceId)) {
-          const generatedLocation = await sourceMaps.getGeneratedLocation(
-            { ...location.start, sourceId },
-            source.toJS()
-          );
-
-          expression = await getMappedExpression(
-            { sourceMaps, getState },
-            generatedLocation,
-            expression
-          );
+          expression = await dispatch(getMappedExpression(expression));
         }
 
         const selectedFrame = getSelectedFrame(getState());

--- a/src/utils/dbg.js
+++ b/src/utils/dbg.js
@@ -1,4 +1,3 @@
-import { bindActionCreators } from "redux";
 import * as timings from "./timings";
 import { prefs, features } from "./prefs";
 import { isDevelopment } from "devtools-config";
@@ -52,11 +51,9 @@ function _formatPausePoints(dbg, url) {
 
 export function setupHelper(obj) {
   const selectors = bindSelectors(obj);
-  const actions = bindActionCreators(obj.actions, obj.store.dispatch);
   const dbg = {
     ...obj,
     selectors,
-    actions,
     prefs,
     features,
     timings,


### PR DESCRIPTION
Refs Issue: #5561

### Summary of Changes

* Convert `getMappedExpression` into a real action
* Avoid double-binding all of the actions in `dbg.actions`

