### PR TITLE
add a search field for getOriginalLocation

### DIFF
--- a/packages/devtools-source-map/src/source-map.js
+++ b/packages/devtools-source-map/src/source-map.js
@@ -155,7 +155,13 @@ async function getAllGeneratedLocations(
   }));
 }
 
-async function getOriginalLocation(location: Location): Promise<Location> {
+type locationOptions = {
+  search?: "LEAST_UPPER_BOUND" | "GREATEST_LOWER_BOUND"
+};
+async function getOriginalLocation(
+  location: Location,
+  { search }: locationOptions = {}
+): Promise<Location> {
   if (!isGeneratedId(location.sourceId)) {
     return location;
   }
@@ -165,11 +171,31 @@ async function getOriginalLocation(location: Location): Promise<Location> {
     return location;
   }
 
-  const { source: sourceUrl, line, column } = map.originalPositionFor({
+  // First check for an exact match
+  let match = map.originalPositionFor({
     line: location.line,
     column: location.column == null ? 0 : location.column
   });
 
+  // If there is not an exact match, look for a match with a bias at the
+  // current location and then on subsequent lines
+  if (search) {
+    let line = location.line;
+    let column = location.column == null ? 0 : location.column;
+
+    while (match.source === null) {
+      match = map.originalPositionFor({
+        line,
+        column,
+        bias: SourceMapConsumer[search]
+      });
+
+      line += search == "LEAST_UPPER_BOUND" ? 1 : -1;
+      column = search == "LEAST_UPPER_BOUND" ? 0 : Infinity;
+    }
+  }
+
+  const { source: sourceUrl, line, column } = match;
   if (sourceUrl == null) {
     // No url means the location didn't map.
     return location;


### PR DESCRIPTION
### Summary of Changes

It is possible that a generated location does not map to a specific original location, in that case we might want to search for the best match given a bias. 