### PR TITLE
[Scopes] Show "optimized out" instead of "unmapped" when resolving import declarations

### DIFF
--- a/src/test/mochitest/browser_dbg-babel-scopes.js
+++ b/src/test/mochitest/browser_dbg-babel-scopes.js
@@ -103,7 +103,7 @@ add_task(async function() {
     { line: 8, column: 6 },
     [
       "arrow",
-      ["argArrow", "(optimized away)"],
+      ["argArrow", "(unmapped)"],
       "Block",
       "arrow()",
       "fn",

--- a/src/test/mochitest/browser_dbg-babel-scopes.js
+++ b/src/test/mochitest/browser_dbg-babel-scopes.js
@@ -220,9 +220,13 @@ add_task(async function() {
     ["val", "(optimized away)"],
     "Module",
 
-    // This value is currently unmapped because import declarations don't map
-    // very well and ones at the end of the file map especially badly.
-    ["aDefault", "(unmapped)"],
+    // This value is currently optimized away, which isn't 100% accurate.
+    // Because import declarations is the last thing in the file, our current
+    // logic doesn't cover _both_ 'var' statements that it generates,
+    // making us use the first, optimized-out binding. Given that imports
+    // are almost never the last thing in a file though, this is probably not
+    // a huge deal for now.
+    ["aDefault", "(optimized away)"],
     ["root", "(optimized away)"],
     ["val", "(optimized away)"],
   ]);

--- a/src/utils/pause/mapScopes/findGeneratedBindingFromPosition.js
+++ b/src/utils/pause/mapScopes/findGeneratedBindingFromPosition.js
@@ -109,10 +109,10 @@ function filterApplicableBindings(
 ): Array<GeneratedBindingLocation> {
   // Any binding overlapping a part of the mapping range.
   return filterSortedArray(bindings, binding => {
-    if (positionCmp(binding.loc.end, mapped.start) < 0) {
+    if (positionCmp(binding.loc.end, mapped.start) <= 0) {
       return -1;
     }
-    if (positionCmp(binding.loc.start, mapped.end) > 0) {
+    if (positionCmp(binding.loc.start, mapped.end) >= 0) {
       return 1;
     }
 


### PR DESCRIPTION
Refs Issue: #5561

### Summary of Changes

* Fixes the binding filtering to more strict
* If an optimized-out value is encountered while resolving import bindings, used it if no better value is found
