### PR TITLE
Removes toJS from getGeneratedSource

### DIFF
--- a/src/actions/sources/loadSourceText.js
+++ b/src/actions/sources/loadSourceText.js
@@ -72,7 +72,7 @@ export function loadSourceText(source: SourceRecord) {
     const newSource = getSource(getState(), source.get("id")).toJS();
 
     if (isOriginalId(newSource.id) && !newSource.isWasm) {
-      const generatedSource = getGeneratedSource(getState(), source.toJS());
+      const generatedSource = getGeneratedSource(getState(), source);
       await dispatch(loadSourceText(generatedSource));
     }
 

--- a/src/components/Editor/Footer.js
+++ b/src/components/Editor/Footer.js
@@ -200,12 +200,11 @@ class SourceFooter extends PureComponent<Props> {
 
 const mapStateToProps = state => {
   const selectedSource = getSelectedSource(state);
-  const selectedId = selectedSource.get("id");
-  const source = selectedSource.toJS();
+  const selectedId = selectedSource.id;
 
   return {
     selectedSource,
-    mappedSource: getGeneratedSource(state, source),
+    mappedSource: getGeneratedSource(state, selectedSource),
     prettySource: getPrettySource(state, selectedId),
     endPanelCollapsed: getPaneCollapse(state, "end")
   };

--- a/src/reducers/sources.js
+++ b/src/reducers/sources.js
@@ -340,11 +340,14 @@ export function getSourceByURL(state: OuterState, url: string): ?SourceRecord {
   return getSourceByUrlInSources(state.sources.sources, url);
 }
 
-export function getGeneratedSource(state: OuterState, source: ?Source) {
-  if (!source || !isOriginalId(source.id)) {
+export function getGeneratedSource(
+  state: OuterState,
+  sourceRecord: ?SourceRecord
+) {
+  if (!sourceRecord || !isOriginalId(sourceRecord.id)) {
     return null;
   }
-  return getSource(state, originalToGeneratedId(source.id));
+  return getSource(state, originalToGeneratedId(sourceRecord.id));
 }
 
 export function getPendingSelectedLocation(state: OuterState) {


### PR DESCRIPTION
`getGeneratedSource` only checks if source exists exists and grabs the `id` off of it. The same can be done with a `Record`, so there should be no need for a `toJS()` here.