### PR TITLE
Prevent selection of breakpoint contents

### DIFF
--- a/src/components/SecondaryPanes/BreakpointItem.js
+++ b/src/components/SecondaryPanes/BreakpointItem.js
@@ -78,6 +78,7 @@ class BreakpointItem extends Component<Props> {
         // $FlowIgnore
         mountNode.innerHTML = "";
         this.editor.appendToLocalElement(mountNode);
+        this.editor.codeMirror.on("mousedown", (_, e) => e.preventDefault());
       }
     }
   }


### PR DESCRIPTION
Clicking-dragging or double clicking inside individual breakpoints allows text selection per breakpoint text, which we've tried turning off with CSS `user-select` for the entire breakpoints panel;  this PR prevents CodeMirror's internal text selection of breakpoint text.