### PR TITLE
Update devtools-reps to 0.22.0.

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "codemirror": "^5.28.0",
     "devtools-launchpad": "^0.0.117",
     "devtools-linters": "^0.0.4",
-    "devtools-reps": "^0.21.1",
+    "devtools-reps": "^0.22.0",
     "devtools-source-map": "^0.15.0",
     "devtools-splitter": "^0.0.6",
     "devtools-utils": "^0.0.11",

--- a/src/components/Editor/Preview/Popup.js
+++ b/src/components/Editor/Preview/Popup.js
@@ -60,7 +60,10 @@ export class Popup extends Component<Props> {
       setPopupObjectProperties,
       popupObjectProperties
     } = this.props;
-    const root = createNode(null, expression, expression, { value });
+    const root = createNode({
+      name: expression,
+      contents: { value }
+    });
 
     if (
       !nodeIsPrimitive(root) &&
@@ -172,7 +175,7 @@ export class Popup extends Component<Props> {
     );
 
     const roots = [
-      createNode(null, "entries", "entries", { value: immutable.entries })
+      createNode({ name: "entries", contents: { value: immutable.entries } })
     ];
 
     return (

--- a/src/components/SecondaryPanes/FrameworkComponent.js
+++ b/src/components/SecondaryPanes/FrameworkComponent.js
@@ -32,7 +32,7 @@ class FrameworkComponent extends PureComponent<Props> {
     const { selectedFrame, setPopupObjectProperties } = this.props;
     const value = selectedFrame.this;
 
-    const root = createNode(null, expression, expression, { value });
+    const root = createNode({ name: expression, contents: { value } });
     const properties = await loadItemProperties(root, createObjectClient);
     if (properties) {
       setPopupObjectProperties(value, properties);

--- a/src/components/SecondaryPanes/tests/__snapshots__/Expressions.spec.js.snap
+++ b/src/components/SecondaryPanes/tests/__snapshots__/Expressions.spec.js.snap
@@ -12,7 +12,7 @@ exports[`Expressions should always have unique keys 1`] = `
     <div
       className="expression-content"
     >
-      <OI
+      <Component
         autoExpandDepth={0}
         createObjectClient={[Function]}
         disableWrap={true}
@@ -49,7 +49,7 @@ exports[`Expressions should always have unique keys 1`] = `
     <div
       className="expression-content"
     >
-      <OI
+      <Component
         autoExpandDepth={0}
         createObjectClient={[Function]}
         disableWrap={true}
@@ -93,7 +93,7 @@ exports[`Expressions should render 1`] = `
     <div
       className="expression-content"
     >
-      <OI
+      <Component
         autoExpandDepth={0}
         createObjectClient={[Function]}
         disableWrap={true}
@@ -130,7 +130,7 @@ exports[`Expressions should render 1`] = `
     <div
       className="expression-content"
     >
-      <OI
+      <Component
         autoExpandDepth={0}
         createObjectClient={[Function]}
         disableWrap={true}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2736,9 +2736,9 @@ devtools-modules@^0.0.33:
   dependencies:
     jest "^19.0.2"
 
-devtools-reps@^0.21.1:
-  version "0.21.1"
-  resolved "https://registry.yarnpkg.com/devtools-reps/-/devtools-reps-0.21.1.tgz#3ea3ac92a5f7bf506eb6ce68b86c764041726c8c"
+devtools-reps@^0.22.0:
+  version "0.22.0"
+  resolved "https://registry.yarnpkg.com/devtools-reps/-/devtools-reps-0.22.0.tgz#5deecfa00831779dfb387c304582856dc89f690e"
   dependencies:
     classnames "^2.2.5"
     devtools-components "^0.4.1"


### PR DESCRIPTION
The only breaking change was the one made in createNode, which
is used a few time in the debugger. Call-sites were updated, as
well as some snapshots.
The jest tests are green, and manual testing on the different
places the OI is used showed no issue.
