### PR TITLE
Fix alignment of next and previous buttons in find-in-file

### DIFF
--- a/src/components/shared/SearchInput.css
+++ b/src/components/shared/SearchInput.css
@@ -78,7 +78,7 @@
 }
 
 .search-field .summary {
-  line-height: 27px;
+  padding-top: 1px;
   padding-right: 10px;
   color: var(--theme-body-color-inactive);
 }
@@ -104,6 +104,11 @@
 
 .search-field .search-nav-buttons .nav-btn:active path {
   fill: var(--theme-comment-alt);
+}
+
+.search-field .search-nav-buttons .nav-btn svg {
+  margin-top: -9px;
+  margin-inline-start: -3px;
 }
 
 .search-field .search-nav-buttons .nav-btn path {


### PR DESCRIPTION
The summary line ("1 of 12") and prev/next buttons are centered.

<img width="753" alt="lineup" src="https://user-images.githubusercontent.com/46655/39933994-15e5c8ca-550a-11e8-8746-2e141681df16.png">