### PR TITLE
[Tabs] Add Unicode support for various URL & filename & Domain name labels

### DIFF
--- a/src/components/Editor/Tab.js
+++ b/src/components/Editor/Tab.js
@@ -23,6 +23,7 @@ import {
   getRawSourceURL,
   isPretty
 } from "../../utils/source";
+import { getUnicodeUrlPath } from "devtools-modules";
 import { copyToTheClipboard } from "../../utils/clipboard";
 import { getTabMenuItems } from "../../utils/tabs";
 
@@ -194,7 +195,7 @@ class Tab extends PureComponent<Props> {
           source={source}
           shouldHide={icon => ["file", "javascript"].includes(icon)}
         />
-        <div className="filename">{filename}</div>
+        <div className="filename">{getUnicodeUrlPath(filename)}</div>
         <CloseButton
           handleClick={onClickClose}
           tooltip={L10N.getStr("sourceTabs.closeTabButtonTooltip")}

--- a/src/utils/source.js
+++ b/src/utils/source.js
@@ -14,6 +14,7 @@ import { endTruncateStr } from "./utils";
 import { basename } from "./path";
 
 import { parse as parseURL } from "url";
+import { getUnicodeUrl, getUnicodeUrlPath } from "devtools-modules";
 export { isMinified } from "./isMinified";
 import { getExtension } from "./sources-tree";
 
@@ -135,8 +136,17 @@ function resolveFileURL(
   return endTruncateStr(name, 50);
 }
 
+/**
+ * Gets a readable filename from a URL for display purposes.
+ *
+ * @memberof utils/source
+ * @static
+ */
 export function getFilenameFromURL(url: string) {
-  return resolveFileURL(url, initialUrl => basename(initialUrl) || "(index)");
+  return resolveFileURL(
+    url,
+    initialUrl => getUnicodeUrlPath(basename(initialUrl)) || "(index)"
+  );
 }
 
 export function getFormattedSourceId(id: string) {
@@ -145,8 +155,8 @@ export function getFormattedSourceId(id: string) {
 }
 
 /**
- * Show a source url's filename.
- * If the source does not have a url, use the source id.
+ * Gets a readable filename from a source URL for display purposes.
+ * If the source does not have a URL, the source ID will be returned instead.
  *
  * @memberof utils/source
  * @static
@@ -166,8 +176,8 @@ export function getFilename(source: Source) {
 }
 
 /**
- * Show a source url.
- * If the source does not have a url, use the source id.
+ * Gets a readable source URL for display purposes.
+ * If the source does not have a URL, the source ID will be returned instead.
  *
  * @memberof utils/source
  * @static
@@ -178,7 +188,7 @@ export function getFileURL(source: Source) {
     return getFormattedSourceId(id);
   }
 
-  return resolveFileURL(url);
+  return resolveFileURL(url, getUnicodeUrl);
 }
 
 const contentTypeModeMap = {

--- a/src/utils/sources-tree/getURL.js
+++ b/src/utils/sources-tree/getURL.js
@@ -6,6 +6,7 @@
 
 import { parse } from "url";
 import { merge } from "lodash";
+import { getUnicodeHostname } from "devtools-modules";
 
 export type ParsedURL = {
   path: string,
@@ -97,7 +98,7 @@ export function getURL(sourceUrl: string, debuggeeUrl: string = ""): ParsedURL {
     case "https:":
       return merge(def, {
         path: pathname,
-        group: host,
+        group: getUnicodeHostname(host),
         filename: filename
       });
   }

--- a/src/utils/tests/source.spec.js
+++ b/src/utils/tests/source.spec.js
@@ -13,6 +13,10 @@ import {
 } from "../source.js";
 
 describe("sources", () => {
+  const unicode = "\u6e2c";
+  const encodedUnicode = encodeURIComponent(unicode);
+  const punycode = "xn--g6w";
+
   describe("getFilename", () => {
     it("should give us a default of (index)", () => {
       expect(
@@ -27,6 +31,14 @@ describe("sources", () => {
         })
       ).toBe("hello.html");
     });
+    it("should give us the readable Unicode filename if encoded", () => {
+      expect(
+        getFilename({
+          url: `http://localhost.com:7999/increment/${encodedUnicode}.html`,
+          id: ""
+        })
+      ).toBe(`${unicode}.html`);
+    });
     it("should truncate the file name when it is more than 50 chars", () => {
       expect(
         getFilename({
@@ -34,6 +46,14 @@ describe("sources", () => {
           id: ""
         })
       ).toBe("...-really-really-really-really-really-long-name.html");
+    });
+    it("should first decode the filename and then truncate it", () => {
+      expect(
+        getFilename({
+          url: `${encodedUnicode.repeat(50)}.html`,
+          id: ""
+        })
+      ).toBe(`...${unicode.repeat(45)}.html`);
     });
     it("should give us the filename excluding the query strings", () => {
       expect(
@@ -54,6 +74,14 @@ describe("sources", () => {
         })
       ).toBe("http://localhost.com:7999/increment/hello.html");
     });
+    it("should give us the readable Unicode file URL if encoded", () => {
+      expect(
+        getFileURL({
+          url: `http://${punycode}.${punycode}:7999/increment/${encodedUnicode}.html`,
+          id: ""
+        })
+      ).toBe(`http://${unicode}.${unicode}:7999/increment/${unicode}.html`);
+    });
     it("should truncate the file url when it is more than 50 chars", () => {
       expect(
         getFileURL({
@@ -61,6 +89,14 @@ describe("sources", () => {
           id: ""
         })
       ).toBe("...ttp://localhost-long.com:7999/increment/hello.html");
+    });
+    it("should first decode the file URL and then truncate it", () => {
+      expect(
+        getFileURL({
+          url: `http://${encodedUnicode.repeat(39)}.html`,
+          id: ""
+        })
+      ).toBe(`...ttp://${unicode.repeat(39)}.html`);
     });
   });
 
@@ -70,12 +106,24 @@ describe("sources", () => {
         getFilenameFromURL("http://localhost.com:7999/increment/hello.html")
       ).toBe("hello.html");
     });
+    it("should give us the readable Unicode filename if encoded", () => {
+      expect(
+        getFilenameFromURL(
+          `http://localhost.com:7999/increment/${encodedUnicode}.html`
+        )
+      ).toBe(`${unicode}.html`);
+    });
     it("should truncate the file name when it is more than 50 chars", () => {
       expect(
         getFilenameFromURL(
           "http://localhost/really-really-really-really-really-really-long-name.html"
         )
       ).toBe("...-really-really-really-really-really-long-name.html");
+    });
+    it("should first decode the filename and then truncate it", () => {
+      expect(
+        getFilenameFromURL(`http://${encodedUnicode.repeat(50)}.html`)
+      ).toBe(`...${unicode.repeat(45)}.html`);
     });
   });
 

--- a/src/utils/tests/source.spec.js
+++ b/src/utils/tests/source.spec.js
@@ -5,6 +5,7 @@
 import {
   getFilename,
   getFileURL,
+  getFilenameFromURL,
   getMode,
   getSourceLineCount,
   isThirdParty,
@@ -28,9 +29,8 @@ describe("sources", () => {
     });
     it("should truncate the file name when it is more than 50 chars", () => {
       expect(
-        getFileURL({
-          url:
-            "http://localhost/really-really-really-really-really-really-long-name.html",
+        getFilename({
+          url: "really-really-really-really-really-really-long-name.html",
           id: ""
         })
       ).toBe("...-really-really-really-really-really-long-name.html");
@@ -61,6 +61,21 @@ describe("sources", () => {
           id: ""
         })
       ).toBe("...ttp://localhost-long.com:7999/increment/hello.html");
+    });
+  });
+
+  describe("getFilenameFromURL", () => {
+    it("should give us the filename", () => {
+      expect(
+        getFilenameFromURL("http://localhost.com:7999/increment/hello.html")
+      ).toBe("hello.html");
+    });
+    it("should truncate the file name when it is more than 50 chars", () => {
+      expect(
+        getFilenameFromURL(
+          "http://localhost/really-really-really-really-really-really-long-name.html"
+        )
+      ).toBe("...-really-really-really-really-really-long-name.html");
     });
   });
 


### PR DESCRIPTION
Fixes Issue: #5977

### Summary of Changes

* Adds Unicode support in source.js so that URL & Filename & Domain name labels display readable Unicode text.
The invovled labels are: groups of source trees, filenames of tabs, tooltips of
filename tabs, filenames of breakpoints.

* Adds Unicode tests for source.js.

### Test Plan

* Unicode support for filename parts can be tested at https://dbg-unicode.glitch.me/

* Unicode support for domain name parts can be tested at http://nic.世界