### PR TITLE
[Tests] add pause on next mochitest

### DIFF
--- a/src/actions/pause/breakOnNext.js
+++ b/src/actions/pause/breakOnNext.js
@@ -15,12 +15,8 @@ import type { ThunkArgs } from "../types";
  * @static
  */
 export function breakOnNext() {
-  return ({ dispatch, client }: ThunkArgs) => {
-    client.breakOnNext();
-
-    return dispatch({
-      type: "BREAK_ON_NEXT",
-      value: true
-    });
+  return async ({ dispatch, client }: ThunkArgs) => {
+    await client.breakOnNext();
+    return dispatch({ type: "BREAK_ON_NEXT" });
   };
 }

--- a/src/test/mochitest/browser.ini
+++ b/src/test/mochitest/browser.ini
@@ -187,6 +187,7 @@ skip-if = os == "linux" # bug 1351952
 [browser_dbg-outline.js]
 [browser_dbg-pause-exceptions.js]
 skip-if = !debug && (os == "win" && os_version == "6.1") # Bug 1456441
+[browser_dbg-pause-on-next.js]
 [browser_dbg-pause-ux.js]
 skip-if = os == "win"
 [browser_dbg-navigation.js]

--- a/src/test/mochitest/browser_dbg-pause-on-next.js
+++ b/src/test/mochitest/browser_dbg-pause-on-next.js
@@ -1,30 +1,15 @@
 /* Any copyright is dedicated to the Public Domain.
  * http://creativecommons.org/publicdomain/zero/1.0/ */
 
-// Tests the breakpoints are hit in various situations.
-
-const expressionSelectors = {
-  plusIcon: ".watch-expressions-pane button.plus",
-  input: "input.input-expression"
-};
+// Tests that when  pause on next is selected, we  pause on the next execution
 
 add_task(async function() {
   const dbg = await initDebugger("doc-scripts.html");
-  const { selectors: { isPaused }, getState } = dbg;
 
-  log('Searching for simple3.js');
-  await selectSource(dbg, "simple3.js");
-
-  log('Press pause button');
   clickElement(dbg, "pause");
-  await waitForDispatch(dbg, "BREAK_ON_NEXT");
-
-  let src = findSource(dbg, "simple3.js");
-  await addBreakpoint(dbg, src, 2);
+  await waitForState(dbg, state => dbg.selectors.getIsWaitingOnBreak(state))
   invokeInTab("simple");
 
-  // Give the debugger enough time to come to a pause
   await waitForPaused(dbg);
-
   assertPaused(dbg);
 });

--- a/src/test/mochitest/browser_dbg-pause-on-next.js
+++ b/src/test/mochitest/browser_dbg-pause-on-next.js
@@ -8,14 +8,6 @@ const expressionSelectors = {
   input: "input.input-expression"
 };
 
-async function addExpression(dbg, input) {
-  info("Adding an expression to evaluate");
-  findElementWithSelector(dbg, expressionSelectors.plusIcon).click();
-  findElementWithSelector(dbg, expressionSelectors.input).focus();
-  type(dbg, input);
-  pressKey(dbg, "Enter");
-}
-
 add_task(async function() {
   const dbg = await initDebugger("doc-scripts.html");
   const { selectors: { isPaused }, getState } = dbg;
@@ -27,7 +19,9 @@ add_task(async function() {
   clickElement(dbg, "pause");
   await waitForDispatch(dbg, "BREAK_ON_NEXT");
 
-  await addExpression(dbg, "simple()");
+  let src = findSource(dbg, "simple3.js");
+  await addBreakpoint(dbg, src, 2);
+  invokeInTab("simple");
 
   // Give the debugger enough time to come to a pause
   await waitForPaused(dbg);

--- a/src/test/mochitest/browser_dbg-pause-on-next.js
+++ b/src/test/mochitest/browser_dbg-pause-on-next.js
@@ -1,0 +1,36 @@
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
+
+// Tests the breakpoints are hit in various situations.
+
+const expressionSelectors = {
+  plusIcon: ".watch-expressions-pane button.plus",
+  input: "input.input-expression"
+};
+
+async function addExpression(dbg, input) {
+  info("Adding an expression to evaluate");
+  findElementWithSelector(dbg, expressionSelectors.plusIcon).click();
+  findElementWithSelector(dbg, expressionSelectors.input).focus();
+  type(dbg, input);
+  pressKey(dbg, "Enter");
+}
+
+add_task(async function() {
+  const dbg = await initDebugger("doc-scripts.html");
+  const { selectors: { isPaused }, getState } = dbg;
+
+  log('Searching for simple3.js');
+  await selectSource(dbg, "simple3.js");
+
+  log('Press pause button');
+  clickElement(dbg, "pause");
+  await waitForDispatch(dbg, "BREAK_ON_NEXT");
+
+  await addExpression(dbg, "simple()");
+
+  // Give the debugger enough time to come to a pause
+  await waitForPaused(dbg);
+
+  assertPaused(dbg);
+});

--- a/src/test/mochitest/helpers.js
+++ b/src/test/mochitest/helpers.js
@@ -251,6 +251,15 @@ function assertNotPaused(dbg) {
   ok(!isPaused(dbg), "client is not paused");
 }
 
+/**
+ * Assert that the debugger is currently paused.
+ * @memberof mochitest/asserts
+ * @static
+ */
+function assertPaused(dbg) {
+  ok(isPaused(dbg), "client is paused");
+}
+
 function getVisibleSelectedFrameLine(dbg) {
   const {
     selectors: { getVisibleSelectedFrame },
@@ -1040,6 +1049,7 @@ const selectors = {
   debugErrorLine: ".new-debug-line-error",
   codeMirror: ".CodeMirror",
   resume: ".resume.active",
+  pause: ".pause.active",
   sourceTabs: ".source-tabs",
   stepOver: ".stepOver.active",
   stepOut: ".stepOut.active",


### PR DESCRIPTION
Fixes Issue: #5446 

### Summary of Changes
* added pause on next test (browser_dbg-pause-on-next.js)

* added pause selector under "selectors" in head.js to support clicking
on pause button

Current version of the test adds an expression to evaluate the function 
instead of using invokeInTab() to trigger pause in the debugger. When 
invokeInTab() is used, it does not seem to activate simple() in 
`src/test/mochitest/examples/simple3.js`

### Test Plan
- [x] In debugger.html project root directory, execute: `yarn mochi browser_dbg-pause-on-next` results in passing test