### PR TITLE
Remove unwanted border from accordion

### DIFF
--- a/src/components/SecondaryPanes/SecondaryPanes.css
+++ b/src/components/SecondaryPanes/SecondaryPanes.css
@@ -30,6 +30,7 @@
 
 .secondary-panes .accordion {
   flex: 1 0 auto;
+  margin-bottom: 0;
 }
 
 .secondary-panes-wrapper .accordion li:last-child ._content {


### PR DESCRIPTION
@violasong's eagle eyes spotted this issue in dark mode (the bottom margin causing the ~30 pixels of light gray):

![image 1](https://user-images.githubusercontent.com/46655/39641596-675a8356-4f94-11e8-88ba-3aa154c8cf1a.png)

It's a result of the accessibility work and turning the accordion into a list.  Fixed the issue by removing bottom margin from the list.