### PR TITLE
[scopes] Support parsing .vue files from original maps.

### DIFF
--- a/packages/devtools-source-map/src/utils/index.js
+++ b/packages/devtools-source-map/src/utils/index.js
@@ -48,6 +48,7 @@ const contentMap = {
   ts: "text/typescript",
   tsx: "text/typescript-jsx",
   jsx: "text/jsx",
+  vue: "text/vue",
   coffee: "text/coffeescript",
   elm: "text/elm",
   cljs: "text/x-clojure"

--- a/src/workers/parser/tests/__snapshots__/getScopes.spec.js.snap
+++ b/src/workers/parser/tests/__snapshots__/getScopes.spec.js.snap
@@ -13273,6 +13273,145 @@ Array [
 ]
 `;
 
+exports[`getScopes finds scope bindings in a vue file at line 14 column 0 1`] = `
+Array [
+  Object {
+    "bindings": Object {
+      "arguments": Object {
+        "refs": Array [],
+        "type": "implicit",
+      },
+      "fnVar": Object {
+        "refs": Array [
+          Object {
+            "declaration": Object {
+              "end": Object {
+                "column": 18,
+                "line": 13,
+                "sourceId": "scopes/vue-sample/originalSource-1",
+              },
+              "start": Object {
+                "column": 4,
+                "line": 13,
+                "sourceId": "scopes/vue-sample/originalSource-1",
+              },
+            },
+            "end": Object {
+              "column": 13,
+              "line": 13,
+              "sourceId": "scopes/vue-sample/originalSource-1",
+            },
+            "start": Object {
+              "column": 8,
+              "line": 13,
+              "sourceId": "scopes/vue-sample/originalSource-1",
+            },
+            "type": "decl",
+          },
+        ],
+        "type": "var",
+      },
+      "this": Object {
+        "refs": Array [],
+        "type": "implicit",
+      },
+    },
+    "displayName": "data",
+    "end": Object {
+      "column": 3,
+      "line": 18,
+      "sourceId": "scopes/vue-sample/originalSource-1",
+    },
+    "start": Object {
+      "column": 2,
+      "line": 12,
+      "sourceId": "scopes/vue-sample/originalSource-1",
+    },
+    "type": "function",
+  },
+  Object {
+    "bindings": Object {
+      "moduleVar": Object {
+        "refs": Array [
+          Object {
+            "declaration": Object {
+              "end": Object {
+                "column": 23,
+                "line": 8,
+                "sourceId": "scopes/vue-sample/originalSource-1",
+              },
+              "start": Object {
+                "column": 0,
+                "line": 8,
+                "sourceId": "scopes/vue-sample/originalSource-1",
+              },
+            },
+            "end": Object {
+              "column": 13,
+              "line": 8,
+              "sourceId": "scopes/vue-sample/originalSource-1",
+            },
+            "start": Object {
+              "column": 4,
+              "line": 8,
+              "sourceId": "scopes/vue-sample/originalSource-1",
+            },
+            "type": "decl",
+          },
+        ],
+        "type": "var",
+      },
+      "this": Object {
+        "refs": Array [],
+        "type": "implicit",
+      },
+    },
+    "displayName": "Module",
+    "end": Object {
+      "column": 1,
+      "line": 27,
+      "sourceId": "scopes/vue-sample/originalSource-1",
+    },
+    "start": Object {
+      "column": 0,
+      "line": 1,
+      "sourceId": "scopes/vue-sample/originalSource-1",
+    },
+    "type": "block",
+  },
+  Object {
+    "bindings": Object {},
+    "displayName": "Lexical Global",
+    "end": Object {
+      "column": 1,
+      "line": 27,
+      "sourceId": "scopes/vue-sample/originalSource-1",
+    },
+    "start": Object {
+      "column": 0,
+      "line": 1,
+      "sourceId": "scopes/vue-sample/originalSource-1",
+    },
+    "type": "block",
+  },
+  Object {
+    "bindings": Object {},
+    "displayName": "Global",
+    "end": Object {
+      "column": 1,
+      "line": 27,
+      "sourceId": "scopes/vue-sample/originalSource-1",
+    },
+    "start": Object {
+      "column": 0,
+      "line": 1,
+      "sourceId": "scopes/vue-sample/originalSource-1",
+    },
+    "type": "object",
+  },
+]
+`;
+
 exports[`getScopes finds scope bindings with expression metadata at line 2 column 0 1`] = `
 Array [
   Object {

--- a/src/workers/parser/tests/fixtures/scopes/vue-sample.vue
+++ b/src/workers/parser/tests/fixtures/scopes/vue-sample.vue
@@ -1,0 +1,26 @@
+<template>
+  <div class="hello">
+    <h1>{{ msg }}</h1>
+  </div>
+</template>
+
+<script>
+var moduleVar = "data";
+
+export default {
+  name: 'HelloWorld',
+  data () {
+    var fnVar = 4;
+
+    return {
+      msg: 'Welcome to Your Vue.js App'
+    };
+  }
+};
+</script>
+
+<style scoped>
+a {
+  color: red;
+}
+</style>

--- a/src/workers/parser/tests/getScopes.spec.js
+++ b/src/workers/parser/tests/getScopes.spec.js
@@ -28,6 +28,12 @@ cases(
   },
   [
     {
+      name: "finds scope bindings in a vue file",
+      file: "scopes/vue-sample",
+      type: "vue",
+      locations: [[14, 0]]
+    },
+    {
       name: "finds scope bindings in a typescript file",
       file: "scopes/ts-sample",
       type: "ts",

--- a/src/workers/parser/tests/helpers/index.js
+++ b/src/workers/parser/tests/helpers/index.js
@@ -13,6 +13,8 @@ export function getSource(name, type = "js") {
   let contentType = "text/javascript";
   if (type === "html") {
     contentType = "text/html";
+  } else if (type === "vue") {
+    contentType = "text/vue";
   } else if (type === "ts") {
     contentType = "text/typescript";
   } else if (type === "tsx") {


### PR DESCRIPTION
Refs Issue: #5561

### Summary of Changes

* Support parsing of `.vue` files for JS content

This allows getSymbols and preview to work in .vue files, among other things. This doesn't currently enable original-scope debugging with Vue, because the sourcemaps generated by Vue aren't quite adequate. It does at least allow for the possibility if the sourcemaps improve in the future however.