### PR TITLE
[scopes] Detect JSX elements as variables in scope visitor.

### DIFF
--- a/src/workers/parser/getScopes/visitor.js
+++ b/src/workers/parser/getScopes/visitor.js
@@ -613,6 +613,19 @@ const scopeCollectionVisitor = {
         end: fromBabelLocation(node.loc.end, state.sourceId),
         meta: buildMetaBindings(state.sourceId, node, ancestors)
       });
+    } else if (isOpeningJSXIdentifier(node, ancestors)) {
+      let freeVariables = state.freeVariables.get(node.name);
+      if (!freeVariables) {
+        freeVariables = [];
+        state.freeVariables.set(node.name, freeVariables);
+      }
+
+      freeVariables.push({
+        type: "ref",
+        start: fromBabelLocation(node.loc.start, state.sourceId),
+        end: fromBabelLocation(node.loc.end, state.sourceId),
+        meta: buildMetaBindings(state.sourceId, node, ancestors)
+      });
     } else if (t.isThisExpression(node)) {
       let freeVariables = state.freeVariables.get("this");
       if (!freeVariables) {
@@ -701,6 +714,27 @@ const scopeCollectionVisitor = {
     }
   }
 };
+
+function isOpeningJSXIdentifier(
+  node: Node,
+  ancestors: TraversalAncestors
+): boolean {
+  if (!t.isJSXIdentifier(node)) {
+    return false;
+  }
+
+  for (let i = ancestors.length - 1; i >= 0; i--) {
+    const { node: parent, key } = ancestors[i];
+
+    if (t.isJSXOpeningElement(parent) && key === "name") {
+      return true;
+    } else if (!t.isJSXMemberExpression(parent) || key !== "object") {
+      break;
+    }
+  }
+
+  return false;
+}
 
 function buildMetaBindings(
   sourceId: SourceId,

--- a/src/workers/parser/tests/__snapshots__/getScopes.spec.js.snap
+++ b/src/workers/parser/tests/__snapshots__/getScopes.spec.js.snap
@@ -11899,6 +11899,148 @@ Array [
 ]
 `;
 
+exports[`getScopes finds scope bindings in a JSX element at line 2 column 0 1`] = `
+Array [
+  Object {
+    "bindings": Object {
+      "SomeComponent": Object {
+        "refs": Array [
+          Object {
+            "declaration": Object {
+              "end": Object {
+                "column": 29,
+                "line": 1,
+                "sourceId": "scopes/jsx-component/originalSource-1",
+              },
+              "start": Object {
+                "column": 0,
+                "line": 1,
+                "sourceId": "scopes/jsx-component/originalSource-1",
+              },
+            },
+            "end": Object {
+              "column": 20,
+              "line": 1,
+              "sourceId": "scopes/jsx-component/originalSource-1",
+            },
+            "importName": "default",
+            "start": Object {
+              "column": 7,
+              "line": 1,
+              "sourceId": "scopes/jsx-component/originalSource-1",
+            },
+            "type": "decl",
+          },
+          Object {
+            "end": Object {
+              "column": 14,
+              "line": 3,
+              "sourceId": "scopes/jsx-component/originalSource-1",
+            },
+            "meta": null,
+            "start": Object {
+              "column": 1,
+              "line": 3,
+              "sourceId": "scopes/jsx-component/originalSource-1",
+            },
+            "type": "ref",
+          },
+          Object {
+            "end": Object {
+              "column": 14,
+              "line": 4,
+              "sourceId": "scopes/jsx-component/originalSource-1",
+            },
+            "meta": null,
+            "start": Object {
+              "column": 1,
+              "line": 4,
+              "sourceId": "scopes/jsx-component/originalSource-1",
+            },
+            "type": "ref",
+          },
+          Object {
+            "end": Object {
+              "column": 14,
+              "line": 5,
+              "sourceId": "scopes/jsx-component/originalSource-1",
+            },
+            "meta": null,
+            "start": Object {
+              "column": 1,
+              "line": 5,
+              "sourceId": "scopes/jsx-component/originalSource-1",
+            },
+            "type": "ref",
+          },
+          Object {
+            "end": Object {
+              "column": 14,
+              "line": 6,
+              "sourceId": "scopes/jsx-component/originalSource-1",
+            },
+            "meta": null,
+            "start": Object {
+              "column": 1,
+              "line": 6,
+              "sourceId": "scopes/jsx-component/originalSource-1",
+            },
+            "type": "ref",
+          },
+        ],
+        "type": "import",
+      },
+      "this": Object {
+        "refs": Array [],
+        "type": "implicit",
+      },
+    },
+    "displayName": "Module",
+    "end": Object {
+      "column": 0,
+      "line": 7,
+      "sourceId": "scopes/jsx-component/originalSource-1",
+    },
+    "start": Object {
+      "column": 0,
+      "line": 1,
+      "sourceId": "scopes/jsx-component/originalSource-1",
+    },
+    "type": "block",
+  },
+  Object {
+    "bindings": Object {},
+    "displayName": "Lexical Global",
+    "end": Object {
+      "column": 0,
+      "line": 7,
+      "sourceId": "scopes/jsx-component/originalSource-1",
+    },
+    "start": Object {
+      "column": 0,
+      "line": 1,
+      "sourceId": "scopes/jsx-component/originalSource-1",
+    },
+    "type": "block",
+  },
+  Object {
+    "bindings": Object {},
+    "displayName": "Global",
+    "end": Object {
+      "column": 0,
+      "line": 7,
+      "sourceId": "scopes/jsx-component/originalSource-1",
+    },
+    "start": Object {
+      "column": 0,
+      "line": 1,
+      "sourceId": "scopes/jsx-component/originalSource-1",
+    },
+    "type": "object",
+  },
+]
+`;
+
 exports[`getScopes finds scope bindings in a module at line 7 column 0 1`] = `
 Array [
   Object {

--- a/src/workers/parser/tests/fixtures/scopes/jsx-component.js
+++ b/src/workers/parser/tests/fixtures/scopes/jsx-component.js
@@ -1,0 +1,6 @@
+import SomeComponent from "";
+
+<SomeComponent attr="value" />;
+<SomeComponent attr="value"></SomeComponent>;
+<SomeComponent.prop attr="value" />;
+<SomeComponent.prop.child attr="value" />;

--- a/src/workers/parser/tests/getScopes.spec.js
+++ b/src/workers/parser/tests/getScopes.spec.js
@@ -39,6 +39,11 @@ cases(
       locations: [[7, 0]]
     },
     {
+      name: "finds scope bindings in a JSX element",
+      file: "scopes/jsx-component",
+      locations: [[2, 0]]
+    },
+    {
       name: "finds scope bindings for complex binding nesting",
       file: "scopes/complex-nesting",
       locations: [[16, 4], [20, 6]]


### PR DESCRIPTION
Refs Issue: #5561

### Summary of Changes

* Ensure that JSXIdentifier nodes inside opening JSX elements are considered JSX variables, excluding all the JSXIdentifiers that _aren_ just property/attribute names.

### Screenshot

<img width="713" alt="screen shot 2018-04-20 at 3 40 00 pm" src="https://user-images.githubusercontent.com/132260/39076603-1f9d3b1e-44b1-11e8-960c-1f3a8a1f72db.png">

Here `UnorderedList` shows up properly.