### PR TITLE
[Search] Fix file search input close button alignment

### DIFF
--- a/src/components/Editor/SearchBar.css
+++ b/src/components/Editor/SearchBar.css
@@ -13,7 +13,7 @@
 }
 
 .search-field .close-btn {
-  margin-top: 12px;
+  align-self: center;
 }
 
 .search-bottom-bar * {


### PR DESCRIPTION
Fixes Issue: #6179 

Here's the Pull Request Doc
https://devtools-html.github.io/debugger.html/CONTRIBUTING.html#pull-requests

### Summary of Changes

* change 1
    Added align-items: center; to .search-bar class in SearchBar.css file.
* change 2
    Removed `margin-top: 12px;` and added `align-self: center;` to `.search-field .close-btn`

### Test Plan

Issue only showed up when opening the search files Modal and search text in file search bar. For testing we only needed to open the search fields and see that the "X" button was vertically centered and it IS.

Example test plan:

- [x] Command-P opens the panel
- [x] Clicking “+” opens the panel
- [x] Clicking a source navigates to the source
- [x] Clicking "x" closes the panel

Here's the Debugger's Testing doc
https://docs.google.com/document/d/1oBMRxV8A2ag2t22YsQOxTdEv0mXKzIg0tggJjRkU1S0/edit#.
Feel free to improve it!

### Screenshots/Videos (OPTIONAL)
![debugger_bug_6179](https://user-images.githubusercontent.com/32307614/39660482-ced84d78-4ff4-11e8-8c29-c295b108c2d9.gif)