### PR TITLE
New Breakpoints UI: Group Breakpoints

### DIFF
--- a/src/components/SecondaryPanes/Breakpoints.css
+++ b/src/components/SecondaryPanes/Breakpoints.css
@@ -10,20 +10,32 @@
   user-select: none;
 }
 
+.breakpoints-list .breakpoint-heading {
+  text-overflow: ellipsis;
+  overflow: hidden;
+}
+
+.breakpoints-list .breakpoint-heading,
 .breakpoints-list .breakpoint {
   font-size: 12px;
   color: var(--theme-content-color1);
-  padding: 0.5em 1em 0.5em 0.5em;
   line-height: 1em;
   position: relative;
   transition: all 0.25s ease;
+  padding: 0.5em 1em 0.5em 0.5em;
 }
 
-html[dir="rtl"] .breakpoints-list .breakpoint {
+.breakpoints-list .breakpoint {
+  display: flex;
+}
+
+html[dir="rtl"] .breakpoints-list .breakpoint,
+html[dir="rtl"] .breakpoints-list .breakpoint-heading {
   border-right: 4px solid transparent;
 }
 
-html:not([dir="rtl"]) .breakpoints-list .breakpoint {
+html:not([dir="rtl"]) .breakpoints-list .breakpoint,
+html:not([dir="rtl"]) .breakpoints-list .breakpoint-heading {
   border-left: 4px solid transparent;
 }
 
@@ -53,6 +65,27 @@ html .breakpoints-list .breakpoint.paused {
   background-color: var(--search-overlays-semitransparent);
 }
 
+.breakpoints-list .breakpoint .breakpoint-line,
+.breakpoints-list .breakpoint-label {
+  font-family: var(--monospace-font-family);
+}
+
+.breakpoints-list .breakpoint .breakpoint-line {
+  font-size: 11px;
+  color: var(--theme-comment);
+  padding-top: 3px;
+  min-width: 14px;
+  text-align: right;
+}
+
+html[dir="rtl"] .breakpoints-list .breakpoint .breakpoint-line {
+  text-align: left;
+}
+
+.breakpoints-list .breakpoint:hover .breakpoint-line {
+  display: none;
+}
+
 .breakpoints-list .breakpoint.paused:hover {
   border-color: var(--breakpoint-active-color-hover);
 }
@@ -62,6 +95,10 @@ html .breakpoints-list .breakpoint.paused {
   display: inline-block;
   padding-inline-start: 2px;
   cursor: default;
+  flex-grow: 1;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  padding-top: 3px;
 }
 
 .breakpoint-label .breakpoint-checkbox {
@@ -88,6 +125,11 @@ html .breakpoints-list .breakpoint.paused {
   offset-inline-end: 13px;
   offset-inline-start: auto;
   top: 9px;
+  display: none;
+}
+
+.breakpoint:hover .close-btn {
+  display: flex;
 }
 
 .breakpoint .close {

--- a/src/test/mochitest/browser_dbg-breakpoints-toggle.js
+++ b/src/test/mochitest/browser_dbg-breakpoints-toggle.js
@@ -1,12 +1,12 @@
 function toggleBreakpoint(dbg, index) {
-  const bp = findElement(dbg, "breakpointItem", index);
+  const bp = findAllElements(dbg, "breakpointItems")[index];
   const input = bp.querySelector("input");
   input.click();
 }
 
 async function removeBreakpoint(dbg, index) {
   const removed = waitForDispatch(dbg, "REMOVE_BREAKPOINT");
-  const bp = findElement(dbg, "breakpointItem", index);
+  const bp = findAllElements(dbg, "breakpointItems")[index];
   bp.querySelector(".close-btn").click();
   await removed;
 }
@@ -80,8 +80,8 @@ add_task(async function() {
   is(bp2.disabled, false, "second breakpoint is enabled");
 
   // Remove the breakpoints
-  await removeBreakpoint(dbg, 1);
-  await removeBreakpoint(dbg, 1);
+  await removeBreakpoint(dbg, 0);
+  await removeBreakpoint(dbg, 0);
 
   const bps = findBreakpoints(dbg);
 

--- a/src/test/mochitest/browser_dbg-breakpoints.js
+++ b/src/test/mochitest/browser_dbg-breakpoints.js
@@ -2,16 +2,9 @@
  * http://creativecommons.org/publicdomain/zero/1.0/ */
 
 function toggleBreakpoint(dbg, index) {
-  const bp = findElement(dbg, "breakpointItem", index);
+  const bp = findAllElements(dbg, "breakpointItems")[index];
   const input = bp.querySelector("input");
   input.click();
-}
-
-async function removeBreakpoint(dbg, index) {
-  const removed = waitForDispatch(dbg, "REMOVE_BREAKPOINT");
-  const bp = findElement(dbg, "breakpointItem", index);
-  bp.querySelector(".close-btn").click();
-  await removed;
 }
 
 async function disableBreakpoint(dbg, index) {
@@ -62,15 +55,15 @@ add_task(async function() {
   await addBreakpoint(dbg, "simple2", 5);
 
   // Disable the first one
-  await disableBreakpoint(dbg, 1);
+  await disableBreakpoint(dbg, 0);
   let bp1 = findBreakpoint(dbg, "simple2", 3);
   let bp2 = findBreakpoint(dbg, "simple2", 5);
   is(bp1.disabled, true, "first breakpoint is disabled");
   is(bp2.disabled, false, "second breakpoint is enabled");
 
   // Disable and Re-Enable the second one
-  await disableBreakpoint(dbg, 2);
-  await enableBreakpoint(dbg, 2);
+  await disableBreakpoint(dbg, 1);
+  await enableBreakpoint(dbg, 1);
   bp2 = findBreakpoint(dbg, "simple2", 5);
   is(bp2.disabled, false, "second breakpoint is enabled");
 });

--- a/src/test/mochitest/browser_dbg-browser-content-toolbox.js
+++ b/src/test/mochitest/browser_dbg-browser-content-toolbox.js
@@ -14,7 +14,7 @@ const {
 } = require("devtools/client/framework/devtools-browser");
 
 function toggleBreakpoint(dbg, index) {
-  const bp = findElement(dbg, "breakpointItem", index);
+  const bp = findAllElements(dbg, "breakpointItems")[index];
   const input = bp.querySelector("input");
   input.click();
 }
@@ -57,12 +57,12 @@ add_task(async function() {
   await addBreakpoint(dbg, "simple2", 3);
 
   info("Disable the breakpoint");
-  await disableBreakpoint(dbg, 1);
+  await disableBreakpoint(dbg, 0);
   let bp = findBreakpoint(dbg, "simple2", 3);
   is(bp.disabled, true, "breakpoint is disabled");
 
   info("Enable the breakpoint");
-  await enableBreakpoint(dbg, 1);
+  await enableBreakpoint(dbg, 0);
   bp = findBreakpoint(dbg, "simple2", 3);
   is(bp.disabled, false, "breakpoint is enabled");
 

--- a/src/test/mochitest/head.js
+++ b/src/test/mochitest/head.js
@@ -943,7 +943,8 @@ const selectors = {
     `.expressions-list .expression-container:nth-child(${i}) .close`,
   expressionNodes: ".expressions-list .tree-node",
   scopesHeader: ".scopes-pane ._header",
-  breakpointItem: i => `.breakpoints-list .breakpoint:nth-child(${i})`,
+  breakpointItem: i => `.breakpoints-list .breakpoint:nth-of-type(${i})`,
+  breakpointItems: `.breakpoints-list .breakpoint`,
   scopes: ".scopes-list",
   scopeNode: i => `.scopes-list .tree-node:nth-child(${i}) .object-label`,
   scopeValue: i =>


### PR DESCRIPTION
Fixes Issue: #5796

This is a WIP for the grouping of breakpoints for the new breakpoints UI.  

## ToDo
- [x] Remove the `renderSourceLocation` function once I'm confident all its contents are accounted for
- [x] Remove hardcoded breakpoint text once https://github.com/devtools-html/debugger.html/pull/5823 has been merged

I'm thinking that syntax highlighting via CodeMirror can be done as a separate PR since it will likely require more thought and, IMO, shouldn't block this.

## Screenshots
![goodalignment](https://user-images.githubusercontent.com/46655/38208575-24991662-3677-11e8-99a8-e67ddffde026.gif)
