### PR TITLE
Combines toJS calls in select.js

### DIFF
--- a/src/actions/sources/select.js
+++ b/src/actions/sources/select.js
@@ -98,8 +98,8 @@ export function selectLocation(location: Location) {
       return;
     }
 
-    const source = getSource(getState(), location.sourceId);
-    if (!source) {
+    const sourceRecord = getSource(getState(), location.sourceId);
+    if (!sourceRecord) {
       // If there is no source we deselect the current selected source
       return dispatch({ type: "CLEAR_SELECTED_SOURCE" });
     }
@@ -109,21 +109,23 @@ export function selectLocation(location: Location) {
       dispatch(closeActiveSearch());
     }
 
-    dispatch(addTab(source.toJS(), 0));
+    const source = sourceRecord.toJS();
 
+    dispatch(addTab(source, 0));
     dispatch({
       type: "SELECT_SOURCE",
-      source: source.toJS(),
+      source,
       location
     });
 
-    await dispatch(loadSourceText(source));
+    await dispatch(loadSourceText(sourceRecord));
     const selectedSource = getSelectedSource(getState());
     if (!selectedSource) {
       return;
     }
 
-    const sourceId = selectedSource.get("id");
+    const sourceId = selectedSource.id;
+
     if (
       prefs.autoPrettyPrint &&
       !getPrettySource(getState(), sourceId) &&
@@ -151,8 +153,8 @@ export function selectSpecificLocation(location: Location) {
       return;
     }
 
-    const source = getSource(getState(), location.sourceId);
-    if (!source) {
+    const sourceRecord = getSource(getState(), location.sourceId);
+    if (!sourceRecord) {
       // If there is no source we deselect the current selected source
       return dispatch({ type: "CLEAR_SELECTED_SOURCE" });
     }
@@ -162,21 +164,22 @@ export function selectSpecificLocation(location: Location) {
       dispatch(closeActiveSearch());
     }
 
-    dispatch(addTab(source.toJS(), 0));
+    const source = sourceRecord.toJS();
 
+    dispatch(addTab(source, 0));
     dispatch({
       type: "SELECT_SOURCE",
-      source: source.toJS(),
+      source,
       location
     });
 
-    await dispatch(loadSourceText(source));
+    await dispatch(loadSourceText(sourceRecord));
     const selectedSource = getSelectedSource(getState());
     if (!selectedSource) {
       return;
     }
 
-    const sourceId = selectedSource.get("id");
+    const sourceId = selectedSource.id;
     dispatch(setSymbols(sourceId));
     dispatch(setOutOfScopeLocations());
   };

--- a/src/actions/tests/tabs.spec.js
+++ b/src/actions/tests/tabs.spec.js
@@ -27,7 +27,7 @@ describe("closing tabs", () => {
     await dispatch(actions.selectLocation({ sourceId: "bar.js" }));
     dispatch(actions.closeTab("http://localhost:8000/examples/foo.js"));
 
-    expect(getSelectedSource(getState()).get("id")).toBe("bar.js");
+    expect(getSelectedSource(getState()).id).toBe("bar.js");
     expect(getSourceTabs(getState()).size).toBe(1);
   });
 


### PR DESCRIPTION
Refactor due to possible performance gains in selectLocation and selectSpecificLocation, which should make the whole application feel snappier by about a quarter of a second each time any of these functions is called.