### PR TITLE
📝: Tweak developer experience for testing and linting

### DIFF
--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -485,7 +485,8 @@ yarn run test:all
 
 #### Unit Tests
 
-`yarn test` - Run tests with [jest].
+`yarn test` - Run all tests and lints with [jest].
+`yarn test:js` - Run the unit tests with [jest].
 
 * [matchers][jest-matchers]
 * [mock functions][jest-mock]

--- a/package.json
+++ b/package.json
@@ -169,12 +169,12 @@
     "workerjs": "github:jasonLaster/workerjs"
   },
   "lint-staged": {
-    "bin/*.js": ["yarn lint", "git add"],
-    "src/*.js": ["yarn lint", "git add"],
-    "src/*/*.js": ["yarn lint", "git add"],
-    "src/*/!(mochitest)**/*.js": ["yarn lint", "git add"],
-    "src/*/!(mochitest)*/**/*.js": ["yarn lint", "git add"],
-    "packages/**/src/*.js": ["yarn lint", "git add"]
+    "bin/*.js": ["yarn lint --findRelatedTests", "git add"],
+    "src/*.js": ["yarn lint --findRelatedTests", "git add"],
+    "src/*/*.js": ["yarn lint --findRelatedTests", "git add"],
+    "src/*/!(mochitest)**/*.js": ["yarn lint --findRelatedTests", "git add"],
+    "src/*/!(mochitest)*/**/*.js": ["yarn lint --findRelatedTests", "git add"],
+    "packages/**/src/*.js": ["yarn lint --findRelatedTests", "git add"]
   },
   "jest-runner-eslint": {
     "cliOptions": {


### PR DESCRIPTION
### Summary of Changes

* Also, document the `test:js` command which runs just the Jest unit test project
* Turns out there is an issue with the list format lint-staged uses and Jest. This fixes it by using
the CLI flag added here https://github.com/facebook/jest/pull/1678


