### PR TITLE
Add a max-width to sourcetabs to avoid chevron overlap

### DIFF
--- a/src/components/Editor/Tabs.css
+++ b/src/components/Editor/Tabs.css
@@ -46,6 +46,7 @@
   position: relative;
   transition: all 0.15s ease;
   min-width: 40px;
+  max-width: 100%;
   overflow: hidden;
   padding: 5px;
   margin-inline-start: 3px;


### PR DESCRIPTION
<img width="224" alt="chevy" src="https://user-images.githubusercontent.com/46655/40443429-ead74164-5e8b-11e8-8355-ee8d53c01531.png">
