### PR TITLE
Fix tabs.spec.js test errors

### DIFF
--- a/src/actions/tests/helpers/threadClient.js
+++ b/src/actions/tests/helpers/threadClient.js
@@ -1,6 +1,7 @@
 import { makeLocationId } from "../../../utils/breakpoint";
 
 function createSource(name) {
+  name = name.replace(/\..*$/, "");
   return {
     source: `function ${name}() {\n  return ${name} \n}`,
     contentType: "text/javascript"


### PR DESCRIPTION
I recently added this `console.error` [here](https://github.com/devtools-html/debugger.html/commit/06e82dbd659e6ff4c326ad3f41241ede0079e428#diff-ab92a985751230e38d1bb820de8456cbR57)

So we're now seeing syntax errors in our test.