### PR TITLE
Fix breakpoint lineheight

### DIFF
--- a/src/components/SecondaryPanes/Breakpoints.css
+++ b/src/components/SecondaryPanes/Breakpoints.css
@@ -19,7 +19,6 @@
 .breakpoints-list .breakpoint {
   font-size: 12px;
   color: var(--theme-content-color1);
-  line-height: 1em;
   position: relative;
   transition: all 0.25s ease;
   padding: 0.5em 1em 0.5em 0.5em;


### PR DESCRIPTION
The bottoms of letters like "g", "j", "y", etc. are being cut off at the bottom due to an unnecessary line-height.

<img width="300" alt="badlineheight" src="https://user-images.githubusercontent.com/46655/38524895-e3bdeac4-3c15-11e8-800a-29a0eb348983.png">
