### PR TITLE
[Travis CI debugging] Make script and hg clone verbose in gecko-clone

### DIFF
--- a/bin/ci/clone-gecko.sh
+++ b/bin/ci/clone-gecko.sh
@@ -8,3 +8,4 @@ hg clone -v https://hg.mozilla.org/mozilla-unified/ firefox
 cd firefox
 hg co $MC_COMMIT
 cd ..
+set +x

--- a/bin/ci/clone-gecko.sh
+++ b/bin/ci/clone-gecko.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 
+set -x
 hg --version
 rm -rf firefox/
-hg clone https://hg.mozilla.org/mozilla-unified/ firefox
+hg clone -v https://hg.mozilla.org/mozilla-unified/ firefox
 
 cd firefox
 hg co $MC_COMMIT

--- a/bin/ci/clone-gecko.sh
+++ b/bin/ci/clone-gecko.sh
@@ -3,7 +3,7 @@
 set -x
 hg --version
 rm -rf firefox/
-hg clone https://hg.mozilla.org/mozilla-unified/ firefox
+travis_retry hg clone https://hg.mozilla.org/mozilla-unified/ firefox
 
 cd firefox
 hg co $MC_COMMIT

--- a/bin/ci/clone-gecko.sh
+++ b/bin/ci/clone-gecko.sh
@@ -3,7 +3,7 @@
 set -x
 hg --version
 rm -rf firefox/
-hg clone -v https://hg.mozilla.org/mozilla-unified/ firefox
+hg clone https://hg.mozilla.org/mozilla-unified/ firefox
 
 cd firefox
 hg co $MC_COMMIT


### PR DESCRIPTION
Hi there - it's Carla from the Travis CI team.

I'm PRing some changes to make the gecko-clone script print the commands that are being executed, as well as adding the verbose flag on `hg clone`. This is to better understand at which stage is the job getting stuck while running in Travis CI.

I assume that the problem might be reproducible in this same PR build, so I don't expect these changes to be merged to master. This is mostly a debugging build 🤞 .

Thanks!