### PR TITLE
Tighten babel type

### DIFF
--- a/src/workers/parser/utils/helpers.js
+++ b/src/workers/parser/utils/helpers.js
@@ -39,7 +39,7 @@ export function isYieldExpression(path: SimplePath) {
 
 export function isObjectShorthand(parent: Node): boolean {
   return (
-    t.isProperty(parent) &&
+    t.isObjectProperty(parent) &&
     parent.key.start == parent.value.start &&
     parent.key.loc.identifierName === parent.value.loc.identifierName
   );


### PR DESCRIPTION
### Summary of Changes
Fixes  
`console.error: (new TypeError("parent.value is null", "resource://devtools/client/debugger/new/parser-worker.js", 1501))`

https://babeljs.io/docs/core-packages/babel-types/#objectproperty


![screen shot 2018-04-20 at 9 40 54 am](https://user-images.githubusercontent.com/254562/39054201-fe8ac25c-447e-11e8-9cc6-e635f1c41e73.png)
