### PR TITLE
[releases] fix timing issue with bin/copy

### DIFF
--- a/bin/copy-assets.js
+++ b/bin/copy-assets.js
@@ -233,7 +233,7 @@ function start() {
   }
 
   console.log("[copy-assets] make webpack bundles");
-  makeBundle({
+  return makeBundle({
     outputPath: path.join(mcPath, bundlePath),
     projectPath,
     watch,
@@ -299,6 +299,6 @@ if (process.argv[1] == __filename) {
     updateAssets = assets;
     watch = _watch
     mcPath = mc
-    start();
+    return start();
   }
 }

--- a/bin/copy.js
+++ b/bin/copy.js
@@ -15,5 +15,9 @@ const assets = args.assets
 
 console.log(`Copying Files to ${mc} with params: `, {watch, assets, symlink})
 
-copyAssets({ assets, mc, watch, symlink})
-copyModules({ mc, watch })
+async function start() {
+  await copyAssets({ assets, mc, watch, symlink})
+  await copyModules({ mc, watch })
+}
+
+start();


### PR DESCRIPTION
### Summary of Changes

When i compared these two runs:

* `node bin/copy-assets.js --mc ../gecko --assets; node bin/copy-modules.js --mc ../gecko`
* `yarn copy --mc ..gecko` 

I was seeing that copy unintentionally had smaller parser and css bundles. This was causing mochitest failures and was the result of a weird timing issue i'd like to not think to hard about.