### PR TITLE
Add a disableFrameTruncate to the Frames component.

### DIFF
--- a/src/components/SecondaryPanes/Frames/index.js
+++ b/src/components/SecondaryPanes/Frames/index.js
@@ -39,6 +39,7 @@ type Props = {
   selectedFrame: Object,
   selectFrame: Function,
   toggleBlackBox: Function,
+  disableFrameTruncate: boolean,
   why: Why
 };
 
@@ -58,7 +59,7 @@ class Frames extends Component<Props, State> {
     super(props);
 
     this.state = {
-      showAllFrames: false
+      showAllFrames: !!props.disableFrameTruncate
     };
   }
 
@@ -170,7 +171,7 @@ class Frames extends Component<Props, State> {
   }
 
   render() {
-    const { frames, why } = this.props;
+    const { frames, disableFrameTruncate, why } = this.props;
 
     if (!frames) {
       return (
@@ -186,7 +187,7 @@ class Frames extends Component<Props, State> {
       <div className="pane frames">
         {this.renderFrames(frames)}
         {renderWhyPaused(why)}
-        {this.renderToggleButton(frames)}
+        {disableFrameTruncate ? null : this.renderToggleButton(frames)}
       </div>
     );
   }

--- a/src/components/SecondaryPanes/Frames/tests/Frames.spec.js
+++ b/src/components/SecondaryPanes/Frames/tests/Frames.spec.js
@@ -71,6 +71,26 @@ describe("Frames", () => {
       expect(getFrames()).toHaveLength(10);
       expect(component).toMatchSnapshot();
     });
+
+    it("disable frame truncation", () => {
+      const framesNumber = 20;
+      const frames = Array.from({ length: framesNumber }, (_, i) => ({
+        id: i + 1
+      }));
+
+      const component = render({
+        frames,
+        disableFrameTruncate: true
+      });
+
+      const getToggleBtn = () => component.find(".show-more");
+      const getFrames = () => component.find("FrameComponent");
+
+      expect(getToggleBtn().exists()).toBeFalsy();
+      expect(getFrames()).toHaveLength(framesNumber);
+
+      expect(component).toMatchSnapshot();
+    });
   });
 
   describe("Blackboxed Frames", () => {

--- a/src/components/SecondaryPanes/Frames/tests/__snapshots__/Frames.spec.js.snap
+++ b/src/components/SecondaryPanes/Frames/tests/__snapshots__/Frames.spec.js.snap
@@ -302,6 +302,335 @@ exports[`Frames Library Frames toggling framework frames 2`] = `
 </div>
 `;
 
+exports[`Frames Supports different number of frames disable frame truncation 1`] = `
+<div
+  className="pane frames"
+>
+  <ul>
+    <Frame
+      copyStackTrace={[Function]}
+      frame={
+        Object {
+          "id": 1,
+        }
+      }
+      frameworkGroupingOn={false}
+      hideLocation={false}
+      key="1"
+      selectFrame={[Function]}
+      selectedFrame={null}
+      shouldMapDisplayName={true}
+      toggleBlackBox={[Function]}
+      toggleFrameworkGrouping={[Function]}
+    />
+    <Frame
+      copyStackTrace={[Function]}
+      frame={
+        Object {
+          "id": 2,
+        }
+      }
+      frameworkGroupingOn={false}
+      hideLocation={false}
+      key="2"
+      selectFrame={[Function]}
+      selectedFrame={null}
+      shouldMapDisplayName={true}
+      toggleBlackBox={[Function]}
+      toggleFrameworkGrouping={[Function]}
+    />
+    <Frame
+      copyStackTrace={[Function]}
+      frame={
+        Object {
+          "id": 3,
+        }
+      }
+      frameworkGroupingOn={false}
+      hideLocation={false}
+      key="3"
+      selectFrame={[Function]}
+      selectedFrame={null}
+      shouldMapDisplayName={true}
+      toggleBlackBox={[Function]}
+      toggleFrameworkGrouping={[Function]}
+    />
+    <Frame
+      copyStackTrace={[Function]}
+      frame={
+        Object {
+          "id": 4,
+        }
+      }
+      frameworkGroupingOn={false}
+      hideLocation={false}
+      key="4"
+      selectFrame={[Function]}
+      selectedFrame={null}
+      shouldMapDisplayName={true}
+      toggleBlackBox={[Function]}
+      toggleFrameworkGrouping={[Function]}
+    />
+    <Frame
+      copyStackTrace={[Function]}
+      frame={
+        Object {
+          "id": 5,
+        }
+      }
+      frameworkGroupingOn={false}
+      hideLocation={false}
+      key="5"
+      selectFrame={[Function]}
+      selectedFrame={null}
+      shouldMapDisplayName={true}
+      toggleBlackBox={[Function]}
+      toggleFrameworkGrouping={[Function]}
+    />
+    <Frame
+      copyStackTrace={[Function]}
+      frame={
+        Object {
+          "id": 6,
+        }
+      }
+      frameworkGroupingOn={false}
+      hideLocation={false}
+      key="6"
+      selectFrame={[Function]}
+      selectedFrame={null}
+      shouldMapDisplayName={true}
+      toggleBlackBox={[Function]}
+      toggleFrameworkGrouping={[Function]}
+    />
+    <Frame
+      copyStackTrace={[Function]}
+      frame={
+        Object {
+          "id": 7,
+        }
+      }
+      frameworkGroupingOn={false}
+      hideLocation={false}
+      key="7"
+      selectFrame={[Function]}
+      selectedFrame={null}
+      shouldMapDisplayName={true}
+      toggleBlackBox={[Function]}
+      toggleFrameworkGrouping={[Function]}
+    />
+    <Frame
+      copyStackTrace={[Function]}
+      frame={
+        Object {
+          "id": 8,
+        }
+      }
+      frameworkGroupingOn={false}
+      hideLocation={false}
+      key="8"
+      selectFrame={[Function]}
+      selectedFrame={null}
+      shouldMapDisplayName={true}
+      toggleBlackBox={[Function]}
+      toggleFrameworkGrouping={[Function]}
+    />
+    <Frame
+      copyStackTrace={[Function]}
+      frame={
+        Object {
+          "id": 9,
+        }
+      }
+      frameworkGroupingOn={false}
+      hideLocation={false}
+      key="9"
+      selectFrame={[Function]}
+      selectedFrame={null}
+      shouldMapDisplayName={true}
+      toggleBlackBox={[Function]}
+      toggleFrameworkGrouping={[Function]}
+    />
+    <Frame
+      copyStackTrace={[Function]}
+      frame={
+        Object {
+          "id": 10,
+        }
+      }
+      frameworkGroupingOn={false}
+      hideLocation={false}
+      key="10"
+      selectFrame={[Function]}
+      selectedFrame={null}
+      shouldMapDisplayName={true}
+      toggleBlackBox={[Function]}
+      toggleFrameworkGrouping={[Function]}
+    />
+    <Frame
+      copyStackTrace={[Function]}
+      frame={
+        Object {
+          "id": 11,
+        }
+      }
+      frameworkGroupingOn={false}
+      hideLocation={false}
+      key="11"
+      selectFrame={[Function]}
+      selectedFrame={null}
+      shouldMapDisplayName={true}
+      toggleBlackBox={[Function]}
+      toggleFrameworkGrouping={[Function]}
+    />
+    <Frame
+      copyStackTrace={[Function]}
+      frame={
+        Object {
+          "id": 12,
+        }
+      }
+      frameworkGroupingOn={false}
+      hideLocation={false}
+      key="12"
+      selectFrame={[Function]}
+      selectedFrame={null}
+      shouldMapDisplayName={true}
+      toggleBlackBox={[Function]}
+      toggleFrameworkGrouping={[Function]}
+    />
+    <Frame
+      copyStackTrace={[Function]}
+      frame={
+        Object {
+          "id": 13,
+        }
+      }
+      frameworkGroupingOn={false}
+      hideLocation={false}
+      key="13"
+      selectFrame={[Function]}
+      selectedFrame={null}
+      shouldMapDisplayName={true}
+      toggleBlackBox={[Function]}
+      toggleFrameworkGrouping={[Function]}
+    />
+    <Frame
+      copyStackTrace={[Function]}
+      frame={
+        Object {
+          "id": 14,
+        }
+      }
+      frameworkGroupingOn={false}
+      hideLocation={false}
+      key="14"
+      selectFrame={[Function]}
+      selectedFrame={null}
+      shouldMapDisplayName={true}
+      toggleBlackBox={[Function]}
+      toggleFrameworkGrouping={[Function]}
+    />
+    <Frame
+      copyStackTrace={[Function]}
+      frame={
+        Object {
+          "id": 15,
+        }
+      }
+      frameworkGroupingOn={false}
+      hideLocation={false}
+      key="15"
+      selectFrame={[Function]}
+      selectedFrame={null}
+      shouldMapDisplayName={true}
+      toggleBlackBox={[Function]}
+      toggleFrameworkGrouping={[Function]}
+    />
+    <Frame
+      copyStackTrace={[Function]}
+      frame={
+        Object {
+          "id": 16,
+        }
+      }
+      frameworkGroupingOn={false}
+      hideLocation={false}
+      key="16"
+      selectFrame={[Function]}
+      selectedFrame={null}
+      shouldMapDisplayName={true}
+      toggleBlackBox={[Function]}
+      toggleFrameworkGrouping={[Function]}
+    />
+    <Frame
+      copyStackTrace={[Function]}
+      frame={
+        Object {
+          "id": 17,
+        }
+      }
+      frameworkGroupingOn={false}
+      hideLocation={false}
+      key="17"
+      selectFrame={[Function]}
+      selectedFrame={null}
+      shouldMapDisplayName={true}
+      toggleBlackBox={[Function]}
+      toggleFrameworkGrouping={[Function]}
+    />
+    <Frame
+      copyStackTrace={[Function]}
+      frame={
+        Object {
+          "id": 18,
+        }
+      }
+      frameworkGroupingOn={false}
+      hideLocation={false}
+      key="18"
+      selectFrame={[Function]}
+      selectedFrame={null}
+      shouldMapDisplayName={true}
+      toggleBlackBox={[Function]}
+      toggleFrameworkGrouping={[Function]}
+    />
+    <Frame
+      copyStackTrace={[Function]}
+      frame={
+        Object {
+          "id": 19,
+        }
+      }
+      frameworkGroupingOn={false}
+      hideLocation={false}
+      key="19"
+      selectFrame={[Function]}
+      selectedFrame={null}
+      shouldMapDisplayName={true}
+      toggleBlackBox={[Function]}
+      toggleFrameworkGrouping={[Function]}
+    />
+    <Frame
+      copyStackTrace={[Function]}
+      frame={
+        Object {
+          "id": 20,
+        }
+      }
+      frameworkGroupingOn={false}
+      hideLocation={false}
+      key="20"
+      selectFrame={[Function]}
+      selectedFrame={null}
+      shouldMapDisplayName={true}
+      toggleBlackBox={[Function]}
+      toggleFrameworkGrouping={[Function]}
+    />
+  </ul>
+</div>
+`;
+
 exports[`Frames Supports different number of frames empty frames 1`] = `
 <div
   className="pane frames"


### PR DESCRIPTION
This prop prevents the debugger from truncating the frames
and show all of them on first render, as well as hide the
toggle button.
This will be useful for the console when we share this module
so we have a similar behavior with the current console stacktrace.