### PR TITLE
Revert "[Sources] Refactored component to use contents.id"

### DIFF
--- a/src/components/PrimaryPanes/SourcesTree.js
+++ b/src/components/PrimaryPanes/SourcesTree.js
@@ -133,7 +133,7 @@ class SourcesTree extends Component<Props, State> {
       nextProps.selectedSource != selectedSource
     ) {
       const highlightItems = getDirectories(
-        getRawSourceURL(nextProps.selectedSource.url),
+        getRawSourceURL(nextProps.selectedSource.get("url")),
         sourceTree
       );
 
@@ -162,20 +162,20 @@ class SourcesTree extends Component<Props, State> {
 
   selectItem = item => {
     if (!nodeHasChildren(item)) {
-      this.props.selectLocation({ sourceId: item.contents.id });
+      this.props.selectLocation({ sourceId: item.contents.get("id") });
     }
   };
 
   getPath = item => {
     const { sources } = this.props;
-    const obj = item.contents.get && item.contents.id;
+    const obj = item.contents.get && item.contents.get("id");
 
     let blackBoxedPart = "";
 
     if (
       typeof obj !== "undefined" &&
       sources.has(obj) &&
-      sources.get(obj).isBlackBoxed
+      sources.get(obj).get("isBlackBoxed")
     ) {
       blackBoxedPart = "update";
     }
@@ -205,7 +205,7 @@ class SourcesTree extends Component<Props, State> {
     }
 
     if (!nodeHasChildren(item)) {
-      const obj = item.contents.id;
+      const obj = item.contents.get("id");
       const source = sources.get(obj);
       const className = classnames(getSourceClassnames(source), "source-icon");
       return <img className={className} />;
@@ -226,7 +226,7 @@ class SourcesTree extends Component<Props, State> {
     const menuOptions = [];
 
     if (!isDirectory(item)) {
-      const source = item.contents.url;
+      const source = item.contents.get("url");
       const copySourceUri2 = {
         id: "node-menu-copy-source",
         label: copySourceUri2Label,


### PR DESCRIPTION
Reverts devtools-html/debugger.html #6184

We're seeing SourcesTree failures and I think this may be the source of those problems.