### PR TITLE
Makes setSymbols dependent on Id only 

### DIFF
--- a/src/actions/ast.js
+++ b/src/actions/ast.js
@@ -64,8 +64,8 @@ export function setSymbols(sourceId: SourceId) {
     await dispatch(
       ({
         type: "SET_SYMBOLS",
-        source: source.toJS(),
-        [PROMISE]: getSymbols(source.id)
+        sourceId,
+        [PROMISE]: getSymbols(sourceId)
       }: Action)
     );
 

--- a/src/actions/types/ASTAction.js
+++ b/src/actions/types/ASTAction.js
@@ -18,7 +18,7 @@ export type ASTAction =
   | PromiseAction<
       {|
         +type: "SET_SYMBOLS",
-        +source: Source
+        +sourceId: string
       |},
       SymbolDeclarations
     >

--- a/src/reducers/ast.js
+++ b/src/reducers/ast.js
@@ -81,13 +81,13 @@ function update(
 ): Record<ASTState> {
   switch (action.type) {
     case "SET_SYMBOLS": {
-      const { source } = action;
+      const { sourceId } = action;
       if (action.status === "start") {
-        return state.setIn(["symbols", source.id], { loading: true });
+        return state.setIn(["symbols", sourceId], { loading: true });
       }
 
       const value = ((action: any): DonePromiseAction).value;
-      return state.setIn(["symbols", source.id], value);
+      return state.setIn(["symbols", sourceId], value);
     }
 
     case "SET_PAUSE_POINTS": {


### PR DESCRIPTION
`setSymbols` currently passes the whole source when it only usues the Id. This allows us to get rid of an unneeded toJS() call