### PR TITLE
fix "set directory root" failure

### DIFF
--- a/src/actions/ui.js
+++ b/src/actions/ui.js
@@ -171,9 +171,12 @@ export function setProjectDirectoryRoot(newRoot: string) {
   return ({ dispatch, getState }: ThunkArgs) => {
     const curRoot = getProjectDirectoryRoot(getState());
     if (newRoot && curRoot) {
-      const temp = newRoot.split("/");
-      temp.splice(0, 2);
-      newRoot = `${curRoot}/${temp.join("/")}`;
+      const temp1 = newRoot.replace(/\/+/g, "/").split("/");
+      const temp2 = curRoot.replace(/\/+/g, "/").split("/");
+      if (temp1[0] !== temp2[0]) {
+        temp1.splice(0, 2);
+        newRoot = `${curRoot}/${temp1.join("/")}`;
+      }
     }
 
     dispatch({


### PR DESCRIPTION
### Summary of Changes

This pull request is a fix to the two issues illustrated below.
Both of the issues related to "Set directory root" on the left panel of the debugger.

Issue 1 - STR:
1. Go to https://firefox-debugger-example-react-js.glitch.me/
2. On the left panel, right click on "Webpack" folder and Click on "Set directory root"
3. Then right click on "app" foler and Click on "Set directory root" ( notice the content is missing ).
![kennugbuqh](https://user-images.githubusercontent.com/23003064/39088618-5b1fd458-4583-11e8-8407-c3e5a97280d2.gif)

Issue 2 - STR:
1. Go to https://davidwalsh.name/
2. On the left panel, right click on "davidwalsh.name" and Click on "Set directory root"
3. Then expand the subfolders; right click on "libs" and Click on "Set directory root" ( notice the content is missing ).
![v5bvqw7akf](https://user-images.githubusercontent.com/23003064/39088620-5eed1de8-4583-11e8-9f0b-4c89dd6479d2.gif)
