### PR TITLE
[WIP] Transpile debugger modules for DevTools loader

### DIFF
--- a/.babel/transform-mc.js
+++ b/.babel/transform-mc.js
@@ -1,0 +1,73 @@
+const _path = require("path");
+const fs = require("fs");
+
+function isRequire(t, node) {
+  return node && t.isCallExpression(node) && node.callee.name == "require";
+}
+
+module.exports = function({ types: t }) {
+  return {
+    visitor: {
+      ModuleDeclaration(path, state) {
+        const source = path.node.source;
+        const value = source && source.value;
+        if (value && value.includes(".css")) {
+          path.remove();
+        }
+      },
+
+      StringLiteral(path, state) {
+        const { mappings, vendors, filePath } = state.opts;
+        let value = path.node.value;
+
+        if (!isRequire(t, path.parent)) {
+          return;
+        }
+
+        // Transform mappings
+        if (Object.keys(mappings).includes(value)) {
+          path.replaceWith(t.stringLiteral(mappings[value]));
+          return;
+        }
+
+        // Transform vendors
+        if (vendors.includes(value)) {
+          path.replaceWith(
+            t.stringLiteral("devtools/client/debugger/new/vendors")
+          );
+
+          let name = value;
+          if (
+            path.parentPath &&
+            path.parentPath.parent &&
+            path.parentPath.parent.id &&
+            path.parentPath.parent.id.name
+          ) {
+            name = path.parentPath.parent.id.name;
+          }
+
+          path.parentPath.replaceWith(
+            t.memberExpression(path.parent, t.stringLiteral(name), true)
+          );
+          return;
+        }
+
+        const dir = _path.dirname(filePath);
+        const depPath = _path.join(dir, `${value}.js`);
+        const exists = fs.existsSync(depPath);
+        if (
+          !exists &&
+          !value.endsWith("index") &&
+          !value.startsWith("devtools")
+        ) {
+          path.replaceWith(t.stringLiteral(`${value}/index`));
+          return;
+        }
+      }
+    }
+  };
+};
+
+// const Services = require("Services");
+// const devtoolsModules = require("devtools/.../vendors")['devtools-modules']
+// const Services = devtoolsModules;

--- a/.babel/transform-mc.js
+++ b/.babel/transform-mc.js
@@ -80,7 +80,7 @@ module.exports = function({ types: t }) {
 
         // Handle require() to files bundled in vendor.js.
         // e.g. require("some-module");
-        //   -> require("devtools/client/debugger/new/vendors").vendored["some-module"];
+        //   -> require("devtools/client/debugger/new/dist/vendors").vendored["some-module"];
         const isVendored = VENDORS.some(vendored => value.endsWith(vendored));
         if (isVendored) {
           // components/shared/Svg is required using various relative paths.
@@ -91,7 +91,7 @@ module.exports = function({ types: t }) {
 
           // Transform the required path to require vendors.js
           path.replaceWith(
-            t.stringLiteral("devtools/client/debugger/new/vendors")
+            t.stringLiteral("devtools/client/debugger/new/dist/vendors")
           );
 
           // Append `.vendored["some-module"]` after the require().

--- a/.babel/transform-mc.js
+++ b/.babel/transform-mc.js
@@ -1,10 +1,38 @@
 const _path = require("path");
 const fs = require("fs");
 
+const mappings = require("../configs/mozilla-central-mappings");
+
+// Add two additional mappings that cannot be reused when creating the
+// webpack bundles.
+mappings["devtools-reps"] = "devtools/client/shared/components/reps/reps.js";
+mappings["devtools-source-map"] = "devtools/client/shared/source-map/index.js";
+
 function isRequire(t, node) {
   return node && t.isCallExpression(node) && node.callee.name == "require";
 }
 
+// List of vendored modules.
+// Should be synchronized with vendors.js
+const VENDORS = [
+  "classnames",
+  "devtools-components",
+  "devtools-config",
+  "devtools-contextmenu",
+  "devtools-modules",
+  "devtools-splitter",
+  "devtools-utils",
+  "fuzzaldrin-plus",
+  "react-transition-group/Transition",
+  "reselect",
+  "Svg",
+  "url",
+];
+
+/**
+ * This Babel plugin is used to transpile a single Debugger module into a module that
+ * can be loaded in Firefox via the regular DevTools loader.
+ */
 module.exports = function({ types: t }) {
   return {
     visitor: {
@@ -17,41 +45,73 @@ module.exports = function({ types: t }) {
       },
 
       StringLiteral(path, state) {
-        const { mappings, vendors, filePath } = state.opts;
+        const { filePath } = state.opts;
         let value = path.node.value;
 
         if (!isRequire(t, path.parent)) {
           return;
         }
 
-        // Transform mappings
+        // Handle require() to files mapped to other mozilla-central files.
+        // e.g. require("devtools-reps")
+        //   -> require("devtools/client/shared/components/reps/reps.js")
         if (Object.keys(mappings).includes(value)) {
           path.replaceWith(t.stringLiteral(mappings[value]));
           return;
         }
 
-        // Transform vendors
-        if (vendors.includes(value)) {
+        // Handle require() to loadash submodules
+        // e.g. require("lodash/escapeRegExp")
+        //   -> require("devtools/client/shared/vendor/lodash").escapeRegExp
+        if (value.startsWith("lodash/")) {
+          const lodashSubModule = value.split("/").pop();
           path.replaceWith(
-            t.stringLiteral("devtools/client/debugger/new/vendors")
+            t.stringLiteral(mappings.lodash)
           );
-
-          let name = value;
-          if (
-            path.parentPath &&
-            path.parentPath.parent &&
-            path.parentPath.parent.id &&
-            path.parentPath.parent.id.name
-          ) {
-            name = path.parentPath.parent.id.name;
-          }
-
           path.parentPath.replaceWith(
-            t.memberExpression(path.parent, t.stringLiteral(name), true)
+            t.memberExpression(
+              path.parent,
+              t.identifier(lodashSubModule)
+            )
           );
           return;
         }
 
+        // Handle require() to files bundled in vendor.js.
+        // e.g. require("some-module");
+        //   -> require("devtools/client/debugger/new/vendors").vendored["some-module"];
+        const isVendored = VENDORS.some(vendored => value.endsWith(vendored));
+        if (isVendored) {
+          // components/shared/Svg is required using various relative paths.
+          // Transform paths such as "../shared/Svg" to "Svg".
+          if (value.endsWith("/Svg")) {
+            value = "Svg";
+          }
+
+          // Transform the required path to require vendors.js
+          path.replaceWith(
+            t.stringLiteral("devtools/client/debugger/new/vendors")
+          );
+
+          // Append `.vendored["some-module"]` after the require().
+          path.parentPath.replaceWith(
+            t.memberExpression(
+              t.memberExpression(
+                path.parent,
+                t.identifier("vendored")
+              ),
+              t.stringLiteral(value),
+              true
+            )
+          );
+          return;
+        }
+
+        // Handle implicit index.js requires:
+        // in a node environment, require("my/folder") will automatically load
+        // my/folder/index.js if available. The DevTools load does not handle
+        // this case, so we need to explicitly transform such requires to point
+        // to the index.js file.
         const dir = _path.dirname(filePath);
         const depPath = _path.join(dir, `${value}.js`);
         const exists = fs.existsSync(depPath);
@@ -67,7 +127,3 @@ module.exports = function({ types: t }) {
     }
   };
 };
-
-// const Services = require("Services");
-// const devtoolsModules = require("devtools/.../vendors")['devtools-modules']
-// const Services = devtoolsModules;

--- a/.babel/transform-mc.js
+++ b/.babel/transform-mc.js
@@ -19,6 +19,7 @@ const VENDORS = [
   "devtools-components",
   "devtools-config",
   "devtools-contextmenu",
+  "devtools-environment",
   "devtools-modules",
   "devtools-splitter",
   "devtools-utils",

--- a/.eslintignore
+++ b/.eslintignore
@@ -7,3 +7,4 @@ src/test/mochitest/**
 bin/
 packages/**/fixtures/**
 node_modules
+out

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ tags
 *~
 webpack-stats/
 package-lock.json
+out

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,8 @@ script:
   - node --version
   - du -sh firefox
   - node ./bin/copy-assets.js --mc ./firefox
+  - node ./bin/copy-modules.js --mc ./firefox
+  - ./bin/ci/build-firefox.sh
   - node ./bin/ci/check-file-sizes.js
   - ./node_modules/.bin/mochii --ci --mc ./firefox --headless devtools/client/debugger/new
   - ./node_modules/.bin/mochii --ci --mc ./firefox --headless

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,20 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "attach",
+      "name": "Attach",
+      "port": 9229
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Launch Program",
+      "program": "${workspaceFolder}/bin/copy-modules.js"
+    }
+  ]
+}

--- a/assets/panel/dist.moz.build
+++ b/assets/panel/dist.moz.build
@@ -3,13 +3,9 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-DIRS += [
-  'dist',
-  'src',
-]
-
 DevToolsModules(
-    'debugger.css',
-    'debugger.js',
-    'panel.js',
+    'parser-worker.js',
+    'pretty-print-worker.js',
+    'search-worker.js',
+    'vendors.js'
 )

--- a/assets/panel/index.html
+++ b/assets/panel/index.html
@@ -3,29 +3,25 @@
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <!DOCTYPE html>
 <html dir="">
-  <head>
-    <link rel="stylesheet"
-          type="text/css"
-          href="chrome://devtools/content/sourceeditor/codemirror/lib/codemirror.css" />
-    <link rel="stylesheet"
-          type="text/css"
-          href="chrome://devtools/content/sourceeditor/codemirror/addon/dialog/dialog.css" />
-    <link rel="stylesheet"
-          type="text/css"
-          href="chrome://devtools/content/sourceeditor/codemirror/mozilla.css" />
-    <link rel="stylesheet" type="text/css" href="resource://devtools/client/debugger/new/debugger.css" />
-  </head>
-  <body>
-    <div id="mount"></div>
-    <script type="application/javascript"
-            src="chrome://devtools/content/shared/theme-switching.js"></script>
-    <script type="text/javascript">
-      const { BrowserLoader } = ChromeUtils.import("resource://devtools/client/shared/browser-loader.js", {});
-      const { require } = BrowserLoader({
-        baseURI: "resource://devtools/client/debugger/new/",
-        window,
-      });
-      Debugger = require("devtools/client/debugger/new/debugger");
-    </script>
-  </body>
+
+<head>
+  <link rel="stylesheet" type="text/css" href="chrome://devtools/content/sourceeditor/codemirror/lib/codemirror.css" />
+  <link rel="stylesheet" type="text/css" href="chrome://devtools/content/sourceeditor/codemirror/addon/dialog/dialog.css" />
+  <link rel="stylesheet" type="text/css" href="chrome://devtools/content/sourceeditor/codemirror/mozilla.css" />
+  <link rel="stylesheet" type="text/css" href="resource://devtools/client/debugger/new/debugger.css" />
+</head>
+
+<body>
+  <div id="mount"></div>
+  <script type="application/javascript" src="chrome://devtools/content/shared/theme-switching.js"></script>
+  <script type="text/javascript">
+    const { BrowserLoader } = ChromeUtils.import("resource://devtools/client/shared/browser-loader.js", {});
+    const { require } = BrowserLoader({
+      baseURI: "resource://devtools/client/debugger/new/src",
+      window,
+    });
+    Debugger = require("devtools/client/debugger/new/src/main");
+  </script>
+</body>
+
 </html>

--- a/assets/panel/index.html
+++ b/assets/panel/index.html
@@ -15,9 +15,10 @@
   <div id="mount"></div>
   <script type="application/javascript" src="chrome://devtools/content/shared/theme-switching.js"></script>
   <script type="text/javascript">
+    window.DebuggerConfig = {"environment":"firefox-panel","logging":false,"clientLogging":false,"firefox":{"mcPath":"./firefox"},"workers":{"parserURL":"resource://devtools/client/debugger/new/parser-worker.js","prettyPrintURL":"resource://devtools/client/debugger/new/pretty-print-worker.js","searchURL":"resource://devtools/client/debugger/new/search-worker.js"},"features":{}};
     const { BrowserLoader } = ChromeUtils.import("resource://devtools/client/shared/browser-loader.js", {});
     const { require } = BrowserLoader({
-      baseURI: "resource://devtools/client/debugger/new/src",
+      baseURI: "resource://devtools/client/debugger/new",
       window,
     });
     Debugger = require("devtools/client/debugger/new/src/main");

--- a/assets/panel/index.html
+++ b/assets/panel/index.html
@@ -15,7 +15,6 @@
   <div id="mount"></div>
   <script type="application/javascript" src="chrome://devtools/content/shared/theme-switching.js"></script>
   <script type="text/javascript">
-    window.DebuggerConfig = {"environment":"firefox-panel","logging":false,"clientLogging":false,"firefox":{"mcPath":"./firefox"},"workers":{"parserURL":"resource://devtools/client/debugger/new/parser-worker.js","prettyPrintURL":"resource://devtools/client/debugger/new/pretty-print-worker.js","searchURL":"resource://devtools/client/debugger/new/search-worker.js"},"features":{}};
     const { BrowserLoader } = ChromeUtils.import("resource://devtools/client/shared/browser-loader.js", {});
     const { require } = BrowserLoader({
       baseURI: "resource://devtools/client/debugger/new",

--- a/assets/panel/moz.build
+++ b/assets/panel/moz.build
@@ -3,6 +3,10 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+DIRS += [
+  'src'
+]
+
 DevToolsModules(
     'debugger.css',
     'debugger.js',
@@ -10,4 +14,5 @@ DevToolsModules(
     'parser-worker.js',
     'pretty-print-worker.js',
     'search-worker.js',
+    'vendors.js'
 )

--- a/bin/copy-assets.js
+++ b/bin/copy-assets.js
@@ -6,6 +6,7 @@ const minimist = require("minimist");
 var fs = require("fs");
 var fsExtra = require("fs-extra");
 const rimraf = require("rimraf");
+const shell = require("shelljs");
 
 const feature = require("devtools-config");
 const getConfig = require("./getConfig");
@@ -57,6 +58,7 @@ const walkSync = (dir, filelist = []) => {
 };
 
 function copySVGs({ projectPath, mcPath }) {
+  console.log("[copy-assets] copy SVGs");
   /*
    * Copying SVGs
    * We want to copy the SVGs that we include in our CSS into the
@@ -111,6 +113,8 @@ function copySVGs({ projectPath, mcPath }) {
 }
 
 function copyTests({ mcPath, projectPath, mcModulePath, shouldSymLink }) {
+  console.log("[copy-assets] copy tests");
+
   const projectTestPath = path.join(projectPath, "src/test/mochitest");
   const mcTestPath = path.join(mcPath, mcModulePath, "test/mochitest");
   if (shouldSymLink) {
@@ -133,6 +137,7 @@ function copyWithReplace(source, target, { cwd }, what, replacement) {
 }
 
 function copyWasmParser({ mcPath, projectPath }) {
+  console.log("[copy-assets] copy wasm parser");
   copyWithReplace(
     require.resolve("wasmparser/dist/WasmParser.js"),
     path.join(mcPath, "devtools/client/shared/vendor/WasmParser.js"),
@@ -163,9 +168,11 @@ function copyWasmParser({ mcPath, projectPath }) {
 }
 
 function start() {
-  console.log("start: copy assets");
+  console.log("[copy-assets] start");
+
   const projectPath = path.resolve(__dirname, "..");
   const mcModulePath = "devtools/client/debugger/new";
+
   let mcPath = args.mc ? args.mc : feature.getValue("firefox.mcPath");
 
   process.env.NODE_ENV = "production";
@@ -176,33 +183,48 @@ function start() {
 
   const config = { shouldSymLink, mcPath, projectPath, mcModulePath };
 
+  console.log("[copy-assets] copy static assets:");
+  console.log("[copy-assets] - properties");
   copyFile(
     path.join(projectPath, "./assets/panel/debugger.properties"),
     path.join(mcPath, "devtools/client/locales/en-US/debugger.properties"),
     { cwd: projectPath }
   );
 
+  console.log("[copy-assets] - preferences");
   copyFile(
     path.join(projectPath, "./assets/panel/prefs.js"),
     path.join(mcPath, "devtools/client/preferences/debugger.js"),
     { cwd: projectPath }
   );
 
+  console.log("[copy-assets] - index.html, index.js");
   copyFile(
     path.join(projectPath, "./assets/panel/index.html"),
     path.join(mcPath, "devtools/client/debugger/new/index.html"),
     { cwd: projectPath }
   );
-
   copyFile(
     path.join(projectPath, "./assets/panel/panel.js"),
     path.join(mcPath, "devtools/client/debugger/new/panel.js"),
     { cwd: projectPath }
   );
 
+  console.log("[copy-assets] - moz.build");
   copyFile(
     path.join(projectPath, "./assets/panel/moz.build"),
     path.join(mcPath, "devtools/client/debugger/new/moz.build"),
+    { cwd: projectPath }
+  );
+
+  // Ensure /dist path exists.
+  const bundlePath = "devtools/client/debugger/new/dist";
+  shell.mkdir("-p", path.join(mcPath, bundlePath));
+
+  console.log("[copy-assets] - dist/moz.build");
+  copyFile(
+    path.join(projectPath, "./assets/panel/dist.moz.build"),
+    path.join(mcPath, bundlePath, "moz.build"),
     { cwd: projectPath }
   );
 
@@ -221,48 +243,50 @@ function start() {
     ));
   }
 
-
+  console.log("[copy-assets] make webpack bundles");
   makeBundle({
-    outputPath: path.join(mcPath, mcModulePath),
+    outputPath: path.join(mcPath, bundlePath),
     projectPath,
     watch,
     updateAssets
   })
-    .then(() => onBundleFinish({mcPath, debuggerPath, projectPath}))
+    .then(() => onBundleFinish({mcPath, bundlePath, projectPath}))
     .catch(err => {
-      console.log(
-        "Uhoh, something went wrong. The error was written to assets-error.log"
-      );
+      console.log("[copy-assets] Uhoh, something went wrong. " +
+                  "The error was written to assets-error.log");
+
       fs.writeFileSync("assets-error.log", JSON.stringify(err, null, 2));
     });
 }
 
-function onBundleFinish({mcPath, debuggerPath, projectPath}) {
-  console.log("done: copy assets");
+function onBundleFinish({mcPath, bundlePath, projectPath}) {
+  console.log("[copy-assets] copy shared bundles to client/shared");
 
   moveFile(
-    path.join(mcPath, debuggerPath, "source-map-worker.js"),
+    path.join(mcPath, bundlePath, "source-map-worker.js"),
     path.join(mcPath, "devtools/client/shared/source-map/worker.js"),
     {cwd: projectPath}
   );
 
   moveFile(
-    path.join(mcPath, debuggerPath, "source-map-index.js"),
+    path.join(mcPath, bundlePath, "source-map-index.js"),
     path.join(mcPath, "devtools/client/shared/source-map/index.js"),
     {cwd: projectPath}
   );
 
   moveFile(
-    path.join(mcPath, debuggerPath, "reps.js"),
+    path.join(mcPath, bundlePath, "reps.js"),
     path.join(mcPath, "devtools/client/shared/components/reps/reps.js"),
     {cwd: projectPath}
   );
 
   moveFile(
-    path.join(mcPath, debuggerPath, "reps.css"),
+    path.join(mcPath, bundlePath, "reps.css"),
     path.join(mcPath, "devtools/client/shared/components/reps/reps.css"),
     {cwd: projectPath}
   );
+
+  console.log("[copy-assets] done");
 }
 
 start();

--- a/bin/copy-modules.js
+++ b/bin/copy-modules.js
@@ -1,0 +1,161 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
+const babel = require("@babel/core");
+const glob = require("glob");
+const fs = require("fs");
+const path = require("path");
+var shell = require("shelljs");
+
+const geckoPath = "../gecko/devtools/client/debugger/new/";
+
+const buildTpl = `# vim: set filetype=python:
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+DIRS += [
+__DIRS__
+]
+
+DevToolsModules(
+__FILES__
+)
+`;
+
+const mappings = {
+  "./source-editor": "devtools/client/sourceeditor/editor",
+  "../editor/source-editor": "devtools/client/sourceeditor/editor",
+  "./test-flag": "devtools/shared/flags",
+  "./fronts-device": "devtools/shared/fronts/device",
+  react: "devtools/client/shared/vendor/react",
+  redux: "devtools/client/shared/vendor/redux",
+  "react-dom": "devtools/client/shared/vendor/react-dom",
+  lodash: "devtools/client/shared/vendor/lodash",
+  immutable: "devtools/client/shared/vendor/immutable",
+  "react-redux": "devtools/client/shared/vendor/react-redux",
+  "prop-types": "devtools/client/shared/vendor/react-prop-types",
+
+  "wasmparser/dist/WasmParser": "devtools/client/shared/vendor/WasmParser",
+  "wasmparser/dist/WasmDis": "devtools/client/shared/vendor/WasmDis",
+
+  // The excluded files below should not be required while the Debugger runs
+  // in Firefox. Here, "devtools/shared/flags" is used as a dummy module.
+  "../assets/panel/debugger.properties": "devtools/shared/flags",
+  "devtools-connection": "devtools/shared/flags",
+  "chrome-remote-interface": "devtools/shared/flags",
+  "devtools-launchpad": "devtools/shared/flags"
+};
+
+const vendors = [
+  "devtools-config",
+  "fuzzaldrin-plus",
+  "devtools-modules",
+  "devtools-utils"
+];
+
+function transform(filePath) {
+  const doc = fs.readFileSync(filePath, "utf8");
+  const out = babel.transformSync(doc, {
+    plugins: [
+      "transform-flow-strip-types",
+      "syntax-trailing-function-commas",
+      "transform-class-properties",
+      "transform-es2015-modules-commonjs",
+      "@babel/plugin-proposal-object-rest-spread",
+      "transform-react-jsx",
+      ["./.babel/transform-mc", { mappings, vendors, filePath }]
+    ]
+  });
+
+  return out.code;
+}
+
+function getFiles() {
+  return glob.sync("./src/**/*.js", {}).filter(file => {
+    return !file.match(/(\/fixtures|\/tests|vendors\.js)/);
+  });
+}
+
+function transformSrc() {
+  getFiles().forEach(file => {
+    const filePath = path.join(__dirname, "..", file);
+    const code = transform(filePath);
+    shell.mkdir("-p", path.join(__dirname, "../out", path.dirname(file)));
+    fs.writeFileSync(path.join(__dirname, "../out", file), code);
+  });
+}
+
+function mozBuilds() {
+  const builds = {};
+
+  getFiles().forEach(file => {
+    if (file.includes("search")) {
+      console.log(file);
+    }
+
+    let dir = path.dirname(file);
+    builds[dir] = builds[dir] || { files: [], dirs: [] };
+    builds[dir].files.push(path.basename(file));
+    let parentDir = path.dirname(dir);
+    const directory = path.basename(dir);
+
+    if (file.includes("search")) {
+      console.log(parentDir);
+    }
+
+    builds[parentDir] = builds[parentDir] || { files: [], dirs: [] };
+    if (!builds[parentDir].dirs.includes(directory)) {
+      builds[parentDir].dirs.push(directory);
+    }
+
+    while (parentDir != ".") {
+      parentDir = path.dirname(parentDir);
+      dir = path.dirname(dir);
+      const directoryName = path.basename(dir);
+
+      builds[parentDir] = builds[parentDir] || { files: [], dirs: [] };
+
+      if (parentDir.includes("search")) {
+        console.log(parentDir, directoryName);
+      }
+
+      if (!builds[parentDir].dirs.includes(directoryName)) {
+        builds[parentDir].dirs.push(directoryName);
+      }
+    }
+  });
+
+  Object.keys(builds).forEach(build => {
+    const { files, dirs } = builds[build];
+
+    const buildPath = path.join(__dirname, "../out", build);
+    shell.mkdir("-p", buildPath);
+
+    const fileStr = files
+      .sort((a, b) => (a.toLowerCase() < b.toLowerCase() ? -1 : 1))
+      .map(file => `    '${file}',`)
+      .join("\n");
+
+    const dirStr = dirs
+      .sort((a, b) => (a.toLowerCase() < b.toLowerCase() ? -1 : 1))
+      .map(dir => `    '${dir}',`)
+      .join("\n");
+
+    const src = buildTpl
+      .replace("__DIRS__", dirStr)
+      .replace("__FILES__", fileStr);
+
+    fs.writeFileSync(path.join(buildPath, "moz.build"), src);
+  });
+}
+
+shell.rm("-rf", "./out");
+shell.mkdir("./out");
+transformSrc();
+mozBuilds();
+shell.cp("-r", "./out/src", "../gecko/devtools/client/debugger/new/");
+
+// const code = transform("./src/workers/parser/index.js");
+// console.log(code.slice(0, 1000));

--- a/bin/copy-modules.js
+++ b/bin/copy-modules.js
@@ -121,10 +121,6 @@ function createMozBuildFiles() {
   });
 }
 
-function getDebuggerPath() {
-
-}
-
 function start() {
   console.log("[copy-modules] start");
 
@@ -145,6 +141,7 @@ function start() {
   console.log("[copy-modules] copying files to: " + mcDebuggerPath);
   shell.cp("-r", "./out/src", mcDebuggerPath);
 
+  console.log("[copy-modules] done");
 }
 
 start();

--- a/bin/copy-modules.js
+++ b/bin/copy-modules.js
@@ -140,6 +140,7 @@ function start() {
 
   console.log("[copy-modules] copying files to: " + mcDebuggerPath);
   shell.cp("-r", "./out/src", mcDebuggerPath);
+  shell.rm("-r", "./out")
 
   console.log("[copy-modules] done");
 }

--- a/configs/mozilla-central-mappings.js
+++ b/configs/mozilla-central-mappings.js
@@ -1,0 +1,28 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
+module.exports = {
+  "./source-editor": "devtools/client/sourceeditor/editor",
+  "../editor/source-editor": "devtools/client/sourceeditor/editor",
+  "./test-flag": "devtools/shared/flags",
+  "./fronts-device": "devtools/shared/fronts/device",
+  immutable: "devtools/client/shared/vendor/immutable",
+  lodash: "devtools/client/shared/vendor/lodash",
+  react: "devtools/client/shared/vendor/react",
+  "react-dom": "devtools/client/shared/vendor/react-dom",
+  "react-dom-factories": "devtools/client/shared/vendor/react-dom-factories",
+  "react-redux": "devtools/client/shared/vendor/react-redux",
+  redux: "devtools/client/shared/vendor/redux",
+  "prop-types": "devtools/client/shared/vendor/react-prop-types",
+
+  "wasmparser/dist/WasmParser": "devtools/client/shared/vendor/WasmParser",
+  "wasmparser/dist/WasmDis": "devtools/client/shared/vendor/WasmDis",
+
+  // The excluded files below should not be required while the Debugger runs
+  // in Firefox. Here, "devtools/shared/flags" is used as a dummy module.
+  "../assets/panel/debugger.properties": "devtools/shared/flags",
+  "devtools-connection": "devtools/shared/flags",
+  "chrome-remote-interface": "devtools/shared/flags",
+  "devtools-launchpad": "devtools/shared/flags"
+};

--- a/package.json
+++ b/package.json
@@ -65,7 +65,9 @@
     "install": "prettier --write package.json"
   },
   "dependencies": {
+    "@babel/plugin-proposal-object-rest-spread": "^7.0.0-beta.46",
     "@babel/types": "^7.0.0-beta.39",
+    "babel-plugin-transform-imports": "^1.5.0",
     "babylon": "^7.0.0-beta.39",
     "codemirror": "^5.28.0",
     "devtools-environment": "0.0.3",

--- a/src/components/Editor/CallSite.js
+++ b/src/components/Editor/CallSite.js
@@ -6,7 +6,7 @@
 import { Component } from "react";
 
 import { markText, toEditorRange } from "../../utils/editor";
-require("./CallSite.css");
+import "./CallSite.css";
 
 type MarkerType = {
   clear: Function

--- a/src/utils/bootstrap.js
+++ b/src/utils/bootstrap.js
@@ -60,7 +60,7 @@ export function bootstrapStore(client: any, { services, toolboxActions }: any) {
 export function bootstrapWorkers() {
   const workerPath = isDevelopment()
     ? "assets/build"
-    : "resource://devtools/client/debugger/new";
+    : "resource://devtools/client/debugger/new/dist";
 
   if (isDevelopment()) {
     // When used in Firefox, the toolbox manages the source map worker.

--- a/src/vendors.js
+++ b/src/vendors.js
@@ -1,0 +1,16 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
+// export * from "./components/shared/Svg";
+
+export * from "devtools-config";
+
+export * from "fuzzaldrin-plus";
+export * from "devtools-modules";
+
+import * as devtoolsUtils from "devtools-utils";
+export { devtoolsUtils as _devtoolsUtils };
+
+import Svg from "./components/shared/Svg";
+export { Svg };

--- a/src/vendors.js
+++ b/src/vendors.js
@@ -2,15 +2,53 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
-// export * from "./components/shared/Svg";
+/**
+ * Vendors.js is a file used to bundle and expose all dependencies needed to run
+ * the transpiled debugger modules when running in Firefox.
+ *
+ * To make transpilation easier, a vendored module should always be imported in
+ * same way:
+ * - always with destructuring (import { a } from "modA";)
+ * - always without destructuring (import modB from "modB")
+ *
+ * Both are fine, but cannot be mixed for the same module.
+ */
 
-export * from "devtools-config";
-
-export * from "fuzzaldrin-plus";
-export * from "devtools-modules";
-
+// Modules imported with destructuring
+import * as devtoolsComponents from "devtools-components";
+import * as devtoolsConfig from "devtools-config";
+import * as devtoolsContextmenu from "devtools-contextmenu";
+import * as devtoolsModules from "devtools-modules";
 import * as devtoolsUtils from "devtools-utils";
-export { devtoolsUtils as _devtoolsUtils };
+import * as fuzzaldrinPlus from "fuzzaldrin-plus";
+import * as transition from "react-transition-group/Transition";
+import * as reselect from "reselect";
+import * as url from "url";
 
+// Modules imported without destructuring
+import classnames from "classnames";
+import devtoolsSplitter from "devtools-splitter";
 import Svg from "./components/shared/Svg";
-export { Svg };
+
+// We cannot directly export literals containing special characters
+// (eg. "my-module/Test") which is why they are nested in "vendored".
+// The keys of the vendored object should match the module names
+// !!! Should remain synchronized with .babel/transform-mc.js !!!
+const vendored = {
+  classnames,
+  "devtools-components": devtoolsComponents,
+  "devtools-config": devtoolsConfig,
+  "devtools-contextmenu": devtoolsContextmenu,
+  "devtools-modules": devtoolsModules,
+  "devtools-splitter": devtoolsSplitter,
+  "devtools-utils": devtoolsUtils,
+  "fuzzaldrin-plus": fuzzaldrinPlus,
+  "react-transition-group/Transition": transition,
+  reselect,
+  // Svg is required via relative paths, so the key is not imported path.
+  // See .babel/transform-mc.js
+  Svg,
+  url
+};
+
+export { vendored };

--- a/src/vendors.js
+++ b/src/vendors.js
@@ -18,6 +18,7 @@
 import * as devtoolsComponents from "devtools-components";
 import * as devtoolsConfig from "devtools-config";
 import * as devtoolsContextmenu from "devtools-contextmenu";
+import * as devtoolsEnvironment from "devtools-environment";
 import * as devtoolsModules from "devtools-modules";
 import * as devtoolsUtils from "devtools-utils";
 import * as fuzzaldrinPlus from "fuzzaldrin-plus";
@@ -39,6 +40,7 @@ const vendored = {
   "devtools-components": devtoolsComponents,
   "devtools-config": devtoolsConfig,
   "devtools-contextmenu": devtoolsContextmenu,
+  "devtools-environment": devtoolsEnvironment,
   "devtools-modules": devtoolsModules,
   "devtools-splitter": devtoolsSplitter,
   "devtools-utils": devtoolsUtils,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -26,8 +26,9 @@ function getEntry(filename) {
 
 const webpackConfig = {
   entry: {
-    debugger: getEntry("main.js"),
+    // debugger: getEntry("main.js"),
     "parser-worker": getEntry("workers/parser/worker.js"),
+    vendors: getEntry("vendors.js"),
     "pretty-print-worker": getEntry("workers/pretty-print/worker.js"),
     "search-worker": getEntry("workers/search/worker.js"),
     "source-map-worker": path.join(

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,9 +5,9 @@
 const toolbox = require("./node_modules/devtools-launchpad/index");
 
 const getConfig = require("./bin/getConfig");
+const mozillaCentralMappings = require("./configs/mozilla-central-mappings");
 const { NormalModuleReplacementPlugin } = require("webpack");
 const path = require("path");
-const projectPath = path.join(__dirname, "src");
 var Visualizer = require("webpack-visualizer-plugin");
 const ObjectRestSpreadPlugin = require("@sucrase/webpack-object-rest-spread-plugin");
 
@@ -21,24 +21,16 @@ function isDevelopment() {
  * hot-module-reloading in local development
  */
 function getEntry(filename) {
-  return [path.join(projectPath, filename)];
+  return [path.join(__dirname, filename)];
 }
 
 const webpackConfig = {
   entry: {
-    // debugger: getEntry("main.js"),
-    "parser-worker": getEntry("workers/parser/worker.js"),
-    vendors: getEntry("vendors.js"),
-    "pretty-print-worker": getEntry("workers/pretty-print/worker.js"),
-    "search-worker": getEntry("workers/search/worker.js"),
-    "source-map-worker": path.join(
-      __dirname,
-      "packages/devtools-source-map/src/worker.js"
-    ),
-    "source-map-index": path.join(
-      __dirname,
-      "packages/devtools-source-map/src/index.js"
-    )
+    "parser-worker": getEntry("src/workers/parser/worker.js"),
+    "pretty-print-worker": getEntry("src/workers/pretty-print/worker.js"),
+    "search-worker": getEntry("src/workers/search/worker.js"),
+    "source-map-worker": getEntry("packages/devtools-source-map/src/worker.js"),
+    "source-map-index": getEntry("packages/devtools-source-map/src/index.js")
   },
 
   output: {
@@ -47,6 +39,17 @@ const webpackConfig = {
     publicPath: "/assets/build"
   }
 };
+
+if (isDevelopment()) {
+  // In local development, use the debugger as a single bundle
+  webpackConfig.entry.debugger = getEntry("src/main.js");
+} else {
+  // In the firefox panel, build the vendored dependencies as a bundle instead,
+  // the other debugger modules will be transpiled to a format that is
+  // compatible with the DevTools Loader.
+  webpackConfig.entry.vendors = getEntry("src/vendors.js");
+  webpackConfig.entry.reps = getEntry("packages/devtools-reps/src/index.js");
+}
 
 function buildConfig(envConfig) {
   const extra = {};
@@ -64,11 +67,6 @@ function buildConfig(envConfig) {
       webpackConfig.plugins.push(viz);
     }
 
-    webpackConfig.entry.reps = path.join(
-      __dirname,
-      "packages/devtools-reps/src/index.js"
-    );
-
     const mappings = [
       [/\.\/mocha/, "./mochitest"],
       [/\.\.\/utils\/mocha/, "../utils/mochitest"],
@@ -76,31 +74,7 @@ function buildConfig(envConfig) {
       [/\.\/percy-stub/, "./percy-webpack"]
     ];
 
-    extra.excludeMap = {
-      "./source-editor": "devtools/client/sourceeditor/editor",
-      "../editor/source-editor": "devtools/client/sourceeditor/editor",
-      "./test-flag": "devtools/shared/flags",
-      "./fronts-device": "devtools/shared/fronts/device",
-      react: "devtools/client/shared/vendor/react",
-      redux: "devtools/client/shared/vendor/redux",
-      "react-dom": "devtools/client/shared/vendor/react-dom",
-      "react-dom-factories":
-        "devtools/client/shared/vendor/react-dom-factories",
-      "prop-types": "devtools/client/shared/vendor/react-prop-types",
-      lodash: "devtools/client/shared/vendor/lodash",
-      immutable: "devtools/client/shared/vendor/immutable",
-      "react-redux": "devtools/client/shared/vendor/react-redux",
-
-      "wasmparser/dist/WasmParser": "devtools/client/shared/vendor/WasmParser",
-      "wasmparser/dist/WasmDis": "devtools/client/shared/vendor/WasmDis",
-
-      // The excluded files below should not be required while the Debugger runs
-      // in Firefox. Here, "devtools/shared/flags" is used as a dummy module.
-      "../assets/panel/debugger.properties": "devtools/shared/flags",
-      "devtools-connection": "devtools/shared/flags",
-      "chrome-remote-interface": "devtools/shared/flags",
-      "devtools-launchpad": "devtools/shared/flags"
-    };
+    extra.excludeMap = mozillaCentralMappings;
 
     mappings.forEach(([regex, res]) => {
       webpackConfig.plugins.push(new NormalModuleReplacementPlugin(regex, res));

--- a/yarn.lock
+++ b/yarn.lock
@@ -82,6 +82,10 @@
   dependencies:
     "@babel/types" "7.0.0-beta.46"
 
+"@babel/helper-plugin-utils@7.0.0-beta.46":
+  version "7.0.0-beta.46"
+  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.46.tgz#f630adbd9d645d0ba2e43f4955b4ad61f44ccdf4"
+
 "@babel/helper-split-export-declaration@7.0.0-beta.44":
   version "7.0.0-beta.44"
   resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.44.tgz#c0b351735e0fbcb3822c8ad8db4e583b05ebd9dc"
@@ -117,6 +121,19 @@
     chalk "^2.0.0"
     esutils "^2.0.2"
     js-tokens "^3.0.0"
+
+"@babel/plugin-proposal-object-rest-spread@^7.0.0-beta.46":
+  version "7.0.0-beta.46"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.0.0-beta.46.tgz#fb3979488a52c1246cdced4a438ace0f47ac985b"
+  dependencies:
+    "@babel/helper-plugin-utils" "7.0.0-beta.46"
+    "@babel/plugin-syntax-object-rest-spread" "7.0.0-beta.46"
+
+"@babel/plugin-syntax-object-rest-spread@7.0.0-beta.46":
+  version "7.0.0-beta.46"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.0.0-beta.46.tgz#03d46637f549757b2d6877b6449901698059d7d8"
+  dependencies:
+    "@babel/helper-plugin-utils" "7.0.0-beta.46"
 
 "@babel/template@7.0.0-beta.44":
   version "7.0.0-beta.44"
@@ -1568,6 +1585,17 @@ babel-plugin-transform-function-bind@^6.22.0:
     babel-plugin-syntax-function-bind "^6.8.0"
     babel-runtime "^6.22.0"
 
+babel-plugin-transform-imports@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-imports/-/babel-plugin-transform-imports-1.5.0.tgz#3105082ab489b1cee162e42d2ffe7b8f7c685f2e"
+  dependencies:
+    babel-types "^6.6.0"
+    is-valid-path "^0.1.1"
+    lodash.camelcase "^4.3.0"
+    lodash.findkey "^4.6.0"
+    lodash.kebabcase "^4.1.1"
+    lodash.snakecase "^4.1.1"
+
 babel-plugin-transform-inline-consecutive-adds@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-inline-consecutive-adds/-/babel-plugin-transform-inline-consecutive-adds-0.3.0.tgz#f07d93689c0002ed2b2b62969bdd99f734e03f57"
@@ -1880,7 +1908,7 @@ babel-traverse@^6.18.0, babel-traverse@^6.23.1, babel-traverse@^6.24.1, babel-tr
     invariant "^2.2.2"
     lodash "^4.17.4"
 
-babel-types@^6.14.0, babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.23.0, babel-types@^6.24.1, babel-types@^6.26.0:
+babel-types@^6.14.0, babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.23.0, babel-types@^6.24.1, babel-types@^6.26.0, babel-types@^6.6.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.26.0.tgz#a3b073f94ab49eb6fa55cd65227a334380632497"
   dependencies:
@@ -5800,6 +5828,12 @@ is-hidden@^1.0.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/is-hidden/-/is-hidden-1.1.1.tgz#82ee6a93aeef3fb007ad5b9457c0584d45329f38"
 
+is-invalid-path@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/is-invalid-path/-/is-invalid-path-0.1.0.tgz#307a855b3cf1a938b44ea70d2c61106053714f34"
+  dependencies:
+    is-glob "^2.0.0"
+
 is-my-ip-valid@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz#7b351b8e8edd4d3995d4d066680e664d94696824"
@@ -5985,6 +6019,12 @@ is-utf8@^0.2.0, is-utf8@^0.2.1:
 is-valid-glob@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-valid-glob/-/is-valid-glob-1.0.0.tgz#29bf3eff701be2d4d315dbacc39bc39fe8f601aa"
+
+is-valid-path@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/is-valid-path/-/is-valid-path-0.1.1.tgz#110f9ff74c37f663e1ec7915eb451f2db93ac9df"
+  dependencies:
+    is-invalid-path "^0.1.0"
 
 is-whitespace-character@^1.0.0:
   version "1.0.2"
@@ -6928,6 +6968,10 @@ lodash.debounce@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
 
+lodash.findkey@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.findkey/-/lodash.findkey-4.6.0.tgz#83058e903b51cbb759d09ccf546dea3ea39c4718"
+
 lodash.flattendeep@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
@@ -6967,6 +7011,10 @@ lodash.memoize@^4.1.2:
 lodash.pick@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.pick/-/lodash.pick-4.4.0.tgz#52f05610fff9ded422611441ed1fc123a03001b3"
+
+lodash.snakecase@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz#39d714a35357147837aefd64b5dcbb16becd8f8d"
 
 lodash.some@^4.5.1, lodash.some@^4.6.0:
   version "4.6.0"


### PR DESCRIPTION
This is a work in progress PR, intended for collaboration and discussion, do not merge!

cc @jasonLaster @ochameau  

I started doing some cleanup, and rebased on latest master.

In my opinion, TODOs:
- [x] cleanup and comment copy-modules.js
- [x] cleanup and comment transform-mc.js
- [x] find alternative to hardcoding `window.DebuggerConfig` in debugger's index
- [x] find alternative to workaround in CallSite.js
- [x] fix mochitest failures
- [x] what to do about allowed dupes -> https://hg.mozilla.org/try/comparison/9b6fdd663985/browser/installer/allowed-dupes.mn
- [x] use copy-modules on travis 