### PR TITLE
[Search] Makes SearchBar update results on enter press

### DIFF
--- a/src/components/Editor/SearchBar.js
+++ b/src/components/Editor/SearchBar.js
@@ -211,13 +211,14 @@ class SearchBar extends Component<Props, State> {
     this.setState({ inputFocused: false });
   };
 
-  onKeyDown = (e: SyntheticKeyboardEvent<HTMLElement>) => {
+  onKeyDown = (e: any) => {
     if (e.key !== "Enter" && e.key !== "F3") {
       return;
     }
 
     this.traverseResults(e, e.shiftKey);
     e.preventDefault();
+    return this.doSearch(e.target.value);
   };
 
   // Renderers


### PR DESCRIPTION
Fixes Issue: #6255

Changes:
makes SearchBar recalculate results

Cause:
Pressing enter after a tab switch relied on the old state and did not update the result count. This lead to a series of undesired outcomes including bad error emoji state and stale count of found items.

Vid after change:
![update_search](https://user-images.githubusercontent.com/23530054/39907411-e78e3b36-54e8-11e8-8b62-a0465b1f31b5.gif)



