### PR TITLE
Ensure expressions input matches display height

### DIFF
--- a/src/components/SecondaryPanes/Expressions.css
+++ b/src/components/SecondaryPanes/Expressions.css
@@ -66,7 +66,7 @@
 
 .expression-container {
   border: 1px;
-  padding: 0.25em 1em 0.25em 0.5em;
+  padding: .60em 1em .60em 0.5em;
   width: 100%;
   color: var(--theme-body-color);
   background-color: var(--theme-body-background);

--- a/src/components/SecondaryPanes/Expressions.css
+++ b/src/components/SecondaryPanes/Expressions.css
@@ -66,7 +66,7 @@
 
 .expression-container {
   border: 1px;
-  padding: .60em 1em .60em 0.5em;
+  padding: 0.6em 1em 0.6em 0.5em;
   width: 100%;
   color: var(--theme-body-color);
   background-color: var(--theme-body-background);


### PR DESCRIPTION
There's a sizable jump between an existing expression and the input box; a jump we should prevent.  Here's how it looks now:

![jumps](https://user-images.githubusercontent.com/46655/39281811-2baa0bfc-48cc-11e8-9377-7ee4c0b87487.gif)
