### PR TITLE
Update shortcuts modal icon to use photon icon

### DIFF
--- a/assets/images/Svg.js
+++ b/assets/images/Svg.js
@@ -25,6 +25,7 @@ const svg = {
   file: require("./file.svg"),
   folder: require("./folder.svg"),
   globe: require("./globe.svg"),
+  help: require("./help.svg"),
   home: require("./home.svg"),
   javascript: require("./javascript.svg"),
   jquery: require("./jquery.svg"),

--- a/assets/images/help.svg
+++ b/assets/images/help.svg
@@ -1,0 +1,6 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <path fill="context-fill" d="M8 1a7 7 0 1 0 7 7 7.008 7.008 0 0 0-7-7zm0 13a6 6 0 1 1 6-6 6.007 6.007 0 0 1-6 6zM8 3.125A2.7 2.7 0 0 0 5.125 6a.875.875 0 0 0 1.75 0c0-1 .6-1.125 1.125-1.125a1.105 1.105 0 0 1 1.13.744.894.894 0 0 1-.53 1.016A2.738 2.738 0 0 0 7.125 9v.337a.875.875 0 0 0 1.75 0v-.37a1.041 1.041 0 0 1 .609-.824A2.637 2.637 0 0 0 10.82 5.16 2.838 2.838 0 0 0 8 3.125zm0 7.625A1.25 1.25 0 1 0 9.25 12 1.25 1.25 0 0 0 8 10.75z"></path>
+</svg>

--- a/src/components/SecondaryPanes/CommandBar.css
+++ b/src/components/SecondaryPanes/CommandBar.css
@@ -30,7 +30,8 @@ img.reverseStepIn,
 img.reverseStepOut,
 img.replay-previous,
 img.replay-next,
-img.resume {
+img.resume,
+img.shortcuts {
   background-color: var(--theme-body-color);
 }
 
@@ -105,6 +106,10 @@ img.resume {
   mask: url(/images/forward.svg) no-repeat;
   mask-size: 75%;
   margin-top: 5px;
+}
+
+.command-bar img.shortcuts {
+  mask: url(/images/help.svg) no-repeat;
 }
 
 .command-bar .replay-inactive {

--- a/src/components/SecondaryPanes/CommandBar.js
+++ b/src/components/SecondaryPanes/CommandBar.js
@@ -81,13 +81,13 @@ function formatKey(action) {
   return formatKeyShortcut(key);
 }
 
-function debugBtn(
-  onClick,
-  type,
-  className,
-  tooltip,
-  disabled = false,
-  ariaPressed = false
+export function debugBtn(
+  onClick: ?Function,
+  type: string,
+  className: string,
+  tooltip: string,
+  disabled: boolean = false,
+  ariaPressed: boolean = false
 ) {
   return (
     <CommandBarButton

--- a/src/components/SecondaryPanes/UtilsBar.js
+++ b/src/components/SecondaryPanes/UtilsBar.js
@@ -5,23 +5,8 @@
 // @flow
 import React, { Component } from "react";
 import classnames from "classnames";
+import { debugBtn } from "./CommandBar";
 import "./CommandBar.css";
-
-function debugBtn(onClick, type, className, tooltip, disabled = false) {
-  const props = {
-    onClick,
-    key: type,
-    "aria-label": tooltip,
-    title: tooltip,
-    disabled
-  };
-
-  return (
-    <button className={classnames(type, className)} {...props}>
-      ?
-    </button>
-  );
-}
 
 type Props = {
   horizontal: boolean,
@@ -33,7 +18,7 @@ class UtilsBar extends Component<Props> {
     return [
       debugBtn(
         this.props.toggleShortcutsModal,
-        "shortcut",
+        "shortcuts",
         "active",
         L10N.getStr("shortcuts.buttonName"),
         false


### PR DESCRIPTION
Fixes Issue: #5917 

### Summary of Changes

* import help photon icon
* export `debugBtn` from `CommandBar`. (should it be exported? should it be in its own file?)
* update shortcuts icon to use exported `debugBtn`

### Test Plan

- [x] Open Debugger
- [x] Clicking (?) icon opens shortcuts modal
- [x] Tooltip shows up.
- [x] Icon responds to events the same way as other icons.
- [x] Icon looks good on dark theme.

### Screenshots/
Before:
![image](https://user-images.githubusercontent.com/1968722/38586977-28cd3b3c-3d20-11e8-91d5-48b517ae1feb.png)

After:
![image](https://user-images.githubusercontent.com/1968722/38587019-47fc0164-3d20-11e8-8c81-cadd9c19d966.png)
