### PR TITLE
Renames getExtension to getFileExtension

### DIFF
--- a/src/utils/source.js
+++ b/src/utils/source.js
@@ -16,7 +16,7 @@ import { basename } from "./path";
 import { parse as parseURL } from "url";
 import { getUnicodeUrl, getUnicodeUrlPath } from "devtools-modules";
 export { isMinified } from "./isMinified";
-import { getExtension } from "./sources-tree";
+import { getFileExtension } from "./sources-tree";
 
 import type { Source, SourceRecord, Location } from "../types";
 import type { SourceMetaDataType } from "../reducers/ast";
@@ -375,5 +375,5 @@ export function getSourceClassnames(
   if (source.isBlackBoxed) {
     return "blackBox";
   }
-  return sourceTypes[getExtension(source.url)] || defaultClassName;
+  return sourceTypes[getFileExtension(source.url)] || defaultClassName;
 }

--- a/src/utils/sources-tree/index.js
+++ b/src/utils/sources-tree/index.js
@@ -19,10 +19,10 @@ export { updateTree } from "./updateTree";
 export {
   createNode,
   createParentMap,
+  getFileExtension,
   getRelativePath,
   isDirectory,
   isExactUrlMatch,
   isNotJavaScript,
-  nodeHasChildren,
-  getExtension
+  nodeHasChildren
 } from "./utils";

--- a/src/utils/sources-tree/utils.js
+++ b/src/utils/sources-tree/utils.js
@@ -37,7 +37,7 @@ export function isDirectory(url: Object) {
   );
 }
 
-export function getExtension(url: string = ""): string {
+export function getFileExtension(url: string = ""): string {
   const parsedUrl = parse(url).pathname;
   if (!parsedUrl) {
     return "";
@@ -46,7 +46,7 @@ export function getExtension(url: string = ""): string {
 }
 
 export function isNotJavaScript(source: Object): boolean {
-  return ["css", "svg", "png"].includes(getExtension(source.url));
+  return ["css", "svg", "png"].includes(getFileExtension(source.url));
 }
 
 export function isInvalidUrl(url: Object, source: SourceRecord) {


### PR DESCRIPTION
Renames getExtension to getFileExtension to make it clear it gets the File extension and not any other we might have introduced in the codebase.