### PR TITLE
Remove busted test until fixed in mc

### DIFF
--- a/src/test/mochitest/browser.ini
+++ b/src/test/mochitest/browser.ini
@@ -158,7 +158,6 @@ skip-if = (os == "win" && ccov) || (os == "win" && !debug) # Bug 1448523, Bug 14
 [browser_dbg-breakpoints.js]
 [browser_dbg-breakpoints-reloading.js]
 [browser_dbg-breakpoints-cond.js]
-[browser_dbg-browser-content-toolbox.js]
 skip-if = !e10s # This test is only valid in e10s
 [browser_dbg-call-stack.js]
 [browser_dbg-scopes.js]


### PR DESCRIPTION
We know this test is busted based on the fix/helpers PR, so I'm checking to see if we can remove it until we fix the test in MC