### PR TITLE
Remove unnecessary `-moz-column-width` property

### DIFF
--- a/src/components/ShortcutsModal.css
+++ b/src/components/ShortcutsModal.css
@@ -4,7 +4,6 @@
 
 .shortcuts-content {
   padding: 15px;
-  -webkit-column-width: 250px;
   column-width: 250px;
   cursor: default;
 }

--- a/src/components/ShortcutsModal.css
+++ b/src/components/ShortcutsModal.css
@@ -4,7 +4,6 @@
 
 .shortcuts-content {
   padding: 15px;
-  -moz-column-width: 250px;
   -webkit-column-width: 250px;
   column-width: 250px;
   cursor: default;


### PR DESCRIPTION
Firefox supports the unprefixed version since version 52, so I’m removing the unnecessary prefix.

## See also:
- [bug 1308587](https://bugzil.la/1308587 "Use script to remove -moz- prefixes from all usages of CSS multi-column properties in the tree (except for code that adds/intentionally-targets prefixed aliases)")
