### PR TITLE
Removes getIn

### DIFF
--- a/src/reducers/ast.js
+++ b/src/reducers/ast.js
@@ -153,7 +153,7 @@ export function getSymbols(state: OuterState, source: Source): ?Symbols {
     return null;
   }
 
-  return state.ast.getIn(["symbols", source.id]) || null;
+  return state.ast.symbols.get(source.id) || null;
 }
 
 export function hasSymbols(state: OuterState, source: Source): boolean {
@@ -189,11 +189,11 @@ export function getEmptyLines(state: OuterState, source: Source) {
     return null;
   }
 
-  return state.ast.getIn(["emptyLines", source.id]);
+  return state.ast.emptyLines.get(source.id);
 }
 
 export function getPausePoints(state: OuterState, sourceId: string) {
-  return state.ast.getIn(["pausePoints", sourceId]);
+  return state.ast.pausePoints.get(sourceId);
 }
 
 export function hasPausePoints(state: OuterState, sourceId: string): boolean {
@@ -211,7 +211,7 @@ export function getPreview(state: OuterState) {
 
 const emptySourceMetaData = {};
 export function getSourceMetaData(state: OuterState, sourceId: string) {
-  return state.ast.getIn(["sourceMetaData", sourceId]) || emptySourceMetaData;
+  return state.ast.sourceMetaData.get(sourceId) || emptySourceMetaData;
 }
 
 export function hasSourceMetaData(state: OuterState, sourceId: string) {

--- a/src/reducers/file-search.js
+++ b/src/reducers/file-search.js
@@ -70,7 +70,7 @@ function update(
     }
 
     case "TOGGLE_FILE_SEARCH_MODIFIER": {
-      const actionVal = !state.getIn(["modifiers", action.modifier]);
+      const actionVal = !state.modifiers[action.modifier];
 
       if (action.modifier == "caseSensitive") {
         prefs.fileSearchCaseSensitive = actionVal;
@@ -98,15 +98,15 @@ function update(
 type OuterState = { fileSearch: Record<FileSearchState> };
 
 export function getFileSearchQuery(state: OuterState): string {
-  return state.fileSearch.get("query");
+  return state.fileSearch.query;
 }
 
 export function getFileSearchModifiers(state: OuterState): Modifiers {
-  return state.fileSearch.get("modifiers");
+  return state.fileSearch.modifiers;
 }
 
 export function getFileSearchResults(state: OuterState) {
-  return state.fileSearch.get("searchResults");
+  return state.fileSearch.searchResults;
 }
 
 export default update;

--- a/src/reducers/pending-breakpoints.js
+++ b/src/reducers/pending-breakpoints.js
@@ -139,7 +139,7 @@ function removeBreakpoint(state, action) {
   const { breakpoint } = action;
 
   const locationId = makePendingLocationId(breakpoint.location);
-  const pendingBp = state.getIn(["pendingBreakpoints", locationId]);
+  const pendingBp = state.pendingBreakpoints.get(locationId);
 
   if (!pendingBp && action.status == "start") {
     return state.set("pendingBreakpoints", I.Map());

--- a/src/reducers/sources.js
+++ b/src/reducers/sources.js
@@ -192,7 +192,7 @@ function updateSource(state: Record<SourcesState>, source: Source | Object) {
     return state;
   }
 
-  const existingSource = state.getIn(["sources", source.id]);
+  const existingSource = state.sources.get(source.id);
 
   if (existingSource) {
     const updatedSource = existingSource.merge(source);


### PR DESCRIPTION
Where possible removes immutable `getIn` calls not needed due to switch to source records.