### PR TITLE
Restore cursor default for breakpoint sidebar

### DIFF
--- a/src/components/SecondaryPanes/Breakpoints.css
+++ b/src/components/SecondaryPanes/Breakpoints.css
@@ -194,6 +194,10 @@ html[dir="rtl"] .breakpoints-list .breakpoint .breakpoint-line {
   visibility: visible;
 }
 
+.CodeMirror.cm-s-mozilla-breakpoint {
+  cursor: default;
+}
+
 .CodeMirror.cm-s-mozilla-breakpoint .CodeMirror-lines {
   padding: 0;
 }
@@ -216,7 +220,6 @@ html[dir="rtl"] .breakpoints-list .breakpoint .breakpoint-line {
 
 .CodeMirror.cm-s-mozilla-breakpoint .CodeMirror-code,
 .CodeMirror.cm-s-mozilla-breakpoint .CodeMirror-scroll {
-  cursor: default;
   pointer-events: none;
 }
 


### PR DESCRIPTION
When we added `pointer-events: none` to fix that really odd breakpoints scroll error, it bricked out `cursor: default` and thus the text cursor is showing when hovering over breakpoints.

Moving this CSS to an element higher in the stack fixes the problem.