### PR TITLE
Group breakpoints for files set in pretty or original URLs

### DIFF
--- a/src/components/SecondaryPanes/Breakpoints.js
+++ b/src/components/SecondaryPanes/Breakpoints.js
@@ -14,7 +14,7 @@ import { groupBy, sortBy } from "lodash";
 import Breakpoint from "./Breakpoint";
 
 import actions from "../../actions";
-import { getFilenameFromURL } from "../../utils/source";
+import { getFilenameFromURL, getRawSourceURL } from "../../utils/source";
 import {
   getSources,
   getSourceInSources,
@@ -200,7 +200,7 @@ class Breakpoints extends Component<Props> {
 
     const groupedBreakpoints = groupBy(
       sortBy([...breakpoints.valueSeq()], bp => bp.location.line),
-      bp => bp.source.url
+      bp => getRawSourceURL(bp.source.url)
     );
 
     return [


### PR DESCRIPTION
I noticed that setting breakpoints between pretty and original URLs was creating two groups (`:formatted`); that's not the best.