### PR TITLE
Moves export statements in front of functions and consts

### DIFF
--- a/src/client/index.js
+++ b/src/client/index.js
@@ -25,7 +25,7 @@ function loadFromPrefs(actions: Object) {
   }
 }
 
-async function onConnect(
+export async function onConnect(
   connection: Object,
   { services, toolboxActions }: Object
 ) {
@@ -56,5 +56,3 @@ async function onConnect(
   bootstrapApp(store);
   return { store, actions, selectors, client: commands };
 }
-
-export { onConnect };

--- a/src/utils/editor/source-documents.js
+++ b/src/utils/editor/source-documents.js
@@ -15,23 +15,23 @@ import type { SymbolDeclarations } from "../../workers/parser";
 
 let sourceDocs = {};
 
-function getDocument(key: string) {
+export function getDocument(key: string) {
   return sourceDocs[key];
 }
 
-function hasDocument(key: string) {
+export function hasDocument(key: string) {
   return !!getDocument(key);
 }
 
-function setDocument(key: string, doc: any) {
+export function setDocument(key: string, doc: any) {
   sourceDocs[key] = doc;
 }
 
-function removeDocument(key: string) {
+export function removeDocument(key: string) {
   delete sourceDocs[key];
 }
 
-function clearDocuments() {
+export function clearDocuments() {
   sourceDocs = {};
 }
 
@@ -42,7 +42,7 @@ function resetLineNumberFormat(editor: SourceEditor) {
   resizeToggleButton(cm);
 }
 
-function updateLineNumberFormat(editor: SourceEditor, sourceId: string) {
+export function updateLineNumberFormat(editor: SourceEditor, sourceId: string) {
   if (!isWasm(sourceId)) {
     return resetLineNumberFormat(editor);
   }
@@ -53,7 +53,7 @@ function updateLineNumberFormat(editor: SourceEditor, sourceId: string) {
   resizeToggleButton(cm);
 }
 
-function updateDocument(editor: SourceEditor, source: SourceRecord) {
+export function updateDocument(editor: SourceEditor, source: SourceRecord) {
   if (!source) {
     return;
   }
@@ -65,7 +65,7 @@ function updateDocument(editor: SourceEditor, source: SourceRecord) {
   updateLineNumberFormat(editor, sourceId);
 }
 
-function clearEditor(editor: SourceEditor) {
+export function clearEditor(editor: SourceEditor) {
   const doc = editor.createDocument();
   editor.replaceDocument(doc);
   editor.setText("");
@@ -73,7 +73,7 @@ function clearEditor(editor: SourceEditor) {
   resetLineNumberFormat(editor);
 }
 
-function showLoading(editor: SourceEditor) {
+export function showLoading(editor: SourceEditor) {
   if (hasDocument("loading")) {
     return;
   }
@@ -85,7 +85,7 @@ function showLoading(editor: SourceEditor) {
   editor.setMode({ name: "text" });
 }
 
-function showErrorMessage(editor: Object, msg: string) {
+export function showErrorMessage(editor: Object, msg: string) {
   let error;
   if (msg.includes("WebAssembly binary source is not available")) {
     error = L10N.getStr("wasmIsNotAvailable");
@@ -115,7 +115,7 @@ function setEditorText(editor: Object, source: Source) {
  * Handle getting the source document or creating a new
  * document with the correct mode and text.
  */
-function showSourceText(
+export function showSourceText(
   editor: Object,
   source: Source,
   symbols?: SymbolDeclarations
@@ -150,17 +150,3 @@ function showSourceText(
   editor.setMode(getMode(source, symbols));
   updateLineNumberFormat(editor, source.id);
 }
-
-export {
-  getDocument,
-  setDocument,
-  hasDocument,
-  removeDocument,
-  clearDocuments,
-  updateLineNumberFormat,
-  updateDocument,
-  clearEditor,
-  showSourceText,
-  showErrorMessage,
-  showLoading
-};

--- a/src/utils/path.js
+++ b/src/utils/path.js
@@ -4,25 +4,23 @@
 
 // @flow
 
-function basename(path: string) {
+export function basename(path: string) {
   return path.split("/").pop();
 }
 
-function dirname(path: string) {
+export function dirname(path: string) {
   const idx = path.lastIndexOf("/");
   return path.slice(0, idx);
 }
 
-function isURL(str: string) {
+export function isURL(str: string) {
   return str.indexOf("://") !== -1;
 }
 
-function isAbsolute(str: string) {
+export function isAbsolute(str: string) {
   return str[0] === "/";
 }
 
-function join(base: string, dir: string) {
+export function join(base: string, dir: string) {
   return `${base}/${dir}`;
 }
-
-export { basename, dirname, isURL, isAbsolute, join };

--- a/src/utils/result-list.js
+++ b/src/utils/result-list.js
@@ -5,7 +5,7 @@
 import { isFirefox } from "devtools-environment";
 import { transitionTimeout } from "../components/shared/Modal";
 
-function scrollList(resultList, index, delayed = false) {
+export function scrollList(resultList, index, delayed = false) {
   if (!resultList.hasOwnProperty(index)) {
     return;
   }
@@ -44,5 +44,3 @@ function chromeScrollList(elem, index) {
 
   resultsEl.scrollTop = Math.max(0, scroll);
 }
-
-export { scrollList };

--- a/src/utils/task.js
+++ b/src/utils/task.js
@@ -7,7 +7,7 @@
 /**
  * This object provides the public module functions.
  */
-const Task = {
+export const Task = {
   // XXX: Not sure if this works in all cases...
   async: function(task) {
     return function() {
@@ -44,5 +44,3 @@ const Task = {
     });
   }
 };
-
-export { Task };

--- a/src/utils/text.js
+++ b/src/utils/text.js
@@ -26,7 +26,7 @@ const isMacOS = appinfo.OS === "Darwin";
  * @memberof utils/text
  * @static
  */
-function formatKeyShortcut(shortcut: string): string {
+export function formatKeyShortcut(shortcut: string): string {
   if (isMacOS) {
     return shortcut
       .replace(/Shift\+/g, "\u21E7 ")
@@ -48,7 +48,10 @@ function formatKeyShortcut(shortcut: string): string {
  * @memberof utils/text
  * @static
  */
-function truncateMiddleText(sourceText: string, maxLength: number): string {
+export function truncateMiddleText(
+  sourceText: string,
+  maxLength: number
+): string {
   let truncatedText = sourceText;
   if (sourceText.length > maxLength) {
     truncatedText = `${sourceText.substring(
@@ -60,5 +63,3 @@ function truncateMiddleText(sourceText: string, maxLength: number): string {
   }
   return truncatedText;
 }
-
-export { formatKeyShortcut, truncateMiddleText };

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -13,7 +13,7 @@
  * @memberof utils/utils
  * @static
  */
-function handleError(err: any) {
+export function handleError(err: any) {
   console.log("ERROR: ", err);
 }
 
@@ -21,7 +21,11 @@ function handleError(err: any) {
  * @memberof utils/utils
  * @static
  */
-function promisify(context: any, method: any, ...args: any): Promise<mixed> {
+export function promisify(
+  context: any,
+  method: any,
+  ...args: any
+): Promise<mixed> {
   return new Promise((resolve, reject) => {
     args.push(response => {
       if (response.error) {
@@ -38,15 +42,13 @@ function promisify(context: any, method: any, ...args: any): Promise<mixed> {
  * @memberof utils/utils
  * @static
  */
-function endTruncateStr(str: any, size: number) {
+export function endTruncateStr(str: any, size: number) {
   if (str.length > size) {
     return `...${str.slice(str.length - size)}`;
   }
   return str;
 }
 
-function waitForMs(ms: number): Promise<void> {
+export function waitForMs(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
-
-export { handleError, promisify, endTruncateStr, waitForMs };

--- a/src/utils/wasm.js
+++ b/src/utils/wasm.js
@@ -31,7 +31,7 @@ function maybeWasmSectionNameResolver(data: Uint8Array) {
  * @memberof utils/wasm
  * @static
  */
-function getWasmText(sourceId: string, data: Uint8Array) {
+export function getWasmText(sourceId: string, data: Uint8Array) {
   const nameResolver = maybeWasmSectionNameResolver(data);
   const parser = new BinaryReader();
   parser.setData(data.buffer, 0, data.length);
@@ -61,7 +61,7 @@ function getWasmText(sourceId: string, data: Uint8Array) {
  * @memberof utils/wasm
  * @static
  */
-function getWasmLineNumberFormatter(sourceId: string) {
+export function getWasmLineNumberFormatter(sourceId: string) {
   const codeOf0 = 48,
     codeOfA = 65;
   const buffer = [
@@ -97,7 +97,7 @@ function getWasmLineNumberFormatter(sourceId: string) {
  * @memberof utils/wasm
  * @static
  */
-function isWasm(sourceId: string) {
+export function isWasm(sourceId: string) {
   return sourceId in wasmStates;
 }
 
@@ -105,7 +105,7 @@ function isWasm(sourceId: string) {
  * @memberof utils/wasm
  * @static
  */
-function lineToWasmOffset(sourceId: string, number: number): ?number {
+export function lineToWasmOffset(sourceId: string, number: number): ?number {
   const wasmState = wasmStates[sourceId];
   if (!wasmState) {
     return undefined;
@@ -121,7 +121,7 @@ function lineToWasmOffset(sourceId: string, number: number): ?number {
  * @memberof utils/wasm
  * @static
  */
-function wasmOffsetToLine(sourceId: string, offset: number): ?number {
+export function wasmOffsetToLine(sourceId: string, offset: number): ?number {
   const wasmState = wasmStates[sourceId];
   if (!wasmState) {
     return undefined;
@@ -133,11 +133,11 @@ function wasmOffsetToLine(sourceId: string, offset: number): ?number {
  * @memberof utils/wasm
  * @static
  */
-function clearWasmStates() {
+export function clearWasmStates() {
   wasmStates = (Object.create(null): any);
 }
 
-function renderWasmText(sourceId: string, { binary }: Object) {
+export function renderWasmText(sourceId: string, { binary }: Object) {
   // binary does not survive as Uint8Array, converting from string
   const data = new Uint8Array(binary.length);
   for (let i = 0; i < data.length; i++) {
@@ -151,13 +151,3 @@ function renderWasmText(sourceId: string, { binary }: Object) {
   }
   return lines;
 }
-
-export {
-  getWasmText,
-  getWasmLineNumberFormatter,
-  isWasm,
-  lineToWasmOffset,
-  wasmOffsetToLine,
-  clearWasmStates,
-  renderWasmText
-};

--- a/src/vendors.js
+++ b/src/vendors.js
@@ -35,7 +35,7 @@ import Svg from "./components/shared/Svg";
 // (eg. "my-module/Test") which is why they are nested in "vendored".
 // The keys of the vendored object should match the module names
 // !!! Should remain synchronized with .babel/transform-mc.js !!!
-const vendored = {
+export const vendored = {
   classnames,
   "devtools-components": devtoolsComponents,
   "devtools-config": devtoolsConfig,
@@ -52,5 +52,3 @@ const vendored = {
   Svg,
   url
 };
-
-export { vendored };


### PR DESCRIPTION
Tracking functions and constants seems easier with all information in one place.

If we separate out the export statement there is an additional step required to check if the function we are looking at is actually being exported.