### PR TITLE
[Editor] Add gutter hover effect

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -45,7 +45,6 @@
     "number-leading-zero": "always",
     "number-no-trailing-zeros": true,
     "selector-combinator-space-after": "always",
-    "selector-combinator-space-before": "always",
     "selector-list-comma-space-before": "never",
     "selector-pseudo-element-colon-notation": "double",
     "selector-type-case": "lower",

--- a/src/components/Editor/Editor.css
+++ b/src/components/Editor/Editor.css
@@ -64,7 +64,8 @@ html[dir="rtl"] .editor-mount {
 
 :not(.empty-line):not(.new-breakpoint) > .CodeMirror-gutter-wrapper:hover > .CodeMirror-linenumber {
   color: white;
-  left: 27px !important;
+  left: auto !important;
+  right: 4px;
 }
 
 .editor-wrapper .breakpoints {

--- a/src/components/Editor/Editor.css
+++ b/src/components/Editor/Editor.css
@@ -51,17 +51,27 @@ html[dir="rtl"] .editor-mount {
   direction: ltr;
 }
 
+.theme-light {
+  --gutter-hover-background-color: #dde1e4;
+}
+
+.theme-dark {
+  --gutter-hover-background-color: #414141;
+}
+
 :not(.empty-line):not(.new-breakpoint) > .CodeMirror-gutter-wrapper:hover {
   width: 60px;
   height: 13px;
   left: -55px !important;
-  background-color: var(--theme-highlight-gray) !important;
+  background-color: var(--gutter-hover-background-color) !important;
   mask: url(/images/breakpoint.svg) no-repeat;
   mask-size: 100%;
   mask-position: 0 1px;
 }
 
-:not(.empty-line):not(.new-breakpoint) > .CodeMirror-gutter-wrapper:hover > .CodeMirror-linenumber {
+:not(.empty-line):not(.new-breakpoint)
+  > .CodeMirror-gutter-wrapper:hover
+  > .CodeMirror-linenumber {
   left: auto !important;
   right: 6px;
   color: var(--theme-body-color);

--- a/src/components/Editor/Editor.css
+++ b/src/components/Editor/Editor.css
@@ -54,20 +54,18 @@ html[dir="rtl"] .editor-mount {
 :not(.empty-line):not(.new-breakpoint) > .CodeMirror-gutter-wrapper:hover {
   width: 60px !important;
   height: 13px;
-  left: -57px !important;
-  background-color: var(--theme-highlight-blue) !important;
+  left: -55px !important;
+  background-color: var(--theme-highlight-gray) !important;
   mask: url(/images/breakpoint.svg) no-repeat;
   mask-size: 100%;
   mask-position: 0 1px;
-  opacity: 0.8;
 }
 
 :not(.empty-line):not(.new-breakpoint)
   > .CodeMirror-gutter-wrapper:hover
   > .CodeMirror-linenumber {
-  color: white;
   left: auto !important;
-  right: 4px;
+  right: 6px;
 }
 
 .editor-wrapper .breakpoints {
@@ -115,6 +113,11 @@ html[dir="rtl"] .editor-mount {
   border-radius: 5px;
   border-color: blue;
   border: 1px solid #00b6ff;
+}
+
+.editor .breakpoint {
+  position: absolute;
+  right: -2px;
 }
 
 .editor.new-breakpoint.folding-enabled svg {

--- a/src/components/Editor/Editor.css
+++ b/src/components/Editor/Editor.css
@@ -52,7 +52,7 @@ html[dir="rtl"] .editor-mount {
 }
 
 :not(.empty-line):not(.new-breakpoint) > .CodeMirror-gutter-wrapper:hover {
-  width: 60px !important;
+  width: 60px;
   height: 13px;
   left: -55px !important;
   background-color: var(--theme-highlight-gray) !important;
@@ -61,11 +61,10 @@ html[dir="rtl"] .editor-mount {
   mask-position: 0 1px;
 }
 
-:not(.empty-line):not(.new-breakpoint)
-  > .CodeMirror-gutter-wrapper:hover
-  > .CodeMirror-linenumber {
+:not(.empty-line):not(.new-breakpoint) > .CodeMirror-gutter-wrapper:hover > .CodeMirror-linenumber {
   left: auto !important;
   right: 6px;
+  color: var(--theme-body-color);
 }
 
 .editor-wrapper .breakpoints {

--- a/src/components/Editor/Editor.css
+++ b/src/components/Editor/Editor.css
@@ -59,10 +59,12 @@ html[dir="rtl"] .editor-mount {
   mask: url(/images/breakpoint.svg) no-repeat;
   mask-size: 100%;
   mask-position: 0 1px;
-  opacity: 0.3;
+  opacity: 0.8;
 }
 
-:not(.empty-line):not(.new-breakpoint) > .CodeMirror-gutter-wrapper:hover > .CodeMirror-linenumber {
+:not(.empty-line):not(.new-breakpoint)
+  > .CodeMirror-gutter-wrapper:hover
+  > .CodeMirror-linenumber {
   color: white;
   left: auto !important;
   right: 4px;
@@ -159,7 +161,10 @@ html[dir="rtl"] .editor-mount {
 }
 
 /* set the linenumber white when there is a breakpoint */
-.cm-s-mozilla .new-breakpoint .CodeMirror-gutter-wrapper .CodeMirror-linenumber {
+.cm-s-mozilla
+  .new-breakpoint
+  .CodeMirror-gutter-wrapper
+  .CodeMirror-linenumber {
   color: white;
 }
 

--- a/src/components/Editor/Editor.css
+++ b/src/components/Editor/Editor.css
@@ -51,6 +51,22 @@ html[dir="rtl"] .editor-mount {
   direction: ltr;
 }
 
+:not(.empty-line):not(.new-breakpoint) > .CodeMirror-gutter-wrapper:hover {
+  width: 60px !important;
+  height: 13px;
+  left: -57px !important;
+  background-color: var(--theme-highlight-blue) !important;
+  mask: url(/images/breakpoint.svg) no-repeat;
+  mask-size: 100%;
+  mask-position: 0 1px;
+  opacity: 0.3;
+}
+
+:not(.empty-line):not(.new-breakpoint) > .CodeMirror-gutter-wrapper:hover > .CodeMirror-linenumber {
+  color: white;
+  left: 27px !important;
+}
+
 .editor-wrapper .breakpoints {
   position: absolute;
   top: 0;

--- a/src/components/Editor/EmptyLines.css
+++ b/src/components/Editor/EmptyLines.css
@@ -1,7 +1,0 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
-/*
-.empty-line .CodeMirror-linenumber {
-  opacity: 0.5;
-} */

--- a/src/components/Editor/EmptyLines.css
+++ b/src/components/Editor/EmptyLines.css
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
-
+/*
 .empty-line .CodeMirror-linenumber {
   opacity: 0.5;
-}
+} */

--- a/src/components/Editor/EmptyLines.js
+++ b/src/components/Editor/EmptyLines.js
@@ -8,8 +8,6 @@ import { getSelectedSource, getEmptyLines } from "../../selectors";
 import type { SourceRecord } from "../../types";
 import { toEditorLine } from "../../utils/editor";
 
-import "./EmptyLines.css";
-
 type props = {
   selectedSource: SourceRecord,
   editor: Object,

--- a/src/components/Editor/EmptyLines.js
+++ b/src/components/Editor/EmptyLines.js
@@ -33,6 +33,7 @@ class EmptyLines extends Component {
     if (!emptyLines) {
       return;
     }
+
     editor.codeMirror.operation(() => {
       emptyLines.forEach(emptyLine => {
         const line = toEditorLine(selectedSource.get("id"), emptyLine);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2790,6 +2790,14 @@ devtools-utils@^0.0.12:
     babel-preset-stage-3 "^6.22.0"
     jest "^19.0.2"
 
+devtools-utils@^0.0.12:
+  version "0.0.12"
+  resolved "https://registry.yarnpkg.com/devtools-utils/-/devtools-utils-0.0.12.tgz#8cb4f461f5fb36532883e5c9bafbd94fdb0ce5f1"
+  dependencies:
+    babel-plugin-transform-flow-strip-types "^6.22.0"
+    babel-preset-stage-3 "^6.22.0"
+    jest "^19.0.2"
+
 dezalgo@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/dezalgo/-/dezalgo-1.0.3.tgz#7f742de066fc748bc8db820569dddce49bf0d456"


### PR DESCRIPTION
Fixes Issue: #5603 

### Summary of Changes

* Add hover effect to gutter line numbers.

### Test Plan

- [x] Open JS file.
- [x] Hover on the gutter line numbers.
- [x] Line numbers should be highlighted.
- [x] Empty lines shouldn't be highlighted.
- [x] Existing breakpoints shouldn't be highlighted.
- [x] Highlight should disappear after leaving gutter area.


### Screenshots/Videos

Before:
![gutter_before](https://user-images.githubusercontent.com/1968722/38780241-b0cf5ac2-40d3-11e8-8e89-41e89fc76f42.gif)


After:
![gutter_after](https://user-images.githubusercontent.com/1968722/38780243-b38180d8-40d3-11e8-94d0-02b8e4ca5bd8.gif)
