### PR TITLE
add the client api for autocomplete

### DIFF
--- a/src/actions/expressions.js
+++ b/src/actions/expressions.js
@@ -50,6 +50,17 @@ export function addExpression(input: string) {
   };
 }
 
+export function autocomplete(input: string, cursor) {
+  return async ({ dispatch, getState, client }: ThunkArgs) => {
+    if (!input) {
+      return;
+    }
+    const frameId = getSelectedFrameId(getState());
+    const result = await client.autocomplete(input, cursor, frameId);
+    await dispatch({ type: "AUTOCOMPLETE", input, result });
+  };
+}
+
 export function clearExpressionError() {
   return { type: "CLEAR_EXPRESSION_ERROR" };
 }

--- a/src/actions/expressions.js
+++ b/src/actions/expressions.js
@@ -50,7 +50,7 @@ export function addExpression(input: string) {
   };
 }
 
-export function autocomplete(input: string, cursor) {
+export function autocomplete(input: string, cursor: number) {
   return async ({ dispatch, getState, client }: ThunkArgs) => {
     if (!input) {
       return;

--- a/src/actions/tests/__snapshots__/expressions.spec.js.snap
+++ b/src/actions/tests/__snapshots__/expressions.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`expressions should get the autocomplete suggestions for the input expression 1`] = `
+exports[`expressions should get the autocomplete matches for the input 1`] = `
 Array [
   "toLocaleString",
   "toSource",

--- a/src/actions/tests/__snapshots__/expressions.spec.js.snap
+++ b/src/actions/tests/__snapshots__/expressions.spec.js.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`expressions should get the autocomplete suggestions for the input expression 1`] = `
+Array [
+  "toLocaleString",
+  "toSource",
+  "toString",
+  "toolbar",
+  "top",
+]
+`;

--- a/src/actions/tests/expressions.spec.js
+++ b/src/actions/tests/expressions.spec.js
@@ -27,7 +27,16 @@ const mockThreadClient = {
       )
     ),
   getFrameScopes: async () => {},
-  sourceContents: () => ({})
+  sourceContents: () => ({}),
+  autocomplete: () => {
+    return new Promise(resolve => {
+      resolve({
+        from: "foo",
+        matches: ["toLocaleString", "toSource", "toString", "toolbar", "top"],
+        matchProp: "to"
+      });
+    });
+  }
 };
 
 describe("expressions", () => {
@@ -118,6 +127,16 @@ describe("expressions", () => {
 
     expect(selectors.getExpression(getState(), "foo").value).toBe("boo");
     expect(selectors.getExpression(getState(), "bar").value).toBe("boo");
+  });
+
+  it("should get the autocomplete matches for the input", async () => {
+    const { dispatch, getState } = createStore(mockThreadClient);
+
+    await dispatch(actions.autocomplete("to", 2));
+
+    expect(
+      selectors.getAutocompleteMatchset(getState(), "to")
+    ).toMatchSnapshot();
   });
 });
 

--- a/src/actions/types/PauseAction.js
+++ b/src/actions/types/PauseAction.js
@@ -76,6 +76,11 @@ export type PauseAction =
   | {|
       +type: "CLEAR_EXPRESSION_ERROR"
     |}
+  | {|
+      +type: "AUTOCOMPLETE",
+      +input: string,
+      +result: Object
+    |}
   | PromiseAction<
       {|
         +type: "MAP_SCOPES",

--- a/src/client/firefox/commands.js
+++ b/src/client/firefox/commands.js
@@ -226,6 +226,20 @@ function evaluate(
   });
 }
 
+function autocomplete(input: string, cursor, frameId: string) {
+  if (!tabTarget || !tabTarget.activeConsole || !input) {
+    return Promise.resolve({});
+  }
+  return new Promise(resolve => {
+    tabTarget.activeConsole.autocomplete(
+      input,
+      cursor,
+      result => resolve(result),
+      frameId
+    );
+  });
+}
+
 function debuggeeCommand(script: Script): ?Promise<void> {
   tabTarget.activeConsole.evaluateJS(script, () => {}, {});
 
@@ -383,6 +397,7 @@ async function fetchWorkers(): Promise<{ workers: Worker[] }> {
 }
 
 const clientCommands = {
+  autocomplete,
   blackBox,
   interrupt,
   eventListeners,

--- a/src/client/firefox/commands.js
+++ b/src/client/firefox/commands.js
@@ -226,7 +226,11 @@ function evaluate(
   });
 }
 
-function autocomplete(input: string, cursor, frameId: string) {
+function autocomplete(
+  input: string,
+  cursor: number,
+  frameId: string
+): Promise<mixed> {
   if (!tabTarget || !tabTarget.activeConsole || !input) {
     return Promise.resolve({});
   }

--- a/src/client/firefox/types.js
+++ b/src/client/firefox/types.js
@@ -226,6 +226,12 @@ export type TabTarget = {
       script: Script,
       func: Function,
       params?: { frameActor?: FrameId }
+    ) => void,
+    autocomplete: (
+      input: string,
+      cursor: number,
+      func: Function,
+      frameId: string
     ) => void
   },
   form: { consoleActor: any },


### PR DESCRIPTION
Fixes Issue: #5467

### Summary of Changes

* Added `autocomplete` client api
* Added a new `autocomplete` action
* Added tests for the action
* Add reducer to locally cache the matches

