### PR TITLE
Initial Components pane for React

### DIFF
--- a/assets/panel/debugger.properties
+++ b/assets/panel/debugger.properties
@@ -392,6 +392,10 @@ callStack.collapse=Collapse rows
 # message to show more of the frames.
 callStack.expand=Expand rows
 
+# LOCALIZATION NOTE (components.header): Header for the 
+# Framework Components pane in the right sidebar.
+components.header=Components
+
 # LOCALIZATION NOTE (editor.searchResults): Editor Search bar message
 # for the summarizing the selected search result. e.g. 5 of 10 results.
 editor.searchResults=%d of %d results

--- a/assets/panel/prefs.js
+++ b/assets/panel/prefs.js
@@ -60,3 +60,4 @@ pref("devtools.debugger.features.code-folding", false);
 pref("devtools.debugger.features.outline", true);
 pref("devtools.debugger.features.replay", false);
 pref("devtools.debugger.features.pause-points", true);
+pref("devtools.debugger.features.component-stack", false);

--- a/src/actions/pause/extra.js
+++ b/src/actions/pause/extra.js
@@ -11,15 +11,29 @@ import { findClosestClass } from "../../utils/ast";
 import type { ThunkArgs } from "../types";
 
 async function getReactProps(evaluate) {
-  const reactDisplayName = await evaluate(
-    "this.hasOwnProperty('_reactInternalFiber') ? " +
-      "this._reactInternalFiber.type.name : " +
-      "this._reactInternalInstance.getName()"
+  const componentNames = await evaluate(
+    `
+    if(this.hasOwnProperty('_reactInternalFiber')) {
+      let componentNames = []; 
+      let componentNode = this._reactInternalFiber; 
+      while(componentNode) { 
+        componentNames.push(componentNode.type.name); 
+        componentNode = componentNode._debugOwner
+      }
+      componentNames;
+    }
+    else {
+      [this._reactInternalInstance.getName()];
+    }
+    `
   );
-
-  return {
-    displayName: reactDisplayName.result
-  };
+  const items =
+    componentNames.result.preview && componentNames.result.preview.items;
+  if (items) {
+    return {
+      componentStack: items
+    };
+  }
 }
 
 async function getImmutableProps(expression: string, evaluate) {
@@ -50,9 +64,7 @@ async function getExtraProps(getState, expression, result, evaluate) {
       }
     }
 
-    if (!props.react) {
-      props.react = await getReactProps(evaluate);
-    }
+    props.react = { ...(await getReactProps(evaluate)), ...props.react };
   }
 
   if (isImmutable(result)) {

--- a/src/actions/pause/extra.js
+++ b/src/actions/pause/extra.js
@@ -31,6 +31,7 @@ async function getReactProps(evaluate) {
     componentNames.result.preview && componentNames.result.preview.items;
   if (items) {
     return {
+      displayName: items[0],
       componentStack: items
     };
   }

--- a/src/actions/tests/__snapshots__/preview.spec.js.snap
+++ b/src/actions/tests/__snapshots__/preview.spec.js.snap
@@ -48,7 +48,9 @@ Object {
   "expression": "this",
   "extra": Object {
     "react": Object {
-      "displayName": "Foo",
+      "componentStack": Array [
+        "Foo",
+      ],
     },
   },
   "location": Object {

--- a/src/actions/tests/__snapshots__/preview.spec.js.snap
+++ b/src/actions/tests/__snapshots__/preview.spec.js.snap
@@ -51,6 +51,7 @@ Object {
       "componentStack": Array [
         "Foo",
       ],
+      "displayName": "Foo",
     },
   },
   "location": Object {

--- a/src/components/SecondaryPanes/ReactComponentStack.js
+++ b/src/components/SecondaryPanes/ReactComponentStack.js
@@ -1,0 +1,42 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
+// @flow
+import React, { PureComponent } from "react";
+import { bindActionCreators } from "redux";
+import { connect } from "react-redux";
+import actions from "../../actions";
+
+import { getExtra } from "../../selectors";
+
+import "./Frames/Frames.css";
+
+type Props = {
+  extra: Object
+};
+
+class ReactComponentStack extends PureComponent<Props> {
+  render() {
+    const { componentStack } = this.props.extra.react;
+    return (
+      <div className="pane frames">
+        <ul>
+          {componentStack
+            .slice()
+            .reverse()
+            .map((component, index) => <li key={index}>{component}</li>)}
+        </ul>
+      </div>
+    );
+  }
+}
+
+export default connect(
+  state => {
+    return {
+      extra: getExtra(state)
+    };
+  },
+  dispatch => bindActionCreators(actions, dispatch)
+)(ReactComponentStack);

--- a/src/components/SecondaryPanes/index.js
+++ b/src/components/SecondaryPanes/index.js
@@ -35,6 +35,7 @@ import Accordion from "../shared/Accordion";
 import CommandBar from "./CommandBar";
 import UtilsBar from "./UtilsBar";
 import FrameworkComponent from "./FrameworkComponent";
+import ReactComponentStack from "./ReactComponentStack";
 
 import Scopes from "./Scopes";
 
@@ -175,6 +176,17 @@ class SecondaryPanes extends Component<Props, State> {
     };
   }
 
+  getComponentStackItem() {
+    return {
+      header: L10N.getStr("components.header"),
+      component: <ReactComponentStack />,
+      opened: prefs.componentStackVisible,
+      onToggle: opened => {
+        prefs.componentStackVisible = opened;
+      }
+    };
+  }
+
   getComponentItem() {
     const { extra: { react } } = this.props;
 
@@ -275,6 +287,9 @@ class SecondaryPanes extends Component<Props, State> {
 
       if (this.props.horizontal) {
         if (extra && extra.react) {
+          if (extra.react.componentStack.length > 1) {
+            items.push(this.getComponentStackItem());
+          }
           items.push(this.getComponentItem());
         }
 

--- a/src/components/SecondaryPanes/index.js
+++ b/src/components/SecondaryPanes/index.js
@@ -287,7 +287,10 @@ class SecondaryPanes extends Component<Props, State> {
 
       if (this.props.horizontal) {
         if (extra && extra.react) {
-          if (extra.react.componentStack.length > 1) {
+          if (
+            features.componentStack &&
+            extra.react.componentStack.length > 1
+          ) {
             items.push(this.getComponentStackItem());
           }
           items.push(this.getComponentItem());

--- a/src/utils/prefs.js
+++ b/src/utils/prefs.js
@@ -52,6 +52,7 @@ if (isDevelopment()) {
   pref("devtools.debugger.features.column-breakpoints", true);
   pref("devtools.debugger.features.replay", true);
   pref("devtools.debugger.features.pause-points", true);
+  pref("devtools.debugger.features.component-stack", true);
 }
 
 export const prefs = new PrefsHelper("devtools", {
@@ -96,7 +97,8 @@ export const features = new PrefsHelper("devtools.debugger.features", {
   outline: ["Bool", "outline"],
   codeFolding: ["Bool", "code-folding"],
   replay: ["Bool", "replay"],
-  pausePoints: ["Bool", "pause-points"]
+  pausePoints: ["Bool", "pause-points"],
+  componentStack: ["Bool", "component-stack"]
 });
 
 if (prefs.debuggerPrefsSchemaVersion !== prefsSchemaVersion) {

--- a/src/utils/prefs.js
+++ b/src/utils/prefs.js
@@ -20,6 +20,7 @@ if (isDevelopment()) {
   pref("devtools.debugger.call-stack-visible", true);
   pref("devtools.debugger.scopes-visible", true);
   pref("devtools.debugger.component-visible", true);
+  pref("devtools.debugger.component-stack-visible", false);
   pref("devtools.debugger.workers-visible", true);
   pref("devtools.debugger.expressions-visible", true);
   pref("devtools.debugger.breakpoints-visible", true);
@@ -62,6 +63,7 @@ export const prefs = new PrefsHelper("devtools", {
   callStackVisible: ["Bool", "debugger.call-stack-visible"],
   scopesVisible: ["Bool", "debugger.scopes-visible"],
   componentVisible: ["Bool", "debugger.component-visible"],
+  componentStackVisible: ["Bool", "debugger.component-stack-visible"],
   workersVisible: ["Bool", "debugger.workers-visible"],
   breakpointsVisible: ["Bool", "debugger.breakpoints-visible"],
   expressionsVisible: ["Bool", "debugger.expressions-visible"],


### PR DESCRIPTION
Related issue: #3792 

### Summary of Changes
* Add a "Components" pane that appears when pausing in a React component. For now, it just lists the component and all its ancestors all the way up to the root.
* This is hidden behind a feature flag for now.

Todo in a future PR: 
* Ability to "select" components. Right now it's just a plain list.
* Improve styling?
* Improve handling for container components created with `connect`? 

### Test Plan
1. Hit a breakpoint at [Frame/index.js#174](https://github.com/calebstdenis/debugger.html/blob/12363ee0bddab3819b781e98bacf00b530015937/src/components/SecondaryPanes/Frames/index.js#L174)
2. Observe the "Components" pane as in the screenshot below

### Screenshots/Videos
![image](https://user-images.githubusercontent.com/7321311/38957611-162fa816-4329-11e8-98f1-03258e035059.png)