### PR TITLE
Sort breakpoints by file name

### DIFF
--- a/src/components/SecondaryPanes/Breakpoints.js
+++ b/src/components/SecondaryPanes/Breakpoints.js
@@ -167,14 +167,16 @@ class Breakpoints extends Component<Props> {
     );
 
     return [
-      ...Object.keys(groupedBreakpoints).map(filename => {
-        return [
-          <div className="breakpoint-heading" title={filename} key={filename}>
-            {filename}
-          </div>,
-          ...groupedBreakpoints[filename].map(bp => this.renderBreakpoint(bp))
-        ];
-      })
+      ...Object.keys(groupedBreakpoints)
+        .sort()
+        .map(filename => {
+          return [
+            <div className="breakpoint-heading" title={filename} key={filename}>
+              {filename}
+            </div>,
+            ...groupedBreakpoints[filename].map(bp => this.renderBreakpoint(bp))
+          ];
+        })
     ];
   }
 


### PR DESCRIPTION
This makes breakpoints show up in a predictable spot.  :)
<img width="300" alt="sortedbreakpoints" src="https://user-images.githubusercontent.com/46655/38335367-acfc0ad4-3823-11e8-8f52-41876b0e1056.png">
