### PR TITLE
[WIP][Tree] Virtualize tree

### DIFF
--- a/packages/devtools-components/src/tests/tree.js
+++ b/packages/devtools-components/src/tests/tree.js
@@ -43,7 +43,6 @@ function mountTree(overrides = {}) {
                 },
                 getRoots: () => ["A", "M"],
                 getKey: x => `key-${x}`,
-                itemHeight: 1,
                 onFocus: x => {
                   this.setState(previousState => {
                     return { focused: x };

--- a/packages/devtools-components/src/tree.js
+++ b/packages/devtools-components/src/tree.js
@@ -372,8 +372,8 @@ class Tree extends Component {
       traversal: []
     };
 
-    this._onExpand = oncePerAnimationFrame(this._onExpand).bind(this);
-    this._onCollapse = oncePerAnimationFrame(this._onCollapse).bind(this);
+    this._onExpand = this._onExpand.bind(this);
+    this._onCollapse = this._onCollapse.bind(this);
     this._focusPrevNode = oncePerAnimationFrame(this._focusPrevNode).bind(this);
     this._focusNextNode = oncePerAnimationFrame(this._focusNextNode).bind(this);
     this._focusParentNode = oncePerAnimationFrame(this._focusParentNode).bind(

--- a/packages/devtools-components/src/tree.js
+++ b/packages/devtools-components/src/tree.js
@@ -12,6 +12,7 @@ require("./tree.css");
 
 // depth
 const AUTO_EXPAND_DEPTH = 0;
+const NUMBER_OF_EXTRA_ITEMS = 50;
 
 /**
  * An arrow that displays whether its node is expanded (▼) or collapsed
@@ -650,10 +651,8 @@ class Tree extends Component {
         let end = index + Math.floor(itemsInViewPort / 2);
 
         if (start < 0) {
-          end += start;
           start = 0;
         } else if (end >= traversal.length) {
-          start -= traversal.length - end - 1;
           end = traversal.length - 1;
         }
 
@@ -864,8 +863,15 @@ class Tree extends Component {
     const { clientHeight, scrollTop } = parent;
     const itemsInViewPort = Math.floor(clientHeight / itemHeight);
 
-    const start = Math.floor(scrollTop / itemHeight);
-    const end = start + itemsInViewPort;
+    let start = Math.floor(scrollTop / itemHeight) - NUMBER_OF_EXTRA_ITEMS;
+    let end = start + itemsInViewPort + 2 * NUMBER_OF_EXTRA_ITEMS;
+
+    if (start < 0) {
+      start = 0;
+    }
+    if (end >= traversal.length) {
+      end = traversal.length - 1;
+    }
 
     const { topSpace, bottomSpace } = this.calculateSpaces(start, end);
 

--- a/packages/devtools-components/src/tree.js
+++ b/packages/devtools-components/src/tree.js
@@ -408,6 +408,11 @@ class Tree extends Component {
       // Always keep the focus on the tree itself.
       this.treeRef.focus();
     }
+
+    const traversal = this._dfsFromRoots(this.props);
+
+    this.setState({ traversal });
+    this.updateTraversal(traversal);
   }
 
   _onScroll(e) {

--- a/packages/devtools-reps/src/object-inspector/tests/component/__snapshots__/classnames.js.snap
+++ b/packages/devtools-reps/src/object-inspector/tests/component/__snapshots__/classnames.js.snap
@@ -19,6 +19,14 @@ exports[`ObjectInspector - classnames has the expected class 1`] = `
   tabIndex="0"
 >
   <div
+    key="top-space"
+    style={
+      Object {
+        "height": 0,
+      }
+    }
+  />
+  <div
     aria-level={1}
     className="tree-node"
     data-expandable={false}
@@ -47,6 +55,14 @@ exports[`ObjectInspector - classnames has the expected class 1`] = `
       </span>
     </div>
   </div>
+  <div
+    key="bottom-space"
+    style={
+      Object {
+        "height": 0,
+      }
+    }
+  />
 </div>
 `;
 
@@ -69,55 +85,13 @@ exports[`ObjectInspector - classnames has the inline class when inline prop is t
   tabIndex="0"
 >
   <div
-    aria-level={1}
-    className="tree-node"
-    data-expandable={false}
-    id="root"
-    onClick={[Function]}
-    role="treeitem"
-  >
-    <div
-      className="node object-node"
-      onClick={[Function]}
-    >
-      <span
-        className="object-label"
-      >
-        root
-      </span>
-      <span
-        className="object-delimiter"
-      >
-        : 
-      </span>
-      <span
-        className="objectBox objectBox-number"
-      >
-        42
-      </span>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`ObjectInspector - classnames has the nowrap class when disableWrap prop is true 1`] = `
-<div
-  aria-activedescendant={null}
-  className="tree nowrap object-inspector"
-  onBlur={[Function]}
-  onFocus={[Function]}
-  onKeyDown={[Function]}
-  onKeyPress={[Function]}
-  onKeyUp={[Function]}
-  role="tree"
-  style={
-    Object {
-      "margin": 0,
-      "padding": 0,
+    key="top-space"
+    style={
+      Object {
+        "height": 0,
+      }
     }
-  }
-  tabIndex="0"
->
+  />
   <div
     aria-level={1}
     className="tree-node"
@@ -147,5 +121,79 @@ exports[`ObjectInspector - classnames has the nowrap class when disableWrap prop
       </span>
     </div>
   </div>
+  <div
+    key="bottom-space"
+    style={
+      Object {
+        "height": 0,
+      }
+    }
+  />
+</div>
+`;
+
+exports[`ObjectInspector - classnames has the nowrap class when disableWrap prop is true 1`] = `
+<div
+  aria-activedescendant={null}
+  className="tree nowrap object-inspector"
+  onBlur={[Function]}
+  onFocus={[Function]}
+  onKeyDown={[Function]}
+  onKeyPress={[Function]}
+  onKeyUp={[Function]}
+  role="tree"
+  style={
+    Object {
+      "margin": 0,
+      "padding": 0,
+    }
+  }
+  tabIndex="0"
+>
+  <div
+    key="top-space"
+    style={
+      Object {
+        "height": 0,
+      }
+    }
+  />
+  <div
+    aria-level={1}
+    className="tree-node"
+    data-expandable={false}
+    id="root"
+    onClick={[Function]}
+    role="treeitem"
+  >
+    <div
+      className="node object-node"
+      onClick={[Function]}
+    >
+      <span
+        className="object-label"
+      >
+        root
+      </span>
+      <span
+        className="object-delimiter"
+      >
+        : 
+      </span>
+      <span
+        className="objectBox objectBox-number"
+      >
+        42
+      </span>
+    </div>
+  </div>
+  <div
+    key="bottom-space"
+    style={
+      Object {
+        "height": 0,
+      }
+    }
+  />
 </div>
 `;

--- a/packages/devtools-reps/src/object-inspector/tests/component/__snapshots__/window.js.snap
+++ b/packages/devtools-reps/src/object-inspector/tests/component/__snapshots__/window.js.snap
@@ -19,6 +19,14 @@ exports[`ObjectInspector - dimTopLevelWindow renders collapsed top-level window 
   tabIndex="0"
 >
   <div
+    key="top-space"
+    style={
+      Object {
+        "height": 0,
+      }
+    }
+  />
+  <div
     aria-expanded={false}
     aria-level={1}
     className="tree-node"
@@ -56,6 +64,14 @@ exports[`ObjectInspector - dimTopLevelWindow renders collapsed top-level window 
       </span>
     </div>
   </div>
+  <div
+    key="bottom-space"
+    style={
+      Object {
+        "height": 0,
+      }
+    }
+  />
 </div>
 `;
 
@@ -77,6 +93,14 @@ exports[`ObjectInspector - dimTopLevelWindow renders sub-level window 1`] = `
   }
   tabIndex="0"
 >
+  <div
+    key="top-space"
+    style={
+      Object {
+        "height": 0,
+      }
+    }
+  />
   <div
     aria-expanded={true}
     aria-level={1}
@@ -143,6 +167,14 @@ exports[`ObjectInspector - dimTopLevelWindow renders sub-level window 1`] = `
       </span>
     </div>
   </div>
+  <div
+    key="bottom-space"
+    style={
+      Object {
+        "height": 0,
+      }
+    }
+  />
 </div>
 `;
 
@@ -164,6 +196,14 @@ exports[`ObjectInspector - dimTopLevelWindow renders window as expected when dim
   }
   tabIndex="0"
 >
+  <div
+    key="top-space"
+    style={
+      Object {
+        "height": 0,
+      }
+    }
+  />
   <div
     aria-expanded={false}
     aria-level={1}
@@ -202,6 +242,14 @@ exports[`ObjectInspector - dimTopLevelWindow renders window as expected when dim
       </span>
     </div>
   </div>
+  <div
+    key="bottom-space"
+    style={
+      Object {
+        "height": 0,
+      }
+    }
+  />
 </div>
 `;
 
@@ -223,6 +271,14 @@ exports[`ObjectInspector - dimTopLevelWindow renders window as expected when dim
   }
   tabIndex="0"
 >
+  <div
+    key="top-space"
+    style={
+      Object {
+        "height": 0,
+      }
+    }
+  />
   <div
     aria-expanded={true}
     aria-level={1}
@@ -304,5 +360,13 @@ exports[`ObjectInspector - dimTopLevelWindow renders window as expected when dim
       </span>
     </div>
   </div>
+  <div
+    key="bottom-space"
+    style={
+      Object {
+        "height": 0,
+      }
+    }
+  />
 </div>
 `;

--- a/src/components/PrimaryPanes/SourcesTree.js
+++ b/src/components/PrimaryPanes/SourcesTree.js
@@ -375,7 +375,7 @@ class SourcesTree extends Component<Props, State> {
       getPath: this.getPath,
       getRoots: roots,
       highlightItems,
-      itemHeight: 21,
+      itemHeight: 21.45,
       key: isEmpty ? "empty" : "full",
       listItems,
       onCollapse,

--- a/src/components/ProjectSearch.js
+++ b/src/components/ProjectSearch.js
@@ -217,7 +217,7 @@ export class ProjectSearch extends Component<Props, State> {
       <div
         className={classnames("file-result", { focused })}
         key={file.sourceId}
-        onClick={e => setExpanded(file, !expanded)}
+        onClick={e => setExpanded(file, !!expanded)}
       >
         <Svg name="arrow" className={classnames({ expanded })} />
         <img className="file" />

--- a/src/components/shared/tests/__snapshots__/ManagedTree.spec.js.snap
+++ b/src/components/shared/tests/__snapshots__/ManagedTree.spec.js.snap
@@ -238,6 +238,14 @@ exports[`ManagedTree sets expanded items 1`] = `
         }
         tabIndex="0"
       >
+        <div
+          key="top-space"
+          style={
+            Object {
+              "height": 0,
+            }
+          }
+        />
         <TreeNode
           depth={0}
           expanded={true}
@@ -322,6 +330,14 @@ exports[`ManagedTree sets expanded items 1`] = `
             </div>
           </div>
         </TreeNode>
+        <div
+          key="bottom-space"
+          style={
+            Object {
+              "height": 0,
+            }
+          }
+        />
       </div>
     </Tree>
   </div>
@@ -424,6 +440,14 @@ exports[`ManagedTree sets expanded items 2`] = `
         }
         tabIndex="0"
       >
+        <div
+          key="top-space"
+          style={
+            Object {
+              "height": 0,
+            }
+          }
+        />
         <TreeNode
           depth={0}
           expanded={false}
@@ -507,6 +531,14 @@ exports[`ManagedTree sets expanded items 2`] = `
             </div>
           </div>
         </TreeNode>
+        <div
+          key="bottom-space"
+          style={
+            Object {
+              "height": 0,
+            }
+          }
+        />
       </div>
     </Tree>
   </div>

--- a/src/components/test/__snapshots__/ProjectSearch.spec.js.snap
+++ b/src/components/test/__snapshots__/ProjectSearch.spec.js.snap
@@ -226,6 +226,14 @@ exports[`ProjectSearch found search results 1`] = `
               }
               tabIndex="0"
             >
+              <div
+                key="top-space"
+                style={
+                  Object {
+                    "height": 0,
+                  }
+                }
+              />
               <TreeNode
                 depth={0}
                 expanded={true}
@@ -704,6 +712,14 @@ exports[`ProjectSearch found search results 1`] = `
                   </div>
                 </div>
               </TreeNode>
+              <div
+                key="bottom-space"
+                style={
+                  Object {
+                    "height": 0,
+                  }
+                }
+              />
             </div>
           </Tree>
         </div>

--- a/src/components/test/__snapshots__/SourcesTree.spec.js.snap
+++ b/src/components/test/__snapshots__/SourcesTree.spec.js.snap
@@ -22,7 +22,7 @@ exports[`SourcesTree After changing expanded nodes Shows the tree with four.js, 
       getParent={[Function]}
       getPath={[Function]}
       getRoots={[Function]}
-      itemHeight={21}
+      itemHeight={21.45}
       key="full"
       onCollapse={[Function]}
       onExpand={[Function]}
@@ -48,7 +48,7 @@ exports[`SourcesTree Should show the tree with nothing expanded 1`] = `
       getParent={[Function]}
       getPath={[Function]}
       getRoots={[Function]}
-      itemHeight={21}
+      itemHeight={21.45}
       key="full"
       onCollapse={[Function]}
       onExpand={[Function]}
@@ -81,7 +81,7 @@ exports[`SourcesTree When loading initial source Shows the tree with one.js, two
       getParent={[Function]}
       getPath={[Function]}
       getRoots={[Function]}
-      itemHeight={21}
+      itemHeight={21.45}
       key="full"
       onCollapse={[Function]}
       onExpand={[Function]}
@@ -162,7 +162,7 @@ exports[`SourcesTree on receiving new props updates highlighted items updates hi
           },
         ]
       }
-      itemHeight={21}
+      itemHeight={21.45}
       key="full"
       onCollapse={[Function]}
       onExpand={[Function]}
@@ -188,7 +188,7 @@ exports[`SourcesTree on receiving new props updates list items updates list item
       getParent={[Function]}
       getPath={[Function]}
       getRoots={[Function]}
-      itemHeight={21}
+      itemHeight={21.45}
       key="full"
       listItems={
         Array [
@@ -562,7 +562,7 @@ exports[`SourcesTree with custom root renders custom root source list 1`] = `
       getParent={[Function]}
       getPath={[Function]}
       getRoots={[Function]}
-      itemHeight={21}
+      itemHeight={21.45}
       key="full"
       onCollapse={[Function]}
       onExpand={[Function]}

--- a/src/test/mochitest/helpers.js
+++ b/src/test/mochitest/helpers.js
@@ -807,7 +807,7 @@ async function expandAllScopes(dbg) {
   }).reverse();
 
   for (const index of indices) {
-    await toggleScopeNode(dbg, index + 1);
+    await toggleScopeNode(dbg, index);
   }
 }
 
@@ -1035,9 +1035,9 @@ const selectors = {
   breakpointItem: i => `.breakpoints-list .breakpoint:nth-of-type(${i})`,
   breakpointItems: `.breakpoints-list .breakpoint`,
   scopes: ".scopes-list",
-  scopeNode: i => `.scopes-list .tree-node:nth-child(${i}) .object-label`,
+  scopeNode: i => `.scopes-list .tree-node:nth-child(${i + 1}) .object-label`,
   scopeValue: i =>
-    `.scopes-list .tree-node:nth-child(${i}) .object-delimiter + *`,
+    `.scopes-list .tree-node:nth-child(${i + 1}) .object-delimiter + *`,
   frame: i => `.frames ul li:nth-child(${i})`,
   frames: ".frames ul li",
   gutter: i => `.CodeMirror-code *:nth-child(${i}) .CodeMirror-linenumber`,
@@ -1061,9 +1061,9 @@ const selectors = {
   sourceMapLink: ".source-footer .mapped-source",
   sourcesFooter: ".sources-panel .source-footer",
   editorFooter: ".editor-pane .source-footer",
-  sourceNode: i => `.sources-list .tree-node:nth-child(${i}) .node`,
+  sourceNode: i => `.sources-list .tree-node:nth-child(${i + 1}) .node`,
   sourceNodes: ".sources-list .tree-node",
-  sourceDirectoryLabel: i => `.sources-list .tree-node:nth-child(${i}) .label`,
+  sourceDirectoryLabel: i => `.sources-list .tree-node:nth-child(${i + 1}) .label`,
   resultItems: ".result-list .result-item",
   fileMatch: ".managed-tree .result",
   popup: ".popover",


### PR DESCRIPTION
Fixes Issue: #4168

### Summary of Changes

* Virtualize the 🌲 component so that we can handle huge trees

Currently, the source tree works really nice and fast. But there are some side effects, the scopes panel has some issues, when we expand, it doesn't expand the first time, but expands second time. I think that's because the properties are fetched asynchronously and the re-render doesn't take place when the results arrive.