### PR TITLE
Fix 6063 - Ensure the expressions box is properly outlined upon focus & blur

### DIFF
--- a/src/components/SecondaryPanes/Expressions.css
+++ b/src/components/SecondaryPanes/Expressions.css
@@ -35,11 +35,6 @@
   }
 }
 
-.input-expression.error {
-  border: 1px solid red;
-  animation: 150ms cubic-bezier(0.07, 0.95, 0, 1) shake;
-}
-
 .input-expression::placeholder {
   font-style: italic;
   color: var(--theme-comment);
@@ -55,9 +50,18 @@
   margin: 0;
   padding: 0;
 }
+
 .expression-input-container {
   display: flex;
+  border: 1px solid transparent;
+}
+
+.expression-input-container.focused {
   border: 1px solid var(--theme-highlight-blue);
+}
+
+.expression-input-container.error {
+  border: 1px solid red;
 }
 
 .expression-container {

--- a/src/components/SecondaryPanes/Expressions.js
+++ b/src/components/SecondaryPanes/Expressions.js
@@ -23,7 +23,8 @@ import "./Expressions.css";
 type State = {
   editing: boolean,
   editIndex: number,
-  inputValue: string
+  inputValue: string,
+  focused: boolean
 };
 
 type Props = {
@@ -52,7 +53,8 @@ class Expressions extends Component<Props, State> {
     this.state = {
       editing: false,
       editIndex: -1,
-      inputValue: ""
+      inputValue: "",
+      focused: false
     };
   }
 
@@ -77,7 +79,7 @@ class Expressions extends Component<Props, State> {
   }
 
   shouldComponentUpdate(nextProps, nextState) {
-    const { editing, inputValue } = this.state;
+    const { editing, inputValue, focused } = this.state;
     const { expressions, expressionError, showInput } = this.props;
 
     return (
@@ -85,7 +87,8 @@ class Expressions extends Component<Props, State> {
       expressionError !== nextProps.expressionError ||
       editing !== nextState.editing ||
       inputValue !== nextState.inputValue ||
-      nextProps.showInput !== showInput
+      nextProps.showInput !== showInput ||
+      focused !== nextState.focused
     );
   }
 
@@ -125,7 +128,12 @@ class Expressions extends Component<Props, State> {
   };
 
   hideInput = () => {
+    this.setState({ focused: false });
     this.props.onExpressionAdded();
+  };
+
+  onFocus = () => {
+    this.setState({ focused: true });
   };
 
   onBlur() {
@@ -211,23 +219,28 @@ class Expressions extends Component<Props, State> {
   };
 
   renderNewExpressionInput() {
-    const { expressionError } = this.props;
-    const { editing, inputValue } = this.state;
+    const { expressionError, expressions } = this.props;
+    const { editing, inputValue, focused } = this.state;
     const error = editing === false && expressionError === true;
     const placeholder: string = error
       ? L10N.getStr("expressions.errorMsg")
       : L10N.getStr("expressions.placeholder");
+    const autoFocus = expressions.size > 0;
+
     return (
-      <li className="expression-input-container">
+      <li
+        className={classnames("expression-input-container", { focused, error })}
+      >
         <form className="expression-input-form" onSubmit={this.handleNewSubmit}>
           <input
-            className={classnames("input-expression", { error })}
+            className="input-expression"
             type="text"
             placeholder={placeholder}
             onChange={this.handleChange}
             onBlur={this.hideInput}
             onKeyDown={this.handleKeyDown}
-            autoFocus="true"
+            onFocus={this.onFocus}
+            autoFocus={autoFocus}
             value={!editing ? inputValue : ""}
           />
           <input type="submit" style={{ display: "none" }} />
@@ -238,10 +251,14 @@ class Expressions extends Component<Props, State> {
 
   renderExpressionEditInput(expression: Expression) {
     const { expressionError } = this.props;
-    const { inputValue, editing } = this.state;
+    const { inputValue, editing, focused } = this.state;
     const error = editing === true && expressionError === true;
+
     return (
-      <span className="expression-input-container" key={expression.input}>
+      <span
+        className={classnames("expression-input-container", { focused, error })}
+        key={expression.input}
+      >
         <form
           className="expression-input-form"
           onSubmit={(e: SyntheticEvent<HTMLFormElement>) =>
@@ -254,6 +271,7 @@ class Expressions extends Component<Props, State> {
             onChange={this.handleChange}
             onBlur={this.clear}
             onKeyDown={this.handleKeyDown}
+            onFocus={this.onFocus}
             value={editing ? inputValue : expression.input}
             ref={c => (this._input = c)}
           />

--- a/src/components/SecondaryPanes/tests/__snapshots__/Expressions.spec.js.snap
+++ b/src/components/SecondaryPanes/tests/__snapshots__/Expressions.spec.js.snap
@@ -86,10 +86,11 @@ exports[`Expressions should always have unique keys 1`] = `
       onSubmit={[Function]}
     >
       <input
-        autoFocus="true"
+        autoFocus={false}
         className="input-expression"
         onBlur={[Function]}
         onChange={[Function]}
+        onFocus={[Function]}
         onKeyDown={[Function]}
         placeholder="Add watch expression"
         type="text"
@@ -194,10 +195,11 @@ exports[`Expressions should render 1`] = `
       onSubmit={[Function]}
     >
       <input
-        autoFocus="true"
+        autoFocus={false}
         className="input-expression"
         onBlur={[Function]}
         onChange={[Function]}
+        onFocus={[Function]}
         onKeyDown={[Function]}
         placeholder="Add watch expression"
         type="text"


### PR DESCRIPTION
Fixes Issue: #6063

Testing:

1.  Click in and out of new expression input, ensure border is on at proper times
2.  Edit and blur from existing input
3.  Click the "+" button to add another input