### PR TITLE
Avoid tree item heigh bouncing by setting lineheight

### DIFF
--- a/src/components/shared/ManagedTree.css
+++ b/src/components/shared/ManagedTree.css
@@ -16,6 +16,8 @@
   display: grid;
   grid-template-columns: 1fr;
   align-content: start;
+
+  line-height: 1.4em;
 }
 
 .managed-tree .tree button {


### PR DESCRIPTION
## Testing
- Choose any source in the tree
- Toggle on and off blackboxing quickly
-  On master you'll see the height of the tree item change a pixel or two
-  With this PR, the item will stay the same height