### PR TITLE
Tab Order Improvements

### DIFF
--- a/src/components/shared/Accordion.js
+++ b/src/components/shared/Accordion.js
@@ -16,7 +16,7 @@ type AccordionItem = {
   className: string,
   opened: boolean,
   onToggle?: () => void,
-  shouldOpen?: () => void
+  shouldOpen?: () => void,
 };
 
 type Props = { items: Array<Object> };
@@ -54,11 +54,11 @@ class Accordion extends Component<Props, State> {
 
     return (
       <div className={item.className} key={i}>
-        <div className="_header" onClick={() => this.handleHeaderClick(i)}>
+        <div className="_header" tabIndex="0" onClick={() => this.handleHeaderClick(i)}>
           <Svg name="arrow" className={opened ? "expanded" : ""} />
           {item.header}
           {item.buttons ? (
-            <div className="header-buttons">{item.buttons}</div>
+            <div className="header-buttons" tabIndex="-1">{item.buttons}</div>
           ) : null}
         </div>
         {opened && (

--- a/src/components/shared/Accordion.js
+++ b/src/components/shared/Accordion.js
@@ -16,7 +16,7 @@ type AccordionItem = {
   className: string,
   opened: boolean,
   onToggle?: () => void,
-  shouldOpen?: () => void,
+  shouldOpen?: () => void
 };
 
 type Props = { items: Array<Object> };
@@ -54,11 +54,17 @@ class Accordion extends Component<Props, State> {
 
     return (
       <div className={item.className} key={i}>
-        <div className="_header" tabIndex="0" onClick={() => this.handleHeaderClick(i)}>
+        <div
+          className="_header"
+          tabIndex="0"
+          onClick={() => this.handleHeaderClick(i)}
+        >
           <Svg name="arrow" className={opened ? "expanded" : ""} />
           {item.header}
           {item.buttons ? (
-            <div className="header-buttons" tabIndex="-1">{item.buttons}</div>
+            <div className="header-buttons" tabIndex="-1">
+              {item.buttons}
+            </div>
           ) : null}
         </div>
         {opened && (

--- a/src/components/shared/tests/__snapshots__/Accordion.spec.js.snap
+++ b/src/components/shared/tests/__snapshots__/Accordion.spec.js.snap
@@ -11,6 +11,7 @@ exports[`Accordion basic render 1`] = `
     <div
       className="_header"
       onClick={[Function]}
+      tabIndex="0"
     >
       <Svg
         className="expanded"
@@ -31,6 +32,7 @@ exports[`Accordion basic render 1`] = `
     <div
       className="_header"
       onClick={[Function]}
+      tabIndex="0"
     >
       <Svg
         className=""
@@ -39,6 +41,7 @@ exports[`Accordion basic render 1`] = `
       Test Accordion Item 2
       <div
         className="header-buttons"
+        tabIndex="-1"
       >
         <button />
       </div>
@@ -51,6 +54,7 @@ exports[`Accordion basic render 1`] = `
     <div
       className="_header"
       onClick={[Function]}
+      tabIndex="0"
     >
       <Svg
         className="expanded"


### PR DESCRIPTION
Fixes part of the 2nd check box (Need to be able to navigate to headers with keyboard) of Issue #4080
In src/components/shared/accordion.js, we changed header-buttons tabIndex from 0 to -1.
This prevents the header-buttons divs (which contain the refresh and add buttons) from being erroneously focused when user cannot interact with them.

Test Plan:

   - [x] Input setInterval(function() { console.log(document.activeElement); }, 3000); into web console to display the active element.
  -  [x] Opened search in files with ctrl+shift+f
   - [x] Navigated headers using Tab button on keyboard

![before fixing focusing](https://user-images.githubusercontent.com/36204746/38887031-a8db442a-4245-11e8-8663-42584cc406b9.gif)
_Before we changed header-buttons tab index to -1, there was a focusing issue where the button was focused when user couldn't interact with it._


![after fixing focusing](https://user-images.githubusercontent.com/36204746/38887035-ab1d2de8-4245-11e8-867d-42b7c18b103d.gif)
_After change, header-buttons are no longer focused while the user cannot interact with them._



Will continue to work on Issue #4080 2nd check box to remove other focusing issues. Just wanted to submit our progress so far! (With @chan750 and @denigrise)
