### PR TITLE
Removes unused react test renderer

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,42 +18,32 @@
     "start": "node bin/dev-server",
     "start-app": "TARGET=application node bin/dev-server",
     "flow": "flow",
-    "eslint-check":
-      "eslint --print-config .eslintrc.js | eslint-config-prettier-check",
+    "eslint-check": "eslint --print-config .eslintrc.js | eslint-config-prettier-check",
     "prettier": "node bin/prettier.js",
     "license-check": "devtools-license-check",
     "links": "ls -l node_modules/ | grep ^l || echo 'no linked packages'",
     "lint": "run-p lint-css lint-js lint-md",
     "lint-css": "stylelint \"src/components/**/*.css\"",
     "lint-js": "eslint *.js \"src/**/*.js\" --fix",
-    "lint-md":
-      "remark -u devtools-linters/markdown/preset -qf *.md src configs docs",
+    "lint-md": "remark -u devtools-linters/markdown/preset -qf *.md src configs docs",
     "lint-fix": "yarn lint-js -- --fix",
-    "mochi":
-      "mochii --mc ./firefox --interactive --default-test-path devtools/client/debugger/new",
+    "mochi": "mochii --mc ./firefox --interactive --default-test-path devtools/client/debugger/new",
     "mochid": "yarn mochi -- --jsdebugger --",
     "mochir": "yarn mochi -- --repeat 10 --",
     "mochih": "yarn mochi -- --headless --",
-    "mochici":
-      "mochii --mc ./firefox --ci --default-test-path devtools/client/debugger/new --headless --",
+    "mochici": "mochii --mc ./firefox --ci --default-test-path devtools/client/debugger/new --headless --",
     "test": "jest",
     "test:watch": "jest --watch",
     "test-coverage": "yarn test -- --coverage",
     "test-all": "yarn test; yarn lint; yarn flow",
-    "firefox":
-      "start-firefox --start --location https://devtools-html.github.io/debugger-examples/",
-    "chrome":
-      "start-chrome --location https://devtools-html.github.io/debugger-examples/",
+    "firefox": "start-firefox --start --location https://devtools-html.github.io/debugger-examples/",
+    "chrome": "start-chrome --location https://devtools-html.github.io/debugger-examples/",
     "copy-assets": "node bin/copy-assets --symlink",
     "copy-assets-watch": "node bin/copy-assets --watch --symlink",
-    "build-docs":
-      "documentation build --format html --sort-order alpha --shallow  --document-exported --output docs/reference/ src/types.js src/utils/ src/reducers/ src/actions/ src/test/mochitest/head.js",
-    "flow-coverage":
-      "flow-coverage-report --threshold 50 -i 'src/actions/*.js' -i 'src/reducers/*.js' -i 'src/utils/*.js' -i 'src/components/*.js' -i 'src/components/**/*.js' -t html -t text",
-    "flow-utils":
-      "flow-coverage-report -i 'src/utils/*.js' -i 'src/utils/**/*.js' -t text",
-    "flow-redux":
-      "flow-coverage-report  -i 'src/reducers/*.js' -i 'src/actions/*.js'  -t text",
+    "build-docs": "documentation build --format html --sort-order alpha --shallow  --document-exported --output docs/reference/ src/types.js src/utils/ src/reducers/ src/actions/ src/test/mochitest/head.js",
+    "flow-coverage": "flow-coverage-report --threshold 50 -i 'src/actions/*.js' -i 'src/reducers/*.js' -i 'src/utils/*.js' -i 'src/components/*.js' -i 'src/components/**/*.js' -t html -t text",
+    "flow-utils": "flow-coverage-report -i 'src/utils/*.js' -i 'src/utils/**/*.js' -t text",
+    "flow-redux": "flow-coverage-report  -i 'src/reducers/*.js' -i 'src/actions/*.js'  -t text",
     "flow-react": "flow-coverage-report -i 'src/components/**/*.js' -t text",
     "postcheckout": "node bin/post-checkout.js",
     "postmerge": "node bin/post-merge.js",
@@ -95,9 +85,18 @@
     "svg-inline-react": "^3.0.0",
     "wasmparser": "^0.5.2"
   },
-  "files": ["src", "assets"],
+  "files": [
+    "src",
+    "assets"
+  ],
   "greenkeeper": {
-    "ignore": ["react", "react-dom", "react-redux", "redux", "codemirror"]
+    "ignore": [
+      "react",
+      "react-dom",
+      "react-redux",
+      "redux",
+      "codemirror"
+    ]
   },
   "main": "src/main.js",
   "author": "Jason Laster <jlaster@mozilla.com>",
@@ -140,7 +139,6 @@
     "npm-run-all": "^4.0.2",
     "prettier": "^1.10.2",
     "pretty-quick": "^1.4.1",
-    "react-test-renderer": "16.3.0",
     "remark-cli": "^5.0.0",
     "remark-lint": "^6.0.1",
     "remark-lint-list-item-bullet-indent": "^1.0.1",
@@ -162,11 +160,26 @@
     "workerjs": "github:jasonLaster/workerjs"
   },
   "lint-staged": {
-    "*.js": ["prettier", "git add"],
-    "src/*.js": ["prettier", "git add"],
-    "src/*/*.js": ["prettier", "git add"],
-    "src/*/!(mochitest)**/*.js": ["prettier", "git add"],
-    "src/*/!(mochitest)*/**/*.js": ["prettier", "git add"]
+    "*.js": [
+      "prettier",
+      "git add"
+    ],
+    "src/*.js": [
+      "prettier",
+      "git add"
+    ],
+    "src/*/*.js": [
+      "prettier",
+      "git add"
+    ],
+    "src/*/!(mochitest)**/*.js": [
+      "prettier",
+      "git add"
+    ],
+    "src/*/!(mochitest)*/**/*.js": [
+      "prettier",
+      "git add"
+    ]
   },
   "jest": {
     "testPathIgnorePatterns": [
@@ -184,9 +197,14 @@
       "!**/*.mock.js",
       "!**/*.spec.js"
     ],
-    "transformIgnorePatterns": ["node_modules/(?!devtools-)"],
+    "transformIgnorePatterns": [
+      "node_modules/(?!devtools-)"
+    ],
     "setupTestFrameworkScriptFile": "<rootDir>/src/test/tests-setup.js",
-    "setupFiles": ["<rootDir>/src/test/shim.js", "jest-localstorage-mock"],
+    "setupFiles": [
+      "<rootDir>/src/test/shim.js",
+      "jest-localstorage-mock"
+    ],
     "snapshotSerializers": [
       "jest-serializer-babel-ast",
       "enzyme-to-json/serializer"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8164,10 +8164,6 @@ react-inlinesvg@^0.8.1:
     httpplease "^0.16.4"
     once "^1.4.0"
 
-react-is@^16.3.0:
-  version "16.3.0"
-  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.3.0.tgz#f0e8bfd8c09b480dd610b8639d9ed65c13601224"
-
 react-reconciler@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/react-reconciler/-/react-reconciler-0.7.0.tgz#9614894103e5f138deeeb5eabaf3ee80eb1d026d"
@@ -8187,15 +8183,6 @@ react-redux@^5.0.6, react-redux@^5.0.7:
     lodash-es "^4.17.5"
     loose-envify "^1.1.0"
     prop-types "^15.6.0"
-
-react-test-renderer@16.3.0:
-  version "16.3.0"
-  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.3.0.tgz#7e88d8cb4c2b95c161b6c6c998991166f74d473e"
-  dependencies:
-    fbjs "^0.8.16"
-    object-assign "^4.1.1"
-    prop-types "^15.6.0"
-    react-is "^16.3.0"
 
 react-test-renderer@^16.0.0-0:
   version "16.2.0"


### PR DESCRIPTION
We are not using react test renderer at all. At the same time we have enzyme, which does the same thing. Removing the less versatile option will lower the number of dependencies.

Also prettify insisted on reformatting the code in the files...