### PR TITLE
Renames SELECT_SOURCE_URL action to setSourceLocation

### DIFF
--- a/src/actions/sources/index.js
+++ b/src/actions/sources/index.js
@@ -3,6 +3,8 @@
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
 // @flow
+import { setSourceLocation } from "./setSourceLocation";
+export { setSourceLocation };
 
 export * from "./loadSourceText";
 export * from "./prettyPrint";

--- a/src/actions/sources/select.js
+++ b/src/actions/sources/select.js
@@ -23,6 +23,8 @@ import { shouldPrettyPrint, isMinified } from "../../utils/source";
 import { createLocation } from "../../utils/location";
 import { getGeneratedLocation } from "../../utils/source-maps";
 
+import { setSourceLocation } from "./";
+
 import {
   getSource,
   getSourceByURL,
@@ -65,13 +67,7 @@ export function selectSourceURL(
       // $FlowIgnore
       await dispatch(selectLocation(location, options.tabIndex));
     } else {
-      dispatch(
-        ({
-          type: "SELECT_SOURCE_URL",
-          url: url,
-          line: options.location ? options.location.line : null
-        }: Action)
-      );
+      dispatch(setSourceLocation(url, options));
     }
   };
 }

--- a/src/actions/sources/setSourceLocation.js
+++ b/src/actions/sources/setSourceLocation.js
@@ -1,0 +1,11 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
+import type { Action } from "../types";
+
+export const setSourceLocation: Action = (url, options) => ({
+  type: "SET_SOURCE_LOCATION",
+  url: url,
+  line: options.location ? options.location.line : null
+});

--- a/src/actions/types/SourceAction.js
+++ b/src/actions/types/SourceAction.js
@@ -26,7 +26,7 @@ export type SourceAction =
       +location?: Location
     |}
   | {|
-      +type: "SELECT_SOURCE_URL",
+      +type: "SET_SOURCE_LOCATION",
       +url: string,
       +line: ?number
     |}

--- a/src/reducers/sources.js
+++ b/src/reducers/sources.js
@@ -105,7 +105,7 @@ function update(
         .set("selectedLocation", { sourceId: "" })
         .set("pendingSelectedLocation", location);
 
-    case "SELECT_SOURCE_URL":
+    case "SET_SOURCE_LOCATION":
       location = {
         url: action.url,
         line: action.line


### PR DESCRIPTION
It seems the action SELECT_SOURCE_URL actually sets/selects the (pending?) source location instead of just setting the URL. It would be great to:
1.) rename this in order to mitigate a naming conflict with `selectSourceURL`
2.) externalize it for easier testing

