### PR TITLE
Fix 6065 - Tighten up the breakpoint spacing

### DIFF
--- a/src/components/SecondaryPanes/Breakpoints.css
+++ b/src/components/SecondaryPanes/Breakpoints.css
@@ -29,6 +29,11 @@
   padding: 0.5em 1em 0.5em 0.5em;
 }
 
+.breakpoints-list .breakpoint {
+    padding-top: 0.25em;
+    padding-bottom: 0.25em;
+}
+
 .breakpoints-exceptions-caught {
   padding: 0 1em 0.5em 2em;
 }

--- a/src/components/SecondaryPanes/Breakpoints.css
+++ b/src/components/SecondaryPanes/Breakpoints.css
@@ -113,7 +113,7 @@ html .breakpoints-list .breakpoint.paused {
 .breakpoints-list .breakpoint .breakpoint-line {
   font-size: 11px;
   color: var(--theme-comment);
-  padding-top: 3px;
+  padding-top: 4px;
   padding-inline-end: 2px;
   min-width: 14px;
   text-align: right;
@@ -166,7 +166,7 @@ html[dir="rtl"] .breakpoints-list .breakpoint .breakpoint-line {
   position: absolute;
   offset-inline-end: 13px;
   offset-inline-start: auto;
-  top: 9px;
+  top: 6px;
   display: none;
 }
 


### PR DESCRIPTION
Fixes Issue: #6065

I halved the vertical space:

<img width="300" alt="vertspacing" src="https://user-images.githubusercontent.com/46655/39207624-0deabbcc-47c6-11e8-92ea-ed9908133bec.png">
