### PR TITLE
Ensure Breakpoint display is unique per file

### DIFF
--- a/src/components/SecondaryPanes/Breakpoints.js
+++ b/src/components/SecondaryPanes/Breakpoints.js
@@ -15,7 +15,7 @@ import { groupBy, sortBy } from "lodash";
 import Breakpoint from "./Breakpoint";
 
 import actions from "../../actions";
-import { getFilename } from "../../utils/source";
+import { getRawSourceURL } from "../../utils/source";
 import {
   getSources,
   getSourceInSources,
@@ -80,10 +80,6 @@ function isCurrentlyPausedAtBreakpoint(
   const bpId = makeLocationId(breakpoint.location);
   const pausedId = makeLocationId(frame.location);
   return bpId === pausedId;
-}
-
-function getBreakpointFilename(source: Source) {
-  return source ? getFilename(source) : "";
 }
 
 function createExceptionOption(
@@ -185,18 +181,29 @@ class Breakpoints extends Component<Props> {
 
     const groupedBreakpoints = groupBy(
       sortBy([...breakpoints.valueSeq()], bp => bp.location.line),
-      bp => getBreakpointFilename(bp.source)
+      // bp => getBreakpointFilename(bp.source)
+      bp => bp.source.url
     );
 
     return [
       ...Object.keys(groupedBreakpoints)
-        .sort()
-        .map(filename => {
+        .sort((urlA, urlB) => {
+          const urlASplit = urlA.split("/");
+          const urlBSplit = urlB.split("/");
+
+          return (
+            urlASplit[urlASplit.length - 1] > urlBSplit[urlBSplit.length - 1]
+          );
+        })
+        .map(url => {
+          const split = getRawSourceURL(url).split("/");
+          const file = split[split.length - 1];
+
           return [
-            <div className="breakpoint-heading" title={filename} key={filename}>
-              {filename}
+            <div className="breakpoint-heading" title={url} key={url}>
+              {file}
             </div>,
-            ...groupedBreakpoints[filename]
+            ...groupedBreakpoints[url]
               .filter(bp => !bp.hidden && bp.text)
               .map((bp, i) => this.renderBreakpoint(bp))
           ];

--- a/src/components/SecondaryPanes/Breakpoints.js
+++ b/src/components/SecondaryPanes/Breakpoints.js
@@ -181,7 +181,6 @@ class Breakpoints extends Component<Props> {
 
     const groupedBreakpoints = groupBy(
       sortBy([...breakpoints.valueSeq()], bp => bp.location.line),
-      // bp => getBreakpointFilename(bp.source)
       bp => bp.source.url
     );
 

--- a/src/workers/parser/pausePoints.js
+++ b/src/workers/parser/pausePoints.js
@@ -98,9 +98,8 @@ function onEnter(node: BabelNode, ancestors: SimplePath[], state) {
 
     if (isCall(value) || t.isFunction(parentNode)) {
       return addEmptyPoint(state, startLocation);
-    } else {
-      return addStopPoint(state, startLocation);
     }
+    return addStopPoint(state, startLocation);
   }
 
   if (isCall(node)) {


### PR DESCRIPTION
This is a start but needs a tiny bit more love.

# To Do
- [ ] Use `getFilename` to remove the query string and ensure its filename display is consistent everywhere