### PR TITLE
Update wasmparser dep: allows to index end of function by offset.

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "redux-saga": "^0.16.0",
     "reselect": "^3.0.1",
     "svg-inline-react": "^3.0.0",
-    "wasmparser": "^0.6.0"
+    "wasmparser": "^0.6.1"
   },
   "private": true,
   "workspaces": ["packages/*"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -12392,9 +12392,9 @@ warning@^3.0.0:
   dependencies:
     loose-envify "^1.0.0"
 
-wasmparser@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/wasmparser/-/wasmparser-0.6.0.tgz#813159b85db5dfe5c2d84bd3fcd2545df3ab6552"
+wasmparser@^0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/wasmparser/-/wasmparser-0.6.1.tgz#211d032bb1001bb7c8771e714f985685eea7957b"
   dependencies:
     "@types/node" "^7.0.52"
 


### PR DESCRIPTION
Fixes Issue: it is not possible to locate/step/break at end of the wasm function

### Summary of Changes

* wasmparser disassembly now assigns right offset to the end of the function (parenthesis)
