### PR TITLE
Removes repeating .toJS() calls in Outline.js

### DIFF
--- a/src/components/PrimaryPanes/Outline.js
+++ b/src/components/PrimaryPanes/Outline.js
@@ -214,17 +214,12 @@ export class Outline extends Component<Props> {
 export default connect(
   state => {
     const selectedSource = getSelectedSource(state);
-    const selectedSourceJS = selectedSource.toJS();
+    const symbols = getSymbols(state, selectedSource);
     return {
-      symbols: getSymbols(state, selectedSource && selectedSourceJS),
+      symbols,
       selectedSource,
       selectedLocation: getSelectedLocation(state),
-      getFunctionText: line =>
-        findFunctionText(
-          line,
-          selectedSourceJS,
-          getSymbols(state, selectedSourceJS)
-        )
+      getFunctionText: line => findFunctionText(line, selectedSource, symbols)
     };
   },
   dispatch => bindActionCreators(actions, dispatch)

--- a/src/components/PrimaryPanes/Outline.js
+++ b/src/components/PrimaryPanes/Outline.js
@@ -214,15 +214,16 @@ export class Outline extends Component<Props> {
 export default connect(
   state => {
     const selectedSource = getSelectedSource(state);
+    const selectedSourceJS = selectedSource.toJS();
     return {
-      symbols: getSymbols(state, selectedSource && selectedSource.toJS()),
+      symbols: getSymbols(state, selectedSource && selectedSourceJS),
       selectedSource,
       selectedLocation: getSelectedLocation(state),
       getFunctionText: line =>
         findFunctionText(
           line,
-          selectedSource.toJS(),
-          getSymbols(state, selectedSource.toJS())
+          selectedSourceJS,
+          getSymbols(state, selectedSourceJS)
         )
     };
   },


### PR DESCRIPTION
since every .toJS() call is about a quarter of a second we should be able to shave off half a second with this refactor every time Outline is called.