### PR TITLE
Stop using Services.telemetry directly. Fixes #6258

### DIFF
--- a/configs/mozilla-central-mappings.js
+++ b/configs/mozilla-central-mappings.js
@@ -24,6 +24,7 @@ module.exports = Object.assign({
   "react-redux": "devtools/client/shared/vendor/react-redux",
   redux: "devtools/client/shared/vendor/redux",
   "prop-types": "devtools/client/shared/vendor/react-prop-types",
+  "devtools-modules/src/utils/telemetry": "devtools/client/shared/telemetry",
 
   "wasmparser/dist/WasmParser": "devtools/client/shared/vendor/WasmParser",
   "wasmparser/dist/WasmDis": "devtools/client/shared/vendor/WasmDis",

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -703,14 +703,16 @@ new preferred method. However Scalars cannot do everything, so both are used.
 * **Histograms**: Distribution of an event
 
 ```js
-const loadSourceHistogram = Services.telemetry.getHistogramById(
-  "DEVTOOLS_DEBUGGER_LOAD_SOURCE_MS"
-);
-loadSourceHistogram.add(delay); // time it took to load the source
+const Telemetry = require("devtools-modules/src/utils/telemetry");
+const telemetry = new Telemetry();
+const loadSourceHistogram = "DEVTOOLS_DEBUGGER_LOAD_SOURCE_MS";
+telemetry.start(loadSourceHistogram, this);
 ```
 
 ```js
-Services.telemetry.scalarAdd("devtools.debugger.source_selected", 1);
+const Telemetry = require("devtools-modules/src/utils/telemetry");
+const telemetry = new Telemetry();
+telemetry.scalarAdd("devtools.debugger.source_selected", 1);
 ```
 
 We also need to add probe definitions, to the [histograms.json] and [scalars.yaml],

--- a/packages/devtools-reps/package.json
+++ b/packages/devtools-reps/package.json
@@ -41,7 +41,7 @@
     "devtools-config": "^0.0.15",
     "devtools-launchpad": "^0.0.125",
     "devtools-license-check": "^0.5.1",
-    "devtools-modules": "^0.0.36",
+    "devtools-modules": "^0.0.37",
     "devtools-services": "^0.0.1",
     "enzyme": "^3.3.0",
     "enzyme-adapter-react-16": "^1.1.1",


### PR DESCRIPTION
This patch adds a telemetry stub and points it at the real `telemetry.js` for code that lives on Mozilla Central.

We also now use `telemetry.start()` and `telemetry.finish()` for the timing inside `src/actions/sources/loadSourceText.js` instead of calculating the duration ourselves.