### PR TITLE
Make plus icon darker in expressions pane

### DIFF
--- a/src/components/SecondaryPanes/Expressions.css
+++ b/src/components/SecondaryPanes/Expressions.css
@@ -2,10 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
-.watch-expressions-pane .plus {
-  margin-top: -2px;
-}
-
 .expression-input-form {
   width: 100%;
 }

--- a/src/components/SecondaryPanes/SecondaryPanes.css
+++ b/src/components/SecondaryPanes/SecondaryPanes.css
@@ -49,10 +49,14 @@
   display: flex;
 }
 
+.secondary-panes .accordion .plus {
+  margin-top: -2px;
+}
+
 .secondary-panes .accordion .plus svg {
   width: 12px;
   margin-top: 3px;
-  fill: var(--theme-comment-alt);
+  fill: var(--theme-body-color);
 }
 
 .secondary-panes .accordion .plus.active svg {


### PR DESCRIPTION
As mentioned in Friday's meeting:

<img width="304" alt="pluslight" src="https://user-images.githubusercontent.com/46655/39141111-5852cf86-46ec-11e8-9af6-16c9f9dcb678.png">

<img width="298" alt="plusdark" src="https://user-images.githubusercontent.com/46655/39141114-5cba5c10-46ec-11e8-84d5-6c949961f7fe.png">
