### PR TITLE
Allow submission of edited expression even if it doesn't change

### DIFF
--- a/src/actions/expressions.js
+++ b/src/actions/expressions.js
@@ -56,7 +56,7 @@ export function clearExpressionError() {
 
 export function updateExpression(input: string, expression: Expression) {
   return async ({ dispatch, getState }: ThunkArgs) => {
-    if (!input || input == expression.input) {
+    if (!input) {
       return;
     }
 


### PR DESCRIPTION
At present, if you create a watch expression,  then double click it, don't change anything, and press ENTER, nothing happens -- the input stays there as though nothing happened.

This PR allows the user to submit no change to an expression. (i.e. "Oops, I didn't mean to edit this one")