### PR TITLE
[reps] Don't include devtools-modules in the reps bundle.

### DIFF
--- a/configs/mozilla-central-mappings.js
+++ b/configs/mozilla-central-mappings.js
@@ -24,5 +24,6 @@ module.exports = {
   "../assets/panel/debugger.properties": "devtools/shared/flags",
   "devtools-connection": "devtools/shared/flags",
   "chrome-remote-interface": "devtools/shared/flags",
-  "devtools-launchpad": "devtools/shared/flags"
+  "devtools-launchpad": "devtools/shared/flags",
+  "devtools-services": "Services"
 };

--- a/packages/devtools-reps/package.json
+++ b/packages/devtools-reps/package.json
@@ -42,6 +42,7 @@
     "devtools-launchpad": "^0.0.125",
     "devtools-license-check": "^0.5.1",
     "devtools-modules": "^0.0.36",
+    "devtools-services": "^0.0.1",
     "enzyme": "^3.3.0",
     "enzyme-adapter-react-16": "^1.1.1",
     "enzyme-to-json": "^3.3.1",

--- a/packages/devtools-reps/src/object-inspector/component.js
+++ b/packages/devtools-reps/src/object-inspector/component.js
@@ -9,7 +9,7 @@ const dom = require("react-dom-factories");
 const { connect } = require("react-redux");
 const { bindActionCreators } = require("redux");
 
-import { Services } from "devtools-modules";
+import Services from "devtools-services";
 const { appinfo } = Services;
 const isMacOS = appinfo.OS === "Darwin";
 

--- a/packages/devtools-reps/webpack.config.js
+++ b/packages/devtools-reps/webpack.config.js
@@ -28,10 +28,6 @@ let webpackConfig = {
       "devtools/client/shared/vendor/react-dom": "react-dom",
       "devtools/client/shared/vendor/react-dom-factories": "react-dom-factories",
       "devtools/client/shared/vendor/react-prop-types": "prop-types",
-      Services: path.join(
-        __dirname,
-        "node_modules/devtools-modules/client/shared/shim/Services"
-      )
     }
   }
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -3502,6 +3502,10 @@ devtools-modules@^0.0.37:
     jest "^20.0.4"
     punycode "^2.1.0"
 
+devtools-services@^0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/devtools-services/-/devtools-services-0.0.1.tgz#9042600c11d1f4d45cc6ca299588a86fac1fbdd5"
+
 devtools-splitter@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/devtools-splitter/-/devtools-splitter-0.0.6.tgz#5692f71ab6fd44cdc5d5ecc1acffaa8771baa934"


### PR DESCRIPTION
We add an alias for Services so we use the one from mozilla-central.
This means we also need to add a moduleMapper entry for jest test to pass.

---

**TEST PLAN**

- `cd packages/devtools-reps; yarn; yarn start`
- Make sure you can access the reps test app and evaluate things

- Creating the reps bundle should work, and it shouldn't include devtools-modules code
- Running the debugger in launchpad should work as well