### PR TITLE
Fix odd cursor text issue

### DIFF
--- a/src/components/SecondaryPanes/Breakpoints.css
+++ b/src/components/SecondaryPanes/Breakpoints.css
@@ -162,6 +162,7 @@ html[dir="rtl"] .breakpoints-list .breakpoint .breakpoint-line {
   display: inline-block;
 }
 
-.CodeMirror.cm-s-mozilla-breakpoint .CodeMirror-code {
+.CodeMirror.cm-s-mozilla-breakpoint .CodeMirror-code,
+.CodeMirror.cm-s-mozilla-breakpoint .CodeMirror-scroll {
   cursor: default;
 }


### PR DESCRIPTION
There's a weird element inside CodeMirror, `.CodeMirror-scroll`, whose height goes like 30 pixels under the breakpoint text:

<img width="309" alt="wtfcursor" src="https://user-images.githubusercontent.com/46655/38426901-73774548-397d-11e8-9204-bb074cb243b8.png">

That element triggers the text cursor for a few pixels under the actual breakpoint text, which feels gross.  This PR prevents that text cursor from ever displaying.