### PR TITLE
[Breakpoints] only set empty lines when there are pause points

### DIFF
--- a/src/utils/ast.js
+++ b/src/utils/ast.js
@@ -54,7 +54,7 @@ export function findEmptyLines(
   const breakpoints = pausePointsList.filter(point => point.types.break);
   const breakpointLines = breakpoints.map(point => point.location.line);
 
-  if (!selectedSource.text) {
+  if (!selectedSource.text || breakpointLines.length == 0) {
     return [];
   }
 


### PR DESCRIPTION
Fixes Issue: #6003

### Summary of Changes

Add an additional guard for when we can't find any pause points

![](http://g.recordit.co/WuCgN4J5QR.gif)