### PR TITLE
Prevent CodeMirror from preventing scroll in breakpoints

### DIFF
--- a/src/components/SecondaryPanes/Breakpoints.css
+++ b/src/components/SecondaryPanes/Breakpoints.css
@@ -217,4 +217,5 @@ html[dir="rtl"] .breakpoints-list .breakpoint .breakpoint-line {
 .CodeMirror.cm-s-mozilla-breakpoint .CodeMirror-code,
 .CodeMirror.cm-s-mozilla-breakpoint .CodeMirror-scroll {
   cursor: default;
+  pointer-events: none;
 }


### PR DESCRIPTION
Fixes Issue: #5978 

### Test Plan

Pull this down, build into Firefox, then try to scroll over breakpoints

I figured this out via:

``` ./mach run --jsdebugger --devtools ```, setting this CSS value with the console, and then scrolling worked as desired.