### PR TITLE
Syntax-highlight breakpoints

### DIFF
--- a/src/components/SecondaryPanes/BreakpointItem.js
+++ b/src/components/SecondaryPanes/BreakpointItem.js
@@ -39,9 +39,14 @@ class BreakpointItem extends Component<Props> {
   componentDidMount() {
     this.setupEditor();
   }
+  componentDidUpdate() {
+    this.setupEditor();
+  }
 
   componentWillUnmount() {
-    this.editor.destroy();
+    if (this.editor) {
+      this.editor.destroy();
+    }
   }
 
   shouldComponentUpdate(nextProps: Props) {

--- a/src/components/SecondaryPanes/BreakpointItem.js
+++ b/src/components/SecondaryPanes/BreakpointItem.js
@@ -11,7 +11,9 @@ import CloseButton from "../shared/Button/Close";
 
 import { createEditor } from "../../utils/breakpoint";
 import { features } from "../../utils/prefs";
+
 import type { LocalBreakpoint } from "./Breakpoints";
+import type SourceEditor from "../../utils/editor/source-editor";
 
 type Props = {
   breakpoint: LocalBreakpoint,
@@ -32,14 +34,17 @@ function getBreakpointLocation(source, line, column) {
 }
 
 class BreakpointItem extends Component<Props> {
+  editor: SourceEditor;
+
   componentDidMount() {
     this.setupEditor();
   }
+
   componentWillUnmount() {
     this.editor.destroy();
   }
 
-  shouldComponentUpdate(nextProps) {
+  shouldComponentUpdate(nextProps: Props) {
     // This is needed, IMO, so we don't need to create
     // loads of CM instances for no reason
     return this.props.breakpoint != nextProps.breakpoint;
@@ -56,8 +61,11 @@ class BreakpointItem extends Component<Props> {
     const node = ReactDOM.findDOMNode(this);
     if (node instanceof HTMLElement) {
       const mountNode = node.querySelector(".breakpoint-label");
-      mountNode.innerHTML = "";
-      this.editor.appendToLocalElement(mountNode);
+      if (node instanceof HTMLElement) {
+        // $FlowIgnore
+        mountNode.innerHTML = "";
+        this.editor.appendToLocalElement(mountNode);
+      }
     }
   }
 

--- a/src/components/SecondaryPanes/BreakpointItem.js
+++ b/src/components/SecondaryPanes/BreakpointItem.js
@@ -50,9 +50,17 @@ class BreakpointItem extends Component<Props> {
   }
 
   shouldComponentUpdate(nextProps: Props) {
-    // This is needed, IMO, so we don't need to create
-    // loads of CM instances for no reason
-    return this.props.breakpoint != nextProps.breakpoint;
+    const prevBreakpoint = this.props.breakpoint;
+    const nextBreakpoint = nextProps.breakpoint;
+
+    return (
+      !prevBreakpoint ||
+      (prevBreakpoint.text != nextBreakpoint.text ||
+        prevBreakpoint.disabled != nextBreakpoint.disabled ||
+        prevBreakpoint.condition != nextBreakpoint.condition ||
+        prevBreakpoint.hidden != nextBreakpoint.hidden ||
+        prevBreakpoint.isCurrentlyPaused != nextBreakpoint.isCurrentlyPaused)
+    );
   }
 
   setupEditor() {

--- a/src/components/SecondaryPanes/BreakpointItem.js
+++ b/src/components/SecondaryPanes/BreakpointItem.js
@@ -4,10 +4,12 @@
 
 // @flow
 import React, { Component } from "react";
+import ReactDOM from "react-dom";
 import classnames from "classnames";
 
 import CloseButton from "../shared/Button/Close";
 
+import { createEditor } from "../../utils/breakpoint";
 import { features } from "../../utils/prefs";
 import type { LocalBreakpoint } from "./Breakpoints";
 
@@ -30,6 +32,35 @@ function getBreakpointLocation(source, line, column) {
 }
 
 class BreakpointItem extends Component<Props> {
+  componentDidMount() {
+    this.setupEditor();
+  }
+  componentWillUnmount() {
+    this.editor.destroy();
+  }
+
+  shouldComponentUpdate(nextProps) {
+    // This is needed, IMO, so we don't need to create
+    // loads of CM instances for no reason
+    return this.props.breakpoint != nextProps.breakpoint;
+  }
+
+  setupEditor() {
+    const { breakpoint } = this.props;
+    this.editor = createEditor(breakpoint.text);
+
+    // disables the default search shortcuts
+    // $FlowIgnore
+    this.editor._initShortcuts = () => {};
+
+    const node = ReactDOM.findDOMNode(this);
+    if (node instanceof HTMLElement) {
+      const mountNode = node.querySelector(".breakpoint-label");
+      mountNode.innerHTML = "";
+      this.editor.appendToLocalElement(mountNode);
+    }
+  }
+
   render() {
     const {
       breakpoint,

--- a/src/components/SecondaryPanes/Breakpoints.css
+++ b/src/components/SecondaryPanes/Breakpoints.css
@@ -147,7 +147,7 @@ html[dir="rtl"] .breakpoints-list .breakpoint .breakpoint-line {
 }
 
 .CodeMirror.cm-s-mozilla-breakpoint .CodeMirror-sizer {
-  min-width: none !important;
+  min-width: initial !important;
 }
 
 .breakpoints-list .breakpoint.disabled .CodeMirror.cm-s-mozilla-breakpoint {
@@ -155,7 +155,7 @@ html[dir="rtl"] .breakpoints-list .breakpoint .breakpoint-line {
   opacity: 0.5;
 }
 
-.CodeMirror.cm-s-mozilla-breakpoint .CodeMirror-line span[role=presentation]  {
+.CodeMirror.cm-s-mozilla-breakpoint .CodeMirror-line span[role=presentation] {
   max-width: 100%;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/src/components/SecondaryPanes/Breakpoints.css
+++ b/src/components/SecondaryPanes/Breakpoints.css
@@ -149,3 +149,8 @@ html[dir="rtl"] .breakpoints-list .breakpoint .breakpoint-line {
 .CodeMirror.cm-s-mozilla-breakpoint .CodeMirror-sizer {
   min-width: none !important;
 }
+
+.breakpoints-list .breakpoint.disabled .CodeMirror.cm-s-mozilla-breakpoint {
+  transition: opacity 0.5s linear;
+  opacity: 0.5;
+}

--- a/src/components/SecondaryPanes/Breakpoints.css
+++ b/src/components/SecondaryPanes/Breakpoints.css
@@ -154,3 +154,10 @@ html[dir="rtl"] .breakpoints-list .breakpoint .breakpoint-line {
   transition: opacity 0.5s linear;
   opacity: 0.5;
 }
+
+.CodeMirror.cm-s-mozilla-breakpoint .CodeMirror-line span[role=presentation]  {
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: inline-block;
+}

--- a/src/components/SecondaryPanes/Breakpoints.css
+++ b/src/components/SecondaryPanes/Breakpoints.css
@@ -161,3 +161,7 @@ html[dir="rtl"] .breakpoints-list .breakpoint .breakpoint-line {
   text-overflow: ellipsis;
   display: inline-block;
 }
+
+.CodeMirror.cm-s-mozilla-breakpoint .CodeMirror-code {
+  cursor: default;
+}

--- a/src/components/SecondaryPanes/Breakpoints.css
+++ b/src/components/SecondaryPanes/Breakpoints.css
@@ -74,6 +74,7 @@ html .breakpoints-list .breakpoint.paused {
   font-size: 11px;
   color: var(--theme-comment);
   padding-top: 3px;
+  padding-inline-end: 2px;
   min-width: 14px;
   text-align: right;
 }
@@ -94,6 +95,7 @@ html[dir="rtl"] .breakpoints-list .breakpoint .breakpoint-line {
   max-width: calc(100% - var(--breakpoint-expression-right-clear-space));
   display: inline-block;
   padding-inline-start: 2px;
+  padding-inline-end: 8px;
   cursor: default;
   flex-grow: 1;
   text-overflow: ellipsis;
@@ -138,4 +140,12 @@ html[dir="rtl"] .breakpoints-list .breakpoint .breakpoint-line {
 
 .breakpoint:hover .close {
   visibility: visible;
+}
+
+.CodeMirror.cm-s-mozilla-breakpoint .CodeMirror-lines {
+  padding: 0;
+}
+
+.CodeMirror.cm-s-mozilla-breakpoint .CodeMirror-sizer {
+  min-width: none !important;
 }

--- a/src/components/SecondaryPanes/Breakpoints.js
+++ b/src/components/SecondaryPanes/Breakpoints.js
@@ -99,10 +99,10 @@ class Breakpoints extends Component<Props> {
     this.props.removeBreakpoint(breakpoint.location);
   }
 
-  renderBreakpoint(breakpoint, key) {
+  renderBreakpoint(breakpoint) {
     return (
       <BreakpointItem
-        key={key}
+        key={breakpoint.locationId}
         breakpoint={breakpoint}
         onClick={() => this.selectBreakpoint(breakpoint)}
         onContextMenu={e =>
@@ -134,7 +134,7 @@ class Breakpoints extends Component<Props> {
           </div>,
           ...groupedBreakpoints[filename]
             .filter(bp => !bp.hidden && bp.text)
-            .map((bp, i) => this.renderBreakpoint(bp, `${filename}-${i}`))
+            .map((bp, i) => this.renderBreakpoint(bp))
         ];
       })
     ];

--- a/src/components/SecondaryPanes/Breakpoints.js
+++ b/src/components/SecondaryPanes/Breakpoints.js
@@ -133,7 +133,7 @@ class Breakpoints extends Component<Props> {
             {filename}
           </div>,
           ...groupedBreakpoints[filename]
-            .filter(bp => !bp.hidden)
+            .filter(bp => !bp.hidden && bp.text)
             .map((bp, i) => this.renderBreakpoint(bp, `${filename}-${i}`))
         ];
       })

--- a/src/utils/breakpoint/create-editor.js
+++ b/src/utils/breakpoint/create-editor.js
@@ -1,0 +1,25 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
+// @flow
+
+import SourceEditor from "../editor/source-editor";
+
+export function createEditor(value) {
+  return new SourceEditor({
+    mode: "javascript",
+    foldGutter: false,
+    enableCodeFolding: false,
+    readOnly: true,
+    lineNumbers: false,
+    theme: "mozilla mozilla-breakpoint",
+    styleActiveLine: false,
+    lineWrapping: false,
+    matchBrackets: false,
+    showAnnotationRuler: false,
+    gutters: [],
+    value: value || "",
+    scrollbarStyle: null
+  });
+}

--- a/src/utils/breakpoint/create-editor.js
+++ b/src/utils/breakpoint/create-editor.js
@@ -18,7 +18,7 @@ export function createEditor(value: string) {
     lineWrapping: false,
     matchBrackets: false,
     showAnnotationRuler: false,
-    gutters: [],
+    gutters: false,
     value: value || "",
     scrollbarStyle: null
   });

--- a/src/utils/breakpoint/create-editor.js
+++ b/src/utils/breakpoint/create-editor.js
@@ -11,7 +11,7 @@ export function createEditor(value: string) {
     mode: "javascript",
     foldGutter: false,
     enableCodeFolding: false,
-    readOnly: true,
+    readOnly: "nocursor",
     lineNumbers: false,
     theme: "mozilla mozilla-breakpoint",
     styleActiveLine: false,

--- a/src/utils/breakpoint/create-editor.js
+++ b/src/utils/breakpoint/create-editor.js
@@ -6,7 +6,7 @@
 
 import SourceEditor from "../editor/source-editor";
 
-export function createEditor(value) {
+export function createEditor(value: string) {
   return new SourceEditor({
     mode: "javascript",
     foldGutter: false,

--- a/src/utils/breakpoint/index.js
+++ b/src/utils/breakpoint/index.js
@@ -8,6 +8,8 @@ import { getBreakpoint } from "../../selectors";
 import assert from "../assert";
 import { features } from "../prefs";
 
+export { createEditor } from "./create-editor";
+
 export { getASTLocation, findScopeByName } from "./astBreakpointLocation";
 
 import type {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -57,6 +57,7 @@ function buildConfig(envConfig) {
 
     extra.excludeMap = {
       "./source-editor": "devtools/client/sourceeditor/editor",
+      "../editor/source-editor": "devtools/client/sourceeditor/editor",
       "./test-flag": "devtools/shared/flags",
       "./fronts-device": "devtools/shared/fronts/device",
       react: "devtools/client/shared/vendor/react",


### PR DESCRIPTION
Fixes Issue: #5849

### Summary of Changes

* Adds syntax highlighting to Breakpoints pane breakpoints
* Improves the layout of close button (more padding to avoid hover / close button movement)

### Test Plan

Add breakpoints, remove breakpoints, disable breakpoints -- ensure all looks good.

### Screenshots

<img width="298" alt="updatedscreenshot" src="https://user-images.githubusercontent.com/46655/38400976-974b738c-3918-11e8-8aee-0ab9378e10d8.png">


### ToDo

- [x] Figure out how to get text-ellipsis working
- [x] Investigate weird case where sometimes a CM instance isn't created and the plain text version of the breakpoint code persists
- [x] Performance - the breakpoints pane seems a bit slower.
- [x] Side Effects - Disable a breakpoint and then add another -- the disabled breakpoint syntax-highlighted code appears enabled for a second and then fades to disabled opacity, despite no action on that element being taken.