### PR TITLE
[pause] Additional pause point guards

### DIFF
--- a/src/actions/pause/paused.js
+++ b/src/actions/pause/paused.js
@@ -43,10 +43,10 @@ async function getOriginalSourceForFrame(state, frame: Frame) {
 export function paused(pauseInfo: Pause) {
   return async function({ dispatch, getState, client, sourceMaps }: ThunkArgs) {
     const { frames, why, loadedObjects } = pauseInfo;
-    const rootFrame = frames.length > 0 ? frames[0] : null;
+    const topFrame = frames.length > 0 ? frames[0] : null;
 
-    if (rootFrame) {
-      const mappedFrame = await updateFrameLocation(rootFrame, sourceMaps);
+    if (topFrame && why.type == "resumeLimit") {
+      const mappedFrame = await updateFrameLocation(topFrame, sourceMaps);
       const source = await getOriginalSourceForFrame(getState(), mappedFrame);
 
       // Ensure that the original file has loaded if there is one.
@@ -62,7 +62,7 @@ export function paused(pauseInfo: Pause) {
       type: "PAUSED",
       why,
       frames,
-      selectedFrameId: rootFrame ? rootFrame.id : undefined,
+      selectedFrameId: topFrame ? topFrame.id : undefined,
       loadedObjects: loadedObjects || []
     });
 

--- a/src/reducers/pause.js
+++ b/src/reducers/pause.js
@@ -242,7 +242,7 @@ function update(
             ...state,
             ...emptyPauseState,
             command: action.command,
-            previousLocation: buildPreviousLocation(state, action)
+            previousLocation: getPauseLocation(state, action)
           }
         : { ...state, command: null };
     }
@@ -270,14 +270,16 @@ function update(
   return state;
 }
 
-function buildPreviousLocation(state, action) {
+function getPauseLocation(state, action) {
   const { frames, previousLocation } = state;
 
+  // NOTE: We store the previous location so that we ensure that we
+  // do not stop at the same location twice when we step over.
   if (action.command !== "stepOver") {
     return null;
   }
 
-  const frame = frames && frames.length > 0 ? frames[0] : null;
+  const frame = frames && frames[0];
   if (!frame) {
     return previousLocation;
   }

--- a/src/utils/pause/stepping.js
+++ b/src/utils/pause/stepping.js
@@ -36,12 +36,13 @@ export function shouldStep(rootFrame: ?Frame, state: State, sourceMaps: any) {
 
   const sameLocation = previousFrameLoc && isEqual(previousFrameLoc, frameLoc);
   const pausePoint = getPausePoint(state, frameLoc);
-  const invalidPauseLocation = pausePoint && !pausePoint.step;
+  const validPauseLocation =
+    pausePoint && (pausePoint.step || pausePoint.break);
 
   // We always want to pause in generated locations
   if (!frameLoc || isGeneratedId(frameLoc.sourceId)) {
     return false;
   }
 
-  return sameLocation || invalidPauseLocation;
+  return sameLocation || !validPauseLocation;
 }


### PR DESCRIPTION
Fixes #5941

### Summary of Changes

Fixes two issues I was seeing

1. pausing at an IF condition w/ a breakpoint would not work 
  - IF was an empty breakpoint
  - should step was not checking if it was a "break" point

2. the debugger was pausing at the same position several time because should step was not taking into account previous locations from resumes or step in
  - this was fixed by updating getPauseLocation


![screen shot 2018-05-10 at 5 22 39 pm](https://user-images.githubusercontent.com/254562/39895025-c394df4a-5476-11e8-8947-adc48e757e56.png)
