### PR TITLE
[ObjectInspector] Add some fulltext tests & minor optimisations

### DIFF
--- a/packages/devtools-reps/src/object-inspector/tests/__mocks__/long-string-client.js
+++ b/packages/devtools-reps/src/object-inspector/tests/__mocks__/long-string-client.js
@@ -1,0 +1,17 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
+function LongStringClient(grip, overrides) {
+  return {
+    grip,
+    substring: function() {
+      return Promise.resolve({
+        fullText: ""
+      });
+    },
+    ...overrides
+  };
+}
+
+module.exports = LongStringClient;

--- a/packages/devtools-reps/src/object-inspector/tests/component/create-long-string-client.js
+++ b/packages/devtools-reps/src/object-inspector/tests/component/create-long-string-client.js
@@ -72,7 +72,7 @@ describe("createLongStringClient", () => {
       const stub = longStringStubs.get("testLoadedFullText");
       const substring = jest.fn(() => Promise.resolve({ fullText: "" }));
       const createLongStringClient = jest.fn(grip =>
-        LongStringClient(grip, { a: x => x })
+        LongStringClient(grip, { substring })
       );
 
       mount(
@@ -95,5 +95,4 @@ describe("createLongStringClient", () => {
       expect(substring.mock.calls).toHaveLength(0);
     });
   });
-
 });

--- a/packages/devtools-reps/src/object-inspector/tests/component/create-long-string-client.js
+++ b/packages/devtools-reps/src/object-inspector/tests/component/create-long-string-client.js
@@ -42,9 +42,6 @@ describe("createLongStringClient", () => {
     it("is called for longStrings with unloaded full text", () => {
       const stub = longStringStubs.get("testUnloadedFullText");
       const substring = jest.fn(() => Promise.resolve({ fullText: "" }));
-      const createLongStringClient = jest.fn(grip =>
-        LongStringClient(grip, { substring })
-      );
 
       mount(
         ObjectInspector({
@@ -58,22 +55,19 @@ describe("createLongStringClient", () => {
             }
           ],
           createObjectClient: ObjectClient(stub),
-          createLongStringClient
+          createLongStringClient: grip => LongStringClient(grip, { substring })
         })
       );
 
       expect(substring.mock.calls[0]).toHaveLength(3);
-      const [initialLength, fullTextLength] = substring.mock.calls[0];
-      expect(initialLength).toBe(stub.initial.length);
-      expect(fullTextLength).toBe(stub.length);
+      const [start, length, callback] = substring.mock.calls[0];
+      expect(start).toBe(stub.initial.length);
+      expect(length).toBe(stub.length);
     });
 
     it("is not called for longString node w/ loaded full text", () => {
       const stub = longStringStubs.get("testLoadedFullText");
       const substring = jest.fn(() => Promise.resolve({ fullText: "" }));
-      const createLongStringClient = jest.fn(grip =>
-        LongStringClient(grip, { substring })
-      );
 
       mount(
         ObjectInspector({
@@ -87,11 +81,10 @@ describe("createLongStringClient", () => {
             }
           ],
           createObjectClient: ObjectClient(stub),
-          createLongStringClient
+          createLongStringClient: grip => LongStringClient(grip, { substring })
         })
       );
 
-      expect(createLongStringClient.mock.calls[0][0]).toBe(stub);
       expect(substring.mock.calls).toHaveLength(0);
     });
   });

--- a/packages/devtools-reps/src/object-inspector/tests/component/create-long-string-client.js
+++ b/packages/devtools-reps/src/object-inspector/tests/component/create-long-string-client.js
@@ -1,0 +1,99 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
+/* global jest */
+
+const { mount } = require("enzyme");
+const React = require("react");
+const { createFactory } = React;
+const ObjectInspector = createFactory(require("../../index"));
+const ObjectClient = require("../__mocks__/object-client");
+const LongStringClient = require("../__mocks__/long-string-client");
+
+const repsPath = "../../../reps";
+const longStringStubs = require(`${repsPath}/stubs/long-string`);
+
+describe("createLongStringClient", () => {
+  it("is called with the expected object for longString node", () => {
+    const stub = longStringStubs.get("testUnloadedFullText");
+    const createLongStringClient = jest.fn(grip => LongStringClient(grip));
+
+    mount(
+      ObjectInspector({
+        autoExpandDepth: 1,
+        roots: [
+          {
+            path: "root",
+            contents: {
+              value: stub
+            }
+          }
+        ],
+        createObjectClient: ObjectClient(stub),
+        createLongStringClient
+      })
+    );
+
+    expect(createLongStringClient.mock.calls[0][0]).toBe(stub);
+  });
+
+  describe("substring", () => {
+    it("is called for longStrings with unloaded full text", () => {
+      const stub = longStringStubs.get("testUnloadedFullText");
+      const substring = jest.fn(() => Promise.resolve({ fullText: "" }));
+      const createLongStringClient = jest.fn(grip =>
+        LongStringClient(grip, { substring })
+      );
+
+      mount(
+        ObjectInspector({
+          autoExpandDepth: 1,
+          roots: [
+            {
+              path: "root",
+              contents: {
+                value: stub
+              }
+            }
+          ],
+          createObjectClient: ObjectClient(stub),
+          createLongStringClient
+        })
+      );
+
+      expect(substring.mock.calls[0]).toHaveLength(3);
+      const [initialLength, fullTextLength] = substring.mock.calls[0];
+      expect(initialLength).toBe(stub.initial.length);
+      expect(fullTextLength).toBe(stub.length);
+    });
+
+    it("is not called for longString node w/ loaded full text", () => {
+      const stub = longStringStubs.get("testLoadedFullText");
+      const substring = jest.fn(() => Promise.resolve({ fullText: "" }));
+      const createLongStringClient = jest.fn(grip =>
+        LongStringClient(grip, { a: x => x })
+      );
+
+      mount(
+        ObjectInspector({
+          autoExpandDepth: 1,
+          roots: [
+            {
+              path: "root",
+              contents: {
+                value: stub
+              }
+            }
+          ],
+          createObjectClient: ObjectClient(stub),
+          createLongStringClient
+        })
+      );
+
+      expect(createLongStringClient.mock.calls[0][0]).toBe(stub);
+      expect(substring.mock.calls).toHaveLength(0);
+    });
+  });
+
+});

--- a/packages/devtools-reps/src/object-inspector/tests/component/create-long-string-client.js
+++ b/packages/devtools-reps/src/object-inspector/tests/component/create-long-string-client.js
@@ -59,8 +59,9 @@ describe("createLongStringClient", () => {
         })
       );
 
+      // Third argument is the callback which holds the string response.
       expect(substring.mock.calls[0]).toHaveLength(3);
-      const [start, length, callback] = substring.mock.calls[0];
+      const [start, length] = substring.mock.calls[0];
       expect(start).toBe(stub.initial.length);
       expect(length).toBe(stub.length);
     });

--- a/packages/devtools-reps/src/object-inspector/tests/utils/should-load-item-full-text.js
+++ b/packages/devtools-reps/src/object-inspector/tests/utils/should-load-item-full-text.js
@@ -1,0 +1,56 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
+const Utils = require("../../utils");
+const { createNode } = Utils.node;
+const { shouldLoadItemFullText } = Utils.loadProperties;
+
+const longStringStubs = require("../../../reps/stubs/long-string");
+const symbolStubs = require("../../../reps/stubs/symbol");
+
+describe("shouldLoadItemFullText", () => {
+  it("returns true for a longString node with unloaded full text", () => {
+    const node = createNode({
+      name: "root",
+      contents: {
+        value: longStringStubs.get("testUnloadedFullText")
+      }
+    });
+    expect(shouldLoadItemFullText(node)).toBeTruthy();
+  });
+
+  it("returns false for a longString node with loaded full text", () => {
+    const node = createNode({
+      name: "root",
+      contents: {
+        value: longStringStubs.get("testLoadedFullText")
+      }
+    });
+    const loadedProperties = new Map([[node.path, true]]);
+    expect(shouldLoadItemFullText(node, loadedProperties)).toBeFalsy();
+  });
+
+  it("returns false for non longString primitive nodes", () => {
+    const values = [
+      "primitive string",
+      1,
+      -1,
+      0,
+      true,
+      false,
+      null,
+      undefined,
+      symbolStubs.get("Symbol")
+    ];
+
+    const nodes = values.map((value, i) =>
+      createNode({
+        name: `root${i}`,
+        contents: { value }
+      })
+    );
+
+    nodes.forEach(node => expect(shouldLoadItemFullText(node)).toBeFalsy());
+  });
+});

--- a/packages/devtools-reps/src/object-inspector/types.js
+++ b/packages/devtools-reps/src/object-inspector/types.js
@@ -10,6 +10,8 @@ export type GripProperties = {
   fullText?: string
 };
 
+export type ObjectInspectorItemContentsValue = {} | number | string | boolean | null | undefined;
+
 export type NodeContents = {
   value: ObjectInspectorItemContentsValue
 };

--- a/packages/devtools-reps/src/object-inspector/types.js
+++ b/packages/devtools-reps/src/object-inspector/types.js
@@ -10,7 +10,13 @@ export type GripProperties = {
   fullText?: string
 };
 
-export type ObjectInspectorItemContentsValue = {} | number | string | boolean | null | undefined;
+export type ObjectInspectorItemContentsValue =
+  | object
+  | number
+  | string
+  | boolean
+  | null
+  | undefined;
 
 export type NodeContents = {
   value: ObjectInspectorItemContentsValue

--- a/packages/devtools-reps/src/object-inspector/utils/client.js
+++ b/packages/devtools-reps/src/object-inspector/utils/client.js
@@ -98,6 +98,7 @@ async function getFullText(
     // loadedProperties map.
     if (nodeHasFullText(item)) {
       resolve({ fullText });
+      return;
     }
 
     longStringClient.substring(initial.length, length, response => {

--- a/packages/devtools-reps/src/object-inspector/utils/client.js
+++ b/packages/devtools-reps/src/object-inspector/utils/client.js
@@ -93,14 +93,13 @@ async function getFullText(
 ): Promise<{ fullText?: string }> {
   const { initial, fullText, length } = getValue(item);
 
-  return new Promise((resolve, reject) => {
-    // Return fullText property if it exists so that it can be added to the
-    // loadedProperties map.
-    if (nodeHasFullText(item)) {
-      resolve({ fullText });
-      return;
-    }
+  // Return fullText property if it exists so that it can be added to the
+  // loadedProperties map.
+  if (nodeHasFullText(item)) {
+    return Promise.resolve({ fullText });
+  }
 
+  return new Promise((resolve, reject) => {
     longStringClient.substring(initial.length, length, response => {
       if (response.error) {
         console.error(

--- a/packages/devtools-reps/src/object-inspector/utils/client.js
+++ b/packages/devtools-reps/src/object-inspector/utils/client.js
@@ -7,9 +7,11 @@ import type {
   GripProperties,
   ObjectClient,
   PropertiesIterator,
-  NodeContents,
+  Node,
   LongStringClient
 } from "../types";
+
+const { getValue, nodeHasFullText } = require("../utils/node");
 
 async function enumIndexedProperties(
   objectClient: ObjectClient,
@@ -87,11 +89,17 @@ async function getPrototype(
 
 async function getFullText(
   longStringClient: LongStringClient,
-  object: NodeContents
+  item: Node
 ): Promise<{ fullText?: string }> {
-  const { initial, length } = object;
+  const { initial, fullText, length } = getValue(item);
 
   return new Promise((resolve, reject) => {
+    // Return fullText property if it exists so that it can be added to the
+    // loadedProperties map.
+    if (nodeHasFullText(item)) {
+      resolve({ fullText });
+    }
+
     longStringClient.substring(initial.length, length, response => {
       if (response.error) {
         console.error(

--- a/packages/devtools-reps/src/object-inspector/utils/load-properties.js
+++ b/packages/devtools-reps/src/object-inspector/utils/load-properties.js
@@ -74,7 +74,7 @@ function loadItemProperties(
   }
 
   if (shouldLoadItemFullText(item, loadedProperties)) {
-    promises.push(getFullText(createLongStringClient(value), value));
+    promises.push(getFullText(createLongStringClient(value), item));
   }
 
   return Promise.all(promises).then(mergeResponses);

--- a/packages/devtools-reps/src/object-inspector/utils/node.js
+++ b/packages/devtools-reps/src/object-inspector/utils/node.js
@@ -37,7 +37,7 @@ import type {
   GripProperties,
   LoadedProperties,
   Node,
-  NodeContents,
+  ObjectInspectorItemContentsValue,
   RdpGrip
 } from "../types";
 
@@ -51,7 +51,7 @@ function getType(item: Node): Symbol {
   return item.type;
 }
 
-function getValue(item: Node): RdpGrip | NodeContents {
+function getValue(item: Node): RdpGrip | ObjectInspectorItemContentsValue {
   if (item && item.contents && item.contents.hasOwnProperty("value")) {
     return item.contents.value;
   }

--- a/packages/devtools-reps/src/reps/rep.js
+++ b/packages/devtools-reps/src/reps/rep.js
@@ -76,7 +76,7 @@ const reps = [
 /**
  * Generic rep that is used for rendering native JS types or an object.
  * The right template used for rendering is picked automatically according
- * to the current value type. The value must be passed is as 'object'
+ * to the current value type. The value must be passed in as the 'object'
  * property.
  */
 const Rep = function(props) {

--- a/packages/devtools-reps/src/reps/stubs/long-string.js
+++ b/packages/devtools-reps/src/reps/stubs/long-string.js
@@ -10,16 +10,19 @@ const initialText = multilineFullText.substring(0, 10000);
 
 const stubs = new Map();
 
-const multilineLongString = {
+stubs.set("testMultiline", {
   type: "longString",
   initial: initialText,
   length: fullTextLength,
   actor: "server1.conn1.child1/longString58"
-};
+});
 
-stubs.set("testMultiline", multilineLongString);
-
-stubs.set("testUnloadedFullText", multilineLongString);
+stubs.set("testUnloadedFullText", {
+  type: "longString",
+  initial: Array(10000).fill("a").join(""),
+  length: 20000,
+  actor:  "server1.conn1.child1/longString58"
+});
 
 stubs.set("testLoadedFullText", {
   type: "longString",
@@ -28,5 +31,6 @@ stubs.set("testLoadedFullText", {
   length: fullTextLength,
   actor: "server1.conn1.child1/longString58"
 });
+
 
 module.exports = stubs;

--- a/packages/devtools-reps/src/reps/stubs/long-string.js
+++ b/packages/devtools-reps/src/reps/stubs/long-string.js
@@ -17,7 +17,6 @@ stubs.set("testUnloadedFullText", {
   actor: "server1.conn1.child1/longString58"
 });
 
-
 stubs.set("testLoadedFullText", {
   type: "longString",
   fullText: multilineFullText,

--- a/packages/devtools-reps/src/reps/stubs/long-string.js
+++ b/packages/devtools-reps/src/reps/stubs/long-string.js
@@ -19,9 +19,11 @@ stubs.set("testMultiline", {
 
 stubs.set("testUnloadedFullText", {
   type: "longString",
-  initial: Array(10000).fill("a").join(""),
+  initial: Array(10000)
+    .fill("a")
+    .join(""),
   length: 20000,
-  actor:  "server1.conn1.child1/longString58"
+  actor: "server1.conn1.child1/longString58"
 });
 
 stubs.set("testLoadedFullText", {
@@ -31,6 +33,5 @@ stubs.set("testLoadedFullText", {
   length: fullTextLength,
   actor: "server1.conn1.child1/longString58"
 });
-
 
 module.exports = stubs;

--- a/packages/devtools-reps/src/reps/stubs/long-string.js
+++ b/packages/devtools-reps/src/reps/stubs/long-string.js
@@ -9,14 +9,16 @@ const fullTextLength = multilineFullText.length;
 const initialText = multilineFullText.substring(0, 10000);
 
 const stubs = new Map();
-stubs.set("testMultiline", {
+
+stubs.set("testUnloadedFullText", {
   type: "longString",
   initial: initialText,
   length: fullTextLength,
   actor: "server1.conn1.child1/longString58"
 });
 
-stubs.set("testFullText", {
+
+stubs.set("testLoadedFullText", {
   type: "longString",
   fullText: multilineFullText,
   initial: initialText,

--- a/packages/devtools-reps/src/reps/stubs/long-string.js
+++ b/packages/devtools-reps/src/reps/stubs/long-string.js
@@ -10,12 +10,16 @@ const initialText = multilineFullText.substring(0, 10000);
 
 const stubs = new Map();
 
-stubs.set("testUnloadedFullText", {
+const multilineLongString = {
   type: "longString",
   initial: initialText,
   length: fullTextLength,
   actor: "server1.conn1.child1/longString58"
-});
+};
+
+stubs.set("testMultiline", multilineLongString);
+
+stubs.set("testUnloadedFullText", multilineLongString);
 
 stubs.set("testLoadedFullText", {
   type: "longString",

--- a/packages/devtools-reps/src/reps/tests/long-string.js
+++ b/packages/devtools-reps/src/reps/tests/long-string.js
@@ -74,7 +74,7 @@ describe("long StringRep", () => {
     "renders with expected text content when grip has a fullText" +
       "property and is open",
     () => {
-      const stub = stubs.get("testFullText");
+      const stub = stubs.get("testLoadedFullText");
       const renderedComponent = shallow(
         StringRep.rep({
           object: stub,
@@ -93,7 +93,7 @@ describe("long StringRep", () => {
     "renders with expected text content when grip has a fullText " +
       "property and is not open",
     () => {
-      const stub = stubs.get("testFullText");
+      const stub = stubs.get("testLoadedFullText");
       const renderedComponent = shallow(
         StringRep.rep({
           object: stub,


### PR DESCRIPTION
Since I didn't have time to add these when the longstring expansion feature was
shipped, due to the then receeding deadline, I had left these out.

There's still need for some more unit tests (`setNodeFullText`,
`getFullText`) and integration tests such as the expand funtionality on the OI
component, but it's a start!