### PR TITLE
Removes toJS from findSourceMatches

### DIFF
--- a/src/actions/project-text-search.js
+++ b/src/actions/project-text-search.js
@@ -79,7 +79,7 @@ export function searchSource(sourceId: string, query: string) {
       return;
     }
 
-    const matches = await findSourceMatches(sourceRecord.toJS(), query);
+    const matches = await findSourceMatches(sourceRecord, query);
     if (!matches.length) {
       return;
     }

--- a/src/test/mochitest/browser_dbg-search-project.js
+++ b/src/test/mochitest/browser_dbg-search-project.js
@@ -27,8 +27,7 @@ function getResultsCount(dbg) {
   const matches = dbg.selectors
     .getTextSearchResults(dbg.getState())
     .valueSeq()
-    .map(file => file.matches)
-    .toJS();
+    .map(file => file.matches);
 
   return [...matches].length;
 }


### PR DESCRIPTION
findSourcematches depends on 3 properties of the source and as such the .toJS() of the full source is not really needed.