### PR TITLE
[QuickOpen] Loading prompt

### DIFF
--- a/src/components/QuickOpenModal.js
+++ b/src/components/QuickOpenModal.js
@@ -361,15 +361,18 @@ export class QuickOpenModal extends Component<Props, State> {
     return !this.getResultCount() && !!query;
   }
 
-  renderLoading = () => {
-    const { symbolsLoading } = this.props;
-
-    if ((this.isFunctionQuery() || this.isVariableQuery()) && symbolsLoading) {
-      return (
-        <div className="loading-indicator">{L10N.getStr("loadingText")}</div>
-      );
+  getSummaryMessage() {
+    let summaryMsg = "";
+    if (this.isGotoQuery()) {
+      summaryMsg = L10N.getStr("shortcuts.gotoLine");
+    } else if (
+      (this.isFunctionQuery() || this.isVariableQuery()) &&
+      this.props.symbolsLoading
+    ) {
+      summaryMsg = L10N.getStr("loadingText");
     }
-  };
+    return summaryMsg;
+  }
 
   render() {
     const { enabled, query } = this.props;
@@ -381,9 +384,6 @@ export class QuickOpenModal extends Component<Props, State> {
     const newResults = results && results.slice(0, 100);
     const items = this.highlightMatching(query, newResults || []);
     const expanded = !!items && items.length > 0;
-    const summaryMsg = this.isGotoQuery()
-      ? L10N.getStr("shortcuts.gotoLine")
-      : "";
 
     return (
       <Modal in={enabled} handleClose={this.closeModal}>
@@ -392,7 +392,7 @@ export class QuickOpenModal extends Component<Props, State> {
           hasPrefix={true}
           count={this.getResultCount()}
           placeholder={L10N.getStr("sourceSearch.search")}
-          summaryMsg={summaryMsg}
+          summaryMsg={this.getSummaryMessage()}
           showErrorEmoji={this.shouldShowErrorEmoji()}
           onChange={this.onChange}
           onKeyDown={this.onKeyDown}
@@ -404,7 +404,6 @@ export class QuickOpenModal extends Component<Props, State> {
           }
           {...(this.isSourceSearch() ? { size: "big" } : {})}
         />
-        {this.renderLoading()}
         {newResults && (
           <ResultList
             key="results"

--- a/src/components/shared/SearchInput.css
+++ b/src/components/shared/SearchInput.css
@@ -90,6 +90,8 @@
 }
 
 .search-field .summary {
+  line-height: 27px;
+  text-align: center;
   padding-right: 10px;
   color: var(--theme-body-color-inactive);
   align-self: center;
@@ -97,7 +99,8 @@
 }
 
 .search-field.big .summary {
-  padding-top: 5px;
+  padding: 5px 0 5px 0;
+  line-height: 2rem;
 }
 
 .search-field .search-nav-buttons {

--- a/src/components/shared/SearchInput.js
+++ b/src/components/shared/SearchInput.js
@@ -141,6 +141,16 @@ class SearchInput extends Component<Props, State> {
     }
   };
 
+  renderSummaryMsg() {
+    const { summaryMsg } = this.props;
+
+    if (!summaryMsg) {
+      return null;
+    }
+
+    return <div className="summary">{summaryMsg}</div>;
+  }
+
   renderNav() {
     const { count, handleNext, handlePrev } = this.props;
     if ((!handleNext && !handlePrev) || (!count || count == 1)) {
@@ -164,7 +174,6 @@ class SearchInput extends Component<Props, State> {
       selectedItemId,
       showErrorEmoji,
       size,
-      summaryMsg,
       showClose
     } = this.props;
 
@@ -202,7 +211,7 @@ class SearchInput extends Component<Props, State> {
         >
           {this.renderSvg()}
           <input {...inputProps} />
-          {summaryMsg && <div className="summary">{summaryMsg}</div>}
+          {this.renderSummaryMsg()}
           {this.renderNav()}
           {showClose && (
             <CloseButton handleClick={handleClose} buttonClass={size} />


### PR DESCRIPTION
Fixes Issue: #6180 

### Summary of Changes

* Move Loading message inside the SearchInput component and update font color
* Add test for loading message in SearchInput.spec
* Update QuickOpenModal snapshot

### Test Plan

Simulate it by telling SearchInput we’re loading

- [x] Command-P opens the panel
- [x] See the `Loading...` message properly displayed

### Screenshots/Videos (OPTIONAL)

![image](https://user-images.githubusercontent.com/3975603/40139819-5ac75b7c-590e-11e8-911e-c18c06aecd50.png)

