### PR TITLE
Preview to the right

### DIFF
--- a/src/components/shared/BracketArrow.css
+++ b/src/components/shared/BracketArrow.css
@@ -44,3 +44,20 @@
   border-top-color: var(--theme-body-background);
   top: -1px;
 }
+
+.bracket-arrow.left::before {
+  border-left-color: transparent;
+  border-right-color: var(--theme-splitter-color);
+  top: 0px;
+}
+
+.theme-dark .bracket-arrow.left::before {
+  border-right-color: var(--theme-body-color);
+}
+
+.bracket-arrow.left::after {
+  border-left-color: transparent;
+  border-right-color: var(--theme-body-background);
+  top: 0px;
+  left: 1px;
+}

--- a/src/components/shared/Popover.css
+++ b/src/components/shared/Popover.css
@@ -12,7 +12,7 @@
   padding-top: 5px;
 }
 
-.popover .preview-popup {
+.popover:not(.orientation-right) .preview-popup {
   margin-left: -55px;
 }
 

--- a/src/components/shared/Popover.js
+++ b/src/components/shared/Popover.js
@@ -65,7 +65,7 @@ class Popover extends Component<Props, State> {
     target: ClientRect,
     editor: ClientRect,
     popover: ClientRect,
-    orientation: Orientation
+    orientation?: Orientation
   ) {
     const estimatedLeft = target.left;
     const estimatedRight = estimatedLeft + popover.width;
@@ -116,11 +116,11 @@ class Popover extends Component<Props, State> {
     return "right";
   }
 
-  calculteTop = (
+  calculateTop = (
     target: ClientRect,
     editor: ClientRect,
     popover: ClientRect,
-    orientation: String
+    orientation?: string
   ) => {
     if (orientation === "down") {
       return target.bottom;
@@ -144,7 +144,7 @@ class Popover extends Component<Props, State> {
         editorRect,
         popoverRect
       );
-      const top = this.calculteTop(
+      const top = this.calculateTop(
         targetRect,
         editorRect,
         popoverRect,

--- a/src/components/shared/tests/__snapshots__/Popover.spec.js.snap
+++ b/src/components/shared/tests/__snapshots__/Popover.spec.js.snap
@@ -23,27 +23,27 @@ exports[`Popover mount popover 1`] = `
   type="popover"
 >
   <div
-    className="popover"
+    className="popover orientation-right"
     onMouseLeave={[Function]}
     style={
       Object {
-        "left": -8,
-        "top": 0,
+        "left": 510,
+        "top": 250,
       }
     }
   >
     <BracketArrow
-      left={350}
-      orientation="up"
-      top={-7}
+      left={-14}
+      orientation="left"
+      top={-202}
     >
       <div
-        className="bracket-arrow up"
+        className="bracket-arrow left"
         style={
           Object {
             "bottom": undefined,
-            "left": 350,
-            "top": -7,
+            "left": -14,
+            "top": -202,
           }
         }
       />

--- a/src/components/shared/tests/__snapshots__/Popover.spec.js.snap
+++ b/src/components/shared/tests/__snapshots__/Popover.spec.js.snap
@@ -125,7 +125,7 @@ exports[`Popover render (tooltip) 1`] = `
 
 exports[`Popover render 1`] = `
 <div
-  className="popover"
+  className="popover orientation-down"
   onMouseLeave={[Function]}
   style={
     Object {


### PR DESCRIPTION
Fixes Issue: #6051 

### Summary of Changes
Most of the changes are in getPopoverCoords, now it's doing 3 things mainly:
1. calculates the popover orientation - should it be placed on top/bottom/right of the token, using the target, popover and editor positions.
2. Using the orientation to calculate the left and top of the popover
3. To determine where the popover arrow should be - calculates `targetMid`

![right](https://user-images.githubusercontent.com/1389071/39509842-5939624c-4df0-11e8-95c7-b2e286ef0488.gif)

### Test Plan

- Set a breakpoint and stop

On large window, behavior should remain unchanged:
- Enlarge the debugger window to max size
- Pick an object to test
- Place the token in the top of the editor.
- Preview opens **under** the token.
- Place the token in the vertical middle of the editor.
- Preview opens **under** the token.
- Place the token in the bottom of the editor
- Preview opens **above** the token.

On Small window, right orientations should affect:
- Decrease the debugger window dimensions so it fits the preview popover fully, but not much more
- Place the token in the top of the editor.
- Preview opens **under** the token.
- Place the token in the 1/4 of the editor.
- Preview opens **right** to the token,the popover's top is clipped to the editor's top.
- Place the token in the vertical middle of the editor.
- Preview opens **right** to the token, the token is centered vertically to the popover.
- Place the token in the 3/4 of the editor.
- Preview opens **right** to the token,the popover's bottom is clipped to the editor's bottom.
- Place the token in the bottom of the editor
- Preview opens **above** the token.

- Decrease the debugger window dimensions so it's smaller then the popover
- Place the token anywhere
- Preview opens to the right of the token, clipped to the top of the window.
 