### PR TITLE
Use file icon for CSS files

### DIFF
--- a/src/utils/source.js
+++ b/src/utils/source.js
@@ -26,8 +26,7 @@ export const sourceTypes = {
   coffee: "coffeescript",
   js: "javascript",
   jsx: "react",
-  ts: "typescript",
-  css: "css"
+  ts: "typescript"
 };
 
 /**


### PR DESCRIPTION
Fixes Issue: #5935 

### Summary of Changes

* Use default (`file`) icon for CSS files as CSS-specific icon doesn't exist.

### Test Plan

- [x] Press Ctrl+P or Command+P to open QuickOpen
- [x] Search for CSS files

### Screenshots

Before:
![image](https://user-images.githubusercontent.com/1968722/38694316-9ad67e40-3e89-11e8-913d-228f0ea3fa63.png)

After:
![image](https://user-images.githubusercontent.com/1968722/38694390-c9ae8154-3e89-11e8-892f-230f3dcab3a2.png)

