### PR TITLE
Re-apply the non-breaking pieces reverted in #6112

### DIFF
--- a/src/actions/pause/mapScopes.js
+++ b/src/actions/pause/mapScopes.js
@@ -251,7 +251,7 @@ function isReliableScope(scope: OriginalScope): boolean {
   }
 
   // As determined by fair dice roll.
-  return totalBindings === 0 || unknownBindings / totalBindings < 0.9;
+  return totalBindings === 0 || unknownBindings / totalBindings < 0.1;
 }
 
 function generateClientScope(

--- a/src/utils/function.js
+++ b/src/utils/function.js
@@ -23,7 +23,9 @@ export function findFunctionText(
     return null;
   }
 
-  const { location: { start, end } } = func;
+  const {
+    location: { start, end }
+  } = func;
   const lines = source.text.split("\n");
   const firstLine = lines[start.line - 1].slice(start.column);
   const lastLine = lines[end.line - 1].slice(0, end.column);

--- a/src/utils/pause/mapScopes/findGeneratedBindingFromPosition.js
+++ b/src/utils/pause/mapScopes/findGeneratedBindingFromPosition.js
@@ -474,6 +474,18 @@ async function getGeneratedLocationRanges(
   const ranges = await sourceMaps.getGeneratedRanges(start, source);
 
   const resultRanges = ranges.reduce((acc, mapRange) => {
+    // Some tooling creates ranges that map a line as a whole, which is useful
+    // for step-debugging, but can easily lead to finding the wrong binding.
+    // To avoid these false-positives, we entirely ignore ranges that cover
+    // full lines.
+    if (
+      locationType === "ref" &&
+      mapRange.columnStart === 0 &&
+      mapRange.columnEnd === Infinity
+    ) {
+      return acc;
+    }
+
     const range = {
       start: {
         line: mapRange.line,

--- a/src/workers/parser/getScopes/visitor.js
+++ b/src/workers/parser/getScopes/visitor.js
@@ -452,25 +452,42 @@ const scopeCollectionVisitor = {
         };
       }
     } else if (t.isClass(node)) {
-      if (t.isClassDeclaration(node) && t.isIdentifier(node.id)) {
-        state.declarationBindingIds.add(node.id);
-        state.scope.bindings[node.id.name] = {
-          type: "let",
-          refs: [
-            {
-              type: "decl",
-              start: fromBabelLocation(node.id.loc.start, state.sourceId),
-              end: fromBabelLocation(node.id.loc.end, state.sourceId),
-              declaration: {
-                start: fromBabelLocation(node.loc.start, state.sourceId),
-                end: fromBabelLocation(node.loc.end, state.sourceId)
-              }
-            }
-          ]
-        };
-      }
-
       if (t.isIdentifier(node.id)) {
+        // For decorated classes, the AST considers the first the decorator
+        // to be the start of the class. For the purposes of mapping class
+        // declarations however, we really want to look for the "class Foo"
+        // piece. To achieve that, we estimate the location of the declaration
+        // instead.
+        let declStart = node.loc.start;
+        if (node.decorators && node.decorators.length > 0) {
+          // Estimate the location of the "class" keyword since it
+          // is unlikely to be a different line than the class name.
+          declStart = {
+            line: node.id.loc.start.line,
+            column: node.id.loc.start.column - "class ".length
+          };
+        }
+
+        const declaration = {
+          start: fromBabelLocation(declStart, state.sourceId),
+          end: fromBabelLocation(node.loc.end, state.sourceId)
+        };
+
+        if (t.isClassDeclaration(node)) {
+          state.declarationBindingIds.add(node.id);
+          state.scope.bindings[node.id.name] = {
+            type: "let",
+            refs: [
+              {
+                type: "decl",
+                start: fromBabelLocation(node.id.loc.start, state.sourceId),
+                end: fromBabelLocation(node.id.loc.end, state.sourceId),
+                declaration
+              }
+            ]
+          };
+        }
+
         const scope = pushTempScope(state, "block", "Class", {
           start: fromBabelLocation(node.loc.start, state.sourceId),
           end: fromBabelLocation(node.loc.end, state.sourceId)
@@ -484,10 +501,7 @@ const scopeCollectionVisitor = {
               type: "decl",
               start: fromBabelLocation(node.id.loc.start, state.sourceId),
               end: fromBabelLocation(node.id.loc.end, state.sourceId),
-              declaration: {
-                start: fromBabelLocation(node.loc.start, state.sourceId),
-                end: fromBabelLocation(node.loc.end, state.sourceId)
-              }
+              declaration
             }
           ]
         };

--- a/src/workers/parser/tests/__snapshots__/getScopes.spec.js.snap
+++ b/src/workers/parser/tests/__snapshots__/getScopes.spec.js.snap
@@ -1724,6 +1724,36 @@ Array [
         ],
         "type": "let",
       },
+      "Second": Object {
+        "refs": Array [
+          Object {
+            "declaration": Object {
+              "end": Object {
+                "column": 15,
+                "line": 14,
+                "sourceId": "scopes/class-declaration/originalSource-1",
+              },
+              "start": Object {
+                "column": 0,
+                "line": 14,
+                "sourceId": "scopes/class-declaration/originalSource-1",
+              },
+            },
+            "end": Object {
+              "column": 12,
+              "line": 14,
+              "sourceId": "scopes/class-declaration/originalSource-1",
+            },
+            "start": Object {
+              "column": 6,
+              "line": 14,
+              "sourceId": "scopes/class-declaration/originalSource-1",
+            },
+            "type": "decl",
+          },
+        ],
+        "type": "let",
+      },
       "this": Object {
         "refs": Array [],
         "type": "implicit",
@@ -1732,7 +1762,7 @@ Array [
     "displayName": "Module",
     "end": Object {
       "column": 0,
-      "line": 12,
+      "line": 15,
       "sourceId": "scopes/class-declaration/originalSource-1",
     },
     "start": Object {
@@ -1747,7 +1777,7 @@ Array [
     "displayName": "Lexical Global",
     "end": Object {
       "column": 0,
-      "line": 12,
+      "line": 15,
       "sourceId": "scopes/class-declaration/originalSource-1",
     },
     "start": Object {
@@ -1792,11 +1822,30 @@ Array [
         ],
         "type": "global",
       },
+      "decorator": Object {
+        "refs": Array [
+          Object {
+            "end": Object {
+              "column": 10,
+              "line": 13,
+              "sourceId": "scopes/class-declaration/originalSource-1",
+            },
+            "meta": null,
+            "start": Object {
+              "column": 1,
+              "line": 13,
+              "sourceId": "scopes/class-declaration/originalSource-1",
+            },
+            "type": "ref",
+          },
+        ],
+        "type": "global",
+      },
     },
     "displayName": "Global",
     "end": Object {
       "column": 0,
-      "line": 12,
+      "line": 15,
       "sourceId": "scopes/class-declaration/originalSource-1",
     },
     "start": Object {
@@ -1959,6 +2008,36 @@ Array [
         ],
         "type": "let",
       },
+      "Second": Object {
+        "refs": Array [
+          Object {
+            "declaration": Object {
+              "end": Object {
+                "column": 15,
+                "line": 14,
+                "sourceId": "scopes/class-declaration/originalSource-1",
+              },
+              "start": Object {
+                "column": 0,
+                "line": 14,
+                "sourceId": "scopes/class-declaration/originalSource-1",
+              },
+            },
+            "end": Object {
+              "column": 12,
+              "line": 14,
+              "sourceId": "scopes/class-declaration/originalSource-1",
+            },
+            "start": Object {
+              "column": 6,
+              "line": 14,
+              "sourceId": "scopes/class-declaration/originalSource-1",
+            },
+            "type": "decl",
+          },
+        ],
+        "type": "let",
+      },
       "this": Object {
         "refs": Array [],
         "type": "implicit",
@@ -1967,7 +2046,7 @@ Array [
     "displayName": "Module",
     "end": Object {
       "column": 0,
-      "line": 12,
+      "line": 15,
       "sourceId": "scopes/class-declaration/originalSource-1",
     },
     "start": Object {
@@ -1982,7 +2061,7 @@ Array [
     "displayName": "Lexical Global",
     "end": Object {
       "column": 0,
-      "line": 12,
+      "line": 15,
       "sourceId": "scopes/class-declaration/originalSource-1",
     },
     "start": Object {
@@ -2027,11 +2106,30 @@ Array [
         ],
         "type": "global",
       },
+      "decorator": Object {
+        "refs": Array [
+          Object {
+            "end": Object {
+              "column": 10,
+              "line": 13,
+              "sourceId": "scopes/class-declaration/originalSource-1",
+            },
+            "meta": null,
+            "start": Object {
+              "column": 1,
+              "line": 13,
+              "sourceId": "scopes/class-declaration/originalSource-1",
+            },
+            "type": "ref",
+          },
+        ],
+        "type": "global",
+      },
     },
     "displayName": "Global",
     "end": Object {
       "column": 0,
-      "line": 12,
+      "line": 15,
       "sourceId": "scopes/class-declaration/originalSource-1",
     },
     "start": Object {
@@ -2279,6 +2377,36 @@ Array [
         ],
         "type": "let",
       },
+      "Second": Object {
+        "refs": Array [
+          Object {
+            "declaration": Object {
+              "end": Object {
+                "column": 15,
+                "line": 14,
+                "sourceId": "scopes/class-declaration/originalSource-1",
+              },
+              "start": Object {
+                "column": 0,
+                "line": 14,
+                "sourceId": "scopes/class-declaration/originalSource-1",
+              },
+            },
+            "end": Object {
+              "column": 12,
+              "line": 14,
+              "sourceId": "scopes/class-declaration/originalSource-1",
+            },
+            "start": Object {
+              "column": 6,
+              "line": 14,
+              "sourceId": "scopes/class-declaration/originalSource-1",
+            },
+            "type": "decl",
+          },
+        ],
+        "type": "let",
+      },
       "this": Object {
         "refs": Array [],
         "type": "implicit",
@@ -2287,7 +2415,7 @@ Array [
     "displayName": "Module",
     "end": Object {
       "column": 0,
-      "line": 12,
+      "line": 15,
       "sourceId": "scopes/class-declaration/originalSource-1",
     },
     "start": Object {
@@ -2302,7 +2430,7 @@ Array [
     "displayName": "Lexical Global",
     "end": Object {
       "column": 0,
-      "line": 12,
+      "line": 15,
       "sourceId": "scopes/class-declaration/originalSource-1",
     },
     "start": Object {
@@ -2347,11 +2475,30 @@ Array [
         ],
         "type": "global",
       },
+      "decorator": Object {
+        "refs": Array [
+          Object {
+            "end": Object {
+              "column": 10,
+              "line": 13,
+              "sourceId": "scopes/class-declaration/originalSource-1",
+            },
+            "meta": null,
+            "start": Object {
+              "column": 1,
+              "line": 13,
+              "sourceId": "scopes/class-declaration/originalSource-1",
+            },
+            "type": "ref",
+          },
+        ],
+        "type": "global",
+      },
     },
     "displayName": "Global",
     "end": Object {
       "column": 0,
-      "line": 12,
+      "line": 15,
       "sourceId": "scopes/class-declaration/originalSource-1",
     },
     "start": Object {

--- a/src/workers/parser/tests/__snapshots__/getScopes.spec.js.snap
+++ b/src/workers/parser/tests/__snapshots__/getScopes.spec.js.snap
@@ -12525,7 +12525,7 @@ Array [
     "displayName": "Lexical Global",
     "end": Object {
       "column": 0,
-      "line": 9,
+      "line": 11,
       "sourceId": "scopes/ts-sample/originalSource-1",
     },
     "start": Object {
@@ -12556,15 +12556,64 @@ Array [
         ],
         "type": "global",
       },
+      "foo": Object {
+        "refs": Array [
+          Object {
+            "declaration": Object {
+              "end": Object {
+                "column": 22,
+                "line": 10,
+                "sourceId": "scopes/ts-sample/originalSource-1",
+              },
+              "start": Object {
+                "column": 0,
+                "line": 10,
+                "sourceId": "scopes/ts-sample/originalSource-1",
+              },
+            },
+            "end": Object {
+              "column": 7,
+              "line": 10,
+              "sourceId": "scopes/ts-sample/originalSource-1",
+            },
+            "start": Object {
+              "column": 4,
+              "line": 10,
+              "sourceId": "scopes/ts-sample/originalSource-1",
+            },
+            "type": "decl",
+          },
+        ],
+        "type": "var",
+      },
       "this": Object {
         "refs": Array [],
         "type": "implicit",
+      },
+      "window": Object {
+        "refs": Array [
+          Object {
+            "end": Object {
+              "column": 21,
+              "line": 10,
+              "sourceId": "scopes/ts-sample/originalSource-1",
+            },
+            "meta": null,
+            "start": Object {
+              "column": 15,
+              "line": 10,
+              "sourceId": "scopes/ts-sample/originalSource-1",
+            },
+            "type": "ref",
+          },
+        ],
+        "type": "global",
       },
     },
     "displayName": "Global",
     "end": Object {
       "column": 0,
-      "line": 9,
+      "line": 11,
       "sourceId": "scopes/ts-sample/originalSource-1",
     },
     "start": Object {
@@ -12715,7 +12764,7 @@ Array [
     "displayName": "Lexical Global",
     "end": Object {
       "column": 0,
-      "line": 9,
+      "line": 11,
       "sourceId": "scopes/ts-sample/originalSource-1",
     },
     "start": Object {
@@ -12746,6 +12795,224 @@ Array [
         ],
         "type": "global",
       },
+      "foo": Object {
+        "refs": Array [
+          Object {
+            "declaration": Object {
+              "end": Object {
+                "column": 22,
+                "line": 10,
+                "sourceId": "scopes/ts-sample/originalSource-1",
+              },
+              "start": Object {
+                "column": 0,
+                "line": 10,
+                "sourceId": "scopes/ts-sample/originalSource-1",
+              },
+            },
+            "end": Object {
+              "column": 7,
+              "line": 10,
+              "sourceId": "scopes/ts-sample/originalSource-1",
+            },
+            "start": Object {
+              "column": 4,
+              "line": 10,
+              "sourceId": "scopes/ts-sample/originalSource-1",
+            },
+            "type": "decl",
+          },
+        ],
+        "type": "var",
+      },
+      "this": Object {
+        "refs": Array [],
+        "type": "implicit",
+      },
+      "window": Object {
+        "refs": Array [
+          Object {
+            "end": Object {
+              "column": 21,
+              "line": 10,
+              "sourceId": "scopes/ts-sample/originalSource-1",
+            },
+            "meta": null,
+            "start": Object {
+              "column": 15,
+              "line": 10,
+              "sourceId": "scopes/ts-sample/originalSource-1",
+            },
+            "type": "ref",
+          },
+        ],
+        "type": "global",
+      },
+    },
+    "displayName": "Global",
+    "end": Object {
+      "column": 0,
+      "line": 11,
+      "sourceId": "scopes/ts-sample/originalSource-1",
+    },
+    "start": Object {
+      "column": 0,
+      "line": 1,
+      "sourceId": "scopes/ts-sample/originalSource-1",
+    },
+    "type": "object",
+  },
+]
+`;
+
+exports[`getScopes finds scope bindings in a typescript-jsx file at line 3 column 0 1`] = `
+Array [
+  Object {
+    "bindings": Object {
+      "Color": Object {
+        "refs": Array [
+          Object {
+            "declaration": Object {
+              "end": Object {
+                "column": 29,
+                "line": 2,
+                "sourceId": "scopes/tsx-sample/originalSource-1",
+              },
+              "start": Object {
+                "column": 0,
+                "line": 2,
+                "sourceId": "scopes/tsx-sample/originalSource-1",
+              },
+            },
+            "end": Object {
+              "column": 10,
+              "line": 2,
+              "sourceId": "scopes/tsx-sample/originalSource-1",
+            },
+            "start": Object {
+              "column": 5,
+              "line": 2,
+              "sourceId": "scopes/tsx-sample/originalSource-1",
+            },
+            "type": "decl",
+          },
+        ],
+        "type": "const",
+      },
+      "Example": Object {
+        "refs": Array [
+          Object {
+            "declaration": Object {
+              "end": Object {
+                "column": 1,
+                "line": 8,
+                "sourceId": "scopes/tsx-sample/originalSource-1",
+              },
+              "start": Object {
+                "column": 0,
+                "line": 4,
+                "sourceId": "scopes/tsx-sample/originalSource-1",
+              },
+            },
+            "end": Object {
+              "column": 13,
+              "line": 4,
+              "sourceId": "scopes/tsx-sample/originalSource-1",
+            },
+            "start": Object {
+              "column": 6,
+              "line": 4,
+              "sourceId": "scopes/tsx-sample/originalSource-1",
+            },
+            "type": "decl",
+          },
+        ],
+        "type": "let",
+      },
+    },
+    "displayName": "Lexical Global",
+    "end": Object {
+      "column": 0,
+      "line": 11,
+      "sourceId": "scopes/tsx-sample/originalSource-1",
+    },
+    "start": Object {
+      "column": 0,
+      "line": 1,
+      "sourceId": "scopes/tsx-sample/originalSource-1",
+    },
+    "type": "block",
+  },
+  Object {
+    "bindings": Object {
+      "Error": Object {
+        "refs": Array [
+          Object {
+            "end": Object {
+              "column": 19,
+              "line": 6,
+              "sourceId": "scopes/tsx-sample/originalSource-1",
+            },
+            "meta": null,
+            "start": Object {
+              "column": 14,
+              "line": 6,
+              "sourceId": "scopes/tsx-sample/originalSource-1",
+            },
+            "type": "ref",
+          },
+        ],
+        "type": "global",
+      },
+      "any": Object {
+        "refs": Array [
+          Object {
+            "end": Object {
+              "column": 14,
+              "line": 10,
+              "sourceId": "scopes/tsx-sample/originalSource-1",
+            },
+            "meta": null,
+            "start": Object {
+              "column": 11,
+              "line": 10,
+              "sourceId": "scopes/tsx-sample/originalSource-1",
+            },
+            "type": "ref",
+          },
+        ],
+        "type": "global",
+      },
+      "foo": Object {
+        "refs": Array [
+          Object {
+            "declaration": Object {
+              "end": Object {
+                "column": 28,
+                "line": 10,
+                "sourceId": "scopes/tsx-sample/originalSource-1",
+              },
+              "start": Object {
+                "column": 0,
+                "line": 10,
+                "sourceId": "scopes/tsx-sample/originalSource-1",
+              },
+            },
+            "end": Object {
+              "column": 7,
+              "line": 10,
+              "sourceId": "scopes/tsx-sample/originalSource-1",
+            },
+            "start": Object {
+              "column": 4,
+              "line": 10,
+              "sourceId": "scopes/tsx-sample/originalSource-1",
+            },
+            "type": "decl",
+          },
+        ],
+        "type": "var",
+      },
       "this": Object {
         "refs": Array [],
         "type": "implicit",
@@ -12754,13 +13021,252 @@ Array [
     "displayName": "Global",
     "end": Object {
       "column": 0,
-      "line": 9,
-      "sourceId": "scopes/ts-sample/originalSource-1",
+      "line": 11,
+      "sourceId": "scopes/tsx-sample/originalSource-1",
     },
     "start": Object {
       "column": 0,
       "line": 1,
-      "sourceId": "scopes/ts-sample/originalSource-1",
+      "sourceId": "scopes/tsx-sample/originalSource-1",
+    },
+    "type": "object",
+  },
+]
+`;
+
+exports[`getScopes finds scope bindings in a typescript-jsx file at line 6 column 4 1`] = `
+Array [
+  Object {
+    "bindings": Object {
+      "arguments": Object {
+        "refs": Array [],
+        "type": "implicit",
+      },
+      "this": Object {
+        "refs": Array [],
+        "type": "implicit",
+      },
+    },
+    "displayName": "method",
+    "end": Object {
+      "column": 3,
+      "line": 7,
+      "sourceId": "scopes/tsx-sample/originalSource-1",
+    },
+    "start": Object {
+      "column": 2,
+      "line": 5,
+      "sourceId": "scopes/tsx-sample/originalSource-1",
+    },
+    "type": "function",
+  },
+  Object {
+    "bindings": Object {
+      "Example": Object {
+        "refs": Array [
+          Object {
+            "declaration": Object {
+              "end": Object {
+                "column": 1,
+                "line": 8,
+                "sourceId": "scopes/tsx-sample/originalSource-1",
+              },
+              "start": Object {
+                "column": 0,
+                "line": 4,
+                "sourceId": "scopes/tsx-sample/originalSource-1",
+              },
+            },
+            "end": Object {
+              "column": 13,
+              "line": 4,
+              "sourceId": "scopes/tsx-sample/originalSource-1",
+            },
+            "start": Object {
+              "column": 6,
+              "line": 4,
+              "sourceId": "scopes/tsx-sample/originalSource-1",
+            },
+            "type": "decl",
+          },
+        ],
+        "type": "const",
+      },
+    },
+    "displayName": "Class",
+    "end": Object {
+      "column": 1,
+      "line": 8,
+      "sourceId": "scopes/tsx-sample/originalSource-1",
+    },
+    "start": Object {
+      "column": 0,
+      "line": 4,
+      "sourceId": "scopes/tsx-sample/originalSource-1",
+    },
+    "type": "block",
+  },
+  Object {
+    "bindings": Object {
+      "Color": Object {
+        "refs": Array [
+          Object {
+            "declaration": Object {
+              "end": Object {
+                "column": 29,
+                "line": 2,
+                "sourceId": "scopes/tsx-sample/originalSource-1",
+              },
+              "start": Object {
+                "column": 0,
+                "line": 2,
+                "sourceId": "scopes/tsx-sample/originalSource-1",
+              },
+            },
+            "end": Object {
+              "column": 10,
+              "line": 2,
+              "sourceId": "scopes/tsx-sample/originalSource-1",
+            },
+            "start": Object {
+              "column": 5,
+              "line": 2,
+              "sourceId": "scopes/tsx-sample/originalSource-1",
+            },
+            "type": "decl",
+          },
+        ],
+        "type": "const",
+      },
+      "Example": Object {
+        "refs": Array [
+          Object {
+            "declaration": Object {
+              "end": Object {
+                "column": 1,
+                "line": 8,
+                "sourceId": "scopes/tsx-sample/originalSource-1",
+              },
+              "start": Object {
+                "column": 0,
+                "line": 4,
+                "sourceId": "scopes/tsx-sample/originalSource-1",
+              },
+            },
+            "end": Object {
+              "column": 13,
+              "line": 4,
+              "sourceId": "scopes/tsx-sample/originalSource-1",
+            },
+            "start": Object {
+              "column": 6,
+              "line": 4,
+              "sourceId": "scopes/tsx-sample/originalSource-1",
+            },
+            "type": "decl",
+          },
+        ],
+        "type": "let",
+      },
+    },
+    "displayName": "Lexical Global",
+    "end": Object {
+      "column": 0,
+      "line": 11,
+      "sourceId": "scopes/tsx-sample/originalSource-1",
+    },
+    "start": Object {
+      "column": 0,
+      "line": 1,
+      "sourceId": "scopes/tsx-sample/originalSource-1",
+    },
+    "type": "block",
+  },
+  Object {
+    "bindings": Object {
+      "Error": Object {
+        "refs": Array [
+          Object {
+            "end": Object {
+              "column": 19,
+              "line": 6,
+              "sourceId": "scopes/tsx-sample/originalSource-1",
+            },
+            "meta": null,
+            "start": Object {
+              "column": 14,
+              "line": 6,
+              "sourceId": "scopes/tsx-sample/originalSource-1",
+            },
+            "type": "ref",
+          },
+        ],
+        "type": "global",
+      },
+      "any": Object {
+        "refs": Array [
+          Object {
+            "end": Object {
+              "column": 14,
+              "line": 10,
+              "sourceId": "scopes/tsx-sample/originalSource-1",
+            },
+            "meta": null,
+            "start": Object {
+              "column": 11,
+              "line": 10,
+              "sourceId": "scopes/tsx-sample/originalSource-1",
+            },
+            "type": "ref",
+          },
+        ],
+        "type": "global",
+      },
+      "foo": Object {
+        "refs": Array [
+          Object {
+            "declaration": Object {
+              "end": Object {
+                "column": 28,
+                "line": 10,
+                "sourceId": "scopes/tsx-sample/originalSource-1",
+              },
+              "start": Object {
+                "column": 0,
+                "line": 10,
+                "sourceId": "scopes/tsx-sample/originalSource-1",
+              },
+            },
+            "end": Object {
+              "column": 7,
+              "line": 10,
+              "sourceId": "scopes/tsx-sample/originalSource-1",
+            },
+            "start": Object {
+              "column": 4,
+              "line": 10,
+              "sourceId": "scopes/tsx-sample/originalSource-1",
+            },
+            "type": "decl",
+          },
+        ],
+        "type": "var",
+      },
+      "this": Object {
+        "refs": Array [],
+        "type": "implicit",
+      },
+    },
+    "displayName": "Global",
+    "end": Object {
+      "column": 0,
+      "line": 11,
+      "sourceId": "scopes/tsx-sample/originalSource-1",
+    },
+    "start": Object {
+      "column": 0,
+      "line": 1,
+      "sourceId": "scopes/tsx-sample/originalSource-1",
     },
     "type": "object",
   },

--- a/src/workers/parser/tests/fixtures/scopes/class-declaration.js
+++ b/src/workers/parser/tests/fixtures/scopes/class-declaration.js
@@ -9,3 +9,6 @@ class Outer {
     }
   }
 }
+
+@decorator
+class Second {}

--- a/src/workers/parser/tests/fixtures/scopes/tsx-sample.tsx
+++ b/src/workers/parser/tests/fixtures/scopes/tsx-sample.tsx
@@ -7,4 +7,4 @@ class Example<T> {
   }
 }
 
-var foo = <any>window;
+var foo = <any>window</any>;

--- a/src/workers/parser/tests/getScopes.spec.js
+++ b/src/workers/parser/tests/getScopes.spec.js
@@ -34,6 +34,12 @@ cases(
       locations: [[3, 0], [6, 4]]
     },
     {
+      name: "finds scope bindings in a typescript-jsx file",
+      file: "scopes/tsx-sample",
+      type: "tsx",
+      locations: [[3, 0], [6, 4]]
+    },
+    {
       name: "finds scope bindings in a module",
       file: "scopes/simple-module",
       locations: [[7, 0]]

--- a/src/workers/parser/tests/helpers/index.js
+++ b/src/workers/parser/tests/helpers/index.js
@@ -15,6 +15,8 @@ export function getSource(name, type = "js") {
     contentType = "text/html";
   } else if (type === "ts") {
     contentType = "text/typescript";
+  } else if (type === "tsx") {
+    contentType = "text/typescript-jsx";
   }
 
   return {

--- a/src/workers/parser/utils/ast.js
+++ b/src/workers/parser/utils/ast.js
@@ -82,7 +82,11 @@ export function getAst(sourceId: string) {
   const { contentType } = source;
   if (contentType == "text/html") {
     ast = parseScriptTags(source.text, htmlParser) || {};
-  } else if (contentType && contentType.match(/(javascript|jsx)/)) {
+  } else if (
+    contentType &&
+    contentType.match(/(javascript|jsx)/) &&
+    !contentType.match(/typescript-jsx/)
+  ) {
     const type = source.id.includes("original") ? "original" : "generated";
     const options = sourceOptions[type];
     ast = parse(source.text, options);
@@ -91,7 +95,11 @@ export function getAst(sourceId: string) {
       ...sourceOptions.original,
       plugins: [
         ...sourceOptions.original.plugins.filter(
-          p => p !== "flow" && p !== "decorators" && p !== "decorators2"
+          p =>
+            p !== "flow" &&
+            p !== "decorators" &&
+            p !== "decorators2" &&
+            (p !== "jsx" || contentType.match(/typescript-jsx/))
         ),
         "decorators",
         "typescript"


### PR DESCRIPTION
Refs Issue: #5561

### Summary of Changes

* Re-apply's #6092, excluding
  * https://github.com/devtools-html/debugger.html/pull/6092/commits/8c8c3b6d0e433dc77a1288aeae0c2e9c77bdb003
  * https://github.com/devtools-html/debugger.html/pull/6092/commits/b34a002856c961ebd709373142d660b25559e452
* Re-apply's #6099

The error in #6112 is due to the generic declaration mapping being too broad in the general case, leading to false-positive binding matches. I'll re-apply those excluded commits in a PR next week once I can get them to only apply in more specific cases that won't lead to false-positive binding matches.