### PR TITLE
Removes toJS from modifiers

### DIFF
--- a/src/actions/file-search.js
+++ b/src/actions/file-search.js
@@ -105,10 +105,9 @@ export function searchContents(query: string, editor: Object) {
     }
 
     const ctx = { ed: editor, cm: editor.codeMirror };
-    const _modifiers = modifiers.toJS();
-    const matches = await getMatches(query, selectedSource.text, _modifiers);
+    const matches = await getMatches(query, selectedSource.text, modifiers);
 
-    const res = find(ctx, query, true, _modifiers);
+    const res = find(ctx, query, true, modifiers);
     if (!res) {
       return;
     }
@@ -140,9 +139,8 @@ export function searchContentsForHighlight(
     }
 
     const ctx = { ed: editor, cm: editor.codeMirror };
-    const _modifiers = modifiers.toJS();
 
-    searchSourceForHighlight(ctx, false, query, true, _modifiers, line, ch);
+    searchSourceForHighlight(ctx, false, query, true, modifiers, line, ch);
   };
 }
 
@@ -165,8 +163,8 @@ export function traverseResults(rev: boolean, editor: Editor) {
     if (modifiers) {
       const matchedLocations = matches || [];
       const results = rev
-        ? findPrev(ctx, query, true, modifiers.toJS())
-        : findNext(ctx, query, true, modifiers.toJS());
+        ? findPrev(ctx, query, true, modifiers)
+        : findNext(ctx, query, true, modifiers);
 
       if (!results) {
         return;

--- a/src/workers/search/build-query.js
+++ b/src/workers/search/build-query.js
@@ -51,7 +51,7 @@ export default function buildQuery(
   modifiers: SearchModifiers,
   { isGlobal = false, ignoreSpaces = false }: QueryOptions
 ): RegExp {
-  const { caseSensitive, regexMatch, wholeWord } = modifiers;
+  const { caseSensitive, regexMatch, wholeWord } = modifiers.toJS();
 
   if (originalQuery === "") {
     return new RegExp(originalQuery);


### PR DESCRIPTION
Currently modifiers are being converted to an object at a very high level in `searchContents`, `searchContentsForHighlight`, `traverseResults` when their value is being used in `buildQuery` or `doSearch`. 

This here is a try to remove the toJS statements and see if mochi passes (jest works already)

Also: It may be possible to get the search modifiers from the state instead of passing them through X functions for a cleaner workflow and a definite source of truth with fewer dependencies. Insight on that would be great.

Structure of passing modifiers through functions:
```
searchContents
	_modifiers = modifiers.toJS();

	functions using objects
	- getMatches
		- buildQuery (destructures modifiers)
	- find
		- doSearch
			- updateOverlay
				- searchOverlay
					- buildQuery
			- searchNext
				- getSearchCursor
					- buildQuery

searchContentsForHighlight
	_modifiers = modifiers.toJS();

	functions using objects
	- searchSourceForHighlight
		- updateOverlay
		- findNextOnLine
			- getSearchCursor
				- buildQuery

traverseResults
	- findPrev (toJS)
		- doSearch
	- findNext (toJS)
		- doSearch
```