### PR TITLE
Removes toJS from getFilename

### DIFF
--- a/src/components/Editor/Footer.js
+++ b/src/components/Editor/Footer.js
@@ -156,8 +156,7 @@ class SourceFooter extends PureComponent<Props> {
   renderSourceSummary() {
     const { mappedSource, jumpToMappedLocation, selectedSource } = this.props;
     if (mappedSource) {
-      const bundleSource = mappedSource.toJS();
-      const filename = getFilename(bundleSource);
+      const filename = getFilename(mappedSource);
       const tooltip = L10N.getFormatStr(
         "sourceFooter.mappedSourceTooltip",
         filename

--- a/src/components/Editor/Tab.js
+++ b/src/components/Editor/Tab.js
@@ -151,8 +151,7 @@ class Tab extends PureComponent<Props> {
       closeTab,
       source
     } = this.props;
-    const src = source.toJS();
-    const filename = getFilename(src);
+    const filename = getFilename(source);
     const sourceId = source.id;
     const active =
       selectedSource &&
@@ -188,7 +187,7 @@ class Tab extends PureComponent<Props> {
         key={sourceId}
         onMouseUp={handleTabClick}
         onContextMenu={e => this.onTabContextMenu(e, sourceId)}
-        title={getFileURL(src)}
+        title={getFileURL(source)}
       >
         <SourceIcon
           source={source}

--- a/src/components/Editor/Tabs.js
+++ b/src/components/Editor/Tabs.js
@@ -109,24 +109,24 @@ class Tabs extends PureComponent<Props, State> {
     }));
   }
 
-  getIconClass(source: SourceRecord) {
-    if (isPretty(source)) {
+  getIconClass(sourceRecord: SourceRecord) {
+    if (isPretty(sourceRecord)) {
       return "prettyPrint";
     }
-    if (source.isBlackBoxed) {
+    if (sourceRecord.isBlackBoxed) {
       return "blackBox";
     }
     return "file";
   }
 
-  renderDropdownSource = (source: SourceRecord) => {
+  renderDropdownSource = (sourceRecord: SourceRecord) => {
     const { selectSpecificSource } = this.props;
-    const filename = getFilename(source.toJS());
+    const filename = getFilename(sourceRecord);
 
-    const onClick = () => selectSpecificSource(source.id);
+    const onClick = () => selectSpecificSource(sourceRecord.id);
     return (
-      <li key={source.id} onClick={onClick}>
-        <img className={`dropdown-icon ${this.getIconClass(source)}`} />
+      <li key={sourceRecord.id} onClick={onClick}>
+        <img className={`dropdown-icon ${this.getIconClass(sourceRecord)}`} />
         {filename}
       </li>
     );


### PR DESCRIPTION
`getFilename` uses the `id` and `url` of the source record to find the name of the file and as such can live without the expensive `toJS` call. Properties on a Record can be accessed via the dot notation (it should even be possible to destructure them).

`getFileUrl` is in a similar situation.