### PR TITLE
Add + icon for adding watch expressions

### DIFF
--- a/src/components/SecondaryPanes/Expressions.css
+++ b/src/components/SecondaryPanes/Expressions.css
@@ -37,7 +37,6 @@
 }
 
 .input-expression::placeholder {
-  text-align: center;
   font-style: italic;
   color: var(--theme-comment);
 }
@@ -54,6 +53,7 @@
 }
 .expression-input-container {
   display: flex;
+  border: 1px solid var(--theme-highlight-blue);
 }
 
 .expression-container {

--- a/src/components/SecondaryPanes/Expressions.js
+++ b/src/components/SecondaryPanes/Expressions.js
@@ -34,7 +34,9 @@ type Props = {
   evaluateExpressions: () => void,
   updateExpression: (input: string, expression: Expression) => void,
   deleteExpression: (expression: Expression) => void,
-  openLink: (url: string) => void
+  openLink: (url: string) => void,
+  showInput: boolean,
+  onExpressionAdded: () => void
 };
 
 class Expressions extends Component<Props, State> {
@@ -46,7 +48,13 @@ class Expressions extends Component<Props, State> {
 
   constructor(props: Props) {
     super(props);
-    this.state = { editing: false, editIndex: -1, inputValue: "" };
+
+    this.state = {
+      editing: false,
+      editIndex: -1,
+      inputValue: "",
+      showInput: false
+    };
   }
 
   componentDidMount() {
@@ -67,16 +75,19 @@ class Expressions extends Component<Props, State> {
     if (this.state.editing && !nextProps.expressionError) {
       this.clear();
     }
+    this.setState({ showInput: nextProps.showInput });
   }
 
   shouldComponentUpdate(nextProps, nextState) {
-    const { editing, inputValue } = this.state;
+    const { editing, inputValue, showInput } = this.state;
     const { expressions, expressionError } = this.props;
+
     return (
       expressions !== nextProps.expressions ||
       expressionError !== nextProps.expressionError ||
       editing !== nextState.editing ||
-      inputValue !== nextState.inputValue
+      inputValue !== nextState.inputValue ||
+      nextProps.showInput !== showInput
     );
   }
 
@@ -115,6 +126,16 @@ class Expressions extends Component<Props, State> {
     }
   };
 
+  hideInput = () => {
+    this.setState({ showInput: false });
+    this.props.onExpressionAdded();
+  };
+
+  onBlur() {
+    this.clear();
+    this.hideInput();
+  }
+
   handleExistingSubmit = async (
     e: SyntheticEvent<HTMLFormElement>,
     expression: Expression
@@ -123,6 +144,7 @@ class Expressions extends Component<Props, State> {
     e.stopPropagation();
 
     this.props.updateExpression(this.state.inputValue, expression);
+    this.hideInput();
   };
 
   handleNewSubmit = async (e: SyntheticEvent<HTMLFormElement>) => {
@@ -135,8 +157,10 @@ class Expressions extends Component<Props, State> {
     this.setState({
       editing: false,
       editIndex: -1,
-      inputValue: this.props.expressionError ? inputValue : ""
+      inputValue: this.props.expressionError ? inputValue : "",
+      showInput: false
     });
+    this.hideInput();
   };
 
   renderExpression = (expression: Expression, index: number) => {
@@ -202,8 +226,9 @@ class Expressions extends Component<Props, State> {
             type="text"
             placeholder={placeholder}
             onChange={this.handleChange}
-            onBlur={this.clear}
+            onBlur={this.hideInput}
             onKeyDown={this.handleKeyDown}
+            autoFocus="true"
             value={!editing ? inputValue : ""}
           />
           <input type="submit" style={{ display: "none" }} />
@@ -241,10 +266,11 @@ class Expressions extends Component<Props, State> {
 
   render() {
     const { expressions } = this.props;
+
     return (
       <ul className="pane expressions-list">
         {expressions.map(this.renderExpression)}
-        {this.renderNewExpressionInput()}
+        {this.state.showInput && this.renderNewExpressionInput()}
       </ul>
     );
   }

--- a/src/components/SecondaryPanes/index.js
+++ b/src/components/SecondaryPanes/index.js
@@ -87,6 +87,18 @@ type Props = {
 };
 
 class SecondaryPanes extends Component<Props> {
+  constructor(props: Props) {
+    super(props);
+
+    this.state = {
+      showExpressionsInput: false
+    };
+  }
+
+  onExpressionAdded = () => {
+    this.setState({ showExpressionsInput: false });
+  };
+
   renderBreakpointsToggle() {
     const {
       toggleAllBreakpoints,
@@ -138,6 +150,15 @@ class SecondaryPanes extends Component<Props> {
         "refresh",
         "refresh",
         L10N.getStr("watchExpressions.refreshButton")
+      ),
+      debugBtn(
+        evt => {
+          evt.stopPropagation();
+          this.setState({ showExpressionsInput: true });
+        },
+        "plus",
+        "plus",
+        L10N.getStr("expressions.placeholder")
       )
     ];
   }
@@ -173,7 +194,12 @@ class SecondaryPanes extends Component<Props> {
       header: L10N.getStr("watchExpressions.header"),
       className: "watch-expressions-pane",
       buttons: this.watchExpressionHeaderButtons(),
-      component: <Expressions />,
+      component: (
+        <Expressions
+          showInput={this.state.showExpressionsInput}
+          onExpressionAdded={this.onExpressionAdded}
+        />
+      ),
       opened: prefs.expressionsVisible,
       onToggle: opened => {
         prefs.expressionsVisible = opened;

--- a/src/components/SecondaryPanes/tests/__snapshots__/Expressions.spec.js.snap
+++ b/src/components/SecondaryPanes/tests/__snapshots__/Expressions.spec.js.snap
@@ -78,32 +78,6 @@ exports[`Expressions should always have unique keys 1`] = `
       </div>
     </div>
   </li>
-  <li
-    className="expression-input-container"
-  >
-    <form
-      className="expression-input-form"
-      onSubmit={[Function]}
-    >
-      <input
-        className="input-expression"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onKeyDown={[Function]}
-        placeholder="Add watch expression"
-        type="text"
-        value=""
-      />
-      <input
-        style={
-          Object {
-            "display": "none",
-          }
-        }
-        type="submit"
-      />
-    </form>
-  </li>
 </ul>
 `;
 
@@ -184,32 +158,6 @@ exports[`Expressions should render 1`] = `
         />
       </div>
     </div>
-  </li>
-  <li
-    className="expression-input-container"
-  >
-    <form
-      className="expression-input-form"
-      onSubmit={[Function]}
-    >
-      <input
-        className="input-expression"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onKeyDown={[Function]}
-        placeholder="Add watch expression"
-        type="text"
-        value=""
-      />
-      <input
-        style={
-          Object {
-            "display": "none",
-          }
-        }
-        type="submit"
-      />
-    </form>
   </li>
 </ul>
 `;


### PR DESCRIPTION
Fixes Issue: #5908

![expressionstoggle](https://user-images.githubusercontent.com/46655/38579183-d0c1c7d6-3ccb-11e8-9815-611ba169e6ce.gif)

Considerations for reviewer:

- [ ] Is there a better way to handle the state and props management to show and hide the input...
- [ ] Any thoughts on better communication between the two widgets so as to prevent unnecessary renders?