### PR TITLE
Expose 'getMappedExpression' from debugger panel and tweak mapping

### DIFF
--- a/assets/panel/panel.js
+++ b/assets/panel/panel.js
@@ -116,6 +116,10 @@ DebuggerPanel.prototype = {
     return { frames, selected };
   },
 
+  getMappedExpression(expression) {
+    return this._actions.getMappedExpression(expression);
+  },
+
   isPaused() {
     return this._selectors.isPaused(this._getState());
   },

--- a/src/test/mochitest/browser_dbg-babel-preview.js
+++ b/src/test/mochitest/browser_dbg-babel-preview.js
@@ -85,19 +85,19 @@ add_task(async function() {
     {
       line: 5,
       column: 7,
-      expression: "doThing;",
+      expression: "doThing",
       result: "doThing(arg)",
     },
     {
       line: 5,
       column: 12,
-      expression: "x;",
+      expression: "x",
       result: "1",
     },
     {
       line: 8,
       column: 16,
-      expression: "doThing;",
+      expression: "doThing",
       result: "doThing(arg)",
     },
   ]);
@@ -110,7 +110,7 @@ add_task(async function() {
     {
       line: 2,
       column: 9,
-      expression: "aVar;",
+      expression: "aVar",
       result: '"var3"',
     },
     {
@@ -128,7 +128,7 @@ add_task(async function() {
     {
       line: 10,
       column: 11,
-      expression: "aVar;",
+      expression: "aVar",
       result: '"var3"',
     },
     {
@@ -148,7 +148,7 @@ add_task(async function() {
     {
       line: 14,
       column: 13,
-      expression: "aVar;",
+      expression: "aVar",
       result: '"var3"',
     },
     {
@@ -193,7 +193,7 @@ add_task(async function() {
     {
       line: 26,
       column: 16,
-      expression: "aNamespace;",
+      expression: "aNamespace",
       fields: [
         ['aNamed', 'a-named'],
         ['default', 'a-default'],
@@ -226,7 +226,7 @@ add_task(async function() {
     {
       line: 35,
       column: 20,
-      expression: "aNamespace2;",
+      expression: "aNamespace2",
       fields: [
         ['aNamed', 'a-named2'],
         ['default', 'a-default2'],

--- a/src/workers/parser/tests/mapOriginalExpression.spec.js
+++ b/src/workers/parser/tests/mapOriginalExpression.spec.js
@@ -23,6 +23,14 @@ describe("mapOriginalExpression", () => {
       a: "_mod.foo",
       b: "_mod.bar"
     });
-    expect(generatedExpression).toEqual("{ _mod.foo; }");
+    expect(generatedExpression).toEqual("{\n  _mod.foo;\n}");
+  });
+
+  it("skips codegen with no mappings", () => {
+    const generatedExpression = mapOriginalExpression("a + b", {
+      a: "a",
+      c: "_c"
+    });
+    expect(generatedExpression).toEqual("a + b");
   });
 });


### PR DESCRIPTION
Refs Issue: #5561

### Summary of Changes

* Expose 'getMappedExpression' on the panel for the console to use
* Avoid rewriting the expression if nothing was rewritten, and drop `concise` so that console expressions don't just get flattened into one line if the user is trying to debug something.
