### PR TITLE
Vertically center the + icon for expressions

### DIFF
--- a/src/components/SecondaryPanes/Expressions.css
+++ b/src/components/SecondaryPanes/Expressions.css
@@ -2,6 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
+.watch-expressions-pane .plus {
+  margin-top: -2px;
+}
+
 .expression-input-form {
   width: 100%;
 }


### PR DESCRIPTION
The + icon is naturally lower than the refresh icon and it's bugging me.  Fixes:

<img width="297" alt="fixplus" src="https://user-images.githubusercontent.com/46655/38592302-eef4eaf0-3d00-11e8-9a7b-3914d7910576.png">
