### PR TITLE
[Breakpoints] Show original breakpoint text

### DIFF
--- a/src/components/Editor/Breakpoint.js
+++ b/src/components/Editor/Breakpoint.js
@@ -12,6 +12,8 @@ import Svg from "../shared/Svg";
 import { getDocument, toEditorLine } from "../../utils/editor";
 import { features } from "../../utils/prefs";
 
+import type { Source, Breakpoint as BreakpointType } from "../../types";
+
 const breakpointSvg = document.createElement("div");
 ReactDOM.render(<Svg name="breakpoint" />, breakpointSvg);
 
@@ -26,8 +28,8 @@ function makeMarker(isDisabled: boolean) {
 }
 
 type Props = {
-  breakpoint: Object,
-  selectedSource: Object,
+  breakpoint: BreakpointType,
+  selectedSource: Source,
   editor: Object
 };
 
@@ -52,7 +54,7 @@ class Breakpoint extends Component<Props> {
       return;
     }
 
-    const sourceId = selectedSource.get("id");
+    const sourceId = selectedSource.id;
     const line = toEditorLine(sourceId, breakpoint.location.line);
 
     editor.codeMirror.setGutterMarker(
@@ -100,7 +102,7 @@ class Breakpoint extends Component<Props> {
       return;
     }
 
-    const sourceId = selectedSource.get("id");
+    const sourceId = selectedSource.id;
     const doc = getDocument(sourceId);
     if (!doc) {
       return;

--- a/src/components/SecondaryPanes/Breakpoint.js
+++ b/src/components/SecondaryPanes/Breakpoint.js
@@ -44,15 +44,13 @@ class Breakpoint extends Component<Props> {
     this.setupEditor();
   }
 
-  componentDidUpdate() {
+  componentDidUpdate(prevProps: Props) {
+    this.destroyEditor();
     this.setupEditor();
   }
 
   componentWillUnmount() {
-    if (this.editor) {
-      this.editor.destroy();
-      this.editor = null;
-    }
+    this.destroyEditor();
   }
 
   shouldComponentUpdate(nextProps: Props) {
@@ -87,6 +85,13 @@ class Breakpoint extends Component<Props> {
     }
 
     return originalText;
+  }
+
+  destroyEditor() {
+    if (this.editor) {
+      this.editor.destroy();
+      this.editor = null;
+    }
   }
 
   setupEditor() {

--- a/src/components/SecondaryPanes/Breakpoint.js
+++ b/src/components/SecondaryPanes/Breakpoint.js
@@ -3,9 +3,11 @@
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
 // @flow
+
 import React, { Component } from "react";
 import ReactDOM from "react-dom";
 import classnames from "classnames";
+import { isGeneratedId } from "devtools-source-map";
 
 import CloseButton from "../shared/Button/Close";
 
@@ -14,9 +16,11 @@ import { features } from "../../utils/prefs";
 
 import type { LocalBreakpoint } from "./Breakpoints";
 import type SourceEditor from "../../utils/editor/source-editor";
+import type { Source } from "../../types";
 
 type Props = {
   breakpoint: LocalBreakpoint,
+  selectedSource: ?Source,
   onClick: Function,
   onContextMenu: Function,
   onChange: Function,
@@ -57,6 +61,7 @@ class Breakpoint extends Component<Props> {
 
     return (
       !prevBreakpoint ||
+      this.props.selectedSource != nextProps.selectedSource ||
       (prevBreakpoint.text != nextBreakpoint.text ||
         prevBreakpoint.disabled != nextBreakpoint.disabled ||
         prevBreakpoint.condition != nextBreakpoint.condition ||
@@ -66,9 +71,22 @@ class Breakpoint extends Component<Props> {
   }
 
   getBreakpointText() {
-    const { breakpoint } = this.props;
+    const { breakpoint, selectedSource } = this.props;
+    const { condition, text, originalText } = breakpoint;
 
-    return breakpoint.condition || breakpoint.text;
+    if (condition) {
+      return condition;
+    }
+
+    if (
+      !selectedSource ||
+      isGeneratedId(selectedSource.id) ||
+      originalText.length == 0
+    ) {
+      return text;
+    }
+
+    return originalText;
   }
 
   setupEditor() {

--- a/src/components/SecondaryPanes/Breakpoints.js
+++ b/src/components/SecondaryPanes/Breakpoints.js
@@ -21,6 +21,7 @@ import {
   getSourceInSources,
   getBreakpoints,
   getPauseReason,
+  getSelectedSource,
   getTopFrame
 } from "../../selectors";
 import { isInterrupted } from "../../utils/pause";
@@ -51,6 +52,7 @@ type BreakpointsMap = I.Map<string, LocalBreakpoint>;
 type Props = {
   breakpoints: BreakpointsMap,
   sources: SourcesMap,
+  selectedSource: Source,
   sourcesMetaData: SourceMetaDataMap,
   enableBreakpoint: Location => void,
   disableBreakpoint: Location => void,
@@ -127,10 +129,13 @@ class Breakpoints extends Component<Props> {
   }
 
   renderBreakpoint(breakpoint) {
+    const { selectedSource } = this.props;
+
     return (
       <Breakpoint
         key={breakpoint.locationId}
         breakpoint={breakpoint}
+        selectedSource={selectedSource}
         onClick={() => this.selectBreakpoint(breakpoint)}
         onContextMenu={e =>
           showContextMenu({ ...this.props, breakpoint, contextMenuEvent: e })
@@ -235,6 +240,9 @@ const _getBreakpoints = createSelector(
 );
 
 export default connect(
-  (state, props) => ({ breakpoints: _getBreakpoints(state) }),
+  (state, props) => ({
+    breakpoints: _getBreakpoints(state),
+    selectedSource: getSelectedSource(state)
+  }),
   dispatch => bindActionCreators(actions, dispatch)
 )(Breakpoints);

--- a/src/types.js
+++ b/src/types.js
@@ -107,6 +107,7 @@ export type Breakpoint = {
   disabled: boolean,
   hidden: boolean,
   text: string,
+  originalText: string,
   condition: ?string
 };
 


### PR DESCRIPTION
Fixes Issue: #6032

### Summary of Changes

Previously we were only showing the generated line. Now we show the correct text based on the context

![](http://g.recordit.co/iJ2zMelfUr.gif)