### PR TITLE
Add the workers to dbg

### DIFF
--- a/docs/dbg.md
+++ b/docs/dbg.md
@@ -1,12 +1,11 @@
 # DBG helper
 
-
 ### store
 
 `dbg.store` redux store.
 
 ```js
-const store = dbg.store.getState()
+const store = dbg.store.getState();
 
 // select a source
 const source = dbg.store.getState().sources.sources.first();
@@ -31,6 +30,17 @@ The selectors are bound so you can call them without `store.getState()`!
 const source = dbg.selectors.getSelectedSource();
 ```
 
+### workers
+
+`dbg.workers` debugger workers (parser, search, sourceMap, prettyPrint).
+The selectors are bound so you can call them without `store.getState()`!
+
+```js
+dbg.workers.parser
+  .getSymbols(dbg.selectors.getSelectedSource().id)
+  .then(console.log);
+```
+
 ### client
 
 `dbg.client` firefox commands.
@@ -38,9 +48,7 @@ The commands are the interface for talking to the debugger server.
 
 ```js
 const source = dbg.selectors.getSelectedSource();
-dbg.client
-  .setBreakpoint({line: 24, sourceId: source.id})
-  .then(console.log)
+dbg.client.setBreakpoint({ line: 24, sourceId: source.id }).then(console.log);
 ```
 
 ### prefs
@@ -48,9 +56,9 @@ dbg.client
 `dbg.prefs` references the PreferencesHelper. You can use `dbg.prefs` to see or change the state of any pref.
 
 ```js
-dbg.prefs.pauseOnExceptions // false
-dbg.prefs.pauseOnExceptions = true
-dbg.prefs.pauseOnExceptions // true
+dbg.prefs.pauseOnExceptions; // false
+dbg.prefs.pauseOnExceptions = true;
+dbg.prefs.pauseOnExceptions; // true
 ```
 
 ### features
@@ -58,11 +66,10 @@ dbg.prefs.pauseOnExceptions // true
 `dbg.features` references the debugger's feature flags. You can use `dbg.features` to see or change the state of any flag.
 
 ```js
-dbg.features.codeCoverage // false
-dbg.features.codeCoverage = true
-dbg.features.codeCoverage // true
+dbg.features.codeCoverage; // false
+dbg.features.codeCoverage = true;
+dbg.features.codeCoverage; // true
 ```
-
 
 ### helpers
 
@@ -71,7 +78,7 @@ dbg.features.codeCoverage // true
 Sometimes you want to quickly grab a source object from the store, but you don't know the full url or source id. The `findSource` function is your friend here :)
 
 ```js
-dbg.helpers.findSource("todo-view")
+dbg.helpers.findSource("todo-view");
 /*
 {
   "isPrettyPrinted": false,
@@ -97,7 +104,7 @@ dbg
     to: dbg.selectors.getSelectedFrame().id,
     type: "evaluateExpressions"
   })
-  .then(console.log)
+  .then(console.log);
 ```
 
 #### evaluate
@@ -105,7 +112,7 @@ dbg
 `dbg.helpers.evaluate` evaluate expressions in the context of the debuggee
 
 ```js
-dbg.helpers.evaluate("2+2")
+dbg.helpers.evaluate("2+2");
 /*
 {
   from: "server1.conn12.child1/consoleActor2",
@@ -116,5 +123,5 @@ dbg.helpers.evaluate("2+2")
 }
 */
 
-dbg.helpers.evaluate("2+2",  r => console.log(`yay ${r.result}`)) // yay 4
+dbg.helpers.evaluate("2+2", r => console.log(`yay ${r.result}`)); // yay 4
 ```

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -37,7 +37,7 @@ async function onConnect(
     toolboxActions
   });
 
-  bootstrapWorkers();
+  const workers = bootstrapWorkers();
   await firefox.onConnect(connection, actions);
   await loadFromPrefs(actions);
 
@@ -45,6 +45,7 @@ async function onConnect(
     store,
     actions,
     selectors,
+    workers: { ...workers, ...services },
     connection,
     client: firefox.clientCommands
   });

--- a/src/test/tests-setup.js
+++ b/src/test/tests-setup.js
@@ -14,17 +14,20 @@ import Adapter from "enzyme-adapter-react-16";
 import { startSourceMapWorker, stopSourceMapWorker } from "devtools-source-map";
 
 import {
-  startPrettyPrintWorker,
-  stopPrettyPrintWorker
+  start as startPrettyPrintWorker,
+  stop as stopPrettyPrintWorker
 } from "../workers/pretty-print";
 
 import {
-  startParserWorker,
-  stopParserWorker,
+  start as startParserWorker,
+  stop as stopParserWorker,
   clearSymbols,
   clearASTs
 } from "../workers/parser";
-import { startSearchWorker, stopSearchWorker } from "../workers/search";
+import {
+  start as startSearchWorker,
+  stop as stopSearchWorker
+} from "../workers/search";
 import { clearDocuments } from "../utils/editor";
 import { clearHistory } from "./utils/history";
 

--- a/src/utils/bootstrap.js
+++ b/src/utils/bootstrap.js
@@ -16,13 +16,10 @@ import {
   isTesting
 } from "devtools-config";
 import { startSourceMapWorker, stopSourceMapWorker } from "devtools-source-map";
-import { startSearchWorker, stopSearchWorker } from "../workers/search";
+import * as search from "../workers/search";
+import * as prettyPrint from "../workers/pretty-print";
+import * as parser from "../workers/parser";
 
-import {
-  startPrettyPrintWorker,
-  stopPrettyPrintWorker
-} from "../workers/pretty-print";
-import { startParserWorker, stopParserWorker } from "../workers/parser";
 import configureStore from "../actions/utils/create-store";
 import reducers from "../reducers";
 import * as selectors from "../selectors";
@@ -70,9 +67,10 @@ export function bootstrapWorkers() {
     // When used in Firefox, the toolbox manages the source map worker.
     startSourceMapWorker(getValue("workers.sourceMapURL"));
   }
-  startPrettyPrintWorker(getValue("workers.prettyPrintURL"));
-  startParserWorker(getValue("workers.parserURL"));
-  startSearchWorker(getValue("workers.searchURL"));
+  prettyPrint.start(getValue("workers.prettyPrintURL"));
+  parser.start(getValue("workers.parserURL"));
+  search.start(getValue("workers.searchURL"));
+  return { prettyPrint, parser, search };
 }
 
 export function teardownWorkers() {
@@ -80,9 +78,9 @@ export function teardownWorkers() {
     // When used in Firefox, the toolbox manages the source map worker.
     stopSourceMapWorker();
   }
-  stopPrettyPrintWorker();
-  stopParserWorker();
-  stopSearchWorker();
+  prettyPrint.stop();
+  parser.stop();
+  search.stop();
 }
 
 export function bootstrapApp(store: any) {

--- a/src/workers/parser/index.js
+++ b/src/workers/parser/index.js
@@ -8,8 +8,8 @@ import { workerUtils } from "devtools-utils";
 const { WorkerDispatcher } = workerUtils;
 
 const dispatcher = new WorkerDispatcher();
-export const startParserWorker = dispatcher.start.bind(dispatcher);
-export const stopParserWorker = dispatcher.stop.bind(dispatcher);
+export const start = dispatcher.start.bind(dispatcher);
+export const stop = dispatcher.stop.bind(dispatcher);
 
 export const getClosestExpression = dispatcher.task("getClosestExpression");
 export const getSymbols = dispatcher.task("getSymbols");

--- a/src/workers/pretty-print/index.js
+++ b/src/workers/pretty-print/index.js
@@ -12,8 +12,8 @@ import assert from "../../utils/assert";
 import type { SourceRecord } from "../../types";
 
 const dispatcher = new WorkerDispatcher();
-export const startPrettyPrintWorker = dispatcher.start.bind(dispatcher);
-export const stopPrettyPrintWorker = dispatcher.stop.bind(dispatcher);
+export const start = dispatcher.start.bind(dispatcher);
+export const stop = dispatcher.stop.bind(dispatcher);
 const _prettyPrint = dispatcher.task("prettyPrint");
 
 type PrettyPrintOpts = {

--- a/src/workers/search/index.js
+++ b/src/workers/search/index.js
@@ -6,9 +6,8 @@ import { workerUtils } from "devtools-utils";
 const { WorkerDispatcher } = workerUtils;
 
 const dispatcher = new WorkerDispatcher();
-export const startSearchWorker = dispatcher.start.bind(dispatcher);
-export const stopSearchWorker = dispatcher.stop.bind(dispatcher);
+export const start = dispatcher.start.bind(dispatcher);
+export const stop = dispatcher.stop.bind(dispatcher);
 
 export const getMatches = dispatcher.task("getMatches");
-export const searchSources = dispatcher.task("searchSources");
 export const findSourceMatches = dispatcher.task("findSourceMatches");


### PR DESCRIPTION
### Summary of Changes

This adds `dbg.worker` references so that developers can debug the debugger's workers