### PR TITLE
Better vertically center the result line in searches

### DIFF
--- a/src/components/shared/SearchInput.css
+++ b/src/components/shared/SearchInput.css
@@ -90,13 +90,14 @@
 }
 
 .search-field .summary {
-  line-height: 27px;
   padding-right: 10px;
   color: var(--theme-body-color-inactive);
+  align-self: center;
+  padding-top: 1px;
 }
 
 .search-field.big .summary {
-  line-height: 40px;
+  padding-top: 5px;
 }
 
 .search-field .search-nav-buttons {


### PR DESCRIPTION
The alignment of the results line could be improved.

## Big

<img width="890" alt="resultsbig" src="https://user-images.githubusercontent.com/46655/40269677-8f78208c-5b47-11e8-96c6-ef611cb93ae3.png">

## Small

<img width="849" alt="resultssmall" src="https://user-images.githubusercontent.com/46655/40269678-931f12cc-5b47-11e8-9fc0-744618f1c355.png">
