### PR TITLE
Revert "Synchronize test changes from Bug 1098374 (#6234)"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
   global:
     - DISPLAY=':99.0'
     - YARN_VERSION='0.24.5'
-    - MC_COMMIT='a1abfeb6a79a' # https://hg.mozilla.org/mozilla-central/shortlog
+    - MC_COMMIT='2243b83d2c5c' # https://hg.mozilla.org/mozilla-central/shortlog
 
 notifications:
   slack:

--- a/src/test/mochitest/browser.ini
+++ b/src/test/mochitest/browser.ini
@@ -7,7 +7,6 @@ support-files =
   helpers.js
   !/devtools/client/commandline/test/helpers.js
   !/devtools/client/shared/test/shared-head.js
-  !/devtools/client/shared/test/telemetry-test-helpers.js
   examples/sourcemapped/polyfill-bundle.js
   examples/sourcemapped/fixtures/typescript-classes/output.js
   examples/sourcemapped/fixtures/typescript-classes/output.js.map


### PR DESCRIPTION
### Summary of Changes

This reverts a useful sync, which started causing travis to give us false positives.