### PR TITLE
Changed tabIndex

### DIFF
--- a/src/components/shared/Accordion.js
+++ b/src/components/shared/Accordion.js
@@ -16,7 +16,7 @@ type AccordionItem = {
   className: string,
   opened: boolean,
   onToggle?: () => void,
-  shouldOpen?: () => void
+  shouldOpen?: () => void,
 };
 
 type Props = { items: Array<Object> };
@@ -54,11 +54,11 @@ class Accordion extends Component<Props, State> {
 
     return (
       <div className={item.className} key={i}>
-        <div className="_header" onClick={() => this.handleHeaderClick(i)}>
+        <div className="_header" tabIndex="0" onClick={() => this.handleHeaderClick(i)}>
           <Svg name="arrow" className={opened ? "expanded" : ""} />
           {item.header}
           {item.buttons ? (
-            <div className="header-buttons">{item.buttons}</div>
+            <div className="header-buttons" tabIndex="-1">{item.buttons}</div>
           ) : null}
         </div>
         {opened && (


### PR DESCRIPTION
Fixes part of the 2nd check box (Need to be able to navigate to headers with keyboard) of Issue #4080 

In src/components/shared/accordion.js, we changed header-buttons tabIndex from 0 to -1.
This prevents the header-buttons (not actual buttons refresh and add) from being erroneously focused when user cannot interact with them. 

Test Plan:
- [x]Input setInterval(function() { console.log(document.activeElement); }, 3000); into web console to display the active element.
- [x]Opened search in files with ctrl+shift+f 
- [x]Navigated headers using Tab button on keyboard

Will continue to work on Issue #4080 2nd check box to remove other focusing issues. Just wanted to submit our progress so far! (With @chan750 and @denigrise)
