### PR TITLE
Fix dbg-breakpoint problem

### DIFF
--- a/src/components/test/__snapshots__/SourcesTree.spec.js.snap
+++ b/src/components/test/__snapshots__/SourcesTree.spec.js.snap
@@ -271,7 +271,7 @@ exports[`SourcesTree renderItem should not show domain item when the projectRoot
     className="no-arrow"
   />
   <img
-    className="javascript source-icon"
+    className="file source-icon"
   />
   <span
     className="label"
@@ -491,7 +491,7 @@ exports[`SourcesTree renderItem should show source item with source icon 1`] = `
     className="no-arrow"
   />
   <img
-    className="javascript source-icon"
+    className="file source-icon"
   />
   <span
     className="label"
@@ -513,7 +513,7 @@ exports[`SourcesTree renderItem should show source item with source icon with fo
     className="no-arrow"
   />
   <img
-    className="javascript source-icon"
+    className="file source-icon"
   />
   <span
     className="label"

--- a/src/utils/source.js
+++ b/src/utils/source.js
@@ -346,7 +346,7 @@ export function getSourceClassnames(
   // Conditionals should be ordered by priority of icon!
   const defaultClassName = "file";
 
-  if (!source) {
+  if (!source || !source.url) {
     return defaultClassName;
   }
 


### PR DESCRIPTION
The breakpoint function currently covered by `SourceIcon` is based on URL; this fixes that test.  We can address icons based on stuff other than URL in the next PR where we change the SourcesTree.