### PR TITLE
[Sources] updated fix "set directory root" bug

### DIFF
--- a/src/actions/tests/ui.spec.js
+++ b/src/actions/tests/ui.spec.js
@@ -80,6 +80,12 @@ describe("ui", () => {
 });
 
 describe("setProjectDirectoryRoot", () => {
+  it("should set domain directory as root", () => {
+    const { dispatch, getState } = createStore();
+    dispatch(actions.setProjectDirectoryRoot("example.com"));
+    expect(getProjectDirectoryRoot(getState())).toBe("example.com");
+  });
+
   it("should set a directory as root directory", () => {
     const { dispatch, getState } = createStore();
     dispatch(actions.setProjectDirectoryRoot("/example.com/foo"));

--- a/src/components/PrimaryPanes/SourcesTree.js
+++ b/src/components/PrimaryPanes/SourcesTree.js
@@ -348,9 +348,10 @@ class SourcesTree extends Component<Props, State> {
     // The "sourceTree.contents[0]" check ensures that there are contents
     // A custom root with no existing sources will be ignored
     if (isCustomRoot) {
-      let rootLabel = projectRoot.split("/").pop();
       const sourceContents = sourceTree.contents[0];
-      if (sourceContents) {
+      let rootLabel = projectRoot.split("/").pop();
+      roots = () => sourceContents.contents;
+      if (sourceContents && sourceContents.name !== rootLabel) {
         rootLabel = sourceContents.contents[0].name;
         roots = () => sourceContents.contents[0].contents;
       }


### PR DESCRIPTION
Updates regarding of PR: #6052 

### Summary of Changes

Fix a minor bug when setting domain directory as root.

STR:

1. Go to http://firefox-dev.tools/debugger-examples/examples/todomvc/
2. On the left panel, right click on "firefox-dev.tools" and Click on "Set directory root"
3. Notice the root name is not displayed correctly.

![n1owkgixyv](https://user-images.githubusercontent.com/23003064/39201838-4446199e-47be-11e8-9538-4230b46b8665.gif)

### Test Case

Added ui test case in regarding to this bug.
