### PR TITLE
Handle 'this' in expression mappings.

### DIFF
--- a/src/workers/parser/mapOriginalExpression.js
+++ b/src/workers/parser/mapOriginalExpression.js
@@ -44,15 +44,23 @@ export default function mapOriginalExpression(
     }
 
     const parentNode = parent.node;
-    if (t.isIdentifier(node) && t.isReferenced(node, parentNode)) {
-      if (mappings.hasOwnProperty(node.name)) {
-        const mapping = mappings[node.name];
-        if (mapping && mapping !== node.name) {
-          const mappingNode = getFirstExpression(parseScript(mapping));
-          replaceNode(ancestors, mappingNode);
 
-          didReplace = true;
-        }
+    let name = null;
+    if (t.isIdentifier(node) && t.isReferenced(node, parentNode)) {
+      name = node.name;
+    } else if (t.isThisExpression(node)) {
+      name = "this";
+    } else {
+      return;
+    }
+
+    if (mappings.hasOwnProperty(name)) {
+      const mapping = mappings[name];
+      if (mapping && mapping !== name) {
+        const mappingNode = getFirstExpression(parseScript(mapping));
+        replaceNode(ancestors, mappingNode);
+
+        didReplace = true;
       }
     }
   });

--- a/src/workers/parser/tests/mapOriginalExpression.spec.js
+++ b/src/workers/parser/tests/mapOriginalExpression.spec.js
@@ -13,6 +13,13 @@ describe("mapOriginalExpression", () => {
     expect(generatedExpression).toEqual("foo + bar;");
   });
 
+  it("this", () => {
+    const generatedExpression = mapOriginalExpression("this.prop;", {
+      this: "_this"
+    });
+    expect(generatedExpression).toEqual("_this.prop;");
+  });
+
   it("member expressions", () => {
     const generatedExpression = mapOriginalExpression("a + b", {
       a: "_mod.foo",


### PR DESCRIPTION
Refs Issue: #5561

### Summary of Changes

* Ensure that we traverse `ThisExpression` nodes when renaming local variables

