### PR TITLE
Improve 'find in files' layout

### DIFF
--- a/src/components/shared/SearchInput.css
+++ b/src/components/shared/SearchInput.css
@@ -21,10 +21,6 @@
   flex-shrink: 0;
 }
 
-.search-field.big {
-  height: 40px;
-}
-
 .search-field i {
   display: block;
   padding: 0;
@@ -33,10 +29,6 @@
 
 .search-field i svg {
   width: 22px;
-}
-
-.search-field.big input {
-  line-height: 40px;
 }
 
 .search-field input {
@@ -72,13 +64,6 @@
   padding-top: 1px;
 }
 
-.search-field.big i.magnifying-glass,
-.search-field.big i.sad-face {
-  padding: 14px;
-  width: 40px;
-  margin-top: -20px;
-}
-
 .search-field .magnifying-glass path,
 .search-field .magnifying-glass ellipse {
   stroke: var(--theme-comment);
@@ -90,10 +75,6 @@
 
 .search-field input.empty {
   color: var(--theme-highlight-orange);
-}
-
-.search-field.big .summary {
-  line-height: 40px;
 }
 
 .search-field .summary {


### PR DESCRIPTION
The 'Find in Files'  magnifying glass | input spacing is a bit tight, so this fixes the issue:

<img width="827" alt="betteralignment" src="https://user-images.githubusercontent.com/46655/39718787-ef376a5e-51fc-11e8-84dd-0392d810a07b.png">
