### PR TITLE
Removes a few instances of toJS()

### DIFF
--- a/src/actions/breakpoints/addBreakpoint.js
+++ b/src/actions/breakpoints/addBreakpoint.js
@@ -25,7 +25,7 @@ export default async function addBreakpoint(
   const location = { ...breakpoint.location, sourceUrl: source.url };
   const generatedLocation = await getGeneratedLocation(
     state,
-    source.toJS(),
+    source,
     location,
     sourceMaps
   );

--- a/src/actions/breakpoints/syncBreakpoint.js
+++ b/src/actions/breakpoints/syncBreakpoint.js
@@ -98,7 +98,7 @@ export async function syncClientBreakpoint(
 
   const scopedGeneratedLocation = await getGeneratedLocation(
     getState(),
-    source.toJS(),
+    source,
     scopedLocation,
     sourceMaps
   );

--- a/src/actions/sources/newSources.js
+++ b/src/actions/sources/newSources.js
@@ -95,7 +95,7 @@ function loadSourceMap(sourceId: SourceId) {
 // select it.
 function checkSelectedSource(sourceId: string) {
   return async ({ dispatch, getState }: ThunkArgs) => {
-    const source = getSource(getState(), sourceId).toJS();
+    const source = getSource(getState(), sourceId);
 
     const pendingLocation = getPendingSelectedLocation(getState());
 

--- a/src/actions/sources/select.js
+++ b/src/actions/sources/select.js
@@ -216,7 +216,7 @@ export function jumpToMappedLocation(location: Location) {
     if (isOriginalId(location.sourceId)) {
       pairedLocation = await getGeneratedLocation(
         getState(),
-        source.toJS(),
+        source,
         location,
         sourceMaps
       );

--- a/src/components/Editor/CallSites.js
+++ b/src/components/Editor/CallSites.js
@@ -189,7 +189,9 @@ function getCallSites(symbols, breakpoints) {
   }
 
   function findBreakpoint(callSite) {
-    const { location: { start, end } } = callSite;
+    const {
+      location: { start, end }
+    } = callSite;
 
     const breakpointId = range(start.column - 1, end.column)
       .map(column => locationKey({ line: start.line, column }))
@@ -212,9 +214,7 @@ export default connect(
     const selectedLocation = getSelectedLocation(state);
     const selectedSource = getSelectedSource(state);
     const sourceId = selectedLocation && selectedLocation.sourceId;
-    const source = selectedSource && selectedSource.toJS();
-
-    const symbols = getSymbols(state, source);
+    const symbols = getSymbols(state, selectedSource);
     const breakpoints = getBreakpointsForSource(state, sourceId);
 
     return {

--- a/src/utils/source-maps.js
+++ b/src/utils/source-maps.js
@@ -16,7 +16,7 @@ export async function getGeneratedLocation(
 
   const { line, sourceId, column } = await sourceMaps.getGeneratedLocation(
     location,
-    source
+    source.toJS()
   );
 
   const generatedSource = getSource(state, sourceId);


### PR DESCRIPTION
- Moves .toJS() inside `getGeneratedLocation` instead of having to call it every time (maybe we will be able to remove it altogether in future?).
- Removes a few instances of toJS() that do not result in a full object being dispatched.