### PR TITLE
Add missing license headers

### DIFF
--- a/assets/images/Svg.js
+++ b/assets/images/Svg.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 const React = require("react");
 import InlineSVG from "svg-inline-react";
 const { isDevelopment } = require("devtools-config");

--- a/src/actions/pause/mapFrames.js
+++ b/src/actions/pause/mapFrames.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 // @flow
 
 import { getFrames, getSymbols, getSource } from "../../selectors";

--- a/src/actions/pause/setExtra.js
+++ b/src/actions/pause/setExtra.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 // @flow
 
 import { getSymbols, getSource, getSelectedFrame } from "../../selectors";

--- a/src/components/QuickOpenModal.css
+++ b/src/components/QuickOpenModal.css
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 .result-item .title .highlight {
   font-weight: bold;
   background-color: transparent;

--- a/src/components/SecondaryPanes/BreakpointsContextMenu.js
+++ b/src/components/SecondaryPanes/BreakpointsContextMenu.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 import { buildMenu, showMenu } from "devtools-contextmenu";
 
 export default function showContextMenu(props) {

--- a/src/components/SecondaryPanes/BreakpointsDropdown.css
+++ b/src/components/SecondaryPanes/BreakpointsDropdown.css
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 .dropdown span.icon-spacer {
   margin-left: 8px;
 }

--- a/src/components/SecondaryPanes/BreakpointsDropdown.js
+++ b/src/components/SecondaryPanes/BreakpointsDropdown.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 import React from "react";
 import Svg from "../shared/Svg";
 import Dropdown from "../shared/Dropdown";

--- a/src/components/shared/Badge.css
+++ b/src/components/shared/Badge.css
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 .badge {
   --size: 17px;
   --radius: calc(var(--size) / 2);

--- a/src/components/shared/Badge.js
+++ b/src/components/shared/Badge.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 // @flow
 import React from "react";
 import "./Badge.css";

--- a/src/components/shared/Button/CommandBarButton.css
+++ b/src/components/shared/Button/CommandBarButton.css
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 .command-bar-button {
   appearance: none;
   background: transparent;

--- a/src/selectors/getRelativeSources.js
+++ b/src/selectors/getRelativeSources.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 // @flow
 
 import { getProjectDirectoryRoot, getSources } from "../selectors";

--- a/src/utils/dbg.js
+++ b/src/utils/dbg.js
@@ -1,4 +1,9 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 // @flow
+
 import * as timings from "./timings";
 import { prefs, features } from "./prefs";
 import { isDevelopment } from "devtools-config";

--- a/src/utils/location.js
+++ b/src/utils/location.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 import type { Location, SourceId } from "../types";
 
 type IncompleteLocation = {

--- a/src/utils/pause/mapScopes/findGeneratedBindingFromPosition.js
+++ b/src/utils/pause/mapScopes/findGeneratedBindingFromPosition.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 // @flow
 
 import { isEqual } from "lodash";

--- a/src/utils/pause/mapScopes/locColumn.js
+++ b/src/utils/pause/mapScopes/locColumn.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 // @flow
 
 import type { Location } from "../../../types";

--- a/src/utils/pause/pausePoints.js
+++ b/src/utils/pause/pausePoints.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 import { reverse, sortBy } from "lodash";
 function insertStrtAt(string, index, newString) {
   const start = string.slice(0, index);

--- a/src/utils/source-queue.js
+++ b/src/utils/source-queue.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 import { throttle } from "lodash";
 
 let newSources;

--- a/src/workers/parser/mapOriginalExpression.js
+++ b/src/workers/parser/mapOriginalExpression.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 // @flow
 
 import { parseScript } from "./utils/ast";


### PR DESCRIPTION
Fixes Issue: #5898 

### Summary of Changes

Added missing license headers to files:
- [x] assets/images/Svg.js
- [x] src/actions/pause/mapFrames.js
- [x] src/actions/pause/setExtra.js
- [x] src/components/SecondaryPanes/BreakpointsContextMenu.js
- [x] src/components/SecondaryPanes/BreakpointsDropdown.css
- [x] src/components/SecondaryPanes/BreakpointsDropdown.js
- [x] src/components/shared/Button/CommandBarButton.css
- [x] src/components/shared/Badge.css
- [x] src/components/shared/Badge.js
- [x] src/components/QuickOpenModal.css
- [x] src/selectors/getRelativeSources.js
- [x] src/utils/pause/mapScopes/findGeneratedBindingFromPosition.js
- [x] src/utils/pause/mapScopes/locColumn.js
- [x] src/utils/pause/pausePoints.js
- [x] src/utils/dbg.js
- [x] src/utils/location.js
- [x] src/utils/source-queue.js
- [x] src/workers/parser/mapOriginalExpression.js

