### PR TITLE
Enable better travis VMs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: python
 node_js: "8"
 
+sudo: required
+
 cache:
   - pip
   - yarn


### PR DESCRIPTION
We are experimenting with better travis vms

```

Hey Jason,

Thank you for your reply and I'm sorry for the confusion.

It looks like your builds aren't running on the right infrastructure to enable these bigger VMs. Hence, could you add the following to your .travis.yml file to route your builds to the right place:

sudo: required

We'll extend the trial until Friday EOD this week and we'll follow-up with you next Monday to see how it went.

Thank you for your patience and talk to you next week!

Cheers,

-- Dominic.


```