### PR TITLE
Fix Photon styling for search inputs

### DIFF
--- a/src/components/QuickOpenModal.js
+++ b/src/components/QuickOpenModal.js
@@ -398,6 +398,7 @@ export class QuickOpenModal extends Component<Props, State> {
           selectedItemId={
             expanded && items[selectedIndex] ? items[selectedIndex].id : ""
           }
+          {...(this.isSourceSearch() ? { size: "big" } : {})}
         />
         {this.renderLoading()}
         {newResults && (

--- a/src/components/shared/SearchInput.css
+++ b/src/components/shared/SearchInput.css
@@ -70,10 +70,6 @@
   width: 24px;
 }
 
-.search-field i.sad-face {
-  padding-top: 1px;
-}
-
 .search-field.big i.magnifying-glass,
 .search-field.big i.sad-face {
   position: absolute;

--- a/src/components/shared/SearchInput.css
+++ b/src/components/shared/SearchInput.css
@@ -12,13 +12,18 @@
 
 .search-field {
   position: relative;
-
+  height: 27px;
   width: calc(100% - 1px);
   background-color: var(--theme-toolbar-background);
   border-bottom: 1px solid var(--theme-splitter-color);
-  padding: 5px 10px;
+  padding-right: 10px;
   display: flex;
   flex-shrink: 0;
+}
+
+.search-field.big {
+  padding: 5px 10px;
+  height: 40px;
 }
 
 .search-field i {
@@ -28,19 +33,27 @@
 }
 
 .search-field i svg {
+  width: 16px;
+}
+
+.search-field.big i svg {
   width: 22px;
 }
 
 .search-field input {
-  position: relative;
-  margin-left: 30px;
   border: none;
   line-height: 30px;
   background-color: var(--theme-toolbar-background);
   color: var(--theme-body-color-active);
   width: calc(100% - 38px);
   flex: 1;
+}
+
+.search-field.big input {
+  position: relative;
+  margin-left: 30px;
   font-size: 14px;
+  line-height: 40px;
 }
 
 .search-field input:focus {
@@ -53,15 +66,18 @@
 
 .search-field i.magnifying-glass,
 .search-field i.sad-face {
-  position: absolute;
-  top: 50%;
-  padding: 2px 0;
+  padding: 6px;
   width: 24px;
-  margin-top: -12px;
 }
 
 .search-field i.sad-face {
   padding-top: 1px;
+}
+
+.search-field.big i.magnifying-glass,
+.search-field.big i.sad-face {
+  position: absolute;
+  width: 40px;
 }
 
 .search-field .magnifying-glass path,
@@ -81,6 +97,10 @@
   line-height: 27px;
   padding-right: 10px;
   color: var(--theme-body-color-inactive);
+}
+
+.search-field.big .summary {
+  line-height: 40px;
 }
 
 .search-field .search-nav-buttons {

--- a/src/components/test/__snapshots__/QuickOpenModal.spec.js.snap
+++ b/src/components/test/__snapshots__/QuickOpenModal.spec.js.snap
@@ -326,7 +326,7 @@ exports[`QuickOpenModal Basic render with mount 1`] = `
               selectedItemId=""
               showClose={false}
               showErrorEmoji={false}
-              size=""
+              size="big"
               summaryMsg=""
             >
               <div
@@ -336,7 +336,7 @@ exports[`QuickOpenModal Basic render with mount 1`] = `
                   aria-expanded={false}
                   aria-haspopup="listbox"
                   aria-owns="result-list"
-                  className="search-field"
+                  className="search-field big"
                   role="combobox"
                 >
                   <Svg
@@ -418,7 +418,7 @@ exports[`QuickOpenModal Renders when enabled 1`] = `
     selectedItemId=""
     showClose={false}
     showErrorEmoji={false}
-    size=""
+    size="big"
     summaryMsg=""
   />
   <ResultList
@@ -608,7 +608,7 @@ exports[`QuickOpenModal showErrorEmoji false when count + query 1`] = `
               selectedItemId=""
               showClose={false}
               showErrorEmoji={false}
-              size=""
+              size="big"
               summaryMsg=""
             >
               <div
@@ -618,7 +618,7 @@ exports[`QuickOpenModal showErrorEmoji false when count + query 1`] = `
                   aria-expanded={true}
                   aria-haspopup="listbox"
                   aria-owns="result-list"
-                  className="search-field"
+                  className="search-field big"
                   role="combobox"
                 >
                   <Svg
@@ -1292,7 +1292,7 @@ exports[`QuickOpenModal updateResults on enable 2`] = `
               selectedItemId=""
               showClose={false}
               showErrorEmoji={false}
-              size=""
+              size="big"
               summaryMsg=""
             >
               <div
@@ -1302,7 +1302,7 @@ exports[`QuickOpenModal updateResults on enable 2`] = `
                   aria-expanded={false}
                   aria-haspopup="listbox"
                   aria-owns="result-list"
-                  className="search-field"
+                  className="search-field big"
                   role="combobox"
                 >
                   <Svg


### PR DESCRIPTION
When we (I) merged the initial QuickOpen style updates for Photon, it became apparent the new CSS was too broad and that elements were enlarged that shouldn't have been -- just QuickOpen should have been increased in size.  This has been bugging me so I've taken the time to fix it.

Command+F (Find in File) and Command+G (Search Again)
<img width="736" alt="1" src="https://user-images.githubusercontent.com/46655/39936774-37313bb4-5513-11e8-8628-74075551e5ac.png">


Command+P (Quick Open)
<img width="660" alt="2" src="https://user-images.githubusercontent.com/46655/39936798-47cf997a-5513-11e8-9c43-8d24a7890d43.png">


Command + Shift + F (Full Project Search)
<img width="740" alt="3" src="https://user-images.githubusercontent.com/46655/39936825-58bf1d46-5513-11e8-95a9-0c50d21503f1.png">


Command + Shift + O (Function Search)
<img width="658" alt="4" src="https://user-images.githubusercontent.com/46655/39936848-67a5852a-5513-11e8-8f7e-3f652c3706fb.png">


Command + ; (Go to line)
<img width="721" alt="5" src="https://user-images.githubusercontent.com/46655/39936866-7451705e-5513-11e8-9d1f-2b3d8704579d.png">
