### PR TITLE
Remove executeSoon()

### DIFF
--- a/src/actions/utils/middleware/promise.js
+++ b/src/actions/utils/middleware/promise.js
@@ -5,7 +5,6 @@
 // @flow
 
 import { fromPairs, toPairs } from "lodash";
-import { executeSoon } from "../../../utils/DevToolsUtils";
 
 import type { ThunkArgs } from "../../types";
 
@@ -40,20 +39,16 @@ function promiseMiddleware({
     // want to.
     return promiseInst
       .then(value => {
-        executeSoon(() => {
-          dispatch({ ...action, status: "done", value: value });
-        });
-        Promise.resolve(value);
+        dispatch({ ...action, status: "done", value: value });
+        return value;
       })
       .catch(error => {
-        executeSoon(() => {
-          dispatch({
-            ...action,
-            status: "error",
-            error: error.message || error
-          });
-          Promise.reject(error);
+        dispatch({
+          ...action,
+          status: "error",
+          error: error.message || error
         });
+        throw error;
       });
   };
 }

--- a/src/test/mochitest/.eslintrc
+++ b/src/test/mochitest/.eslintrc
@@ -7,7 +7,6 @@
     "ContentTask": false,
     "ContentTaskUtils": false,
     "EventUtils": false,
-    "executeSoon": false,
     "expectUncaughtException": false,
     "export_assertions": false,
     "extractJarToTmp": false,

--- a/src/utils/DevToolsUtils.js
+++ b/src/utils/DevToolsUtils.js
@@ -9,8 +9,4 @@ export function reportException(who, exception) {
   console.error(msg, exception);
 }
 
-export function executeSoon(fn) {
-  setTimeout(fn, 0);
-}
-
 export default assert;

--- a/src/utils/tests/DevToolsUtils.spec.js
+++ b/src/utils/tests/DevToolsUtils.spec.js
@@ -1,4 +1,4 @@
-import { reportException, executeSoon } from "../DevToolsUtils.js";
+import { reportException } from "../DevToolsUtils.js";
 
 describe("DevToolsUtils", () => {
   describe("reportException", () => {
@@ -19,17 +19,6 @@ describe("DevToolsUtils", () => {
       reportException(who, exception);
 
       expect(console.error).toBeCalledWith(`${who}${msgTxt}`, exception);
-    });
-  });
-
-  describe("executeSoon", () => {
-    it("calls setTimeout with 0 ms", () => {
-      global.setTimeout = jest.fn();
-      const fnc = () => {};
-
-      executeSoon(fnc);
-
-      expect(setTimeout).toBeCalledWith(fnc, 0);
     });
   });
 });


### PR DESCRIPTION
If I understand correctly we use executeSoon in the promises to delay dispatching an action until the moment when there is a free spot in the event loop. This leads to nested promises and a situation where I believe we could achieve a very similar thing just by returning one promise.

The suggestion contains a full version of the implementation. I'd be very interested in insights on this matter.