### PR TITLE
Render object as grip when noGrip is false

### DIFF
--- a/packages/devtools-reps/src/reps/array.js
+++ b/packages/devtools-reps/src/reps/array.js
@@ -142,10 +142,11 @@ function getLength(object) {
   return object.length;
 }
 
-function supportsObject(object) {
+function supportsObject(object, noGrip = false) {
   return (
-    Array.isArray(object) ||
-    Object.prototype.toString.call(object) === "[object Arguments]"
+    noGrip &&
+    (Array.isArray(object) ||
+      Object.prototype.toString.call(object) === "[object Arguments]")
   );
 }
 

--- a/packages/devtools-reps/src/reps/object.js
+++ b/packages/devtools-reps/src/reps/object.js
@@ -175,8 +175,8 @@ function isInterestingProp(value) {
   return type == "boolean" || type == "number" || (type == "string" && value);
 }
 
-function supportsObject(object) {
-  return true;
+function supportsObject(object, noGrip = false) {
+  return noGrip;
 }
 
 // Exports from this module

--- a/packages/devtools-reps/src/reps/rep.js
+++ b/packages/devtools-reps/src/reps/rep.js
@@ -70,7 +70,8 @@ const reps = [
   SymbolRep,
   InfinityRep,
   NaNRep,
-  Accessor
+  Accessor,
+  Obj
 ];
 
 /**
@@ -101,7 +102,7 @@ const Rep = function(props) {
  * @param noGrip {Boolean} If true, will only check reps not made for remote
  *                         objects.
  */
-function getRep(object, defaultRep = Obj, noGrip = false) {
+function getRep(object, defaultRep = Grip, noGrip = false) {
   for (let i = 0; i < reps.length; i++) {
     const rep = reps[i];
     try {

--- a/packages/devtools-reps/src/reps/tests/array.js
+++ b/packages/devtools-reps/src/reps/tests/array.js
@@ -13,12 +13,12 @@ const { maxLengthMap } = ArrayRep;
 describe("Array", () => {
   it("selects Array Rep as expected", () => {
     const stub = [];
-    expect(getRep(stub)).toBe(ArrayRep.rep);
+    expect(getRep(stub, undefined, true)).toBe(ArrayRep.rep);
   });
 
   it("renders empty array as expected", () => {
     const object = [];
-    const renderRep = props => shallow(Rep({ object, ...props }));
+    const renderRep = props => shallow(Rep({ object, noGrip: true, ...props }));
 
     const defaultOutput = "[]";
     expect(renderRep({ mode: undefined }).text()).toBe(defaultOutput);
@@ -29,7 +29,7 @@ describe("Array", () => {
 
   it("renders basic array as expected", () => {
     const object = [1, "foo", {}];
-    const renderRep = props => shallow(Rep({ object, ...props }));
+    const renderRep = props => shallow(Rep({ object, noGrip: true, ...props }));
 
     const defaultOutput = '[ 1, "foo", {} ]';
     expect(renderRep({ mode: undefined }).text()).toBe(defaultOutput);
@@ -40,7 +40,7 @@ describe("Array", () => {
 
   it("renders array with more than SHORT mode max props as expected", () => {
     const object = Array(maxLengthMap.get(MODE.SHORT) + 1).fill("foo");
-    const renderRep = props => shallow(Rep({ object, ...props }));
+    const renderRep = props => shallow(Rep({ object, noGrip: true, ...props }));
 
     const defaultShortOutput = `[ ${Array(maxLengthMap.get(MODE.SHORT))
       .fill('"foo"')
@@ -57,7 +57,7 @@ describe("Array", () => {
 
   it("renders array with more than LONG mode maximum props as expected", () => {
     const object = Array(maxLengthMap.get(MODE.LONG) + 1).fill("foo");
-    const renderRep = props => shallow(Rep({ object, ...props }));
+    const renderRep = props => shallow(Rep({ object, noGrip: true, ...props }));
 
     const defaultShortOutput = `[ ${Array(maxLengthMap.get(MODE.SHORT))
       .fill('"foo"')
@@ -75,7 +75,7 @@ describe("Array", () => {
   it("renders recursive array as expected", () => {
     const object = [1];
     object.push(object);
-    const renderRep = props => shallow(Rep({ object, ...props }));
+    const renderRep = props => shallow(Rep({ object, noGrip: true, ...props }));
 
     const defaultOutput = "[ 1, […] ]";
     expect(renderRep({ mode: undefined }).text()).toBe(defaultOutput);
@@ -93,7 +93,7 @@ describe("Array", () => {
         p4: "s4"
       }
     ];
-    const renderRep = props => shallow(Rep({ object, ...props }));
+    const renderRep = props => shallow(Rep({ object, noGrip: true, ...props }));
 
     const defaultOutput = "[ {…} ]";
     expect(renderRep({ mode: undefined }).text()).toBe(defaultOutput);

--- a/packages/devtools-reps/src/reps/tests/failure.js
+++ b/packages/devtools-reps/src/reps/tests/failure.js
@@ -34,10 +34,25 @@ describe("test Failure", () => {
   it("Fallback array rendering has expected text content", () => {
     const renderedComponent = shallow(
       Rep({
-        object: [1, stub, 2]
+        object: {
+          type: "object",
+          class: "Array",
+          actor: "server1.conn0.obj337",
+          extensible: true,
+          frozen: false,
+          sealed: false,
+          ownPropertyLength: 4,
+          preview: {
+            kind: "ArrayLike",
+            length: 3,
+            items: [1, stub, 2]
+          }
+        }
       })
     );
-    expect(renderedComponent.text()).toEqual("[ 1, Invalid object, 2 ]");
+    expect(renderedComponent.text()).toEqual(
+      "Array(3) [ 1, Invalid object, 2 ]"
+    );
   });
 });
 

--- a/packages/devtools-reps/src/reps/tests/grip.js
+++ b/packages/devtools-reps/src/reps/tests/grip.js
@@ -634,3 +634,23 @@ describe.skip("Grip - Object with __proto__ property", () => {
     expect(renderRep({ mode: MODE.LONG }).text()).toBe(defaultOutput);
   });
 });
+
+// Test that object that might look like raw objects or arrays are rendered
+// as grips when the `noGrip` parameter is not passed.
+describe("Object - noGrip prop", () => {
+  it("empty object", () => {
+    expect(getRep({})).toBe(Grip.rep);
+  });
+
+  it("object with custom property", () => {
+    expect(getRep({ foo: 123 })).toBe(Grip.rep);
+  });
+
+  it("empty array", () => {
+    expect(getRep([])).toBe(Grip.rep);
+  });
+
+  it("array with some item", () => {
+    expect(getRep([123])).toBe(Grip.rep);
+  });
+});

--- a/packages/devtools-reps/src/reps/tests/object.js
+++ b/packages/devtools-reps/src/reps/tests/object.js
@@ -16,7 +16,7 @@ describe("Object - Basic", () => {
   const defaultOutput = "Object {  }";
 
   it("selects the correct rep", () => {
-    expect(getRep(object)).toBe(Obj.rep);
+    expect(getRep(object, undefined, true)).toBe(Obj.rep);
   });
 
   it("renders basic object as expected", () => {
@@ -121,16 +121,18 @@ describe("Object - Nested", () => {
     'Object { strProp: "test string", objProp: {…},' + " arrProp: […] }";
 
   it("renders nested object as expected", () => {
-    expect(renderComponent(object, { mode: undefined }).text()).toEqual(
-      defaultOutput
-    );
-    expect(renderComponent(object, { mode: MODE.TINY }).text()).toEqual("{…}");
-    expect(renderComponent(object, { mode: MODE.SHORT }).text()).toEqual(
-      defaultOutput
-    );
-    expect(renderComponent(object, { mode: MODE.LONG }).text()).toEqual(
-      defaultOutput
-    );
+    expect(
+      renderComponent(object, { mode: undefined, noGrip: true }).text()
+    ).toEqual(defaultOutput);
+    expect(
+      renderComponent(object, { mode: MODE.TINY, noGrip: true }).text()
+    ).toEqual("{…}");
+    expect(
+      renderComponent(object, { mode: MODE.SHORT, noGrip: true }).text()
+    ).toEqual(defaultOutput);
+    expect(
+      renderComponent(object, { mode: MODE.LONG, noGrip: true }).text()
+    ).toEqual(defaultOutput);
   });
 });
 

--- a/packages/devtools-reps/src/reps/tests/string-with-url.js
+++ b/packages/devtools-reps/src/reps/tests/string-with-url.js
@@ -396,7 +396,7 @@ describe("test String with URL", () => {
     const string = `${url} some other text`;
     const object = [string];
     const openLink = jest.fn();
-    const element = renderRep(object, { openLink });
+    const element = renderRep(object, { openLink, noGrip: true });
     expect(element.text()).toEqual(`[ "${string}" ]`);
 
     const link = element.find("a");
@@ -432,7 +432,7 @@ describe("test String with URL", () => {
     const string = `${url} some other text`;
     const object = { test: string };
     const openLink = jest.fn();
-    const element = renderRep(object, { openLink });
+    const element = renderRep(object, { openLink, noGrip: true });
     expect(element.text()).toEqual(`Object { test: "${string}" }`);
 
     const link = element.find("a");


### PR DESCRIPTION
`noGrip` defaults to `false` so the default rep should be `Grip` instead of `Obj`. The current behavior causes problems like https://bugzil.la/1377668 and https://bugzil.la/1457701. Better fail fast and loud and require `noGrip = true` for raw objects or arrays.

### Summary of Changes

 - The default rep is now `Grip` instead of `Obj`.
 - The `Obj` and `ArrayRep` reps will refuse to render the object if `noGrip = true` is not specified.
 - Fixed various tests that relied on the previous bad behavior.

### Test Plan

I ported the changes to my mozilla-central repo and ensured that [browser_net_json-long.js](https://searchfox.org/mozilla-central/source/devtools/client/netmonitor/test/browser_net_json-long.js) fails, because netmonitor needs `noGrip = true` (https://bugzil.la/1457701). Better fail fast and loud than only in hard to detect edge cases. In this case, without `noGrip = true`, an object with properties is rendered as `{}` instead of `{…}`.
