### PR TITLE
Started highlighting the searched terms when clicking on a ProjectSearch result

### DIFF
--- a/src/actions/navigation.js
+++ b/src/actions/navigation.js
@@ -4,7 +4,7 @@
 
 // @flow
 
-import { clearDocuments } from "../utils/editor";
+import { clearDocuments, removeEditor } from "../utils/editor";
 import sourceQueue from "../utils/source-queue";
 import { getSources } from "../reducers/sources";
 import { waitForMs } from "../utils/utils";
@@ -37,6 +37,7 @@ export function willNavigate(event: Object) {
     await sourceMaps.clearSourceMaps();
     clearWasmStates();
     clearDocuments();
+    removeEditor();
     clearSymbols();
     clearASTs();
     clearScopes();

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -53,6 +53,7 @@ import {
   getCursorLine,
   toSourceLine,
   getDocument,
+  setEditor,
   scrollToColumn,
   toEditorPosition,
   getSourceLocationFromMouseEvent,
@@ -177,6 +178,7 @@ class Editor extends PureComponent<Props, State> {
     }
 
     this.setState({ editor });
+    setEditor(editor);
     return editor;
   }
 

--- a/src/components/ProjectSearch.js
+++ b/src/components/ProjectSearch.js
@@ -11,6 +11,7 @@ import classnames from "classnames";
 import { bindActionCreators } from "redux";
 import actions from "../actions";
 
+import { getEditor } from "../utils/editor";
 import { highlightMatches } from "../utils/project-search";
 
 import { statusType } from "../reducers/project-text-search";
@@ -31,6 +32,7 @@ import type { List } from "immutable";
 import type { Location } from "../types";
 import type { ActiveSearchType } from "../reducers/types";
 import type { StatusType } from "../reducers/project-text-search";
+type Editor = ?Object;
 
 import "./ProjectSearch.css";
 
@@ -68,7 +70,13 @@ type Props = {
   closeProjectSearch: () => void,
   searchSources: (query: string) => void,
   clearSearch: () => void,
-  selectLocation: (location: Location, tabIndex?: string) => void
+  selectLocation: (location: Location, tabIndex?: string) => void,
+  doSearchForHighlight: (
+    query: string,
+    editor: Editor,
+    line: number,
+    column: number
+  ) => void
 };
 
 function getFilePath(item: Item, index?: number) {
@@ -133,6 +141,12 @@ export class ProjectSearch extends Component<Props, State> {
 
   selectMatchItem = (matchItem: Match) => {
     this.props.selectLocation({ ...matchItem });
+    this.props.doSearchForHighlight(
+      this.state.inputValue,
+      getEditor(),
+      matchItem.line,
+      matchItem.column
+    );
   };
 
   getResults = (): Result[] => {

--- a/src/components/tests/ProjectSearch.spec.js
+++ b/src/components/tests/ProjectSearch.spec.js
@@ -56,6 +56,7 @@ function render(overrides = {}, mounted = false) {
     clearSearch: jest.fn(),
     updateSearchStatus: jest.fn(),
     selectLocation: jest.fn(),
+    doSearchForHighlight: jest.fn(),
     ...overrides
   };
 

--- a/src/components/tests/__snapshots__/ProjectSearch.spec.js.snap
+++ b/src/components/tests/__snapshots__/ProjectSearch.spec.js.snap
@@ -41,6 +41,7 @@ exports[`ProjectSearch found search results 1`] = `
   activeSearch="project"
   clearSearch={[Function]}
   closeProjectSearch={[Function]}
+  doSearchForHighlight={[Function]}
   query="match"
   results={
     Immutable.List [

--- a/src/utils/editor/index.js
+++ b/src/utils/editor/index.js
@@ -19,6 +19,21 @@ import { isOriginalId } from "devtools-source-map";
 import type { AstLocation } from "../../workers/parser";
 import type { EditorPosition, EditorRange } from "../editor/types";
 import type { Location } from "../../types";
+type Editor = Object;
+
+let editor: ?Editor;
+
+export function setEditor(_editor: Editor) {
+  editor = _editor;
+}
+
+export function getEditor() {
+  return editor;
+}
+
+export function removeEditor() {
+  editor = null;
+}
 
 export function shouldShowPrettyPrint(selectedSource) {
   if (!selectedSource) {
@@ -122,21 +137,21 @@ function isVisible(codeMirror: any, top: number, left: number) {
   return inXView && inYView;
 }
 
-export function markText(editor: any, className, { start, end }: EditorRange) {
-  return editor.codeMirror.markText(
+export function markText(_editor: any, className, { start, end }: EditorRange) {
+  return _editor.codeMirror.markText(
     { ch: start.column, line: start.line },
     { ch: end.column, line: end.line },
     { className }
   );
 }
 
-export function lineAtHeight(editor, sourceId, event) {
-  const editorLine = editor.codeMirror.lineAtHeight(event.clientY);
-  return toSourceLine(sourceId, editorLine);
+export function lineAtHeight(_editor, sourceId, event) {
+  const _editorLine = _editor.codeMirror.lineAtHeight(event.clientY);
+  return toSourceLine(sourceId, _editorLine);
 }
 
-export function getSourceLocationFromMouseEvent(editor, selectedLocation, e) {
-  const { line, ch } = editor.codeMirror.coordsChar({
+export function getSourceLocationFromMouseEvent(_editor, selectedLocation, e) {
+  const { line, ch } = _editor.codeMirror.coordsChar({
     left: e.clientX,
     top: e.clientY
   });


### PR DESCRIPTION
Issue: #3829

### Summary of Changes

I took the function flow used to do what I believe to be file searches and removed some of lines that did not seem necessary if only highlighting was needed.

File search function flow:
`doSearch` (`actions/file-search.js`) --> `searchContents` (`actions/file-search.js`) --> `find` (`utils/editor/source-search.js`)  --> `doSearch` (`utils/editor/source-search.js`) --> `searchNext` (`utils/editor/source-search.js`)

I added these new functions to only get the highlighting without touching the current file search:
`doSearchForHighlight` (`actions/file-search.js`) --> `searchContentsForHighlight` (`actions/file-search.js`) --> `searchSourceForHighlight` (`utils/editor/source-search.js`)  --> `findNextOnLine` (`utils/editor/source-search.js`)

- Started calling `doSearchForHighlight` when a `ProjectSearch` result is selected
- Added functions to get the `Editor` object in the `ProjectSearch` component


### Test Plan
- [ ] In Debugee, go to http://firefox-dev.tools/debugger-examples/examples/todomvc/
- [ ] In Debugger, open Project Search (`Ctrl/Cmd + Shift + F`)
- [ ] In Debugger, project search for "app" (type "app", then press `Enter`)
- [ ] In Debugger, click a project search result
- [ ] See that all instances of "app" in the file have a box highlight
- [ ] See that the specifically selected project search result is fully highlighted

### Screenshots
Before
![image](https://user-images.githubusercontent.com/12681350/38325054-f17e49c4-380f-11e8-92dc-115040232103.png)


After
![image](https://user-images.githubusercontent.com/12681350/38324989-c1c1a618-380f-11e8-96fd-a17ef7431d3f.png)
