### PR TITLE
Fix blank debugger when debugging service workers

### DIFF
--- a/src/client/firefox/commands.js
+++ b/src/client/firefox/commands.js
@@ -332,6 +332,11 @@ async function fetchSources() {
  */
 async function checkServerSupportsListWorkers() {
   const root = await tabTarget.root;
+  // root is not available on all debug targets.
+  if (!root) {
+    return false;
+  }
+
   const deviceFront = await getDeviceFront(debuggerClient, root);
   const description = await deviceFront.getDescription();
 


### PR DESCRIPTION
Service worker debugging was broken with https://github.com/devtools-html/debugger.html/pull/5761 , my bad! Looks like not all debugging target have a root client defined. 