### PR TITLE
Stop the propagation on tree node click.

### DIFF
--- a/packages/devtools-components/src/tree.js
+++ b/packages/devtools-components/src/tree.js
@@ -786,6 +786,10 @@ class Tree extends Component {
         onExpand: this._onExpand,
         onCollapse: this._onCollapse,
         onClick: e => {
+          // We can stop the propagation since click handler on the node can be
+          // created in `renderItem`.
+          e.stopPropagation();
+
           // Since the user just clicked the node, there's no need to check if
           // it should be scrolled into view.
           this._focus(item, { preventAutoScroll: true });


### PR DESCRIPTION
Not having it was causing issue in the console (See [Bug 1463057](https://bugzilla.mozilla.org/show_bug.cgi\?id\=1463057)),
and I think it's safe to stop the propagation since click events are handled
through renderItem result.


### Test Plan

- Made sure all the object inspectors could be expanded (watch expression, scopes panel and preview popup)
- Made sure you can still edit a watch expression
- Made sure you can still select a source clicking on an item in the Source panel
