### PR TITLE
🐛: Fix bug with lint-staged arguments

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "lint:jest": "jest -c jest-lint.config.js",
     "lint:md":
       "remark -u devtools-linters/markdown/preset -qf *.md src configs docs",
+    "lint:s": "run-s \"lint:jest --findRelatedTests\" lint:md",
     "mochi":
       "mochii --mc ./firefox --interactive --default-test-path devtools/client/debugger/new",
     "mochid": "yarn mochi -- --jsdebugger --",
@@ -169,12 +170,12 @@
     "workerjs": "github:jasonLaster/workerjs"
   },
   "lint-staged": {
-    "bin/*.js": ["yarn lint --findRelatedTests", "git add"],
-    "src/*.js": ["yarn lint --findRelatedTests", "git add"],
-    "src/*/*.js": ["yarn lint --findRelatedTests", "git add"],
-    "src/*/!(mochitest)**/*.js": ["yarn lint --findRelatedTests", "git add"],
-    "src/*/!(mochitest)*/**/*.js": ["yarn lint --findRelatedTests", "git add"],
-    "packages/**/src/*.js": ["yarn lint --findRelatedTests", "git add"]
+    "bin/*.js": ["yarn lint:s", "git add"],
+    "src/*.js": ["yarn lint:s", "git add"],
+    "src/*/*.js": ["yarn lint:s", "git add"],
+    "src/*/!(mochitest)**/*.js": ["yarn lint:s", "git add"],
+    "src/*/!(mochitest)*/**/*.js": ["yarn lint:s", "git add"],
+    "packages/**/src/*.js": ["yarn lint:s", "git add"]
   },
   "jest-runner-eslint": {
     "cliOptions": {


### PR DESCRIPTION
Fixes Issue: #<issue number>

### Summary of Changes

* @jasonLaster found this bug where arguments were getting swallowed or sent to the wrong place I think this should fix it.
