### PR TITLE
Fix sourcemaps off

### DIFF
--- a/src/actions/sources/newSources.js
+++ b/src/actions/sources/newSources.js
@@ -44,7 +44,11 @@ function createOriginalSource(
 }
 
 function loadSourceMaps(sources) {
-  return async function({ dispatch, getState, sourceMaps }: ThunkArgs) {
+  return async function({ dispatch, sourceMaps }: ThunkArgs) {
+    if (!sourceMaps) {
+      return;
+    }
+
     const originalSources = await Promise.all(
       sources.map(source => dispatch(loadSourceMap(source.id)))
     );
@@ -61,7 +65,7 @@ function loadSourceMap(sourceId: SourceId) {
   return async function({ dispatch, getState, sourceMaps }: ThunkArgs) {
     const source = getSource(getState(), sourceId).toJS();
 
-    if (!isGeneratedId(sourceId) || !source.sourceMapURL) {
+    if (!sourceMaps || !isGeneratedId(sourceId) || !source.sourceMapURL) {
       return;
     }
 

--- a/src/actions/sources/tests/newSources.spec.js
+++ b/src/actions/sources/tests/newSources.spec.js
@@ -71,4 +71,10 @@ describe("sources - new sources", () => {
     await dispatch(actions.newSource(makeSource("base.js")));
     expect(getOriginalURLs).not.toHaveBeenCalled();
   });
+
+  it("should not fail if there isn't a source map service", async () => {
+    const store = createStore(threadClient, {}, null);
+    await store.dispatch(actions.newSource(makeSource("base.js")));
+    expect(getSources(store.getState()).size).toEqual(1);
+  });
 });

--- a/src/utils/test-head.js
+++ b/src/utils/test-head.js
@@ -30,7 +30,7 @@ function createStore(client: any, initialState: any = {}, sourceMapsMock: any) {
       return {
         ...args,
         client,
-        sourceMaps: sourceMapsMock || sourceMaps
+        sourceMaps: sourceMapsMock !== undefined ? sourceMapsMock : sourceMaps
       };
     }
   })(combineReducers(reducers), initialState);


### PR DESCRIPTION
Fixes #5028

### Summary of Changes

- We used to crash when the sourcemaps service was not available. 
- This now adds a check so it doesn't fail.