### PR TITLE
[Preview] identify if it is react

### DIFF
--- a/src/actions/pause/extra.js
+++ b/src/actions/pause/extra.js
@@ -5,7 +5,7 @@
 // @flow
 
 import { inComponent, getSelectedFrame } from "../../selectors";
-import { isImmutable } from "../../utils/preview";
+import { isImmutablePreview } from "../../utils/preview";
 
 import type { ThunkArgs } from "../types";
 
@@ -60,7 +60,7 @@ async function getExtraProps(getState, expression, result, evaluate) {
     props.react = await getReactProps(evaluate, component);
   }
 
-  if (isImmutable(result)) {
+  if (isImmutablePreview(result)) {
     props.immutable = await getImmutableProps(expression, evaluate);
   }
 

--- a/src/components/SecondaryPanes/Frames/WhyPaused.js
+++ b/src/components/SecondaryPanes/Frames/WhyPaused.js
@@ -16,7 +16,7 @@ function renderExceptionSummary(exception: string | Grip) {
   }
 
   const preview = exception.preview;
-  if (!preview) {
+  if (!preview || !preview.name || !preview.message) {
     return;
   }
 

--- a/src/components/SecondaryPanes/FrameworkComponent.js
+++ b/src/components/SecondaryPanes/FrameworkComponent.js
@@ -8,7 +8,6 @@ import { connect } from "react-redux";
 import actions from "../../actions";
 
 import { createObjectClient } from "../../client/firefox";
-
 import { getSelectedFrame, getAllPopupObjectProperties } from "../../selectors";
 
 import { ObjectInspector, ObjectInspectorUtils } from "devtools-reps";

--- a/src/types.js
+++ b/src/types.js
@@ -251,15 +251,6 @@ export type Expression = {
  * @static
  */
 
-export type PreviewGrip = {
-  kind: string,
-  url: string,
-  fileName: string,
-  message: string,
-  name: string,
-  ownProperties?: Object
-};
-
 /**
  * Grip
  * @memberof types
@@ -272,9 +263,14 @@ export type Grip = {
   frozen: boolean,
   isGlobal: boolean,
   ownPropertyLength: number,
-  preview?: PreviewGrip,
+  ownProperties: Object,
+  preview?: Grip,
   sealed: boolean,
-  type: string
+  type: string,
+  url?: string,
+  fileName?: string,
+  message?: string,
+  name?: string
 };
 
 /**

--- a/src/utils/pause/why.js
+++ b/src/utils/pause/why.js
@@ -37,6 +37,7 @@ export function getPauseReason(why?: Why): string | null {
   if (!reasons[reasonType]) {
     console.log("Please file an issue: reasonType=", reasonType);
   }
+
   return reasons[reasonType];
 }
 

--- a/src/utils/preview.js
+++ b/src/utils/preview.js
@@ -7,36 +7,30 @@
 import type { Grip } from "../types";
 
 const IMMUTABLE_FIELDS = ["_root", "__ownerID", "__altered", "__hash"];
+const REACT_FIELDS = ["_reactInternalInstance", "_reactInternalFiber"];
 
-export function isImmutable(result: Grip) {
-  if (!result || !result.preview) {
+export function isImmutablePreview(result: ?Grip) {
+  return result && isImmutable(result.preview);
+}
+
+export function isImmutable(result: ?Grip) {
+  if (!result || typeof result.ownProperties != "object") {
     return;
   }
 
-  const ownProperties = result.preview.ownProperties;
-  if (!ownProperties) {
-    return;
-  }
-
+  const ownProperties = result.ownProperties;
   return IMMUTABLE_FIELDS.every(field =>
     Object.keys(ownProperties).includes(field)
   );
 }
 
-export function isReactComponent(result: Grip) {
-  if (!result || !result.preview) {
+export function isReactComponent(result: ?Grip) {
+  if (!result || typeof result.ownProperties != "object") {
     return;
   }
 
-  const ownProperties = result.preview.ownProperties;
-  if (!ownProperties) {
-    return;
-  }
-
-  return (
-    Object.keys(ownProperties).includes("_reactInternalInstance") ||
-    Object.keys(ownProperties).includes("_reactInternalFiber")
-  );
+  const ownProperties = result.ownProperties;
+  return REACT_FIELDS.some(field => Object.keys(ownProperties).includes(field));
 }
 
 export function isConsole(expression: string) {


### PR DESCRIPTION
### Summary of Changes

When we switched to using inComponent, we stopped differentiating between hovering on `this` and other properties as a result, Popup always assumed we wanted to preview the component.