### PR TITLE
Removes a toJS()

### DIFF
--- a/src/components/PrimaryPanes/SourcesTree.js
+++ b/src/components/PrimaryPanes/SourcesTree.js
@@ -207,16 +207,9 @@ class SourcesTree extends Component<Props, State> {
     if (!nodeHasChildren(item)) {
       const obj = item.contents.get("id");
       const source = sources.get(obj);
-      return (
-        <img
-          className={classnames(
-            getSourceClassnames(source.toJS()),
-            "source-icon"
-          )}
-        />
-      );
+      const className = classnames(getSourceClassnames(source), "source-icon");
+      return <img className={className} />;
     }
-
     return <img className="folder" />;
   };
 


### PR DESCRIPTION
`getSourceClassnames()` works the same way when it gets a clean object or something from immutable. The result is the same.