### PR TITLE
Introduce and Implement a SourceIcon Component

### DIFF
--- a/src/components/Editor/Tab.js
+++ b/src/components/Editor/Tab.js
@@ -14,7 +14,6 @@ import { CloseButton } from "../shared/Button";
 
 import type { List } from "immutable";
 import type { SourceRecord } from "../../types";
-import type { SourceMetaDataType } from "../../reducers/ast";
 
 import actions from "../../actions";
 
@@ -29,7 +28,6 @@ import { getTabMenuItems } from "../../utils/tabs";
 
 import {
   getSelectedSource,
-  getSourceMetaData,
   getActiveSearch,
   getSourcesForTabs
 } from "../../selectors";
@@ -47,8 +45,7 @@ type Props = {
   togglePrettyPrint: string => void,
   showSource: string => void,
   source: SourceRecord,
-  activeSearch: string,
-  sourceMetaData: SourceMetaDataType
+  activeSearch: string
 };
 
 class Tab extends PureComponent<Props> {
@@ -152,8 +149,7 @@ class Tab extends PureComponent<Props> {
       selectedSource,
       selectSpecificSource,
       closeTab,
-      source,
-      sourceMetaData
+      source
     } = this.props;
     const src = source.toJS();
     const filename = getFilename(src);
@@ -196,7 +192,6 @@ class Tab extends PureComponent<Props> {
       >
         <SourceIcon
           source={source}
-          sourceMetaData={sourceMetaData}
           renderNothingIfIncludes={["file", "javascript"]}
         />
         <div className="filename">{filename}</div>
@@ -215,7 +210,6 @@ const mapStateToProps = (state, { source }) => {
   return {
     tabSources: getSourcesForTabs(state),
     selectedSource: selectedSource,
-    sourceMetaData: getSourceMetaData(state, source.id),
     activeSearch: getActiveSearch(state)
   };
 };

--- a/src/components/Editor/Tab.js
+++ b/src/components/Editor/Tab.js
@@ -192,7 +192,7 @@ class Tab extends PureComponent<Props> {
       >
         <SourceIcon
           source={source}
-          renderNothingIfIncludes={["file", "javascript"]}
+          shouldHide={icon => ["file", "javascript"].includes(icon)}
         />
         <div className="filename">{filename}</div>
         <CloseButton

--- a/src/components/Editor/Tab.js
+++ b/src/components/Editor/Tab.js
@@ -9,6 +9,7 @@ import { connect } from "react-redux";
 
 import { showMenu, buildMenu } from "devtools-contextmenu";
 
+import SourceIcon from "../shared/SourceIcon";
 import { CloseButton } from "../shared/Button";
 
 import type { List } from "immutable";
@@ -24,7 +25,7 @@ import {
   isPretty
 } from "../../utils/source";
 import { copyToTheClipboard } from "../../utils/clipboard";
-import { getSourceAnnotation, getTabMenuItems } from "../../utils/tabs";
+import { getTabMenuItems } from "../../utils/tabs";
 
 import {
   getSelectedSource,
@@ -162,7 +163,6 @@ class Tab extends PureComponent<Props> {
       sourceId == selectedSource.get("id") &&
       (!this.isProjectSearchEnabled() && !this.isSourceSearchEnabled());
     const isPrettyCode = isPretty(source);
-    const sourceAnnotation = getSourceAnnotation(source, sourceMetaData);
 
     function onClickClose(e) {
       e.stopPropagation();
@@ -194,7 +194,11 @@ class Tab extends PureComponent<Props> {
         onContextMenu={e => this.onTabContextMenu(e, sourceId)}
         title={getFileURL(src)}
       >
-        {sourceAnnotation}
+        <SourceIcon
+          source={source}
+          sourceMetaData={sourceMetaData}
+          renderNothingIfIncludes={["file", "javascript"]}
+        />
         <div className="filename">{filename}</div>
         <CloseButton
           handleClick={onClickClose}

--- a/src/components/Editor/Tabs.css
+++ b/src/components/Editor/Tabs.css
@@ -98,6 +98,7 @@
   height: 14px;
   width: 14px;
   background: var(--theme-highlight-bluegrey);
+  top: 0;
 }
 
 .source-tab .blackBox path {

--- a/src/components/Editor/Tabs.css
+++ b/src/components/Editor/Tabs.css
@@ -81,7 +81,6 @@
 
 .source-tab img.prettyPrint,
 .source-tab .source-icon.blackBox {
-  padding-top: 12px;
   height: 12px;
   width: 12px;
   align-self: center;
@@ -94,7 +93,6 @@
 .source-tab img.react {
   mask: url(/images/react.svg) no-repeat;
   mask-size: 100%;
-  padding-top: 12px;
   height: 14px;
   width: 14px;
   background: var(--theme-highlight-bluegrey);
@@ -129,7 +127,7 @@ html[dir="rtl"] img.moreTabs {
   text-overflow: ellipsis;
   overflow: hidden;
   padding: 0 4px;
-  align-self: flex-start;
+  align-self: center;
 }
 
 .source-tab .close-btn {

--- a/src/components/Editor/Tabs.css
+++ b/src/components/Editor/Tabs.css
@@ -75,31 +75,20 @@
   fill: var(--theme-body-color);
 }
 
-.source-tab img.prettyPrint {
-  mask: url(/images/prettyPrint.svg) no-repeat;
-  mask-size: 100%;
+.source-tab .source-icon {
+  margin-inline-end: 0;
+}
+
+.source-tab img.prettyPrint,
+.source-tab .source-icon.blackBox {
   padding-top: 12px;
   height: 12px;
   width: 12px;
-  background: var(--theme-highlight-blue);
+  align-self: center;
 }
 
 .source-tab .prettyPrint path {
   fill: var(--theme-textbox-box-shadow);
-}
-
-.source-tab .blackBox,
-.source-tab .prettyPrint {
-  align-self: center;
-}
-
-.source-tab img.blackBox {
-  mask: url(/images/blackBox.svg) no-repeat;
-  mask-size: 100%;
-  padding-top: 12px;
-  height: 12px;
-  width: 12px;
-  background: var(--theme-highlight-blue);
 }
 
 .source-tab img.react {

--- a/src/components/SecondaryPanes/Breakpoints.css
+++ b/src/components/SecondaryPanes/Breakpoints.css
@@ -17,11 +17,14 @@
 .breakpoints-list .breakpoint-heading {
   text-overflow: ellipsis;
   overflow: hidden;
-  padding-top: 0.75em;
+  display: flex;
+  width: 100%;
+  align-items: center;
 }
 
-.breakpoints-list .breakpoint-heading .source-icon.prettyPrint {
-  top: 3px;
+/* temporary until we refactor the sources tree and tab icon styles */
+.breakpoints-list .breakpoint-heading .source-icon.file {
+  top: 0;
 }
 
 .breakpoints-list .breakpoint-heading,

--- a/src/components/SecondaryPanes/Breakpoints.css
+++ b/src/components/SecondaryPanes/Breakpoints.css
@@ -20,6 +20,10 @@
   padding-top: 0.75em;
 }
 
+.breakpoints-list .breakpoint-heading .source-icon.prettyPrint {
+  top: 3px;
+}
+
 .breakpoints-list .breakpoint-heading,
 .breakpoints-list .breakpoint {
   font-size: 12px;

--- a/src/components/SecondaryPanes/Breakpoints.js
+++ b/src/components/SecondaryPanes/Breakpoints.js
@@ -12,6 +12,7 @@ import { createSelector } from "reselect";
 import { groupBy, sortBy } from "lodash";
 
 import Breakpoint from "./Breakpoint";
+import SourceIcon from "../shared/SourceIcon";
 
 import actions from "../../actions";
 import {
@@ -228,6 +229,7 @@ class Breakpoints extends Component<Props> {
               key={url}
               onClick={() => this.props.selectSource(source.id)}
             >
+              <SourceIcon source={source} />
               {getFilename(source)}
             </div>,
             ...groupBreakpoints.map(bp => this.renderBreakpoint(bp))

--- a/src/components/shared/SourceIcon.css
+++ b/src/components/shared/SourceIcon.css
@@ -1,0 +1,22 @@
+.source-icon {
+    position: relative;
+    background-color: var(--theme-comment);
+    width: 15px;
+    height: 15px;
+}
+
+.source-icon.prettyPrint {
+  mask: url(/images/prettyPrint.svg) no-repeat;
+  mask-size: 100%;
+  background: var(--theme-highlight-blue);
+}
+
+.source-tab .prettyPrint {
+  fill: var(--theme-textbox-box-shadow);
+}
+
+.source-icon.blackBox {
+  mask: url(/images/blackBox.svg) no-repeat;
+  mask-size: 100%;
+  background: var(--theme-highlight-blue);
+}

--- a/src/components/shared/SourceIcon.css
+++ b/src/components/shared/SourceIcon.css
@@ -29,8 +29,3 @@
   mask-size: 100%;
   background: var(--theme-highlight-bluegrey);
 }
-
-.source-icon.javascript,
-.source-icon.react {
-  top: 2px;
-}

--- a/src/components/shared/SourceIcon.css
+++ b/src/components/shared/SourceIcon.css
@@ -24,3 +24,7 @@
   mask-size: 100%;
   background: var(--theme-highlight-blue);
 }
+
+.source-icon.javascript {
+  top: 2px;
+}

--- a/src/components/shared/SourceIcon.css
+++ b/src/components/shared/SourceIcon.css
@@ -25,6 +25,12 @@
   background: var(--theme-highlight-blue);
 }
 
-.source-icon.javascript {
+.source-icon.react {
+  mask-size: 100%;
+  background: var(--theme-highlight-bluegrey);
+}
+
+.source-icon.javascript,
+.source-icon.react {
   top: 2px;
 }

--- a/src/components/shared/SourceIcon.css
+++ b/src/components/shared/SourceIcon.css
@@ -1,17 +1,21 @@
 .source-icon {
-    position: relative;
-    background-color: var(--theme-comment);
-    width: 15px;
-    height: 15px;
+  position: relative;
+  background-color: var(--theme-comment);
+  mask-size: 100%;
+  display: inline-block;
+  margin-inline-end: 5px;
+}
+
+.source-icon,
+.source-icon svg {
+  width: 15px;
+  height: 15px;
 }
 
 .source-icon.prettyPrint {
   mask: url(/images/prettyPrint.svg) no-repeat;
   mask-size: 100%;
   background: var(--theme-highlight-blue);
-}
-
-.source-tab .prettyPrint {
   fill: var(--theme-textbox-box-shadow);
 }
 

--- a/src/components/shared/SourceIcon.js
+++ b/src/components/shared/SourceIcon.js
@@ -6,7 +6,10 @@
 
 import React, { PureComponent } from "react";
 
+import { connect } from "react-redux";
+
 import { getSourceClassnames } from "../../utils/source";
+import { getSourceMetaData } from "../../selectors";
 
 import type Source from "../../types";
 import type { SourceMetaDataType } from "../../reducers/ast";
@@ -16,7 +19,7 @@ import "./SourceIcon.css";
 type Props = {
   source: Source,
   // sourceMetaData will provide framework information
-  sourceMetaData?: SourceMetaDataType,
+  sourceMetaData: SourceMetaDataType,
   // Array of strings representing cases where we prefer to get no image
   renderNothingIfIncludes?: Array
 };
@@ -37,4 +40,8 @@ class SourceIcon extends PureComponent<Props> {
   }
 }
 
-export default SourceIcon;
+export default connect((state, props) => {
+  return {
+    sourceMetaData: getSourceMetaData(state, props.source.id)
+  };
+})(SourceIcon);

--- a/src/components/shared/SourceIcon.js
+++ b/src/components/shared/SourceIcon.js
@@ -1,0 +1,38 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
+// @flow
+
+import React, { PureComponent } from "react";
+
+import { getSourceClassnames } from "../../utils/source";
+
+import type Source from "../../types";
+import type { SourceMetaDataType } from "../../reducers/ast";
+
+import "./SourceIcon.css";
+
+type Props = {
+  source: Source,
+  sourceMetaData?: SourceMetaDataType,
+  renderNothingIfIncludes?: Array
+};
+
+class SourceIcon extends PureComponent<Props> {
+  render() {
+    const { renderNothingIfIncludes, source } = this.props;
+    const iconClass = getSourceClassnames(source);
+
+    if (
+      renderNothingIfIncludes &&
+      renderNothingIfIncludes.includes(iconClass)
+    ) {
+      return null;
+    }
+
+    return <img className={`source-icon ${iconClass}`} />;
+  }
+}
+
+export default SourceIcon;

--- a/src/components/shared/SourceIcon.js
+++ b/src/components/shared/SourceIcon.js
@@ -11,7 +11,7 @@ import { connect } from "react-redux";
 import { getSourceClassnames } from "../../utils/source";
 import { getSourceMetaData } from "../../selectors";
 
-import type Source from "../../types";
+import type { Source } from "../../types";
 import type { SourceMetaDataType } from "../../reducers/ast";
 
 import "./SourceIcon.css";
@@ -21,7 +21,7 @@ type Props = {
   // sourceMetaData will provide framework information
   sourceMetaData: SourceMetaDataType,
   // Array of strings representing cases where we prefer to get no image
-  renderNothingIfIncludes?: Array
+  renderNothingIfIncludes?: string[]
 };
 
 class SourceIcon extends PureComponent<Props> {

--- a/src/components/shared/SourceIcon.js
+++ b/src/components/shared/SourceIcon.js
@@ -20,19 +20,16 @@ type Props = {
   source: Source,
   // sourceMetaData will provide framework information
   sourceMetaData: SourceMetaDataType,
-  // Array of strings representing cases where we prefer to get no image
-  renderNothingIfIncludes?: string[]
+  // An additional validator for the icon returned
+  shouldHide?: Function
 };
 
 class SourceIcon extends PureComponent<Props> {
   render() {
-    const { renderNothingIfIncludes, source, sourceMetaData } = this.props;
+    const { shouldHide, source, sourceMetaData } = this.props;
     const iconClass = getSourceClassnames(source, sourceMetaData);
 
-    if (
-      renderNothingIfIncludes &&
-      renderNothingIfIncludes.includes(iconClass)
-    ) {
+    if (shouldHide && shouldHide(iconClass)) {
       return null;
     }
 

--- a/src/components/shared/SourceIcon.js
+++ b/src/components/shared/SourceIcon.js
@@ -15,7 +15,9 @@ import "./SourceIcon.css";
 
 type Props = {
   source: Source,
+  // sourceMetaData will provide framework information
   sourceMetaData?: SourceMetaDataType,
+  // Array of strings representing cases where we prefer to get no image
   renderNothingIfIncludes?: Array
 };
 

--- a/src/components/shared/SourceIcon.js
+++ b/src/components/shared/SourceIcon.js
@@ -21,8 +21,8 @@ type Props = {
 
 class SourceIcon extends PureComponent<Props> {
   render() {
-    const { renderNothingIfIncludes, source } = this.props;
-    const iconClass = getSourceClassnames(source);
+    const { renderNothingIfIncludes, source, sourceMetaData } = this.props;
+    const iconClass = getSourceClassnames(source, sourceMetaData);
 
     if (
       renderNothingIfIncludes &&

--- a/src/components/shared/Svg.css
+++ b/src/components/shared/Svg.css
@@ -12,7 +12,6 @@
 
 .folder,
 .domain,
-.source-icon,
 .file,
 .extension {
   background-color: var(--theme-comment);
@@ -21,7 +20,7 @@
 .worker,
 .file,
 .folder,
-.source-icon,
+.sources-list .source-icon,
 .extension {
   position: relative;
   top: 2px;
@@ -43,8 +42,7 @@
 }
 
 img.domain,
-img.folder,
-img.source-icon {
+img.folder {
   width: 15px;
   height: 15px;
 }
@@ -101,7 +99,7 @@ img.file {
 img.domain,
 img.folder,
 img.file,
-img.source-icon,
+.sources-list img.source-icon,
 img.extension {
   mask-size: 100%;
   margin-inline-end: 5px;

--- a/src/utils/source.js
+++ b/src/utils/source.js
@@ -351,7 +351,7 @@ export function getSourceClassnames(
   }
 
   if (sourceMetaData && sourceMetaData.framework) {
-    return <img className={sourceMetaData.framework.toLowerCase()} />;
+    return sourceMetaData.framework.toLowerCase();
   }
 
   if (isPretty(source)) {

--- a/src/utils/source.js
+++ b/src/utils/source.js
@@ -18,6 +18,7 @@ export { isMinified } from "./isMinified";
 import { getExtension } from "./sources-tree";
 
 import type { Source, SourceRecord, Location } from "../types";
+import type { SourceMetaDataType } from "../reducers/ast";
 import type { SymbolDeclarations } from "../workers/parser";
 
 type transformUrlCallback = string => string;
@@ -338,10 +339,28 @@ export function getTextAtPosition(source: Source, location: Location) {
   return lineText.slice(column, column + 100).trim();
 }
 
-export function getSourceClassnames(source: Object) {
-  if (source && source.isBlackBoxed) {
+export function getSourceClassnames(
+  source: Object,
+  sourceMetaData?: SourceMetaDataType
+) {
+  // Conditionals should be ordered by priority of icon!
+  const defaultClassName = "file";
+
+  if (!source) {
+    return defaultClassName;
+  }
+
+  if (sourceMetaData && sourceMetaData.framework) {
+    return <img className={sourceMetaData.framework.toLowerCase()} />;
+  }
+
+  if (isPretty(source)) {
+    return "prettyPrint";
+  }
+
+  if (source.isBlackBoxed) {
     return "blackBox";
   }
 
-  return sourceTypes[getExtension(source)] || "file";
+  return sourceTypes[getExtension(source)] || defaultClassName;
 }

--- a/src/utils/tabs.js
+++ b/src/utils/tabs.js
@@ -4,12 +4,8 @@
 
 // @flow
 
-import React from "react";
-
 import type { List } from "immutable";
 import type { SourceRecord } from "../types";
-import type { SourceMetaDataType } from "../reducers/ast";
-import { isPretty } from "./source";
 
 type SourcesList = List<SourceRecord>;
 /*
@@ -43,27 +39,6 @@ export function getHiddenTabs(
     const element = sourceTabEls[index];
     return element && hasTopOffset(element);
   });
-}
-
-export function getSourceAnnotation(
-  source: SourceRecord,
-  sourceMetaData: SourceMetaDataType
-) {
-  const framework =
-    sourceMetaData && sourceMetaData.framework
-      ? sourceMetaData.framework
-      : false;
-
-  if (framework) {
-    return <img className={framework.toLowerCase()} />;
-  }
-
-  if (isPretty(source)) {
-    return <img className="prettyPrint" />;
-  }
-  if (source.isBlackBoxed) {
-    return <img className="blackBox" />;
-  }
 }
 
 export function getTabMenuItems() {


### PR DESCRIPTION
Fixes Issue: #5999, #6000, #6001(?)

### Summary of Changes

Debugger uses many icons throughout the App, most of the time based on characteristics of a source, yet we have multiple places where icons are calculated, and thus having one component to do all that repeated work would help with consistency of UI and maintainability of code.

### Test Plan

Since this PR is only meant to cover the breakpoints pane and tabs, open tabs in blackboxed, pretty-print, and react states, and ensure they look good.  Ensure the same in the breakpoints pane.  Check out the tree that icons look good there as well.

### ToDo

I don't want this PR to grow out of control but there are a few things that still need to happen:

#### *Musts* Before Merge

- [x] Fix the vertical alignment of icons in tabs
- [x] For some really weird reason the React icon doesn't show up in a tab until its tab is selected -- really weird.  Maybe we're calculating data in a lazy fashion?

### Total Components that will Require Implementation
- [ ] SourcesTree - this will be difficult because we're creating icons by `item`, not source
- [ ] ResultList - specifically the QuickOpen, where we also need to be tab-aware
- [ ] Workers pane - lowest priority, IMO