### PR TITLE
Add title for each expression

### DIFF
--- a/src/components/SecondaryPanes/Expressions.js
+++ b/src/components/SecondaryPanes/Expressions.js
@@ -202,6 +202,7 @@ class Expressions extends Component<Props, State> {
       <li
         className="expression-container"
         key={input}
+        title={expression.input}
         onDoubleClick={(items, options) =>
           this.editExpression(expression, index)
         }

--- a/src/components/SecondaryPanes/tests/__snapshots__/Expressions.spec.js.snap
+++ b/src/components/SecondaryPanes/tests/__snapshots__/Expressions.spec.js.snap
@@ -8,6 +8,7 @@ exports[`Expressions should always have unique keys 1`] = `
     className="expression-container"
     key="expression1"
     onDoubleClick={[Function]}
+    title="expression1"
   >
     <div
       className="expression-content"
@@ -45,6 +46,7 @@ exports[`Expressions should always have unique keys 1`] = `
     className="expression-container"
     key="expression2"
     onDoubleClick={[Function]}
+    title="expression2"
   >
     <div
       className="expression-content"
@@ -116,6 +118,7 @@ exports[`Expressions should render 1`] = `
     className="expression-container"
     key="expression1"
     onDoubleClick={[Function]}
+    title="expression1"
   >
     <div
       className="expression-content"
@@ -153,6 +156,7 @@ exports[`Expressions should render 1`] = `
     className="expression-container"
     key="expression2"
     onDoubleClick={[Function]}
+    title="expression2"
   >
     <div
       className="expression-content"


### PR DESCRIPTION
Provides a nice hover title for longer expressions; this is consistent with breakpoint items.