### PR TITLE
[Tabs] chevron image overlaps other tabs

### DIFF
--- a/src/components/Editor/Tabs.css
+++ b/src/components/Editor/Tabs.css
@@ -52,6 +52,8 @@
   margin-top: 3px;
   cursor: default;
   height: 27px;
+  width: 100%;
+  max-width: fit-content;
 }
 
 .source-tab:first-child {


### PR DESCRIPTION
https://github.com/devtools-html/debugger.html/issues/6347

### Summary of Changes

The problem: when one only tab is left in the debugger editor, it does not scale down with the editor width. That creates the overlapping issue as from ticket.
Tuned up `.source-tab`'s width to prevent the situation described above.

Tested on FF 60 and Chrome 67

### Test Plan

Open multiple tabs on the debugger editor and drag the editor pane as much as possible, to reduce the space availabale for tabs to the minimum as possible.

Expected: the last tab displayed will reduce its width accordingly to the space available. Also the dropdown button (to see the hidden tabs) is expected to render correctly (a bug prevent the button icon to render properly, but clicking on it is still possible to see it).

### Screenshots/Videos (OPTIONAL)
_lot of space to render tabs: all ok_
<img width="1438" alt="screen shot 2018-05-19 at 16 01 26" src="https://user-images.githubusercontent.com/1615395/40269395-3569bdf8-5b7e-11e8-8fbb-648822dcb7ea.png">

_suddenly no more space to render tabs: all hidden but one, that resize accordingly to the space available_
<img width="1440" alt="screen shot 2018-05-19 at 16 01 42" src="https://user-images.githubusercontent.com/1615395/40269396-35801fda-5b7e-11e8-9549-f9647dff0df9.png">

_also dropdown button reachable 👍_
<img width="1437" alt="screen shot 2018-05-19 at 16 01 50" src="https://user-images.githubusercontent.com/1615395/40269397-3597e1f6-5b7e-11e8-9ab4-0b9fe96feeba.png">

