### PR TITLE
Minor tweeks to search input icons and close button

### DIFF
--- a/src/components/ProjectSearch.css
+++ b/src/components/ProjectSearch.css
@@ -87,7 +87,7 @@
 }
 
 .project-text-search .search-field .close-btn.big {
-  margin-top: 6px;
+  margin-top: 2px;
 }
 
 .project-text-search .managed-tree {

--- a/src/components/shared/SearchInput.css
+++ b/src/components/shared/SearchInput.css
@@ -66,7 +66,10 @@
 
 .search-field i.magnifying-glass,
 .search-field i.sad-face {
-  padding: 6px;
+  padding-top: 5px;
+  padding-bottom: 5px;
+  padding-inline-end: 10px;
+  padding-inline-start: 5px;
   width: 24px;
 }
 
@@ -74,6 +77,11 @@
 .search-field.big i.sad-face {
   position: absolute;
   width: 40px;
+}
+
+.search-field.big i.sad-face {
+  padding-top: 4px;
+  padding-inline-start: 4px;
 }
 
 .search-field .magnifying-glass path,
@@ -92,16 +100,11 @@
 .search-field .summary {
   line-height: 27px;
   text-align: center;
-  padding-right: 10px;
+  padding-inline-end: 10px;
   color: var(--theme-body-color-inactive);
   align-self: center;
   padding-top: 1px;
   white-space: nowrap;
-}
-
-.search-field.big .summary {
-  padding: 5px 0 5px 0;
-  line-height: 2rem;
 }
 
 .search-field .search-nav-buttons {


### PR DESCRIPTION
This fixes a few minor nits to the search inputs, including:

- The change between smily and magnifying glass looked weird, I think because of the difference in the overall design, so I shifted the smily and the transition feels smoother.

- The close button was a few pixels low 

- Added end spacing to result summary; it looks lit now

<img width="736" alt="smallresults" src="https://user-images.githubusercontent.com/46655/40380675-63363a98-5dbf-11e8-96f8-efa1fbcb4e65.png">

<img width="742" alt="resultalignment" src="https://user-images.githubusercontent.com/46655/40380677-66378c24-5dbf-11e8-9193-88f29c283e81.png">

![smilymagnify](https://user-images.githubusercontent.com/46655/40380683-6958f6c2-5dbf-11e8-89c6-716490a380c3.gif)
