### PR TITLE
[Sources] Refactored component to use contents.id

### DIFF
--- a/src/components/PrimaryPanes/SourcesTree.js
+++ b/src/components/PrimaryPanes/SourcesTree.js
@@ -162,28 +162,20 @@ class SourcesTree extends Component<Props, State> {
 
   selectItem = item => {
     if (!nodeHasChildren(item)) {
-      this.props.selectLocation({ sourceId: item.contents.get("id") });
+      this.props.selectLocation({ sourceId: item.contents.id });
     }
   };
 
   getPath = item => {
-    const { sources } = this.props;
-    const obj = item.contents.get && item.contents.get("id");
-
-    let blackBoxedPart = "";
-
-    if (
-      typeof obj !== "undefined" &&
-      sources.has(obj) &&
-      sources.get(obj).get("isBlackBoxed")
-    ) {
-      blackBoxedPart = "update";
+    if (nodeHasChildren(item)) {
+        return item.path;
     }
 
+    const blackBoxedPart = item.contents.isBlackBoxed ? "update" : "";
     return `${item.path}/${item.name}/${blackBoxedPart}`;
   };
 
-  getIcon = (sources, item, depth) => {
+  getIcon = (item, depth) => {
     const { debuggeeUrl, projectRoot } = this.props;
 
     if (item.path === "webpack://") {
@@ -203,10 +195,9 @@ class SourcesTree extends Component<Props, State> {
         />
       );
     }
-
+    
     if (!nodeHasChildren(item)) {
-      const obj = item.contents.get("id");
-      const source = sources.get(obj);
+      const source = item.contents;
       return (
         <img
           className={classnames(
@@ -233,7 +224,7 @@ class SourcesTree extends Component<Props, State> {
     const menuOptions = [];
 
     if (!isDirectory(item)) {
-      const source = item.contents.get("url");
+      const source = item.contents.url;
       const copySourceUri2 = {
         id: "node-menu-copy-source",
         label: copySourceUri2Label,
@@ -281,8 +272,7 @@ class SourcesTree extends Component<Props, State> {
       <i className="no-arrow" />
     );
 
-    const { sources } = this.props;
-    const icon = this.getIcon(sources, item, depth);
+    const icon = this.getIcon(item, depth);
 
     return (
       <div


### PR DESCRIPTION
…s.id instead of contents.get("id").

Fixes Issue: #5738 

### Summary of Changes

* Modified SourceTree.js to use content.id instead of content.get("id").

### Test Plan

We ran the testing suite using Yarn and we opened the debugger and tested the primary features.

Here's the Debugger's Testing doc
https://docs.google.com/document/d/1oBMRxV8A2ag2t22YsQOxTdEv0mXKzIg0tggJjRkU1S0/edit#.
Feel free to improve it!
