### PR TITLE
Add eslint rule for license header

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,14 @@
 {
   "parser": "babel-eslint",
-  "plugins": ["react", "mozilla", "flowtype", "babel", "prettier", "import"],
+  "plugins": [
+    "react",
+    "mozilla",
+    "flowtype",
+    "babel",
+    "prettier",
+    "import",
+    "file-header"
+  ],
   "globals": {
     "atob": true,
     "btoa": true,
@@ -91,7 +99,7 @@
     // impair readability, but also not required either.
     "comma-dangle": 0,
     // Warn about cyclomatic complexity in functions.
-    "complexity": ["error", {"max": 22}],
+    "complexity": ["error", { "max": 22 }],
     // Don't warn for inconsistent naming when capturing this (not so important
     // with auto-binding fat arrow functions).
     "consistent-this": 0,
@@ -421,6 +429,17 @@
     "operator-linebreak": 0,
 
     // Rules from the prettier plugin
-    "prettier/prettier": "error"
+    "prettier/prettier": "error",
+
+    "file-header/file-header": [
+      "error",
+      [
+        "This Source Code Form is subject to the terms of the Mozilla Public",
+        "License, v. 2.0. If a copy of the MPL was not distributed with this",
+        "file, You can obtain one at <http://mozilla.org/MPL/2.0/>."
+      ],
+      "block",
+      ["-\\*-(.*)-\\*-", "eslint(.*)", "vim(.*)"]
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "devtools-splitter": "^0.0.6",
     "devtools-utils": "^0.0.11",
     "enzyme-adapter-react-16": "^1.1.1",
+    "eslint-plugin-file-header": "0.0.1",
     "eslint-plugin-import": "^2.8.0",
     "fuzzaldrin-plus": "^0.6.0",
     "immutable": "^3.8.2",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
 var mapUrl = require("postcss-url-mapper");
 const debug = require("debug")("launchpad");

--- a/src/actions/breakpoints/tests/syncing.spec.js
+++ b/src/actions/breakpoints/tests/syncing.spec.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 jest.mock("../../../utils/source-maps", () => ({
   getGeneratedLocation: jest.fn()
 }));

--- a/src/actions/event-listeners.js
+++ b/src/actions/event-listeners.js
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
 /* global window gThreadClient setNamedTimeout EVENTS */
 /* eslint no-shadow: 0  */

--- a/src/actions/sources/tests/loadSource.spec.js
+++ b/src/actions/sources/tests/loadSource.spec.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 import {
   actions,
   selectors,

--- a/src/actions/sources/tests/newSources.spec.js
+++ b/src/actions/sources/tests/newSources.spec.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 import {
   actions,
   selectors,

--- a/src/actions/sources/tests/prettyPrint.spec.js
+++ b/src/actions/sources/tests/prettyPrint.spec.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 import {
   actions,
   selectors,

--- a/src/actions/sources/tests/select.spec.js
+++ b/src/actions/sources/tests/select.spec.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 import {
   actions,
   selectors,

--- a/src/actions/tests/ast.spec.js
+++ b/src/actions/tests/ast.spec.js
@@ -1,4 +1,7 @@
 /* eslint max-nested-callbacks: ["error", 6] */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
 import {
   createStore,

--- a/src/actions/tests/breakpoints.spec.js
+++ b/src/actions/tests/breakpoints.spec.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 import {
   createStore,
   selectors,

--- a/src/actions/tests/expressions.spec.js
+++ b/src/actions/tests/expressions.spec.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 import { actions, selectors, createStore } from "../../utils/test-head";
 
 const mockThreadClient = {

--- a/src/actions/tests/file-search.spec.js
+++ b/src/actions/tests/file-search.spec.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 import { createStore, selectors, actions } from "../../utils/test-head";
 
 const {

--- a/src/actions/tests/helpers/breakpoints.js
+++ b/src/actions/tests/helpers/breakpoints.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 export function mockPendingBreakpoint(overrides = {}) {
   const { sourceUrl, line, column, condition, disabled, hidden } = overrides;
   return {

--- a/src/actions/tests/helpers/readFixture.js
+++ b/src/actions/tests/helpers/readFixture.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 import fs from "fs";
 import path from "path";
 

--- a/src/actions/tests/helpers/threadClient.js
+++ b/src/actions/tests/helpers/threadClient.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 import { makeLocationId } from "../../../utils/breakpoint";
 
 function createSource(name) {

--- a/src/actions/tests/navigation.spec.js
+++ b/src/actions/tests/navigation.spec.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 import { createStore, selectors, actions } from "../../utils/test-head";
 describe("navigation", () => {
   it("connect sets the debuggeeUrl", async () => {

--- a/src/actions/tests/pause.spec.js
+++ b/src/actions/tests/pause.spec.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 import {
   actions,
   selectors,

--- a/src/actions/tests/pending-breakpoints.spec.js
+++ b/src/actions/tests/pending-breakpoints.spec.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 // TODO: we would like to mock this in the local tests
 import {
   generateBreakpoint,

--- a/src/actions/tests/preview.spec.js
+++ b/src/actions/tests/preview.spec.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 import {
   createStore,
   selectors,

--- a/src/actions/tests/project-text-search.spec.js
+++ b/src/actions/tests/project-text-search.spec.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 import {
   actions,
   createStore,

--- a/src/actions/tests/source-tree.spec.js
+++ b/src/actions/tests/source-tree.spec.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 import { actions, selectors, createStore } from "../../utils/test-head";
 const { getExpandedState } = selectors;
 

--- a/src/actions/tests/tabs.spec.js
+++ b/src/actions/tests/tabs.spec.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 import {
   actions,
   selectors,

--- a/src/actions/tests/toolbox.spec.js
+++ b/src/actions/tests/toolbox.spec.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 import { actions, createStore } from "../../utils/test-head";
 const threadClient = {
   evaluate: jest.fn()

--- a/src/actions/tests/ui.spec.js
+++ b/src/actions/tests/ui.spec.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 import {
   createStore,
   selectors,

--- a/src/actions/types/ASTAction.js
+++ b/src/actions/types/ASTAction.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 // @flow
 
 import type { SourceMetaDataType } from "../../reducers/ast.js";

--- a/src/actions/types/BreakpointAction.js
+++ b/src/actions/types/BreakpointAction.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 // @flow
 
 import type { Breakpoint, Location } from "../../types";

--- a/src/actions/types/PauseAction.js
+++ b/src/actions/types/PauseAction.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 // @flow
 
 import type { Command } from "../../reducers/types";

--- a/src/actions/types/SourceAction.js
+++ b/src/actions/types/SourceAction.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 // @flow
 
 import type { Location, Source } from "../../types";

--- a/src/actions/types/UIAction.js
+++ b/src/actions/types/UIAction.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 // @flow
 
 import type {

--- a/src/actions/utils/middleware/log.js
+++ b/src/actions/utils/middleware/log.js
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 /* global window */
 
 import { isTesting } from "devtools-config";

--- a/src/actions/utils/middleware/timing.js
+++ b/src/actions/utils/middleware/timing.js
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
 /* global window */
 

--- a/src/client/firefox/tests/commands.spec.js
+++ b/src/client/firefox/tests/commands.spec.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 import { setupCommands, clientCommands } from "../commands";
 
 function makeThreadCLient(resp) {

--- a/src/client/firefox/tests/onconnect.spec.js
+++ b/src/client/firefox/tests/onconnect.spec.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 import { onConnect } from "../../firefox";
 
 const tabTarget = {

--- a/src/components/Editor/tests/Breakpoints.spec.js
+++ b/src/components/Editor/tests/Breakpoints.spec.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 import React from "react";
 import { shallow } from "enzyme";
 import Breakpoints from "../Breakpoints";

--- a/src/components/Editor/tests/DebugLine.spec.js
+++ b/src/components/Editor/tests/DebugLine.spec.js
@@ -1,4 +1,7 @@
 /* eslint max-nested-callbacks: ["error", 7] */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
 import React from "react";
 import { shallow } from "enzyme";

--- a/src/components/Editor/tests/Editor.spec.js
+++ b/src/components/Editor/tests/Editor.spec.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 import React from "react";
 import { shallow } from "enzyme";
 import Editor from "../index";

--- a/src/components/Editor/tests/SearchBar.spec.js
+++ b/src/components/Editor/tests/SearchBar.spec.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 import React from "react";
 import { shallow } from "enzyme";
 import SearchBar from "../SearchBar";

--- a/src/components/SecondaryPanes/Frames/tests/Frame.spec.js
+++ b/src/components/SecondaryPanes/Frames/tests/Frame.spec.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 import React from "react";
 import { shallow } from "enzyme";
 import Frame from "../Frame.js";

--- a/src/components/SecondaryPanes/Frames/tests/FrameMenu.spec.js
+++ b/src/components/SecondaryPanes/Frames/tests/FrameMenu.spec.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 import FrameMenu from "../FrameMenu";
 import { kebabCase } from "lodash";
 

--- a/src/components/SecondaryPanes/Frames/tests/Frames.spec.js
+++ b/src/components/SecondaryPanes/Frames/tests/Frames.spec.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 import React from "react";
 import { shallow } from "enzyme";
 import { Map } from "immutable";

--- a/src/components/SecondaryPanes/Frames/tests/Group.spec.js
+++ b/src/components/SecondaryPanes/Frames/tests/Group.spec.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 import React from "react";
 import { shallow } from "enzyme";
 import Group from "../Group.js";

--- a/src/components/SecondaryPanes/tests/Expressions.spec.js
+++ b/src/components/SecondaryPanes/tests/Expressions.spec.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 import React from "react";
 import { shallow } from "enzyme";
 import Expressions from "../Expressions";

--- a/src/components/shared/VisibilityHandler.js
+++ b/src/components/shared/VisibilityHandler.js
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this file,
- * You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
 /**
  * Helper class to disable panel rendering when it is in background.

--- a/src/components/shared/tests/Accordion.spec.js
+++ b/src/components/shared/tests/Accordion.spec.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 import React from "react";
 import { shallow } from "enzyme";
 

--- a/src/components/shared/tests/Badge.spec.js
+++ b/src/components/shared/tests/Badge.spec.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 import React from "react";
 import { shallow } from "enzyme";
 

--- a/src/components/shared/tests/BracketArrow.spec.js
+++ b/src/components/shared/tests/BracketArrow.spec.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 import React from "react";
 import { shallow } from "enzyme";
 

--- a/src/components/shared/tests/Button.spec.js
+++ b/src/components/shared/tests/Button.spec.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 import React from "react";
 import { shallow } from "enzyme";
 

--- a/src/components/shared/tests/Dropdown.spec.js
+++ b/src/components/shared/tests/Dropdown.spec.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 import React from "react";
 import { shallow } from "enzyme";
 

--- a/src/components/shared/tests/ManagedTree.spec.js
+++ b/src/components/shared/tests/ManagedTree.spec.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 import React from "react";
 import { mount, shallow } from "enzyme";
 

--- a/src/components/shared/tests/Popover.spec.js
+++ b/src/components/shared/tests/Popover.spec.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 import React from "react";
 import { mount, shallow } from "enzyme";
 

--- a/src/components/shared/tests/PreviewFunction.spec.js
+++ b/src/components/shared/tests/PreviewFunction.spec.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 import React from "react";
 import { shallow } from "enzyme";
 import PreviewFunction from "../PreviewFunction";

--- a/src/components/shared/tests/ResultList.spec.js
+++ b/src/components/shared/tests/ResultList.spec.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 import React from "react";
 import { shallow } from "enzyme";
 import ResultList from "../ResultList";

--- a/src/components/shared/tests/SearchInput.spec.js
+++ b/src/components/shared/tests/SearchInput.spec.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 import React from "react";
 import { shallow } from "enzyme";
 

--- a/src/components/tests/Outline.spec.js
+++ b/src/components/tests/Outline.spec.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 import React from "react";
 import { shallow } from "enzyme";
 import Outline from "../../components/PrimaryPanes/Outline";

--- a/src/components/tests/ProjectSearch.spec.js
+++ b/src/components/tests/ProjectSearch.spec.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 import React from "react";
 import { mount, shallow } from "enzyme";
 import { List } from "immutable";

--- a/src/components/tests/QuickOpenModal.spec.js
+++ b/src/components/tests/QuickOpenModal.spec.js
@@ -1,4 +1,7 @@
 /* eslint max-nested-callbacks: ["error", 4] */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
 import React from "react";
 import { shallow, mount } from "enzyme";

--- a/src/components/tests/SourcesTree.spec.js
+++ b/src/components/tests/SourcesTree.spec.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 import React from "react";
 import { shallow } from "enzyme";
 import SourcesTree from "../../components/PrimaryPanes/SourcesTree";

--- a/src/components/tests/WhyPaused.spec.js
+++ b/src/components/tests/WhyPaused.spec.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 import { shallow } from "enzyme";
 import renderWhyPaused from "../SecondaryPanes/Frames/WhyPaused.js";
 

--- a/src/reducers/async-requests.js
+++ b/src/reducers/async-requests.js
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
 /**
  * Async request reducer

--- a/src/reducers/event-listeners.js
+++ b/src/reducers/event-listeners.js
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
 /**
  * Event listeners reducer

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
 /**
  * Reducer index

--- a/src/reducers/quick-open.js
+++ b/src/reducers/quick-open.js
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
 /**
  * Quick Open reducer

--- a/src/reducers/tests/breakpoints.spec.js
+++ b/src/reducers/tests/breakpoints.spec.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 // @flow
 declare var describe: (name: string, func: () => void) => void;
 declare var it: (desc: string, func: () => void) => void;

--- a/src/reducers/tests/quick-open.spec.js
+++ b/src/reducers/tests/quick-open.spec.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 // @flow
 declare var describe: (name: string, func: () => void) => void;
 declare var test: (desc: string, func: () => void) => void;

--- a/src/reducers/tests/sources.spec.js
+++ b/src/reducers/tests/sources.spec.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 // @flow
 declare var describe: (name: string, func: () => void) => void;
 declare var it: (desc: string, func: () => void) => void;

--- a/src/reducers/tests/ui.spec.js
+++ b/src/reducers/tests/ui.spec.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 // @flow
 declare var describe: (name: string, func: () => void) => void;
 declare var it: (desc: string, func: () => void) => void;

--- a/src/reducers/types.js
+++ b/src/reducers/types.js
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
 /**
  * Types reducer

--- a/src/test/__mocks__/styleMock.js
+++ b/src/test/__mocks__/styleMock.js
@@ -1,1 +1,5 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 module.exports = {};

--- a/src/test/__mocks__/svgMock.js
+++ b/src/test/__mocks__/svgMock.js
@@ -1,1 +1,5 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 module.exports = "<svg></svg>";

--- a/src/test/shim.js
+++ b/src/test/shim.js
@@ -1,1 +1,5 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 global.requestAnimationFrame = callback => setTimeout(callback, 0);

--- a/src/test/tests-setup.js
+++ b/src/test/tests-setup.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 global.Worker = require("workerjs");
 
 import path from "path";

--- a/src/test/utils/history.js
+++ b/src/test/utils/history.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 let logs = [];
 export function getHistory(query: ?string = null) {
   if (!query) {

--- a/src/utils/breakpoint/tests/astBreakpointLocation.spec.js
+++ b/src/utils/breakpoint/tests/astBreakpointLocation.spec.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 import { getASTLocation } from "../astBreakpointLocation.js";
 import {
   getSource,

--- a/src/utils/editor/source-editor.js
+++ b/src/utils/editor/source-editor.js
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
 /**
  * CodeMirror source editor utils

--- a/src/utils/editor/tests/create-editor.spec.js
+++ b/src/utils/editor/tests/create-editor.spec.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 import { createEditor } from "../create-editor";
 import SourceEditor from "../source-editor";
 

--- a/src/utils/editor/tests/editor.spec.js
+++ b/src/utils/editor/tests/editor.spec.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 import { Record } from "immutable";
 import {
   shouldShowPrettyPrint,

--- a/src/utils/editor/tests/get-token-location.spec.js
+++ b/src/utils/editor/tests/get-token-location.spec.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 import { getTokenLocation } from "../get-token-location";
 
 describe("getTokenLocation", () => {

--- a/src/utils/editor/tests/source-search.spec.js
+++ b/src/utils/editor/tests/source-search.spec.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 import { find, getMatchIndex, removeOverlay } from "../source-search";
 
 const getCursor = jest.fn(() => ({ line: 90, ch: 54 }));

--- a/src/utils/pause/frames/tests/displayName.spec.js
+++ b/src/utils/pause/frames/tests/displayName.spec.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 import {
   formatCopyName,
   formatDisplayName,

--- a/src/utils/pause/frames/tests/getLibraryFromUrl.spec.js
+++ b/src/utils/pause/frames/tests/getLibraryFromUrl.spec.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 import { getLibraryFromUrl } from "../getLibraryFromUrl";
 
 describe("getLibraryFromUrl", () => {

--- a/src/utils/pause/mapScopes/filtering.js
+++ b/src/utils/pause/mapScopes/filtering.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 // @flow
 
 function findInsertionLocation<T>(

--- a/src/utils/pause/scopes/tests/getFramePopVariables.spec.js
+++ b/src/utils/pause/scopes/tests/getFramePopVariables.spec.js
@@ -1,4 +1,7 @@
 /* eslint max-nested-callbacks: ["error", 4] */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
 import { getFramePopVariables } from "../utils";
 

--- a/src/utils/pause/scopes/tests/scopes.spec.js
+++ b/src/utils/pause/scopes/tests/scopes.spec.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 import { getScopes } from "..";
 
 describe("scopes", () => {

--- a/src/utils/sources-tree/tests/collapseTree.spec.js
+++ b/src/utils/sources-tree/tests/collapseTree.spec.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 import { Map } from "immutable";
 
 import {

--- a/src/utils/sources-tree/tests/sortTree.spec.js
+++ b/src/utils/sources-tree/tests/sortTree.spec.js
@@ -1,4 +1,7 @@
 /* eslint max-nested-callbacks: ["error", 4]*/
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
 import { Map } from "immutable";
 

--- a/src/utils/sources-tree/tests/treeOrder.spec.js
+++ b/src/utils/sources-tree/tests/treeOrder.spec.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 import { getDomain } from "../treeOrder";
 
 describe("getDomain", () => {

--- a/src/utils/sources-tree/tests/utils.spec.js
+++ b/src/utils/sources-tree/tests/utils.spec.js
@@ -1,4 +1,7 @@
 /* eslint max-nested-callbacks: ["error", 4]*/
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
 import I, { Map } from "immutable";
 

--- a/src/utils/task.js
+++ b/src/utils/task.js
@@ -1,8 +1,8 @@
 /* -*- indent-tabs-mode: nil; js-indent-level: 2 -*- */
 /* vim: set ts=2 et sw=2 tw=80 filetype=javascript: */
 /* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this file,
- * You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
 /**
  * This object provides the public module functions.

--- a/src/utils/tests/DevToolsUtils.spec.js
+++ b/src/utils/tests/DevToolsUtils.spec.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 import { reportException, executeSoon } from "../DevToolsUtils.js";
 
 describe("DevToolsUtils", () => {

--- a/src/utils/tests/assert.spec.js
+++ b/src/utils/tests/assert.spec.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 import assert from "../assert.js";
 
 let testAssertMessageHead, testAssertMessage;

--- a/src/utils/tests/ast.spec.js
+++ b/src/utils/tests/ast.spec.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 import { findBestMatchExpression } from "../ast";
 
 import { getSymbols } from "../../workers/parser/getSymbols";

--- a/src/utils/tests/clipboard.spec.js
+++ b/src/utils/tests/clipboard.spec.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 import { copyToTheClipboard } from "../clipboard";
 
 let clipboardTestCopyString, expectedCopyEvent;

--- a/src/utils/tests/expressions.spec.js
+++ b/src/utils/tests/expressions.spec.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 import { wrapExpression, sanitizeInput, getValue } from "../expressions";
 
 function createError(preview) {

--- a/src/utils/tests/fromJS.spec.js
+++ b/src/utils/tests/fromJS.spec.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 import fromJS from "../fromJS";
 
 const preview = {

--- a/src/utils/tests/function.spec.js
+++ b/src/utils/tests/function.spec.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 import { findFunctionText } from "../function";
 
 import { getSymbols } from "../../workers/parser/getSymbols";

--- a/src/utils/tests/indentation.spec.js
+++ b/src/utils/tests/indentation.spec.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 import { correctIndentation, getIndentation } from "../indentation";
 
 describe("indentation", () => {

--- a/src/utils/tests/isMinified.spec.js
+++ b/src/utils/tests/isMinified.spec.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 import I from "immutable";
 import { isMinified } from "../isMinified";
 

--- a/src/utils/tests/log.spec.js
+++ b/src/utils/tests/log.spec.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 import { log } from "../log.js";
 
 let logArgFirst, logArgSecond, logArgArray, logPrefix;

--- a/src/utils/tests/path.spec.js
+++ b/src/utils/tests/path.spec.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 import { basename, dirname, isURL, isAbsolute, join } from "../path";
 
 const fullTestURL = "https://www.example.com/some/endpoint";

--- a/src/utils/tests/project-search.spec.js
+++ b/src/utils/tests/project-search.spec.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 import { highlightMatches } from "../project-search";
 
 describe("project search - highlightMatches", () => {

--- a/src/utils/tests/quick-open.spec.js
+++ b/src/utils/tests/quick-open.spec.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 import cases from "jest-in-case";
 import { parseQuickOpenQuery, parseLineColumn } from "../quick-open";
 

--- a/src/utils/tests/source.spec.js
+++ b/src/utils/tests/source.spec.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 import {
   getFilename,
   getFileURL,

--- a/src/utils/tests/utils.spec.js
+++ b/src/utils/tests/utils.spec.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 import { handleError, promisify, endTruncateStr, waitForMs } from "../utils";
 
 describe("handleError()", () => {

--- a/src/utils/tests/wasm.spec.js
+++ b/src/utils/tests/wasm.spec.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 import {
   isWasm,
   lineToWasmOffset,

--- a/src/workers/parser/getScopes/visitor.js
+++ b/src/workers/parser/getScopes/visitor.js
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
 // @flow
 

--- a/src/workers/parser/tests/contains.spec.js
+++ b/src/workers/parser/tests/contains.spec.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 import {
   containsPosition,
   containsLocation,

--- a/src/workers/parser/tests/findOutOfScopeLocations.spec.js
+++ b/src/workers/parser/tests/findOutOfScopeLocations.spec.js
@@ -1,4 +1,7 @@
 /* eslint max-nested-callbacks: ["error", 4]*/
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
 import findOutOfScopeLocations from "../findOutOfScopeLocations";
 

--- a/src/workers/parser/tests/framework.spec.js
+++ b/src/workers/parser/tests/framework.spec.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 import { getFramework } from "../frameworks";
 import { getSource, getOriginalSource } from "./helpers";
 import { setSource } from "../sources";

--- a/src/workers/parser/tests/getScopes.spec.js
+++ b/src/workers/parser/tests/getScopes.spec.js
@@ -1,4 +1,7 @@
 /* eslint max-nested-callbacks: ["error", 4]*/
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
 import getScopes from "../getScopes";
 import { setSource } from "../sources";

--- a/src/workers/parser/tests/getSymbols.spec.js
+++ b/src/workers/parser/tests/getSymbols.spec.js
@@ -1,4 +1,7 @@
 /* eslint max-nested-callbacks: ["error", 4]*/
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
 import { formatSymbols } from "../utils/formatSymbols";
 import { getSource, getOriginalSource } from "./helpers";

--- a/src/workers/parser/tests/helpers/index.js
+++ b/src/workers/parser/tests/helpers/index.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 import fs from "fs";
 import path from "path";
 

--- a/src/workers/parser/tests/mapOriginalExpression.spec.js
+++ b/src/workers/parser/tests/mapOriginalExpression.spec.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 import mapOriginalExpression from "../mapOriginalExpression";
 
 describe("mapOriginalExpression", () => {

--- a/src/workers/parser/tests/pauseLocation.spec.js
+++ b/src/workers/parser/tests/pauseLocation.spec.js
@@ -1,4 +1,7 @@
 /* eslint max-nested-callbacks: ["error", 4]*/
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
 import { isInvalidPauseLocation } from "../pauseLocation";
 import { setSource } from "../sources";

--- a/src/workers/parser/tests/pausePoints.spec.js
+++ b/src/workers/parser/tests/pausePoints.spec.js
@@ -1,4 +1,8 @@
 /* eslint max-nested-callbacks: ["error", 4]*/
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 import cases from "jest-in-case";
 import { formatPausePoints } from "../../../utils/pause/pausePoints";
 

--- a/src/workers/parser/tests/sources.spec.js
+++ b/src/workers/parser/tests/sources.spec.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 import { hasSource, getSource, setSource, clearSources } from "../sources";
 
 import type { Source } from "../../../types";

--- a/src/workers/parser/tests/steps.spec.js
+++ b/src/workers/parser/tests/steps.spec.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 import { getNextStep } from "../steps";
 import { getSource } from "./helpers";
 import { setSource } from "../sources";

--- a/src/workers/parser/tests/validate.spec.js
+++ b/src/workers/parser/tests/validate.spec.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 import { hasSyntaxError } from "../validate";
 
 describe("has syntax error", () => {

--- a/src/workers/parser/utils/tests/ast.spec.js
+++ b/src/workers/parser/utils/tests/ast.spec.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 import { getAst } from "../ast";
 import { setSource } from "../../sources";
 import cases from "jest-in-case";

--- a/src/workers/search/tests/build-query.spec.js
+++ b/src/workers/search/tests/build-query.spec.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 import { escapeRegExp } from "lodash";
 import buildQuery from "../build-query";
 

--- a/src/workers/search/tests/get-matches.spec.js
+++ b/src/workers/search/tests/get-matches.spec.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 import getMatches from "../get-matches";
 
 describe("search", () => {

--- a/src/workers/search/tests/project-search.spec.js
+++ b/src/workers/search/tests/project-search.spec.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 import { findSourceMatches } from "../project-search";
 
 const text = `

--- a/wallaby.conf.js
+++ b/wallaby.conf.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 module.exports = function(wallaby) {
   return {
     files: [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 const toolbox = require("./node_modules/devtools-launchpad/index");
 
 const getConfig = require("./bin/getConfig");

--- a/yarn.lock
+++ b/yarn.lock
@@ -3261,6 +3261,10 @@ eslint-plugin-babel@^5.0.0:
   dependencies:
     eslint-rule-composer "^0.1.1"
 
+eslint-plugin-file-header@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-file-header/-/eslint-plugin-file-header-0.0.1.tgz#8de79de79c9ab35ac212db8e977e5003803b8bfb"
+
 eslint-plugin-flowtype@^2.36.0:
   version "2.46.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-flowtype/-/eslint-plugin-flowtype-2.46.1.tgz#c4f81d580cd89c82bc3a85a1ccf4ae3a915143a4"


### PR DESCRIPTION
Fixes Issue: #5155

### Summary of Changes

* Added eslint rule that checks for presence of comment header in the file - [eslint-plugin-file-header](https://github.com/Sekhmet/eslint-plugin-file-header)
* Added missing headers (or updated old ones) with `--fix` (it only updated files linted by eslint, other ones have to be handled separatly).

### Test Plan

- [x] Add new file without header
- [x] Remove or modify license header in existing file