### PR TITLE
add --watch to copy-modules

### DIFF
--- a/docs/debugging-firefox.md
+++ b/docs/debugging-firefox.md
@@ -2,10 +2,10 @@
 
 ### Getting Started
 
-1. *Get the code* `./bin/prepare-mochitests-dev`
-2. *Go to the firefox directory* `cd firefox`
-3. *Build Firefox* `./mach build` [see docs][mach]
-4. *Run Firefox* `./mach run` [see docs][mach]
+1.  _Get the code_ `./bin/prepare-mochitests-dev`
+2.  _Go to the firefox directory_ `cd firefox`
+3.  _Build Firefox_ `./mach build` [see docs][mach]
+4.  _Run Firefox_ `./mach run` [see docs][mach]
 
 ### Firefox Code Base
 
@@ -13,7 +13,7 @@ Firefox is a large project, but for the most part the relevant source code is in
 
 #### Updating the Debugger
 
-You can update the debugger by running `yarn copy-assets` or `yarn copy-assets-watch`. The script will use webpack to bundle the debugger and copy the bundle into `devtools/client/debugger/new/debugger.js`.
+You can update the debugger by running `yarn copy-assets` or `yarn watch`. The script will use webpack to bundle the debugger and copy the bundle into `devtools/client/debugger/new/debugger.js`.
 
 > Remember, every time the code changes in firefox you need to re-run `./mach build`!
 
@@ -23,6 +23,6 @@ Firefox has built the toolbox so that it is powerful enough to debug the Firefox
 
 #### Debugging the Debugger Server
 
-The server code lives in  `/devtools/server`. It can be a bit difficult to debug, so the best thing to do is to add *log* statements in the code with the special `dump` command e.g. `dump(">> I am here\n")`. When you do, you'll see the logs in the terminal and in the browser toolbox console.
+The server code lives in `/devtools/server`. It can be a bit difficult to debug, so the best thing to do is to add _log_ statements in the code with the special `dump` command e.g. `dump(">> I am here\n")`. When you do, you'll see the logs in the terminal and in the browser toolbox console.
 
 [mach]: https://developer.mozilla.org/en-US/docs/Mozilla/Developer_guide/mach

--- a/docs/mochitests.md
+++ b/docs/mochitests.md
@@ -1,10 +1,10 @@
 ## Mochitests
 
-  - [Getting Started](#getting-started)
-  - [Running the tests](#running-the-tests)
-  - [Mochi](#mochi)
-  - [Writing Tests](#writing-tests)
-  - [Debugging Intermittents](#debugging-intermittents)
+* [Getting Started](#getting-started)
+* [Running the tests](#running-the-tests)
+* [Mochi](#mochi)
+* [Writing Tests](#writing-tests)
+* [Debugging Intermittents](#debugging-intermittents)
 
 We use [mochitests] to do integration testing. Mochitests are part of Firefox and allow us to test the debugger literally as you would use it (as a devtools panel).
 
@@ -33,7 +33,7 @@ reflected in the new firefox directory.
 
 ### Running the tests
 
-* `yarn copy-assets-watch` copies new bundles into the firefox directory
+* `yarn watch` copies new bundles into the firefox directory
 * `yarn mochi` runs the tests in a second process
 
 ### Mochi
@@ -60,11 +60,10 @@ The mochitests run in a special environment, which make `console.log` a little d
 If you want a convenience method for logging in the test, `log` is a bit cleaner than `dump`.
 
 ```js
-  console.log(">>> YO")
-  log("FOO", { t: 3 })
-  dump(">> FOOO\n");
+console.log(">>> YO");
+log("FOO", { t: 3 });
+dump(">> FOOO\n");
 ```
-
 
 ### Pausing the test
 
@@ -93,8 +92,8 @@ which use shared selectors. You can also find any element with the
 `findElementWithSelector` function.
 
 ```js
-  findElement(dbg, "sourceNode", 3);
-  findElementWithSelector(dbg, ".sources-list .focused");
+findElement(dbg, "sourceNode", 3);
+findElementWithSelector(dbg, ".sources-list .focused");
 ```
 
 ### Evaluating in the debuggee
@@ -103,11 +102,11 @@ If you want to evaluate a function in the debuggee context you can use
 the `invokeInTab` function. Under the hood it is using `ContentTask.spawn`.
 
 ```js
-invokeInTab(dbg, "doSomething")
+invokeInTab(dbg, "doSomething");
 ```
 
 ```js
-ContentTask.spawn(gBrowser.selectedBrowser, null, function* () {
+ContentTask.spawn(gBrowser.selectedBrowser, null, function*() {
   content.wrappedJSObject.foo();
 });
 ```
@@ -120,9 +119,9 @@ The first step for debugging an integration test is establishing a clear sequenc
 
 The mochitest logs provide some context:
 
-1. The actions that fired
-2. Assertion Passes/Failures
-3. Events that the test waited for: dispatches, state changes
+1.  The actions that fired
+2.  Assertion Passes/Failures
+3.  Events that the test waited for: dispatches, state changes
 
 > NOTE: it might be nice to run the tests in headless mode: `yarn mochih browser_dbg-editor-highlight`
 
@@ -139,12 +138,11 @@ We recommend prefixing your logs and formatting them so they are easy to scan e.
 * `info(">> Current breakpoints ${breakpoints.map(bp => bp.location.line).join(", ")}\n")`
 * `info(">> Symbols for source ${source.url} ${JSON.stringify(symbols)}\n")`
 
-At some point, it can be nice to pause the test and debug it.  Mochitest makes it easy to pause the test at `debugger` statements  with the `--jsdebugger` flag.
+At some point, it can be nice to pause the test and debug it. Mochitest makes it easy to pause the test at `debugger` statements with the `--jsdebugger` flag.
 You can run the test with `yarn mochid {test_name}` (ex: `browser_dbg-editor-highlight`).
 
 ![](https://shipusercontent.com/e8441c77ab9ff6e84e5561b05bc25da2/Screen%20Shot%202017-10-26%20at%205.45.05%20PM.png)
 ![](https://shipusercontent.com/57e41ae7227a46b2b6ae8b66956729ea/Screen%20Shot%202017-10-26%20at%205.44.54%20PM.png)
-
 
 #### Debugging Intermittents
 
@@ -170,7 +168,6 @@ cd firefox
 ```
 
 Visit the [mochitest](https://developer.mozilla.org/en-US/docs/Mozilla/Projects/Mochitest) MDN page to learn more about mochitests and more advanced arguments. A few tips:
-
 
 #### For Windows Developers
 
@@ -209,7 +206,7 @@ If you add new tests, make sure to list them in the `browser.ini` file. You will
 In addition to the standard Mochitest API, we provide the following functions to help write tests. All of these expect a `dbg` context which is returned from `initDebugger` which should be called at the beginning of the test. An example skeleton test looks like this:
 
 ```js
-add_task(function* () {
+add_task(function*() {
   const dbg = yield initDebugger("doc_simple.html", "code_simple.js");
   // do some stuff
   ok(state.foo, "Foo is OK");
@@ -220,7 +217,6 @@ The Debugger Mochitest API Documentation can be found [here](https://devtools-ht
 
 [head]: https://github.com/devtools-html/debugger.html/blob/master/src/test/mochitest/head.js
 [mochitests]: https://developer.mozilla.org/en-US/docs/Mozilla/Projects/Mochitest
-
 [waiting]: https://github.com/devtools-html/debugger.html/commit/7b4762d9333108b15d81bc41e12182370c81e81c
 [server-oops]: https://github.com/devtools-html/debugger.html/commit/7e54e6b46181b747a828ab2dc1db96c88313db95#diff-4fb7729ef51f162ae50b7c3bc020a1e3
 [pretty-printing]: https://github.com/devtools-html/debugger.html/commit/6a66ce54faf8239fb358462c53c022a75615aae6#diff-a81153d2e92178917a135261f4245c39R12

--- a/docs/running-as-firefox-panel.md
+++ b/docs/running-as-firefox-panel.md
@@ -61,11 +61,13 @@ Now we can put these pieces together. After you copy over the assets, you can ru
 debugger inside the panel!
 
 in debugger project (`projects/debugger.html` or wherever you have it!):
+
 ```
 yarn copy-assets
 ```
 
 in firefox project (`projects/firefox` or wherever you have it!):
+
 ```
 ./mach build faster && ./mach run
 ```
@@ -76,6 +78,7 @@ On to the fun stuff. Each time you change something you will need to copy over y
 do this like so!
 
 in yarn:
+
 ```
 yarn copy-assets
 ```
@@ -85,15 +88,14 @@ That will build the debugger and copy over all the relevant files into `firefox`
 It's annoying to have to manually update the bundle every single time though. If you want to automatically update the bundle in Firefox whenever you make a change, run this:
 
 ```
-yarn copy-assets-watch
+yarn watch
 ```
 
 Now you can make code changes the bundle will be automatically built for you inside `firefox`.
-
 
 ### Getting Help
 
 There are lots of helpful folks who'd be happy to answer
 your questions on [slack][slack].
 
-[slack]:https://devtools-html-slack.herokuapp.com/
+[slack]: https://devtools-html-slack.herokuapp.com/

--- a/package.json
+++ b/package.json
@@ -44,8 +44,9 @@
       "start-firefox --start --location https://devtools-html.github.io/debugger-examples/",
     "chrome":
       "start-chrome --location https://devtools-html.github.io/debugger-examples/",
-    "copy-assets": "node bin/copy-assets --symlink",
     "copy-assets-watch": "node bin/copy-assets --watch --symlink",
+    "copy-modules-watch": "node bin/copy-modules --watch",
+    "watch": "run-p copy-assets-watch copy-modules-watch",
     "build-docs":
       "documentation build --format html --sort-order alpha --shallow  --document-exported --output docs/reference/ src/types.js src/utils/ src/reducers/ src/actions/ src/test/mochitest/head.js",
     "flow-coverage":


### PR DESCRIPTION
### Summary of Changes

- adds the ability to watch files so that we can incrementally transpile changed files while testing...
- adds a new `yarn watch` command that replaces `copy-assets-watch`
