### PR TITLE
Removes stray toJS from getSymbols

### DIFF
--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -608,7 +608,7 @@ const mapStateToProps = state => {
     hitCount: getHitCountForSource(state, sourceId),
     coverageOn: getCoverageEnabled(state),
     conditionalPanelLine: getConditionalPanelLine(state),
-    symbols: getSymbols(state, selectedSource && selectedSource.toJS())
+    symbols: getSymbols(state, selectedSource)
   };
 };
 


### PR DESCRIPTION
all other `getSymbols` lack toJS, missed this one.