### PR TITLE
[QuickOpen] Path is too wide #5860

### DIFF
--- a/src/components/shared/ResultList.css
+++ b/src/components/shared/ResultList.css
@@ -61,7 +61,6 @@
   line-height: 1.5em;
   word-break: break-all;
   text-overflow: ellipsis;
-  overflow: hidden;
   white-space: nowrap;
 }
 


### PR DESCRIPTION
Fixes Issue: #5860

### Summary of Changes

* change 1 - Add a feature path to be visible at QuickOpen Modal Dialog  #resolve +review @jasonLaster.

### Test Plan

STR:
open QO via cmd+p
press `<escape> button`

Please resize browser. 
My recommendation is width to be `500px` and `600px`

ER: Filenames to be visible. 
Example: https://youtu.be/oNu0U7MDZgo