### PR TITLE
[scopes] Optimize the performance of looking up the generated binding for a mapped original location

### DIFF
--- a/src/actions/pause/mapScopes.js
+++ b/src/actions/pause/mapScopes.js
@@ -441,7 +441,7 @@ function buildGeneratedBindingList(
   // Sort so we can binary-search.
   return generatedBindings.sort((a, b) => {
     const aStart = a.loc.start;
-    const bStart = a.loc.start;
+    const bStart = b.loc.start;
 
     if (aStart.line === bStart.line) {
       return locColumn(aStart) - locColumn(bStart);

--- a/src/utils/pause/mapScopes/filtering.js
+++ b/src/utils/pause/mapScopes/filtering.js
@@ -1,0 +1,45 @@
+// @flow
+
+function findInsertionLocation<T>(
+  array: Array<T>,
+  callback: T => number
+): number {
+  let left = 0;
+  let right = array.length;
+  while (left < right) {
+    const mid = Math.floor((left + right) / 2);
+    const item = array[mid];
+
+    const result = callback(item);
+    if (result === 0) {
+      left = mid;
+      break;
+    }
+    if (result >= 0) {
+      right = mid;
+    } else {
+      left = mid + 1;
+    }
+  }
+
+  // Ensure the value is the start of any set of matches.
+  let i = left;
+  while (i > 0 && callback(array[i]) >= 0) {
+    i--;
+  }
+  return i + 1;
+}
+
+export function filterSortedArray<T>(
+  array: Array<T>,
+  callback: T => number
+): Array<T> {
+  const start = findInsertionLocation(array, callback);
+
+  const results = [];
+  for (let i = start; i < array.length && callback(array[i]) === 0; i++) {
+    results.push(array[i]);
+  }
+
+  return results;
+}

--- a/src/utils/pause/mapScopes/findGeneratedBindingFromPosition.js
+++ b/src/utils/pause/mapScopes/findGeneratedBindingFromPosition.js
@@ -4,13 +4,13 @@
 
 // @flow
 
-import { isEqual } from "lodash";
 import type {
   BindingLocation,
   BindingLocationType,
   BindingType
 } from "../../../workers/parser";
 import { locColumn } from "./locColumn";
+import { filterSortedArray } from "./filtering";
 
 import type { Source, Location, BindingContents } from "../../../types";
 // eslint-disable-next-line max-len
@@ -90,11 +90,43 @@ export async function findGeneratedBindingFromPosition(
   return null;
 }
 
+function filterApplicableBindings(
+  bindings: Array<GeneratedBindingLocation>,
+  mapped: {
+    start: Location,
+    end: Location
+  }
+): Array<GeneratedBindingLocation> {
+  // Any binding overlapping a part of the mapping range.
+  return filterSortedArray(bindings, binding => {
+    if (positionCmp(binding.loc.end, mapped.start) < 0) {
+      return -1;
+    }
+
+    // Currently we allow ranges to count if they start 1 character before,
+    // so we allow that when filtering here.
+    // See mapBindingReferenceToDescriptor for more info.
+    if (
+      positionCmp(
+        {
+          ...binding.loc.start,
+          column: locColumn(binding.loc.start) - 1
+        },
+        mapped.end
+      ) > 0
+    ) {
+      return 1;
+    }
+
+    return 0;
+  });
+}
+
 /**
  * Given a mapped range over the generated source, attempt to resolve a real
  * binding descriptor that can be used to access the value.
  */
-async function findGeneratedNormalReference(
+async function findGeneratedReference(
   type: BindingType,
   generatedAstBindings: Array<GeneratedBindingLocation>,
   mapped: {
@@ -103,7 +135,9 @@ async function findGeneratedNormalReference(
     end: Location
   }
 ): Promise<GeneratedDescriptor | null> {
-  return generatedAstBindings.reduce(async (acc, val) => {
+  const bindings = filterApplicableBindings(generatedAstBindings, mapped);
+
+  return bindings.reduce(async (acc, val) => {
     const accVal = await acc;
     if (accVal) {
       return accVal;
@@ -122,7 +156,16 @@ async function findGeneratedImportReference(
     end: Location
   }
 ): Promise<GeneratedDescriptor | null> {
-  return generatedAstBindings.reduce(async (acc, val) => {
+  let bindings = filterApplicableBindings(generatedAstBindings, mapped);
+
+  // When wrapped, for instance as `Object(ns.default)`, the `Object` binding
+  // will be the first in the list. To avoid resolving `Object` as the
+  // value of the import itself, we potentially skip the first binding.
+  if (bindings.length > 1 && !bindings[0].loc.meta && bindings[1].loc.meta) {
+    bindings = bindings.slice(1);
+  }
+
+  return bindings.reduce(async (acc, val) => {
     const accVal = await acc;
     if (accVal) {
       return accVal;
@@ -145,7 +188,9 @@ async function findGeneratedImportDeclaration(
     importName: string
   }
 ): Promise<GeneratedDescriptor | null> {
-  return generatedAstBindings.reduce(async (acc, val) => {
+  const bindings = filterApplicableBindings(generatedAstBindings, mapped);
+
+  return bindings.reduce(async (acc, val) => {
     const accVal = await acc;
     if (accVal) {
       return accVal;
@@ -400,8 +445,20 @@ async function getGeneratedLocationRange(
   // binding's location can point at the start of a binding listed after
   // it, so we need to make sure it maps to a location that actually has
   // a size in order to avoid picking up the wrong descriptor.
-  if (isEqual(start, end)) {
+  if (positionCmp(start, end) === 0) {
     return null;
+  }
+  if (positionCmp(start, end) > 0) {
+    // This will be fixed in future range work, but right now it is
+    // possible for the start to be after the end because of the way we
+    // map ranges. For now we create a placeholder single-character range.
+    return {
+      start,
+      end: {
+        ...start,
+        column: start.column + 1
+      }
+    };
   }
 
   return { start, end };


### PR DESCRIPTION
Refs Issue: #5561

### Summary of Changes

* Finally get around to using binary search to look up the generated bindings that may be applicable for a mapped location, taking lookup times from `O(N * M)` to `O(N * log(N))`

This is a first step for performance optimization for original scopes. We'll also want to implement batched location mapping like @jasonLaster had in https://github.com/devtools-html/debugger.html/pull/5892, though that will have to wait for some additional work around range mapping.