### PR TITLE
Speed up initial load

### DIFF
--- a/src/components/Editor/Tabs.js
+++ b/src/components/Editor/Tabs.js
@@ -77,7 +77,7 @@ class Tabs extends PureComponent<Props, State> {
   }
 
   componentDidMount() {
-    this.updateHiddenTabs();
+    window.requestIdleCallback(this.updateHiddenTabs);
     window.addEventListener("resize", this.onResize);
   }
 
@@ -89,7 +89,7 @@ class Tabs extends PureComponent<Props, State> {
    * Updates the hiddenSourceTabs state, by
    * finding the source tabs which are wrapped and are not on the top row.
    */
-  updateHiddenTabs() {
+  updateHiddenTabs = () => {
     if (!this.refs.sourceTabs) {
       return;
     }
@@ -102,7 +102,7 @@ class Tabs extends PureComponent<Props, State> {
     }
 
     this.setState({ hiddenTabs });
-  }
+  };
 
   toggleSourcesDropdown(e) {
     this.setState(prevState => ({

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -183,8 +183,6 @@ class Editor extends PureComponent<Props, State> {
   }
 
   componentDidMount() {
-    const editor = this.setupEditor();
-
     const { selectedSource } = this.props;
     const { shortcuts } = this.context;
 
@@ -201,8 +199,6 @@ class Editor extends PureComponent<Props, State> {
     shortcuts.on("Esc", this.onEscape);
     shortcuts.on(searchAgainPrevKey, this.onSearchAgain);
     shortcuts.on(searchAgainKey, this.onSearchAgain);
-
-    updateDocument(editor, selectedSource);
   }
 
   componentWillUnmount() {
@@ -223,12 +219,18 @@ class Editor extends PureComponent<Props, State> {
   }
 
   componentDidUpdate(prevProps, prevState) {
+    const { selectedSource } = this.props;
     // NOTE: when devtools are opened, the editor is not set when
     // the source loads so we need to wait until the editor is
     // set to update the text and size.
-    if (!prevState.editor && this.state.editor) {
-      this.setText(this.props);
-      this.setSize(this.props);
+    if (!prevState.editor && selectedSource) {
+      if (!this.state.editor) {
+        const editor = this.setupEditor();
+        updateDocument(editor, selectedSource);
+      } else {
+        this.setText(this.props);
+        this.setSize(this.props);
+      }
     }
   }
 
@@ -456,6 +458,7 @@ class Editor extends PureComponent<Props, State> {
       return;
     }
 
+    // check if we previously had a selected source
     if (!selectedSource) {
       return this.clearEditor();
     }

--- a/src/components/PrimaryPanes/SourcesTree.js
+++ b/src/components/PrimaryPanes/SourcesTree.js
@@ -81,17 +81,6 @@ class SourcesTree extends Component<Props, State> {
   renderItem: Function;
   mounted: boolean;
 
-  constructor(props) {
-    super(props);
-    const { debuggeeUrl, sources, projectRoot } = this.props;
-
-    this.state = createTree({
-      projectRoot,
-      debuggeeUrl,
-      sources
-    });
-  }
-
   componentWillReceiveProps(nextProps) {
     const {
       projectRoot,
@@ -100,6 +89,16 @@ class SourcesTree extends Component<Props, State> {
       shownSource,
       selectedSource
     } = this.props;
+
+    if (!this.state) {
+      return this.setState(
+        createTree({
+          sources: nextProps.sources,
+          debuggeeUrl: nextProps.debuggeeUrl,
+          projectRoot: nextProps.projectRoot
+        })
+      );
+    }
 
     const { uncollapsedTree, sourceTree } = this.state;
 
@@ -322,6 +321,10 @@ class SourcesTree extends Component<Props, State> {
 
   render() {
     const { expanded, projectRoot } = this.props;
+    if (!this.state) {
+      return null;
+    }
+
     const {
       focusedItem,
       highlightItems,


### PR DESCRIPTION
### Summary of Changes

* The initial react App Mount used to take 220ms now it takes 55ms
* The old App Mount used to build the Source Tree, instantiate CodeMirror, and calculate hidden tabs
* This work is now postponed...

### Old
![screen shot 2018-04-18 at 4 58 28 pm](https://user-images.githubusercontent.com/254562/38958013-0245ac00-432a-11e8-89fd-50e0e10e4c95.png)

### New 
![screen shot 2018-04-18 at 4 48 41 pm](https://user-images.githubusercontent.com/254562/38958025-0c8aa6ac-432a-11e8-8ba6-e831419c7078.png)

### New Profile
we can toggle devtools really fast now!

![screen shot 2018-04-18 at 4 56 00 pm](https://user-images.githubusercontent.com/254562/38958040-15e206aa-432a-11e8-8fa9-d21de04b9e54.png)

