### PR TITLE
Generate debugger bundle when copying assets and keep only CSS artifact

### DIFF
--- a/assets/panel/dist.moz.build
+++ b/assets/panel/dist.moz.build
@@ -4,6 +4,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 DevToolsModules(
+    'debugger.css',
     'parser-worker.js',
     'pretty-print-worker.js',
     'search-worker.js',

--- a/assets/panel/index.html
+++ b/assets/panel/index.html
@@ -8,7 +8,7 @@
   <link rel="stylesheet" type="text/css" href="chrome://devtools/content/sourceeditor/codemirror/lib/codemirror.css" />
   <link rel="stylesheet" type="text/css" href="chrome://devtools/content/sourceeditor/codemirror/addon/dialog/dialog.css" />
   <link rel="stylesheet" type="text/css" href="chrome://devtools/content/sourceeditor/codemirror/mozilla.css" />
-  <link rel="stylesheet" type="text/css" href="resource://devtools/client/debugger/new/debugger.css" />
+  <link rel="stylesheet" type="text/css" href="resource://devtools/client/debugger/new/dist/debugger.css" />
 </head>
 
 <body>

--- a/assets/panel/moz.build
+++ b/assets/panel/moz.build
@@ -9,7 +9,5 @@ DIRS += [
 ]
 
 DevToolsModules(
-    'debugger.css',
-    'debugger.js',
     'panel.js',
 )

--- a/bin/copy-assets.js
+++ b/bin/copy-assets.js
@@ -260,8 +260,10 @@ function start() {
 }
 
 function onBundleFinish({mcPath, bundlePath, projectPath}) {
-  console.log("[copy-assets] copy shared bundles to client/shared");
+  console.log("[copy-assets] delete debugger.js bundle");
+  fs.unlinkSync(path.join(mcPath, bundlePath, "debugger.js"))
 
+  console.log("[copy-assets] copy shared bundles to client/shared");
   moveFile(
     path.join(mcPath, bundlePath, "source-map-worker.js"),
     path.join(mcPath, "devtools/client/shared/source-map/worker.js"),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -26,6 +26,9 @@ function getEntry(filename) {
 
 const webpackConfig = {
   entry: {
+    // We always generate the debugger bundle, but we will only copy the CSS
+    // artifact over to mozilla-central.
+    debugger: getEntry("src/main.js"),
     "parser-worker": getEntry("src/workers/parser/worker.js"),
     "pretty-print-worker": getEntry("src/workers/pretty-print/worker.js"),
     "search-worker": getEntry("src/workers/search/worker.js"),
@@ -40,10 +43,7 @@ const webpackConfig = {
   }
 };
 
-if (isDevelopment()) {
-  // In local development, use the debugger as a single bundle
-  webpackConfig.entry.debugger = getEntry("src/main.js");
-} else {
+if (!isDevelopment()) {
   // In the firefox panel, build the vendored dependencies as a bundle instead,
   // the other debugger modules will be transpiled to a format that is
   // compatible with the DevTools Loader.


### PR DESCRIPTION
- keep generating the debugger bundle in both development/nonDevelopment configurations
- modify copy assets to delete the debugger.js bundle
- update moz.build to remove references to debugger.js and debugger.css
- udpate dist/moz/build to add reference to debugger.css
- update references to new/debugger.css to new/dist/debugger.cdd 