### PR TITLE
Replace explicitOriginalTarget usage with relatedTarget in Tree

### DIFF
--- a/packages/devtools-components/src/tree.js
+++ b/packages/devtools-components/src/tree.js
@@ -819,13 +819,14 @@ class Tree extends Component {
             return;
           }
 
-          const { explicitOriginalTarget } = nativeEvent;
+          const { relatedTarget } = nativeEvent;
+
           // Only set default focus to the first tree node if the focus came
           // from outside the tree (e.g. by tabbing to the tree from other
           // external elements).
           if (
-            explicitOriginalTarget !== this.treeRef &&
-            !this.treeRef.contains(explicitOriginalTarget)
+            relatedTarget !== this.treeRef &&
+            !this.treeRef.contains(relatedTarget)
           ) {
             this._focus(traversal[0].item);
           }


### PR DESCRIPTION
bgrins is looking into removing explicitOriginalTarget from the platform,
and here, replacing it with relatedTarget has no effect on the Tree component.

### Test Plan

- Pull this patch
- `cd packages/devtools-reps; yarn; yarn start`
- Open the reps test app and launch a new Firefox window
- In the app, evaluate `[]`
- Click on the TINY mode array to expand it
- Make sure that clicking the `length` property does select the length node
- Hit <kbd>Tab</kbd> to focus the SHORT array and make sure the node gets selected