### PR TITLE
Makes addTab only dependent on url

### DIFF
--- a/src/actions/sources/select.js
+++ b/src/actions/sources/select.js
@@ -107,7 +107,7 @@ export function selectLocation(location: Location) {
 
     const source = sourceRecord.toJS();
 
-    dispatch(addTab(source, 0));
+    dispatch(addTab(source.url, 0));
     dispatch(
       ({
         type: "SELECT_SOURCE",

--- a/src/actions/sources/tabs.js
+++ b/src/actions/sources/tabs.js
@@ -20,13 +20,12 @@ import {
   removeSourceFromTabList
 } from "../../selectors";
 
-import type { Source } from "../../types";
 import type { Action, ThunkArgs } from "../types";
 
-export function addTab(source: Source, tabIndex: number): Action {
+export function addTab(url: string, tabIndex: number): Action {
   return {
     type: "ADD_TAB",
-    source,
+    url,
     tabIndex
   };
 }

--- a/src/actions/types/SourceAction.js
+++ b/src/actions/types/SourceAction.js
@@ -49,7 +49,7 @@ export type SourceAction =
     >
   | {|
       +type: "ADD_TAB",
-      +source: Source,
+      +url: string,
       +tabIndex: number
     |}
   | {|

--- a/src/actions/types/index.js
+++ b/src/actions/types/index.js
@@ -45,6 +45,12 @@ type ProjectTextSearchResult = {
   matches: MatchedLocations[]
 };
 
+type AddTabAction = {|
+  +type: "ADD_TAB",
+  +url: string,
+  +tabIndex: ?number
+|};
+
 type ReplayAction =
   | {|
       +type: "TRAVEL_TO",
@@ -142,6 +148,7 @@ export type { ASTAction } from "./ASTAction";
  * @static
  */
 export type Action =
+  | AddTabAction
   | SourceAction
   | BreakpointAction
   | PauseAction

--- a/src/reducers/sources.js
+++ b/src/reducers/sources.js
@@ -116,7 +116,7 @@ function update(
 
     case "ADD_TAB":
       return state.merge({
-        tabs: updateTabList({ sources: state }, action.source.url)
+        tabs: updateTabList({ sources: state }, action.url)
       });
 
     case "MOVE_TAB":


### PR DESCRIPTION
`addTab` and `ADD_TAB` only use the source url, so in order to clear up some things further down the line it would be really useful to decouple `addTab` from needing the whole source object.