### PR TITLE
Fix a few nits from #6166

### DIFF
--- a/src/components/SecondaryPanes/Expressions.js
+++ b/src/components/SecondaryPanes/Expressions.js
@@ -103,8 +103,7 @@ class Expressions extends Component<Props, State> {
     if (!prevState.editing && this.state.editing) {
       input.setSelectionRange(0, input.value.length);
       input.focus();
-    }
-    else if (this.props.showInput && !this.state.focused) {
+    } else if (this.props.showInput && !this.state.focused) {
       input.focus();
     }
   }

--- a/src/components/SecondaryPanes/Expressions.js
+++ b/src/components/SecondaryPanes/Expressions.js
@@ -88,8 +88,7 @@ class Expressions extends Component<Props, State> {
       editing !== nextState.editing ||
       inputValue !== nextState.inputValue ||
       nextProps.showInput !== showInput ||
-      focused !== nextState.focused ||
-      (showInput === true && nextProps === true && !focused)
+      focused !== nextState.focused
     );
   }
 
@@ -233,7 +232,6 @@ class Expressions extends Component<Props, State> {
     const placeholder: string = error
       ? L10N.getStr("expressions.errorMsg")
       : L10N.getStr("expressions.placeholder");
-    const autoFocus = showInput;
 
     return (
       <li
@@ -248,7 +246,7 @@ class Expressions extends Component<Props, State> {
             onBlur={this.hideInput}
             onKeyDown={this.handleKeyDown}
             onFocus={this.onFocus}
-            autoFocus={autoFocus}
+            autoFocus={showInput}
             value={!editing ? inputValue : ""}
             ref={c => (this._input = c)}
           />

--- a/src/components/SecondaryPanes/Expressions.js
+++ b/src/components/SecondaryPanes/Expressions.js
@@ -88,14 +88,23 @@ class Expressions extends Component<Props, State> {
       editing !== nextState.editing ||
       inputValue !== nextState.inputValue ||
       nextProps.showInput !== showInput ||
-      focused !== nextState.focused
+      focused !== nextState.focused ||
+      (showInput === true && nextProps === true && !focused)
     );
   }
 
   componentDidUpdate(prevProps, prevState) {
-    if (this._input && !prevState.editing) {
-      const input = this._input;
+    const input = this._input;
+
+    if (!input) {
+      return;
+    }
+
+    if (!prevState.editing && this.state.editing) {
       input.setSelectionRange(0, input.value.length);
+      input.focus();
+    }
+    else if (this.props.showInput && !this.state.focused) {
       input.focus();
     }
   }
@@ -219,13 +228,13 @@ class Expressions extends Component<Props, State> {
   };
 
   renderNewExpressionInput() {
-    const { expressionError, expressions } = this.props;
+    const { expressionError, showInput } = this.props;
     const { editing, inputValue, focused } = this.state;
     const error = editing === false && expressionError === true;
     const placeholder: string = error
       ? L10N.getStr("expressions.errorMsg")
       : L10N.getStr("expressions.placeholder");
-    const autoFocus = expressions.size > 0;
+    const autoFocus = showInput;
 
     return (
       <li
@@ -242,6 +251,7 @@ class Expressions extends Component<Props, State> {
             onFocus={this.onFocus}
             autoFocus={autoFocus}
             value={!editing ? inputValue : ""}
+            ref={c => (this._input = c)}
           />
           <input type="submit" style={{ display: "none" }} />
         </form>

--- a/src/components/SecondaryPanes/index.js
+++ b/src/components/SecondaryPanes/index.js
@@ -213,6 +213,10 @@ class SecondaryPanes extends Component<Props, State> {
   }
 
   getWatchItem(): AccordionPaneItem {
+    if (this.state.showExpressionsInput) {
+      prefs.expressionsVisible = true;
+    }
+
     return {
       header: L10N.getStr("watchExpressions.header"),
       className: "watch-expressions-pane",

--- a/src/components/SecondaryPanes/index.js
+++ b/src/components/SecondaryPanes/index.js
@@ -147,30 +147,37 @@ class SecondaryPanes extends Component<Props, State> {
   watchExpressionHeaderButtons() {
     const { expressions } = this.props;
 
-    if (!expressions.size) {
-      return [];
+    const buttons = [];
+
+    if (expressions.size) {
+      buttons.push(
+        debugBtn(
+          evt => {
+            evt.stopPropagation();
+            this.props.evaluateExpressions();
+          },
+          "refresh",
+          "refresh",
+          L10N.getStr("watchExpressions.refreshButton")
+        )
+      );
     }
 
-    return [
+    buttons.push(
       debugBtn(
         evt => {
-          evt.stopPropagation();
-          this.props.evaluateExpressions();
-        },
-        "refresh",
-        "refresh",
-        L10N.getStr("watchExpressions.refreshButton")
-      ),
-      debugBtn(
-        evt => {
-          evt.stopPropagation();
+          if (prefs.expressionsVisible) {
+            evt.stopPropagation();
+          }
           this.setState({ showExpressionsInput: true });
         },
         "plus",
         "plus",
         L10N.getStr("expressions.placeholder")
       )
-    ];
+    );
+
+    return buttons;
   }
 
   getScopeItem(): AccordionPaneItem {
@@ -213,10 +220,6 @@ class SecondaryPanes extends Component<Props, State> {
   }
 
   getWatchItem(): AccordionPaneItem {
-    if (this.state.showExpressionsInput) {
-      prefs.expressionsVisible = true;
-    }
-
     return {
       header: L10N.getStr("watchExpressions.header"),
       className: "watch-expressions-pane",

--- a/src/components/SecondaryPanes/tests/__snapshots__/Expressions.spec.js.snap
+++ b/src/components/SecondaryPanes/tests/__snapshots__/Expressions.spec.js.snap
@@ -86,7 +86,6 @@ exports[`Expressions should always have unique keys 1`] = `
       onSubmit={[Function]}
     >
       <input
-        autoFocus={false}
         className="input-expression"
         onBlur={[Function]}
         onChange={[Function]}
@@ -195,7 +194,6 @@ exports[`Expressions should render 1`] = `
       onSubmit={[Function]}
     >
       <input
-        autoFocus={false}
         className="input-expression"
         onBlur={[Function]}
         onChange={[Function]}

--- a/src/components/shared/Accordion.css
+++ b/src/components/shared/Accordion.css
@@ -64,6 +64,7 @@
   display: flex;
   margin-left: auto;
   padding-right: 5px;
+  outline: 0;
 }
 
 .accordion .header-buttons .add-button {


### PR DESCRIPTION
This addresses two nits from #6166:

- Removes outline
- Opens accordion item if not open and the "+" is clicked

Also:

- Now always shows the "+", since the pane could be closed and someone might know how to open it to add an expression

Test plan:

- Click the "+" icon with the pane closed and opened, ensure the input gets focused
- Edit an existing expression, ensure the editing experience is good.

I'll address the last item in that issue once we prefect breakpoints.