### PR TITLE
Switched getExtraProps to use findClosestFunction to get the component name.

### DIFF
--- a/src/actions/ast.js
+++ b/src/actions/ast.js
@@ -11,7 +11,8 @@ import {
   isPaused
 } from "../selectors";
 
-import { mapFrames } from "./pause";
+import { mapFrames, setExtra } from "./pause";
+
 import { setInScopeLines } from "./ast/setInScopeLines";
 import {
   getSymbols,
@@ -68,6 +69,7 @@ export function setSymbols(sourceId: SourceId) {
     );
 
     if (isPaused(getState())) {
+      await dispatch(setExtra());
       await dispatch(mapFrames());
     }
 

--- a/src/actions/pause/fetchExtra.js
+++ b/src/actions/pause/fetchExtra.js
@@ -1,0 +1,24 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
+// @flow
+
+import { getSelectedFrame } from "../../selectors";
+import { getExtra } from "../preview";
+import type { ThunkArgs } from "../types";
+
+export function fetchExtra() {
+  return async function({ dispatch, getState }: ThunkArgs) {
+    const frame = getSelectedFrame(getState());
+    if (!frame) {
+      return;
+    }
+
+    const extra = await dispatch(getExtra("this;", frame.this, frame));
+    dispatch({
+      type: "ADD_EXTRA",
+      extra: extra
+    });
+  };
+}

--- a/src/actions/pause/fetchScopes.js
+++ b/src/actions/pause/fetchScopes.js
@@ -6,9 +6,8 @@
 
 import { getSelectedFrame, getGeneratedFrameScope } from "../../selectors";
 import { mapScopes } from "./mapScopes";
-import { getExtra } from "../preview";
 import { PROMISE } from "../utils/middleware/promise";
-
+import { setExtra } from "./setExtra";
 import type { ThunkArgs } from "../types";
 
 export function fetchScopes() {
@@ -18,15 +17,13 @@ export function fetchScopes() {
       return;
     }
 
-    const extra = await dispatch(getExtra("this;", frame.this, frame));
-
     const scopes = dispatch({
       type: "ADD_SCOPES",
       frame,
-      extra,
       [PROMISE]: client.getFrameScopes(frame)
     });
 
+    await dispatch(setExtra());
     await dispatch(mapScopes(scopes, frame));
   };
 }

--- a/src/actions/pause/index.js
+++ b/src/actions/pause/index.js
@@ -25,6 +25,7 @@ export { resumed } from "./resumed";
 export { continueToHere } from "./continueToHere";
 export { breakOnNext } from "./breakOnNext";
 export { mapFrames } from "./mapFrames";
+export { setExtra } from "./setExtra";
 export { setPopupObjectProperties } from "./setPopupObjectProperties";
 export { pauseOnExceptions } from "./pauseOnExceptions";
 export { selectFrame } from "./selectFrame";

--- a/src/actions/pause/mapFrames.js
+++ b/src/actions/pause/mapFrames.js
@@ -37,10 +37,7 @@ export function mapDisplayNames(frames: Frame[], getState: () => State) {
       return frame;
     }
 
-    const originalFunction = findClosestFunction(
-      symbols.functions,
-      frame.location
-    );
+    const originalFunction = findClosestFunction(symbols, frame.location);
 
     if (!originalFunction) {
       return frame;

--- a/src/actions/pause/setExtra.js
+++ b/src/actions/pause/setExtra.js
@@ -1,0 +1,18 @@
+// @flow
+
+import { getSymbols, getSource, getSelectedFrame } from "../../selectors";
+import { fetchExtra } from "./fetchExtra";
+
+import type { ThunkArgs } from "../types";
+
+export function setExtra() {
+  return async function({ dispatch, getState, sourceMaps }: ThunkArgs) {
+    const frame = getSelectedFrame(getState());
+    const source = getSource(getState(), frame.location.sourceId);
+    const symbols = getSymbols(getState(), source);
+
+    if (symbols && symbols.classes) {
+      dispatch(fetchExtra());
+    }
+  };
+}

--- a/src/actions/types.js
+++ b/src/actions/types.js
@@ -317,9 +317,12 @@ type PauseAction =
       frames: Frame[]
     |}
   | {|
+      type: "ADD_EXTRA",
+      extra: any
+    |}
+  | {|
       type: "ADD_SCOPES",
       frame: Frame,
-      extra: any,
       status: AsyncStatus,
       value: Scope
     |};

--- a/src/components/Editor/EditorMenu.js
+++ b/src/components/Editor/EditorMenu.js
@@ -251,7 +251,7 @@ export default connect(
           getSymbols(state, selectedSource)
         ),
       getFunctionLocation: line =>
-        findClosestFunction(getSymbols(state, selectedSource).functions, {
+        findClosestFunction(getSymbols(state, selectedSource), {
           line,
           column: Infinity
         })

--- a/src/reducers/pause.js
+++ b/src/reducers/pause.js
@@ -130,8 +130,12 @@ function update(
       return { ...state, frames: action.frames };
     }
 
+    case "ADD_EXTRA": {
+      return { ...state, extra: action.extra };
+    }
+
     case "ADD_SCOPES": {
-      const { frame, extra, status, value } = action;
+      const { frame, status, value } = action;
       const selectedFrameId = frame.id;
 
       const generated = {
@@ -143,7 +147,6 @@ function update(
       };
       return {
         ...state,
-        extra: extra,
         frameScopes: {
           ...state.frameScopes,
           generated

--- a/src/utils/ast.js
+++ b/src/utils/ast.js
@@ -8,11 +8,14 @@ import { without, range } from "lodash";
 
 import type { Location, Source, ColumnPosition } from "../types";
 
-import type { AstPosition, AstLocation, PausePoint } from "../workers/parser";
 import type {
+  AstPosition,
+  AstLocation,
+  PausePoint,
+  SymbolDeclaration,
   SymbolDeclarations,
-  FunctionDeclaration
-} from "../workers/parser/getSymbols";
+  ClassDeclaration
+} from "../workers/parser";
 
 export function findBestMatchExpression(
   symbols: SymbolDeclarations,
@@ -68,11 +71,11 @@ export function containsPosition(a: AstLocation, b: AstPosition) {
   return startsBefore && endsAfter;
 }
 
-export function findClosestFunction(
-  functions: FunctionDeclaration[],
+function findClosestofSymbolDeclaration(
+  declarations: SymbolDeclaration[] | ClassDeclaration[],
   location: Location
 ) {
-  return functions.reduce((found, currNode) => {
+  return declarations.reduce((found, currNode) => {
     if (
       currNode.name === "anonymous" ||
       !containsPosition(currNode.location, {
@@ -99,4 +102,26 @@ export function findClosestFunction(
 
     return currNode;
   }, null);
+}
+
+export function findClosestFunction(
+  symbols: SymbolDeclarations,
+  location: Location
+) {
+  const { functions } = symbols;
+  if (!functions) {
+    return null;
+  }
+  return findClosestofSymbolDeclaration(functions, location);
+}
+
+export function findClosestClass(
+  symbols: SymbolDeclarations,
+  location: Location
+) {
+  const { classes } = symbols;
+  if (!classes) {
+    return null;
+  }
+  return findClosestofSymbolDeclaration(classes, location);
 }

--- a/src/utils/ast.js
+++ b/src/utils/ast.js
@@ -12,7 +12,7 @@ import type {
   AstPosition,
   AstLocation,
   PausePoint,
-  SymbolDeclaration,
+  FunctionDeclaration,
   SymbolDeclarations,
   ClassDeclaration
 } from "../workers/parser";
@@ -72,7 +72,7 @@ export function containsPosition(a: AstLocation, b: AstPosition) {
 }
 
 function findClosestofSymbolDeclaration(
-  declarations: SymbolDeclaration[] | ClassDeclaration[],
+  declarations: FunctionDeclaration[] | ClassDeclaration[],
   location: Location
 ) {
   return declarations.reduce((found, currNode) => {

--- a/src/utils/ast.js
+++ b/src/utils/ast.js
@@ -12,9 +12,7 @@ import type {
   AstPosition,
   AstLocation,
   PausePoint,
-  FunctionDeclaration,
-  SymbolDeclarations,
-  ClassDeclaration
+  SymbolDeclarations
 } from "../workers/parser";
 
 export function findBestMatchExpression(
@@ -71,10 +69,11 @@ export function containsPosition(a: AstLocation, b: AstPosition) {
   return startsBefore && endsAfter;
 }
 
-function findClosestofSymbolDeclaration(
-  declarations: FunctionDeclaration[] | ClassDeclaration[],
-  location: Location
-) {
+function findClosestofSymbol(declarations: any[], location: Location) {
+  if (!declarations) {
+    return null;
+  }
+
   return declarations.reduce((found, currNode) => {
     if (
       currNode.name === "anonymous" ||
@@ -109,10 +108,7 @@ export function findClosestFunction(
   location: Location
 ) {
   const { functions } = symbols;
-  if (!functions) {
-    return null;
-  }
-  return findClosestofSymbolDeclaration(functions, location);
+  return findClosestofSymbol(functions, location);
 }
 
 export function findClosestClass(
@@ -120,8 +116,5 @@ export function findClosestClass(
   location: Location
 ) {
   const { classes } = symbols;
-  if (!classes) {
-    return null;
-  }
-  return findClosestofSymbolDeclaration(classes, location);
+  return findClosestofSymbol(classes, location);
 }

--- a/src/utils/breakpoint/astBreakpointLocation.js
+++ b/src/utils/breakpoint/astBreakpointLocation.js
@@ -20,9 +20,7 @@ export function getASTLocation(
     return { name: undefined, offset: location };
   }
 
-  const functions = [...symbols.functions];
-
-  const scope = findClosestFunction(functions, location);
+  const scope = findClosestFunction(symbols, location);
   if (scope) {
     // we only record the line, but at some point we may
     // also do column offsets

--- a/src/utils/function.js
+++ b/src/utils/function.js
@@ -6,7 +6,7 @@ import { findClosestFunction } from "./ast";
 import { correctIndentation } from "./indentation";
 
 export function findFunctionText(line, source, symbols) {
-  const func = findClosestFunction(symbols.functions, {
+  const func = findClosestFunction(symbols, {
     line,
     column: Infinity
   });

--- a/src/workers/parser/index.js
+++ b/src/workers/parser/index.js
@@ -44,6 +44,7 @@ export type {
 
 export type { AstLocation, AstPosition, PausePoint } from "./types";
 export type {
+  ClassDeclaration,
   SymbolDeclaration,
   SymbolDeclarations,
   FunctionDeclaration


### PR DESCRIPTION
### Summary of Changes
- Changed getExtraProps to use findClosestFunction, which has now been changed to findClosestofSymbolDeclaration to find the name of the component even when in production  code.

### Screenshots
Before
<img width="599" alt="screen shot 2018-04-03 at 1 58 12 pm" src="https://user-images.githubusercontent.com/14250545/38272818-96739732-3747-11e8-8a81-064c60871eaf.png">

After
<img width="592" alt="screen shot 2018-04-03 at 2 02 36 pm" src="https://user-images.githubusercontent.com/14250545/38272854-b6ac7370-3747-11e8-856e-47a5edcdb57a.png">

