### PR TITLE
Added check to ensure that the objectProperties are set from the asyn…

### DIFF
--- a/src/components/SecondaryPanes/FrameworkComponent.js
+++ b/src/components/SecondaryPanes/FrameworkComponent.js
@@ -50,6 +50,9 @@ class FrameworkComponent extends PureComponent<Props> {
     };
 
     const loadedRootProperties = popupObjectProperties[value.actor];
+    if (!loadedRootProperties) {
+      return null;
+    }
 
     let roots = getChildren({
       item: root,


### PR DESCRIPTION
Added check to ensure that the objectProperties are set from the async componentWillMount before trying to render the FrameworkComponent.

Fixes Issue: #5953 

### Summary of Changes
* Do not try to getChildren of root node if object properties have yet to be set in state.

### Test Plan
- Reproduced the original bug, and that it is resolved.

### Screenshots
Before:
![before](https://user-images.githubusercontent.com/14250545/38707060-f47a6f00-3e6c-11e8-880f-cefef8efc99d.gif)

Error: 
![error](https://user-images.githubusercontent.com/132260/38700579-63ac606c-3e50-11e8-9279-4b89040bbbac.png)

After:
![after](https://user-images.githubusercontent.com/14250545/38707061-f49c92ec-3e6c-11e8-86b9-f76148200e01.gif)


