### PR TITLE
Fix onCmdCtrlClick handler.

### DIFF
--- a/packages/devtools-reps/src/object-inspector/component.js
+++ b/packages/devtools-reps/src/object-inspector/component.js
@@ -9,6 +9,10 @@ const dom = require("react-dom-factories");
 const { connect } = require("react-redux");
 const { bindActionCreators } = require("redux");
 
+import { Services } from "devtools-modules";
+const { appinfo } = Services;
+const isMacOS = appinfo.OS === "Darwin";
+
 import Components from "devtools-components";
 const Tree = createFactory(Components.Tree);
 require("./index.css");
@@ -381,7 +385,10 @@ class ObjectInspector extends Component<Props> {
         block: nodeIsBlock(item)
       }),
       onClick: e => {
-        if (e.metaKey && onCmdCtrlClick) {
+        if (
+          onCmdCtrlClick &&
+          ((isMacOS && e.metaKey) || (!isMacOS && e.ctrlKey))
+        ) {
           onCmdCtrlClick(item, {
             depth,
             event: e,

--- a/packages/devtools-reps/src/object-inspector/tests/component/events.js
+++ b/packages/devtools-reps/src/object-inspector/tests/component/events.js
@@ -121,7 +121,7 @@ describe("ObjectInspector - properties", () => {
     );
 
     const node = oi.find(".node").first();
-    node.simulate("click", { metaKey: true });
+    node.simulate("click", { ctrlKey: true });
 
     expect(onCmdCtrlClick.mock.calls).toHaveLength(1);
   });


### PR DESCRIPTION
We weren't checking the appropriate event property on non-mac OSes.

This still need some webpack configuration, because I don't want to get devtools-modules into the reps bundle.
