### PR TITLE
[Tabs] Improve truncation of long filenames

### DIFF
--- a/src/components/Editor/Tab.js
+++ b/src/components/Editor/Tab.js
@@ -196,7 +196,9 @@ class Tab extends PureComponent<Props> {
           source={source}
           shouldHide={icon => ["file", "javascript"].includes(icon)}
         />
-        <div className="filename">{truncateMiddleText(getUnicodeUrlPath(filename), 30)}</div>
+        <div className="filename">
+          {truncateMiddleText(getUnicodeUrlPath(filename), 30)}
+        </div>
         <CloseButton
           handleClick={onClickClose}
           tooltip={L10N.getStr("sourceTabs.closeTabButtonTooltip")}

--- a/src/components/Editor/Tab.js
+++ b/src/components/Editor/Tab.js
@@ -12,6 +12,8 @@ import { showMenu, buildMenu } from "devtools-contextmenu";
 import SourceIcon from "../shared/SourceIcon";
 import { CloseButton } from "../shared/Button";
 
+import { truncateMiddleText } from "../../utils/text";
+
 import type { List } from "immutable";
 import type { SourceRecord } from "../../types";
 
@@ -194,7 +196,7 @@ class Tab extends PureComponent<Props> {
           source={source}
           shouldHide={icon => ["file", "javascript"].includes(icon)}
         />
-        <div className="filename">{getUnicodeUrlPath(filename)}</div>
+        <div className="filename">{truncateMiddleText(getUnicodeUrlPath(filename), 30)}</div>
         <CloseButton
           handleClick={onClickClose}
           tooltip={L10N.getStr("sourceTabs.closeTabButtonTooltip")}

--- a/src/utils/tests/text.spec.js
+++ b/src/utils/tests/text.spec.js
@@ -8,7 +8,7 @@ describe("text", () => {
   it("should truncate the text in the middle", () => {
     const sourceText = "this is a very long text and ends here";
     expect(truncateMiddleText(sourceText, 30)).toMatch(
-      "this is a ver...and ends here"
+      "this is a ver... and ends here"
     );
   });
   it("should keep the text as it is", () => {

--- a/src/utils/tests/text.spec.js
+++ b/src/utils/tests/text.spec.js
@@ -1,0 +1,20 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
+import { truncateMiddleText } from "../text";
+
+describe("text", () => {
+  it("should truncate the text in the middle", () => {
+    const sourceText = "this is a very long text and ends here";
+    expect(truncateMiddleText(sourceText, 30)).toMatch(
+      "this is a ver...and ends here"
+    );
+  });
+  it("should keep the text as it is", () => {
+    const sourceText = "this is a short text ends here";
+    expect(truncateMiddleText(sourceText, 30)).toMatch(
+      "this is a short text ends here"
+    );
+  });
+});

--- a/src/utils/text.js
+++ b/src/utils/text.js
@@ -39,4 +39,26 @@ function formatKeyShortcut(shortcut: string): string {
     .replace(/Shift\+/g, "Shift ");
 }
 
-export { formatKeyShortcut };
+/**
+ * Truncates the received text to the maxLength in the format:
+ * Original: 'this is a very long text and ends here'
+ * Truncated: 'this is a ver...and ends here'
+ * @param {String} sourceText - Source text
+ * @param {Number} maxLength - Max allowed length
+ * @memberof utils/text
+ * @static
+ */
+function truncateMiddleText(sourceText: string, maxLength: number): string {
+  let truncatedText = sourceText;
+  if (sourceText.length > maxLength) {
+    truncatedText = `${sourceText.substring(
+      0,
+      Math.round(maxLength / 2) - 2
+    )}...${sourceText.substring(
+      sourceText.length - Math.round(maxLength / 2 - 2)
+    )}`;
+  }
+  return truncatedText;
+}
+
+export { formatKeyShortcut, truncateMiddleText };

--- a/src/utils/text.js
+++ b/src/utils/text.js
@@ -55,7 +55,7 @@ function truncateMiddleText(sourceText: string, maxLength: number): string {
       0,
       Math.round(maxLength / 2) - 2
     )}...${sourceText.substring(
-      sourceText.length - Math.round(maxLength / 2 - 2)
+      sourceText.length - Math.round(maxLength / 2 - 1)
     )}`;
   }
   return truncatedText;


### PR DESCRIPTION
Fixes Issue: #5019 

### Summary of Changes

* Create a utility method to truncate text in the middle (...)
* Create test for this utility method

### Test Plan
- [x] Open Debugger when viewing a github issues page
- [x] Navigate to `assets-cdn.github.com > assets > frameworks-alsxsljd...`
- [x] See the name has been truncated in the middle (showing the extension and first part of the name)

### Screenshots
![image](https://user-images.githubusercontent.com/3975603/40248280-af253f16-5a8c-11e8-8520-f4d567c05e40.png)
