### PR TITLE
Turn off auto-pretty-print by default for dev mode

### DIFF
--- a/src/utils/prefs.js
+++ b/src/utils/prefs.js
@@ -13,7 +13,7 @@ const pref = Services.pref;
 
 if (isDevelopment()) {
   pref("devtools.debugger.alphabetize-outline", false);
-  pref("devtools.debugger.auto-pretty-print", true);
+  pref("devtools.debugger.auto-pretty-print", false);
   pref("devtools.source-map.client-service.enabled", true);
   pref("devtools.debugger.pause-on-exceptions", false);
   pref("devtools.debugger.ignore-caught-exceptions", false);


### PR DESCRIPTION
This is causing too many issues at the moment.  We should turn it off in dev mode until we have the time to tidy everything up.