### PR TITLE
removes toJS from ResultsList

### DIFF
--- a/packages/devtools-reps/src/launchpad/components/ResultsList.js
+++ b/packages/devtools-reps/src/launchpad/components/ResultsList.js
@@ -34,20 +34,17 @@ class ResultsList extends Component {
 
     return dom.div(
       { className: "expressions" },
-      expressions
-        .entrySeq()
-        .toJS()
-        .map(([key, expression]) =>
-          Result({
-            key,
-            expression: expression.toJS(),
-            showResultPacket: () => showResultPacket(key),
-            hideResultPacket: () => hideResultPacket(key),
-            createObjectClient,
-            createLongStringClient,
-            releaseActor
-          })
-        )
+      expressions.entrySeq().map(([key, expression]) =>
+        Result({
+          key,
+          expression,
+          showResultPacket: () => showResultPacket(key),
+          hideResultPacket: () => hideResultPacket(key),
+          createObjectClient,
+          createLongStringClient,
+          releaseActor
+        })
+      )
     );
   }
 }


### PR DESCRIPTION
Since .map() and .reverse() work on Immutable maps there might be no need for the .toJS() at all.