### PR TITLE
Don't show buttons that aren't usable

### DIFF
--- a/src/components/SecondaryPanes/index.js
+++ b/src/components/SecondaryPanes/index.js
@@ -15,6 +15,7 @@ import {
   getBreakpoints,
   getBreakpointsDisabled,
   getBreakpointsLoading,
+  getExpressions,
   getIsWaitingOnBreak,
   getShouldPauseOnExceptions,
   getShouldIgnoreCaughtExceptions,
@@ -70,6 +71,7 @@ type State = {
 };
 
 type Props = {
+  expressions: List<Expression>,
   extra: Object,
   evaluateExpressions: Function,
   hasFrames: boolean,
@@ -142,6 +144,12 @@ class SecondaryPanes extends Component<Props, State> {
   }
 
   watchExpressionHeaderButtons() {
+    const { expressions } = this.props;
+
+    if (!expressions.size) {
+      return [];
+    }
+
     return [
       debugBtn(
         evt => {
@@ -394,6 +402,7 @@ SecondaryPanes.contextTypes = {
 
 export default connect(
   state => ({
+    expressions: getExpressions(state),
     extra: getExtra(state),
     hasFrames: !!getTopFrame(state),
     breakpoints: getBreakpoints(state),

--- a/src/components/SecondaryPanes/index.js
+++ b/src/components/SecondaryPanes/index.js
@@ -8,7 +8,9 @@ import PropTypes from "prop-types";
 import React, { Component } from "react";
 import { connect } from "react-redux";
 import { bindActionCreators } from "redux";
+import { List } from "immutable";
 
+import type { Expression } from "../../types";
 import actions from "../../actions";
 import {
   getTopFrame,
@@ -196,9 +198,7 @@ class SecondaryPanes extends Component<Props, State> {
   }
 
   getComponentItem() {
-    const {
-      extra: { react }
-    } = this.props;
+    const { extra: { react } } = this.props;
 
     return {
       header: react.displayName,

--- a/src/components/SecondaryPanes/index.js
+++ b/src/components/SecondaryPanes/index.js
@@ -10,7 +10,6 @@ import { connect } from "react-redux";
 import { bindActionCreators } from "redux";
 import { List } from "immutable";
 
-import type { Expression } from "../../types";
 import actions from "../../actions";
 import {
   getTopFrame,
@@ -44,6 +43,7 @@ import Scopes from "./Scopes";
 
 import "./SecondaryPanes.css";
 
+import type { Expression } from "../../types";
 import type { WorkersList } from "../../reducers/types";
 
 type AccordionPaneItem = {

--- a/src/test/mochitest/browser_dbg-expressions-error.js
+++ b/src/test/mochitest/browser_dbg-expressions-error.js
@@ -23,7 +23,11 @@ function getValue(dbg, index) {
 }
 
 async function addExpression(dbg, input) {
-  findElementWithSelector(dbg, expressionSelectors.plusIcon).click();
+  const plusIcon = findElementWithSelector(dbg, expressionSelectors.plusIcon);
+  if(plusIcon) {
+    plusIcon.click();
+  }
+  
   const evaluation = waitForDispatch(dbg, "EVALUATE_EXPRESSION");
   findElementWithSelector(dbg, expressionSelectors.input).focus();
   type(dbg, input);

--- a/src/test/mochitest/browser_dbg-expressions.js
+++ b/src/test/mochitest/browser_dbg-expressions.js
@@ -34,7 +34,11 @@ function assertEmptyValue(dbg, index) {
 
 async function addExpression(dbg, input) {
   info("Adding an expression");
-  findElementWithSelector(dbg, expressionSelectors.plusIcon).click();
+
+  const plusIcon = findElementWithSelector(dbg, expressionSelectors.plusIcon);
+  if(plusIcon) {
+    plusIcon.click();
+  }
   findElementWithSelector(dbg, expressionSelectors.input).focus();
   type(dbg, input);
   pressKey(dbg, "Enter");


### PR DESCRIPTION
As off now, we show the "refresh" and "+" buttons for Expressions but ... they don't do anything when there are no expressions made.  This PR hides those buttons when no expressions exist.