### PR TITLE
replace pauseOnExceptionsItem with pauseOnExceptionsItem2

### DIFF
--- a/assets/panel/debugger.properties
+++ b/assets/panel/debugger.properties
@@ -96,9 +96,9 @@ ignoreExceptionsItem=Ignore exceptions
 # item shown when a user is adding a new breakpoint.
 pauseOnUncaughtExceptionsItem=Pause on uncaught exceptions
 
-# LOCALIZATION NOTE (pauseOnExceptionsItem): The pause on exceptions checkbox description
+# LOCALIZATION NOTE (pauseOnExceptionsItem2): The pause on exceptions checkbox description
 # when the debugger will pause on all exceptions.
-pauseOnExceptionsItem=Pause on exceptions
+pauseOnExceptionsItem2=Pause on exceptions
 
 # LOCALIZATION NOTE (ignoreCaughtExceptionsItem): The pause on exceptions checkbox description
 # when the debugger will not pause on any caught exception

--- a/src/components/SecondaryPanes/Breakpoints.js
+++ b/src/components/SecondaryPanes/Breakpoints.js
@@ -172,7 +172,7 @@ class Breakpoints extends Component<Props> {
     const isEmpty = breakpoints.size == 0;
 
     const exceptionsBox = createExceptionOption(
-      L10N.getStr("pauseOnExceptionsItem"),
+      L10N.getStr("pauseOnExceptionsItem2"),
       shouldPauseOnExceptions,
       () => pauseOnExceptions(!shouldPauseOnExceptions, false),
       "breakpoints-exceptions"


### PR DESCRIPTION
We accidentally reverted pauseOnExceptionsItem2 when we synced between master and release.

https://bugzilla.mozilla.org/show_bug.cgi?id=1462630#c8