### PR TITLE
Separates plugins and resources by host

### DIFF
--- a/src/utils/sources-tree/getURL.js
+++ b/src/utils/sources-tree/getURL.js
@@ -43,19 +43,19 @@ export function getURL(sourceUrl: string, debuggeeUrl: string = ""): ParsedURL {
       // Ignore `javascript:` URLs for now
       return def;
 
-    case "webpack:":
-      // A Webpack source is a special case
+    case "moz-extension:":
+    case "resource:":
       return merge(def, {
-        path: path,
-        group: "webpack://",
-        filename: filename
+        path,
+        group: `${protocol}//${host || ""}`,
+        filename
       });
 
+    case "webpack:":
     case "ng:":
-      // An Angular source is a special case
       return merge(def, {
         path: path,
-        group: "ng://",
+        group: `${protocol}//`,
         filename: filename
       });
 
@@ -76,16 +76,14 @@ export function getURL(sourceUrl: string, debuggeeUrl: string = ""): ParsedURL {
 
     case null:
       if (pathname && pathname.startsWith("/")) {
-        // If it's just a URL like "/foo/bar.js", resolve it to the file
-        // protocol
+        // use file protocol for a URL like "/foo/bar.js"
         return merge(def, {
           path: path,
           group: "file://",
           filename: filename
         });
       } else if (host === null) {
-        // We don't know what group to put this under, and it's a script
-        // with a weird URL. Just group them all under an anonymous group.
+        // use anonymous group for weird URLs
         return merge(def, {
           path: url,
           group: defaultDomain,

--- a/src/utils/sources-tree/tests/__snapshots__/addToTree.spec.js.snap
+++ b/src/utils/sources-tree/tests/__snapshots__/addToTree.spec.js.snap
@@ -70,9 +70,9 @@ exports[`sources-tree addToTree uses debuggeeUrl as default 1`] = `
     - reducers path=localhost:4242/reducers 
       - index.js path=localhost:4242/reducers/index.js source_id=undefined 
     - index.js path=localhost:4242/index.js source_id=undefined 
-  - resource:// path=resource:// 
-    - modules path=resource:///modules 
-      - ExtensionContent.jsm path=resource:///modules/ExtensionContent.jsm source_id=undefined 
+  - resource://gre path=resource://gre 
+    - modules path=resource://gre/modules 
+      - ExtensionContent.jsm path=resource://gre/modules/ExtensionContent.jsm source_id=undefined 
   - voz37vlg5.codesandbox.io path=voz37vlg5.codesandbox.io 
     - static path=voz37vlg5.codesandbox.io/static 
       - js path=voz37vlg5.codesandbox.io/static/js 

--- a/src/utils/sources-tree/tests/utils.spec.js
+++ b/src/utils/sources-tree/tests/utils.spec.js
@@ -177,6 +177,16 @@ describe("sources tree", () => {
       const urlObject = getURL("https://a/c");
       expect(urlObject.filename).toBe("(index)");
     });
+
+    it("separates resources by protocol and host", () => {
+      const urlObject = getURL("moz-extension://xyz/123");
+      expect(urlObject.group).toBe("moz-extension://xyz");
+    });
+
+    it("creates a group name for webpack", () => {
+      const urlObject = getURL("webpack://src/component.jsx");
+      expect(urlObject.group).toBe("webpack://");
+    });
   });
 
   describe("isNotJavaScript", () => {


### PR DESCRIPTION
Fixes Issue: #5759

Adds separation for plugins and resources displayed in source tree by host:

Screenshot:
![screenshot-20180526084059-280x189](https://user-images.githubusercontent.com/23530054/40573344-9245f1b2-60c0-11e8-95fa-9ba65746ce7f.png)
