### PR TITLE
Fix getTextAtPosition() for wasm sources.

### DIFF
--- a/src/utils/source.js
+++ b/src/utils/source.js
@@ -331,6 +331,10 @@ export function getTextAtPosition(source: Source, location: Location) {
   const line = location.line;
   const column = location.column || 0;
 
+  if (source.isWasm) {
+    return "";
+  }
+
   const lineText = source.text.split("\n")[line - 1];
   if (!lineText) {
     return "";


### PR DESCRIPTION
Fixes Issue: source.text.split is not a function error message appears if source is wasm one.

### Summary of Changes

* Return empty string for wasm source.

### Test Plan

Example test plan:

- [x] Debug https://yurydelendik.github.io/wasm-source-map-emscripten/pi.html
- [x] Set breakpoint e.g. at wasm-source-map-emscripten/calc.cpp:14

