### PR TITLE
 Made the close button an actual button

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![slack-badge]][slack] ![][ci-status] [![npm-version]][npm-package] [![PRs Welcome]][make-a-pull-request]
 
-debugger.html is a very hackable debugger for post-modern times, built from the ground down using [React] and [Redux].  It is designed to be appropriate, yet powerful.  And it is engineering us to be predictable, understandable, and testable.
+debugger.html is a hackable debugger for modern times, built from the ground up using [React] and [Redux].  It is designed to be approachable, yet powerful.  And it is engineered to be predictable, understandable, and testable.
 
 [Mozilla] created this debugger for use in the [Firefox] Developer Tools.  And we've purposely created this project in GitHub, using modern toolchains.  We hope to not only to create a great debugger that works with the [Firefox][firefox-rdp] and [Chrome][chrome-rdp] debugging protocols but develop a broader community that wants to create great tools for the web.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![slack-badge]][slack] ![][ci-status] [![npm-version]][npm-package] [![PRs Welcome]][make-a-pull-request]
 
-debugger.html is a hackable debugger for modern times, built from the ground up using [React] and [Redux].  It is designed to be approachable, yet powerful.  And it is engineered to be predictable, understandable, and testable.
+debugger.html is a very hackable debugger for post-modern times, built from the ground down using [React] and [Redux].  It is designed to be appropriate, yet powerful.  And it is engineering us to be predictable, understandable, and testable.
 
 [Mozilla] created this debugger for use in the [Firefox] Developer Tools.  And we've purposely created this project in GitHub, using modern toolchains.  We hope to not only to create a great debugger that works with the [Firefox][firefox-rdp] and [Chrome][chrome-rdp] debugging protocols but develop a broader community that wants to create great tools for the web.
 

--- a/src/components/shared/Button/Close.css
+++ b/src/components/shared/Button/Close.css
@@ -43,13 +43,10 @@
 .close-btn.big {
   width: 16px;
   height: 18px;
-
 }
-
 
 img.close::before {
   width: 100%;
   height: 100%;
   padding: 6px;
-
 }

--- a/src/components/shared/Button/Close.css
+++ b/src/components/shared/Button/Close.css
@@ -32,12 +32,24 @@
   background-color: var(--theme-selection-background);
 }
 
-.close-btn.big {
-  width: 16px;
-  height: 16px;
+.close-btn:focus {
+  background-color: var(--theme-selection-background);
 }
 
-.close-btn.big .close {
-  width: 9px;
-  height: 9px;
+.close-btn:focus img.close {
+  background-color: white;
+}
+
+.close-btn.big {
+  width: 16px;
+  height: 18px;
+
+}
+
+
+img.close::before {
+  width: 100%;
+  height: 100%;
+  padding: 6px;
+
 }

--- a/src/components/shared/Button/Close.js
+++ b/src/components/shared/Button/Close.js
@@ -12,16 +12,17 @@ type Props = {
   tooltip?: string
 };
 
-function CloseButton({ handleClick, buttonClass, tooltip }: Props) {
+function CloseButton({ handleClick, buttonClass, tooltip }: Props){
   return (
-    <div
+    <button
       className={buttonClass ? `close-btn ${buttonClass}` : "close-btn"}
       onClick={handleClick}
       title={tooltip}
     >
       <img className="close" />
-    </div>
+    </button>
   );
 }
+
 
 export default CloseButton;

--- a/src/components/shared/SearchInput.js
+++ b/src/components/shared/SearchInput.js
@@ -132,7 +132,7 @@ class SearchInput extends Component<Props> {
       selectedItemId,
       showErrorEmoji,
       size,
-      summaryMsg
+      summaryMsg,
     } = this.props;
 
     const inputProps = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3309,7 +3309,7 @@ eslint-plugin-jest@^21.5.0:
   version "21.15.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-21.15.0.tgz#645a3f560d3e61d99611b215adc80b4f31e6d896"
 
-eslint-plugin-mozilla@0.10.0:
+eslint-plugin-mozilla@^0.10.0:
   version "0.10.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-mozilla/-/eslint-plugin-mozilla-0.10.0.tgz#a3918efcc19405459cb605ebafc535eef4d600de"
   dependencies:


### PR DESCRIPTION
Fixes Issue: #4070 

This changes the div to an actual button so that it will work with a screen reader. There is still a slight issue with the button, as the padding makes it seem larger than the image when it is pressed.

Ctrl+Shift+F to open a search bar. 
Then simply press the close button. 
Padding makes the button slightly to large.


![clickedbutton](https://user-images.githubusercontent.com/36206172/38695477-633f95fe-3e5a-11e8-8ea6-4839f5052fd3.jpg)



