### PR TITLE
[Search] results label should not wrap 

### DIFF
--- a/src/components/shared/SearchInput.css
+++ b/src/components/shared/SearchInput.css
@@ -96,6 +96,7 @@
   color: var(--theme-body-color-inactive);
   align-self: center;
   padding-top: 1px;
+  white-space: nowrap;
 }
 
 .search-field.big .summary {


### PR DESCRIPTION
Fixes Issue: #6354

### Summary of Changes

* Added CSS rule to prevent search results label from wrapping.

### Test Plan

- [x] Command-P opens the panel
- [x] Find a file to search
- [x] Search for something with a lot of results
- [x] Resize window
- [x] "results" label no longer wraps to next line.


### Screenshot
![](http://g.recordit.co/jEaQP75Dn8.gif)