### PR TITLE
[WIP] Stopped highlighting the current line location on reload.

### DIFF
--- a/src/actions/sources/select.js
+++ b/src/actions/sources/select.js
@@ -91,7 +91,10 @@ export function selectSource(sourceId: string) {
  * @memberof actions/sources
  * @static
  */
-export function selectLocation(location: Location) {
+export function selectLocation(
+  location: Location,
+  isLocatingBreakpoint: boolean = false
+) {
   return async ({ dispatch, getState, client }: ThunkArgs) => {
     if (!client) {
       // No connection, do nothing. This happens when the debugger is
@@ -117,7 +120,7 @@ export function selectLocation(location: Location) {
       ({
         type: "SELECT_SOURCE",
         source,
-        location
+        location: { ...location, isLocatingBreakpoint }
       }: Action)
     );
 

--- a/src/components/Editor/HighlightLine.js
+++ b/src/components/Editor/HighlightLine.js
@@ -61,14 +61,15 @@ export class HighlightLine extends Component<Props> {
     const { sourceId, line } = selectedLocation;
     const editorLine = toEditorLine(sourceId, line);
 
+    if (!this.isStepping && !selectedLocation.isLocatingBreakpoint) {
+      return false;
+    }
     if (!isDocumentReady(selectedSource, selectedLocation)) {
       return false;
     }
-
     if (this.isStepping && editorLine === this.previousEditorLine) {
       return false;
     }
-
     return true;
   }
 
@@ -100,15 +101,14 @@ export class HighlightLine extends Component<Props> {
       return;
     }
     this.isStepping = false;
-    const editorLine = toEditorLine(sourceId, line);
-    this.previousEditorLine = editorLine;
+    this.previousEditorLine = toEditorLine(sourceId, line);
 
     if (!line || isDebugLine(selectedFrame, selectedLocation)) {
       return;
     }
 
     const doc = getDocument(sourceId);
-    doc.addLineClass(editorLine, "line", "highlight-line");
+    doc.addLineClass(this.previousEditorLine, "line", "highlight-line");
   }
 
   clearHighlightLine(selectedLocation: Location, selectedSource: SourceRecord) {

--- a/src/components/SecondaryPanes/Breakpoints.js
+++ b/src/components/SecondaryPanes/Breakpoints.js
@@ -57,7 +57,7 @@ type Props = {
   sourcesMetaData: SourceMetaDataMap,
   enableBreakpoint: Location => void,
   disableBreakpoint: Location => void,
-  selectLocation: Object => void,
+  selectLocation: (Object, boolean) => void,
   removeBreakpoint: string => void,
   removeAllBreakpoints: () => void,
   removeBreakpoints: BreakpointsMap => void,
@@ -131,7 +131,7 @@ class Breakpoints extends Component<Props> {
   }
 
   selectBreakpoint(breakpoint) {
-    this.props.selectLocation(breakpoint.location);
+    this.props.selectLocation(breakpoint.location, true);
   }
 
   removeBreakpoint(event, breakpoint) {

--- a/src/test/mochitest/.eslintrc
+++ b/src/test/mochitest/.eslintrc
@@ -47,6 +47,7 @@
     "isPaused": false,
     "assertPausedLocation": false,
     "assertHighlightLocation": false,
+    "assertNoHighlightLocation": false,
     "createDebuggerContext": false,
     "initDebugger": false,
     "invokeInTab": false,

--- a/src/test/mochitest/browser_dbg-editor-highlight.js
+++ b/src/test/mochitest/browser_dbg-editor-highlight.js
@@ -1,8 +1,8 @@
 /* Any copyright is dedicated to the Public Domain.
  * http://creativecommons.org/publicdomain/zero/1.0/ */
 
-// Tests that the editor will always highight the right line, no
-// matter if the source text doesn't exist yet or even if the source
+// Tests that the editor will not highight a line instantly after selecting a source,
+// no matter if the source text doesn't exist yet or even if the source
 // doesn't exist.
 
 add_task(async function() {
@@ -16,18 +16,15 @@ add_task(async function() {
 
   await selectSource(dbg, sourceUrl, 66)
 
-  // TODO: revisit highlighting lines when the debugger opens
-  // assertHighlightLocation(dbg, "long.js", 66);
-
   log(`Select line 16 and make sure the editor scrolled.`);
   await selectSource(dbg, "long.js", 16);
   await waitForElementWithSelector(dbg, ".CodeMirror-code > .highlight-line");
-  assertHighlightLocation(dbg, "long.js", 16);
+  assertNoHighlightLocation(dbg, "long.js", 16);
 
-  log(`Select several locations and check that we have one highlight`);
+  log(`Select several locations and check that we have no highlight`);
   await selectSource(dbg, "long.js", 17);
   await selectSource(dbg, "long.js", 18);
-  assertHighlightLocation(dbg, "long.js", 18);
+  assertNoHighlightLocation(dbg, "long.js", 18);
 
   // Test jumping to a line in a source that exists but hasn't been
   // loaded yet.
@@ -35,11 +32,11 @@ add_task(async function() {
   selectSource(dbg, "simple1.js", 6);
 
   // Make sure the source is in the loading state, wait for it to be
-  // fully loaded, and check the highlighted line.
+  // fully loaded, and check that the line is not highlighted.
   const simple1 = findSource(dbg, "simple1.js");
   is(getSource(getState(), simple1.id).get("loadedState"), "loading");
 
   await waitForSelectedSource(dbg, "simple1.js");
   ok(getSource(getState(), simple1.id).text);
-  assertHighlightLocation(dbg, "simple1.js", 6);
+  assertNoHighlightLocation(dbg, "simple1.js", 6);
 });

--- a/src/test/mochitest/head.js
+++ b/src/test/mochitest/head.js
@@ -405,6 +405,44 @@ function assertHighlightLocation(dbg, source, line) {
     "Line is highlighted"
   );
 }
+/**
+ * Assert that the debugger is not highlighting the location.
+ *
+ * @memberof mochitest/asserts
+ * @param {Object} dbg
+ * @param {String} source
+ * @param {Number} line
+ * @static
+ */
+function assertNoHighlightLocation(dbg, source, line) {
+  const { selectors: { getSelectedSource }, getState } = dbg;
+  source = findSource(dbg, source);
+
+  // Check the selected source
+  is(
+    getSelectedSource(getState()).get("url"),
+    source.url,
+    "source url is correct"
+  );
+
+  // Check the lack of a highlight line
+  const lineEl = findElement(dbg, "highlightLine");
+  ok(!lineEl, "No line is highlighted");
+
+  is(
+    findAllElements(dbg, "highlightLine").length,
+    0,
+    "0 lines are highlighted"
+  );
+
+  ok(isVisibleInEditor(dbg, lineEl), "Not-highlighted line is visible");
+  ok(
+    !getCM(dbg)
+      .lineInfo(line - 1)
+      .wrapClass.includes("highlight-line"),
+    "No line is highlighted"
+  );
+}
 
 /**
  * Returns boolean for whether the debugger is paused.


### PR DESCRIPTION
Fixes Issue: #5633

### Summary of Changes
* Made `HighlightLine` component only set the highlight if it `isStepping` or the location was requested by clicking on a breakpoint
* Made breakpoint-clicking give the property of `isLocatingBreakpoint` to `selectedLocation` object

### Test Plan
- [x] Open http://firefox-dev.tools/debugger-examples/examples/todomvc/ as debugee
- [x] In `Sources`: open `firefox-dev.tools`, open `debugger-examples/examples/todomvc`, open `bower_components`, open `js`, open `views`, open `app-view.js`
- [x] Put a breakpoint on line 31 of `app-view.js`
- [x] Refresh http://firefox-dev.tools/debugger-examples/examples/todomvc/
- [x] Notice the current location line is not highlighted in grey

### Videos
Before
![before](https://user-images.githubusercontent.com/12681350/38752171-497ff1d0-3f28-11e8-87b3-6f7e5798395b.gif)

After
![after](https://user-images.githubusercontent.com/12681350/38752160-438bcb1e-3f28-11e8-9665-bf073e0f58c8.gif)

