### PR TITLE
Removes toJS from setPausePoints

### DIFF
--- a/src/actions/ast.js
+++ b/src/actions/ast.js
@@ -110,16 +110,17 @@ export function setPausePoints(sourceId: SourceId) {
       return;
     }
 
-    const pausePoints = await getPausePoints(source.id);
+    const pausePoints = await getPausePoints(sourceId);
 
-    if (isGeneratedId(source.id)) {
-      await client.setPausePoints(source.id, pausePoints);
+    if (isGeneratedId(sourceId)) {
+      await client.setPausePoints(sourceId, pausePoints);
     }
 
     dispatch(
       ({
         type: "SET_PAUSE_POINTS",
-        source: source.toJS(),
+        sourceText: source.text,
+        sourceId,
         pausePoints
       }: Action)
     );

--- a/src/actions/types/ASTAction.js
+++ b/src/actions/types/ASTAction.js
@@ -24,7 +24,8 @@ export type ASTAction =
     >
   | {|
       +type: "SET_PAUSE_POINTS",
-      +source: Source,
+      +sourceText: string,
+      +sourceId: string,
       +pausePoints: PausePoints
     |}
   | {|

--- a/src/actions/types/ASTAction.js
+++ b/src/actions/types/ASTAction.js
@@ -5,7 +5,6 @@
 // @flow
 
 import type { SourceMetaDataType } from "../../reducers/ast.js";
-import type { Source } from "../../types";
 import type {
   SymbolDeclarations,
   AstLocation,

--- a/src/reducers/ast.js
+++ b/src/reducers/ast.js
@@ -91,12 +91,12 @@ function update(
     }
 
     case "SET_PAUSE_POINTS": {
-      const { source, pausePoints } = action;
-      const emptyLines = findEmptyLines(source, pausePoints);
+      const { sourceText, sourceId, pausePoints } = action;
+      const emptyLines = findEmptyLines(sourceText, pausePoints);
 
       return state
-        .setIn(["pausePoints", source.id], pausePoints)
-        .setIn(["emptyLines", source.id], emptyLines);
+        .setIn(["pausePoints", sourceId], pausePoints)
+        .setIn(["emptyLines", sourceId], emptyLines);
     }
 
     case "OUT_OF_SCOPE_LOCATIONS": {

--- a/src/utils/ast.js
+++ b/src/utils/ast.js
@@ -7,7 +7,7 @@
 import { xor, range } from "lodash";
 import { convertToList } from "./pause/pausePoints";
 
-import type { Location, Source, ColumnPosition } from "../types";
+import type { Location, ColumnPosition } from "../types";
 import type { Symbols } from "../reducers/ast";
 
 import type { AstPosition, AstLocation, PausePoints } from "../workers/parser";
@@ -40,11 +40,8 @@ export function findBestMatchExpression(
     }, null);
 }
 
-export function findEmptyLines(
-  selectedSource: Source,
-  pausePoints: PausePoints
-) {
-  if (!pausePoints || !selectedSource) {
+export function findEmptyLines(sourceText: string, pausePoints: PausePoints) {
+  if (!pausePoints || !sourceText) {
     return [];
   }
 
@@ -53,11 +50,11 @@ export function findEmptyLines(
   const breakpoints = pausePointsList.filter(point => point.types.break);
   const breakpointLines = breakpoints.map(point => point.location.line);
 
-  if (!selectedSource.text || breakpointLines.length == 0) {
+  if (!sourceText || breakpointLines.length == 0) {
     return [];
   }
 
-  const lineCount = selectedSource.text.split("\n").length;
+  const lineCount = sourceText.split("\n").length;
   const sourceLines = range(1, lineCount + 1);
   return xor(sourceLines, breakpointLines);
 }


### PR DESCRIPTION
setPausePoints only really uses id and text, so in order to get rid of the toJS it needed some scope changes in arguments passed.
