### PR TITLE
Fix 6066 - Improve Breakpoint Grouping Uniqueness and Functionality

### DIFF
--- a/src/components/SecondaryPanes/Breakpoints.js
+++ b/src/components/SecondaryPanes/Breakpoints.js
@@ -202,14 +202,26 @@ class Breakpoints extends Component<Props> {
         .map(url => {
           const split = getRawSourceURL(url).split("/");
           const file = split[split.length - 1];
+          const groupBreakpoints = groupedBreakpoints[url].filter(
+            bp => !bp.hidden && (bp.text || bp.originalText)
+          );
+
+          if (!groupBreakpoints.length) {
+            return null;
+          }
 
           return [
-            <div className="breakpoint-heading" title={url} key={url}>
+            <div
+              className="breakpoint-heading"
+              title={url}
+              key={url}
+              onClick={() =>
+                this.props.selectLocation(groupBreakpoints[0].location)
+              }
+            >
               {file}
             </div>,
-            ...groupedBreakpoints[url]
-              .filter(bp => !bp.hidden && bp.text)
-              .map(bp => this.renderBreakpoint(bp))
+            ...groupBreakpoints.map(bp => this.renderBreakpoint(bp))
           ];
         })
     ];

--- a/src/components/SecondaryPanes/Breakpoints.js
+++ b/src/components/SecondaryPanes/Breakpoints.js
@@ -15,7 +15,7 @@ import { groupBy, sortBy } from "lodash";
 import Breakpoint from "./Breakpoint";
 
 import actions from "../../actions";
-import { getRawSourceURL } from "../../utils/source";
+import { getFilenameFromURL } from "../../utils/source";
 import {
   getSources,
   getSourceInSources,
@@ -192,12 +192,11 @@ class Breakpoints extends Component<Props> {
 
     return [
       ...Object.keys(groupedBreakpoints)
-        .sort((urlA, urlB) => urlA.split("/").pop() > urlB.split("/").pop())
+        .sort(
+          (urlA, urlB) => getFilenameFromURL(urlA) > getFilenameFromURL(urlB)
+        )
         .map(url => {
-          const file = getRawSourceURL(url)
-            .split("/")
-            .pop()
-            .split("?")[0];
+          const file = getFilenameFromURL(url);
           const groupBreakpoints = groupedBreakpoints[url].filter(
             bp => !bp.hidden && (bp.text || bp.originalText)
           );

--- a/src/components/SecondaryPanes/Breakpoints.js
+++ b/src/components/SecondaryPanes/Breakpoints.js
@@ -53,6 +53,7 @@ type Props = {
   breakpoints: BreakpointsMap,
   sources: SourcesMap,
   selectedSource: Source,
+  selectSourceURL: (string, Object) => void,
   sourcesMetaData: SourceMetaDataMap,
   enableBreakpoint: Location => void,
   disableBreakpoint: Location => void,
@@ -191,17 +192,10 @@ class Breakpoints extends Component<Props> {
 
     return [
       ...Object.keys(groupedBreakpoints)
-        .sort((urlA, urlB) => {
-          const urlASplit = urlA.split("/");
-          const urlBSplit = urlB.split("/");
-
-          return (
-            urlASplit[urlASplit.length - 1] > urlBSplit[urlBSplit.length - 1]
-          );
-        })
+        .sort((urlA, urlB) => urlA.split("/").pop() > urlB.split("/").pop())
         .map(url => {
           const split = getRawSourceURL(url).split("/");
-          const file = split[split.length - 1];
+          const file = split[split.length - 1].split("?")[0];
           const groupBreakpoints = groupedBreakpoints[url].filter(
             bp => !bp.hidden && (bp.text || bp.originalText)
           );
@@ -215,9 +209,7 @@ class Breakpoints extends Component<Props> {
               className="breakpoint-heading"
               title={url}
               key={url}
-              onClick={() =>
-                this.props.selectLocation(groupBreakpoints[0].location)
-              }
+              onClick={() => this.props.selectSourceURL(url)}
             >
               {file}
             </div>,

--- a/src/components/SecondaryPanes/Breakpoints.js
+++ b/src/components/SecondaryPanes/Breakpoints.js
@@ -197,8 +197,7 @@ class Breakpoints extends Component<Props> {
           const file = getRawSourceURL(url)
             .split("/")
             .pop()
-            .split("?")
-            .pop();
+            .split("?")[0];
           const groupBreakpoints = groupedBreakpoints[url].filter(
             bp => !bp.hidden && (bp.text || bp.originalText)
           );

--- a/src/components/SecondaryPanes/Breakpoints.js
+++ b/src/components/SecondaryPanes/Breakpoints.js
@@ -103,6 +103,20 @@ function createExceptionOption(
   );
 }
 
+function sortFilenames(urlA, urlB) {
+  const filenameA = getFilenameFromURL(urlA);
+  const filenameB = getFilenameFromURL(urlB);
+
+  if (filenameA > filenameB) {
+    return 1;
+  }
+  if (filenameA < filenameB) {
+    return -1;
+  }
+
+  return 0;
+}
+
 class Breakpoints extends Component<Props> {
   handleBreakpointCheckbox(breakpoint) {
     if (breakpoint.loading) {
@@ -192,9 +206,7 @@ class Breakpoints extends Component<Props> {
 
     return [
       ...Object.keys(groupedBreakpoints)
-        .sort(
-          (urlA, urlB) => getFilenameFromURL(urlA) > getFilenameFromURL(urlB)
-        )
+        .sort(sortFilenames)
         .map(url => {
           const file = getFilenameFromURL(url);
           const groupBreakpoints = groupedBreakpoints[url].filter(

--- a/src/components/SecondaryPanes/Breakpoints.js
+++ b/src/components/SecondaryPanes/Breakpoints.js
@@ -53,7 +53,7 @@ type Props = {
   breakpoints: BreakpointsMap,
   sources: SourcesMap,
   selectedSource: Source,
-  selectSourceURL: (string, Object) => void,
+  selectSource: String => void,
   sourcesMetaData: SourceMetaDataMap,
   enableBreakpoint: Location => void,
   disableBreakpoint: Location => void,
@@ -194,8 +194,11 @@ class Breakpoints extends Component<Props> {
       ...Object.keys(groupedBreakpoints)
         .sort((urlA, urlB) => urlA.split("/").pop() > urlB.split("/").pop())
         .map(url => {
-          const split = getRawSourceURL(url).split("/");
-          const file = split[split.length - 1].split("?")[0];
+          const file = getRawSourceURL(url)
+            .split("/")
+            .pop()
+            .split("?")
+            .pop();
           const groupBreakpoints = groupedBreakpoints[url].filter(
             bp => !bp.hidden && (bp.text || bp.originalText)
           );
@@ -209,7 +212,9 @@ class Breakpoints extends Component<Props> {
               className="breakpoint-heading"
               title={url}
               key={url}
-              onClick={() => this.props.selectSourceURL(url)}
+              onClick={() =>
+                this.props.selectSource(groupBreakpoints[0].source.id)
+              }
             >
               {file}
             </div>,


### PR DESCRIPTION
Fixes Issue: #6066

Winding down my day by reopening this.

- Files of the same name are no longer grouped
- Files are sorted by name
- Clicking a group heading opens the given resource
