### PR TITLE
[Sources] Reveal in tree opens the left sidebar

### DIFF
--- a/src/actions/ui.js
+++ b/src/actions/ui.js
@@ -68,6 +68,14 @@ export function showSource(sourceId: string) {
   return ({ dispatch, getState }: ThunkArgs) => {
     const source = getSource(getState(), sourceId);
 
+    if (getPaneCollapse(getState(), "start")) {
+      dispatch({
+        type: "TOGGLE_PANE",
+        position: "start",
+        paneCollapsed: false
+      });
+    }
+
     dispatch(setPrimaryPaneTab("sources"));
     dispatch({
       type: "SHOW_SOURCE",


### PR DESCRIPTION
**Fixes Issue: #5869** 

### Summary of Changes

When selecting ` Reveal in tree` from the context menu, it now checks:
 - if the left panel is collapsed
   - opens if it is 

### Test Plan

- [x] Select `Reveal in tree` with the left panel **closed** to make sure it opened
- [x] Select `Reveal in tree` with the left panel **opened** to make sure it didn't collapse
- [x] With the context menu opened, enter `Shift` + `Alt` + `r` will also open the left panel

### Screenshots/Videos

![debugger_html_issue5869](https://user-images.githubusercontent.com/15523758/38449580-a76f93c6-39de-11e8-8c6f-c14a6cb6e510.gif)