### PR TITLE
[scopes] Use the scope visitor to avoid rewriting shadowed bindings in console expressions

### DIFF
--- a/src/utils/function.js
+++ b/src/utils/function.js
@@ -23,7 +23,9 @@ export function findFunctionText(
     return null;
   }
 
-  const { location: { start, end } } = func;
+  const {
+    location: { start, end }
+  } = func;
   const lines = source.text.split("\n");
   const firstLine = lines[start.line - 1].slice(start.column);
   const lastLine = lines[end.line - 1].slice(0, end.column);

--- a/src/workers/parser/getScopes/index.js
+++ b/src/workers/parser/getScopes/index.js
@@ -5,6 +5,7 @@
 // @flow
 
 import {
+  buildScopeList,
   parseSourceScopes,
   type SourceScope,
   type ParsedScope,
@@ -41,6 +42,8 @@ export default function getScopes(location: Location): SourceScope[] {
 export function clearScopes() {
   parsedScopesCache = new Map();
 }
+
+export { buildScopeList };
 
 /**
  * Searches all scopes and their bindings at the specific location.

--- a/src/workers/parser/getScopes/visitor.js
+++ b/src/workers/parser/getScopes/visitor.js
@@ -142,6 +142,10 @@ export function parseSourceScopes(sourceId: SourceId): ?Array<ParsedScope> {
     return null;
   }
 
+  return buildScopeList(ast, sourceId);
+}
+
+export function buildScopeList(ast: Node, sourceId: SourceId) {
   const { global, lexical } = createGlobalScope(ast, sourceId);
 
   const state = {

--- a/src/workers/parser/tests/mapOriginalExpression.spec.js
+++ b/src/workers/parser/tests/mapOriginalExpression.spec.js
@@ -44,4 +44,17 @@ describe("mapOriginalExpression", () => {
     });
     expect(generatedExpression).toEqual("a + b");
   });
+
+  it("shadowed bindings", () => {
+    const generatedExpression = mapOriginalExpression(
+      "window.thing = function fn(){ var a; a; b; }; a; b; ",
+      {
+        a: "_a",
+        b: "_b"
+      }
+    );
+    expect(generatedExpression).toEqual(
+      "window.thing = function fn() {\n  var a;\n  a;\n  _b;\n};\n\n_a;\n_b;"
+    );
+  });
 });


### PR DESCRIPTION
Refs Issue: #5561

### Summary of Changes

* Use the parser worker's scope visitor to ensure that only variables in the proper scope are rewritten in the console