### PR TITLE
Prevent blackbox icon from causing jump in SourcesTree

### DIFF
--- a/src/components/PrimaryPanes/Sources.css
+++ b/src/components/PrimaryPanes/Sources.css
@@ -191,8 +191,9 @@
   width: 13px;
   height: 13px;
   display: inline-block;
-  margin-inline-end: 5px;
-  margin-bottom: -2px;
+  margin-inline-end: 6px;
+  margin-inline-start: 1px;
+  margin-top: 2px;
 }
 
 .sources-list .managed-tree .tree .node.focused img {


### PR DESCRIPTION
If you quickly click the Blackbox icon in the Editor footer, you'll notice a shift in not only the SourcesTree icon position but text of the tree item;  this happens because the JS icon is set to 15x15 and blackbox is 13x13.  

I've updated this PR to (1) vertically and horizontally center blackbox icon and (2) prevent the weird text movement.