### PR TITLE
Use addons icons for extensions

### DIFF
--- a/assets/images/Svg.js
+++ b/assets/images/Svg.js
@@ -22,6 +22,7 @@ const svg = {
   coffeescript: require(`./coffeescript.svg`),
   dojo: require("./dojo.svg"),
   domain: require("./domain.svg"),
+  extension: require("./extension.svg"),
   file: require("./file.svg"),
   folder: require("./folder.svg"),
   globe: require("./globe.svg"),

--- a/assets/images/extension.svg
+++ b/assets/images/extension.svg
@@ -1,0 +1,6 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <path fill="context-fill" d="M14.5 8c-.971 0-1 1-1.75 1a.765.765 0 0 1-.75-.75V5a1 1 0 0 0-1-1H7.75A.765.765 0 0 1 7 3.25c0-.75 1-.779 1-1.75C8 .635 7.1 0 6 0S4 .635 4 1.5c0 .971 1 1 1 1.75a.765.765 0 0 1-.75.75H1a1 1 0 0 0-1 1v2.25A.765.765 0 0 0 .75 8c.75 0 .779-1 1.75-1C3.365 7 4 7.9 4 9s-.635 2-1.5 2c-.971 0-1-1-1.75-1a.765.765 0 0 0-.75.75V15a1 1 0 0 0 1 1h3.25a.765.765 0 0 0 .75-.75c0-.75-1-.779-1-1.75 0-.865.9-1.5 2-1.5s2 .635 2 1.5c0 .971-1 1-1 1.75a.765.765 0 0 0 .75.75H11a1 1 0 0 0 1-1v-3.25a.765.765 0 0 1 .75-.75c.75 0 .779 1 1.75 1 .865 0 1.5-.9 1.5-2s-.635-2-1.5-2z"></path>
+</svg>

--- a/assets/panel/debugger.properties
+++ b/assets/panel/debugger.properties
@@ -654,6 +654,10 @@ addWatchExpressionText=Add watch expression
 # variables view popup.
 addWatchExpressionButton=Watch
 
+# LOCALIZATION NOTE (extensionsText): The text that is displayed to represent
+# "moz-extension" directories in the source tree
+extensionsText=Extensions
+
 # LOCALIZATION NOTE (emptyVariablesText): The text that is displayed in the
 # variables pane when there are no variables to display.
 emptyVariablesText=No variables to display

--- a/src/components/PrimaryPanes/SourcesTree.js
+++ b/src/components/PrimaryPanes/SourcesTree.js
@@ -309,7 +309,8 @@ class SourcesTree extends Component<Props, State> {
   renderItemName(name) {
     const hosts = {
       "ng://": "Angular",
-      "webpack://": "Webpack"
+      "webpack://": "Webpack",
+      "moz-extension://": L10N.getStr("extensionsText")
     };
 
     return hosts[name] || name;

--- a/src/components/PrimaryPanes/SourcesTree.js
+++ b/src/components/PrimaryPanes/SourcesTree.js
@@ -188,9 +188,10 @@ class SourcesTree extends Component<Props, State> {
 
     if (item.path === "webpack://") {
       return <Svg name="webpack" />;
-    }
-    if (item.path === "ng://") {
+    } else if (item.path === "ng://") {
       return <Svg name="angular" />;
+    } else if (item.path === "moz-extension://") {
+      return <img className="extension" />;
     }
 
     if (depth === 0 && projectRoot === "") {

--- a/src/components/shared/Svg.css
+++ b/src/components/shared/Svg.css
@@ -13,14 +13,16 @@
 .folder,
 .domain,
 .source-icon,
-.file {
+.file,
+.extension {
   background-color: var(--theme-comment);
 }
 
 .worker,
 .file,
 .folder,
-.source-icon {
+.source-icon,
+.extension {
   position: relative;
   top: 2px;
 }
@@ -45,6 +47,12 @@ img.folder,
 img.source-icon {
   width: 15px;
   height: 15px;
+}
+
+img.extension {
+  width: 13px;
+  height: 13px;
+  margin-inline-start: 2px;
 }
 
 img.result-item-icon {
@@ -80,6 +88,10 @@ img.typescript {
   mask: url(/images/typescript.svg) no-repeat;
 }
 
+img.extension {
+  mask: url(/images/extension.svg) no-repeat;
+}
+
 img.file {
   mask: url(/images/file.svg) no-repeat;
   width: 13px;
@@ -89,7 +101,8 @@ img.file {
 img.domain,
 img.folder,
 img.file,
-img.source-icon {
+img.source-icon,
+img.extension {
   mask-size: 100%;
   margin-inline-end: 5px;
   display: inline-block;


### PR DESCRIPTION
I thought it would be cool to show an icon for Firefox extensions:

<img width="246" alt="extensions" src="https://user-images.githubusercontent.com/46655/38591782-2396725e-3cfe-11e8-9074-61c9d834ca46.png">
