### PR TITLE
Fix two type errors

### DIFF
--- a/src/components/SecondaryPanes/FrameworkComponent.js
+++ b/src/components/SecondaryPanes/FrameworkComponent.js
@@ -78,7 +78,7 @@ class FrameworkComponent extends PureComponent<Props> {
 
   render() {
     const { selectedFrame } = this.props;
-    if (isReactComponent(selectedFrame.this)) {
+    if (selectedFrame && isReactComponent(selectedFrame.this)) {
       return this.renderReactComponent();
     }
 

--- a/src/utils/source-maps.js
+++ b/src/utils/source-maps.js
@@ -20,11 +20,14 @@ export async function getGeneratedLocation(
   );
 
   const generatedSource = getSource(state, sourceId);
-  const sourceUrl = generatedSource.get("url");
+  if (!generatedSource) {
+    return location;
+  }
+
   return {
     line,
     sourceId,
     column: column === 0 ? undefined : column,
-    sourceUrl
+    sourceUrl: generatedSource.url
   };
 }


### PR DESCRIPTION
Fixes two type errors

1. framework component is a new component, which was missing a guard
2. getGeneratedLocation is a timing issue with hot reloading