### PR TITLE
[PauseOnExceptions] should wait while setting

### DIFF
--- a/src/actions/pause/pauseOnExceptions.js
+++ b/src/actions/pause/pauseOnExceptions.js
@@ -17,7 +17,7 @@ export function pauseOnExceptions(
   shouldPauseOnCaughtExceptions: boolean
 ) {
   return ({ dispatch, client }: ThunkArgs) => {
-    dispatch({
+    return dispatch({
       type: "PAUSE_ON_EXCEPTIONS",
       shouldPauseOnExceptions,
       shouldPauseOnCaughtExceptions,


### PR DESCRIPTION
Fixes Issue: #5509 #4360

### Summary of Changes

We had a race case where we would call `pauseOnExceptions` which would do an interrupt and a resume, but not block on other actions. This caused some pretty unpredictable behavior.

The order of events was

- start pausing
- start loading a source
- POE triggers resume
- pausing cant do things like fetch environments or evaluate expressions