### PR TITLE
optimistically enable breakpoint in UI

### DIFF
--- a/src/actions/breakpoints.js
+++ b/src/actions/breakpoints.js
@@ -165,10 +165,16 @@ export function enableBreakpoint(location: Location) {
       return;
     }
 
+    // To instantly reflect in the UI, we optimistically enable the breakpoint
+    const enabledBreakpoint = {
+      ...breakpoint,
+      disabled: false
+    };
+
     return dispatch(
       ({
         type: "ENABLE_BREAKPOINT",
-        breakpoint,
+        breakpoint: enabledBreakpoint,
         [PROMISE]: addBreakpointPromise(
           getState,
           client,


### PR DESCRIPTION
Fixes Issue: #6277 

### Summary of Changes

* When enabling a breakpoint, we don't wait for the response from server, but the breakpoint is enabled optimistically

### Test Plan

- [x] Add breakpoints
- [x] Try enable/disable them
