### PR TITLE
Unbundle reps.

### DIFF
--- a/.babel/transform-mc.js
+++ b/.babel/transform-mc.js
@@ -5,7 +5,7 @@ const mappings = require("../configs/mozilla-central-mappings");
 
 // Add two additional mappings that cannot be reused when creating the
 // webpack bundles.
-mappings["devtools-reps"] = "devtools/client/shared/components/reps/reps.js";
+mappings["devtools-reps"] = "devtools/client/shared/components/reps/src/index.js";
 mappings["devtools-source-map"] = "devtools/client/shared/source-map/index.js";
 
 function isRequire(t, node) {

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,8 +46,7 @@ install:
   - python --version
   - node --version
   - du -sh firefox
-  - node ./bin/copy-assets.js --mc ./firefox
-  - node ./bin/copy-modules.js --mc ./firefox
+  - node ./bin/copy
   - ./bin/ci/build-firefox.sh
   - node ./bin/ci/check-file-sizes.js
 

--- a/assets/module-manifest.json
+++ b/assets/module-manifest.json
@@ -20574,7 +20574,292 @@
       "../../parse5/lib/serializer/serializer_stream.js": 1752,
       "../../parse5/lib/sax/index.js": 1753,
       "../../parse5/lib/sax/dev_null_stream.js": 1754,
-      "../../parse5/lib/sax/parser_feedback_simulator.js": 1755
+      "../../parse5/lib/sax/parser_feedback_simulator.js": 1755,
+      "external \"devtools/client/shared/vendor/react-prop-types\"": 1758,
+      "external \"devtools/client/shared/vendor/react-dom-factories\"": 1759,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/selectors/index.js": 1760,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/rep-utils.js": 1761,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/constants.js": 1762,
+      "external \"devtools/client/shared/vendor/react-redux\"": 1763,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-source-map/src/index.js": 1764,
+      "../../@babel/types/lib/index.js": 1765,
+      "../../@babel/types/lib/validators/generated/index.js": 1766,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/rep.js": 1767,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../devtools-environment/index.js": 1768,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/string.js": 1769,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/array.js": 1770,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/prop-rep.js": 1771,
+      "../../@babel/types/lib/builders/generated/index.js": 1772,
+      "external \"devtools/client/shared/vendor/immutable\"": 1773,
+      "../../@babel/types/lib/definitions/index.js": 1774,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-utils/index.js": 1775,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/components/shared/Button/index.js": 1776,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/actions/sources/index.js": 1777,
+      "../../@babel/types/lib/definitions/utils.js": 1778,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-source-map/src/utils/index.js": 1779,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-utils/src/privileged-network-request.js": 1780,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-utils/src/worker-utils.js": 1781,
+      "external \"devtools/client/shared/vendor/redux\"": 1782,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/index.js": 1783,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/grip.js": 1784,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/object-inspector/utils/index.js": 1785,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/object-inspector/utils/node.js": 1786,
+      "../../@babel/types/lib/constants/index.js": 1787,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/pause/frames/index.js": 1788,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-components/index.js": 1789,
+      "../../node-libs-browser/node_modules/punycode/punycode.js": 1790,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/pause/mapScopes/locColumn.js": 1791,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-components/src/tree.js": 1792,
+      "../../extract-text-webpack-plugin/dist/loader.js??ref--3-0!../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../packages/devtools-components/src/tree.css": 1793,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/function.js": 1794,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/shared/dom-node-constants.js": 1795,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/error.js": 1796,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/grip-array.js": 1797,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/shared/grip-length-bubble.js": 1798,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/grip-map.js": 1799,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/grip-map-entry.js": 1800,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/object-inspector/utils/client.js": 1801,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/object-inspector/utils/load-properties.js": 1802,
+      "../../@babel/types/lib/validators/isValidIdentifier.js": 1803,
+      "../../@babel/types/lib/clone/cloneNode.js": 1804,
+      "../../../packages/devtools-source-map/node_modules/source-map/lib/util.js": 1805,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/pause/frames/getFrameUrl.js": 1806,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/preview.js": 1807,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/pause/index.js": 1808,
+      "../../@babel/types/lib/retrievers/getBindingIdentifiers.js": 1809,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../devtools-modules/src/source-utils.js": 1810,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../devtools-modules/src/unicode-url.js": 1811,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/source-queue.js": 1812,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/pause/mapScopes/positionCmp.js": 1813,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/actions/sources/prettyPrint.js": 1814,
+      "../../svg-inline-react/lib/index.js": 1815,
+      "../../svg-inline-react/lib/util.js": 1816,
+      "../../svg-inline-loader/index.js!../../../assets/images/babel.svg": 1817,
+      "../../svg-inline-loader/index.js!../../../assets/images/breadcrumbs-divider.svg": 1818,
+      "../../svg-inline-loader/index.js!../../../assets/images/coffeescript.svg": 1819,
+      "../../svg-inline-loader/index.js!../../../assets/images/extension.svg": 1820,
+      "../../svg-inline-loader/index.js!../../../assets/images/home.svg": 1821,
+      "../../svg-inline-loader/index.js!../../../assets/images/javascript.svg": 1822,
+      "../../svg-inline-loader/index.js!../../../assets/images/tab.svg": 1823,
+      "../../svg-inline-loader/index.js!../../../assets/images/typescript.svg": 1824,
+      "../../svg-inline-loader/index.js!../../../assets/images/rxjs.svg": 1825,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/components/shared/Button/CommandBarButton.js": 1826,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/components/shared/SourceIcon.js": 1827,
+      "../../extract-text-webpack-plugin/dist/loader.js??ref--3-0!../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../packages/devtools-reps/src/reps/reps.css": 1828,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/undefined.js": 1829,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/null.js": 1830,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/number.js": 1831,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/object.js": 1832,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/symbol.js": 1833,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/infinity.js": 1834,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/nan.js": 1835,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/accessor.js": 1836,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/attribute.js": 1837,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/date-time.js": 1838,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/document.js": 1839,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/document-type.js": 1840,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/event.js": 1841,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/promise.js": 1842,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/regexp.js": 1843,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/stylesheet.js": 1844,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/comment-node.js": 1845,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/element-node.js": 1846,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/text-node.js": 1847,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/window.js": 1848,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/object-with-text.js": 1849,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/object-with-url.js": 1850,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/object-inspector/index.js": 1851,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/object-inspector/component.js": 1852,
+      "../../extract-text-webpack-plugin/dist/loader.js??ref--3-0!../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../packages/devtools-reps/src/object-inspector/index.css": 1853,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/object-inspector/utils/selection.js": 1854,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/object-inspector/actions.js": 1855,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/object-inspector/store.js": 1856,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/shared/redux/middleware/thunk.js": 1857,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/shared/redux/middleware/waitUntilService.js": 1858,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/object-inspector/reducer.js": 1859,
+      "../../@babel/types/lib/utils/shallowEqual.js": 1860,
+      "../../@babel/types/lib/definitions/core.js": 1861,
+      "../../@babel/types/lib/validators/is.js": 1862,
+      "../../@babel/types/lib/validators/isType.js": 1863,
+      "../../@babel/types/lib/definitions/es2015.js": 1864,
+      "../../@babel/types/lib/utils/inherit.js": 1865,
+      "../../@babel/generator/lib/generators/types.js": 1866,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-source-map/src/utils/sourceMapRequests.js": 1867,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/pause/pausePoints.js": 1868,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/reducers/replay.js": 1869,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/pause/frames/getLibraryFromUrl.js": 1870,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/log.js": 1871,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/pause/mapScopes/filtering.js": 1872,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/pause/mapScopes/mappingContains.js": 1873,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/actions/pause/extra.js": 1874,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/actions/sources/blackbox.js": 1875,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/actions/sources/tabs.js": 1876,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/actions/pause/mapFrames.js": 1877,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/tabs.js": 1878,
+      "../../@babel/types/lib/validators/buildMatchMemberExpression.js": 1879,
+      "../../@babel/types/lib/validators/matchesPattern.js": 1880,
+      "../../@babel/types/lib/validators/validate.js": 1881,
+      "../../@babel/types/lib/validators/isNode.js": 1882,
+      "../../@babel/types/lib/modifications/flow/removeTypeDuplicates.js": 1883,
+      "../../@babel/types/lib/clone/clone.js": 1884,
+      "../../@babel/types/lib/comments/addComments.js": 1885,
+      "../../@babel/types/lib/comments/inheritInnerComments.js": 1886,
+      "../../@babel/types/lib/comments/inheritLeadingComments.js": 1887,
+      "../../@babel/types/lib/comments/inheritsComments.js": 1888,
+      "../../@babel/types/lib/comments/inheritTrailingComments.js": 1889,
+      "../../@babel/types/lib/converters/toBlock.js": 1890,
+      "../../@babel/types/lib/converters/toIdentifier.js": 1891,
+      "../../@babel/types/lib/modifications/removePropertiesDeep.js": 1892,
+      "../../@babel/types/lib/traverse/traverseFast.js": 1893,
+      "../../@babel/types/lib/modifications/removeProperties.js": 1894,
+      "../../@babel/types/lib/validators/isLet.js": 1895,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/workers/parser/utils/simple-path.js": 1896,
+      "../../@babel/generator/lib/index.js": 1897,
+      "../../@babel/generator/lib/node/index.js": 1898,
+      "../../@babel/generator/lib/generators/modules.js": 1899,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/workers/parser/getScopes/index.js": 1900,
+      "../../../packages/devtools-source-map/node_modules/source-map/source-map.js": 1901,
+      "../../../packages/devtools-source-map/node_modules/source-map/lib/source-map-generator.js": 1902,
+      "../../../packages/devtools-source-map/node_modules/source-map/lib/base64-vlq.js": 1903,
+      "../../../packages/devtools-source-map/node_modules/source-map/lib/array-set.js": 1904,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/isMinified.js": 1905,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/sources-tree/updateTree.js": 1906,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/selectors/inComponent.js": 1907,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/selectors/getCallStackFrames.js": 1908,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/pause/frames/annotateFrames.js": 1909,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/pause/frames/collapseFrames.js": 1910,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/pause/frames/displayName.js": 1911,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/selectors/visibleSelectedFrame.js": 1912,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/selectors/getRelativeSources.js": 1913,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/selectors/breakpointSources.js": 1914,
+      "external \"devtools/shared/fronts/device\"": 1915,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/dbg.js": 1916,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/defer.js": 1917,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/pause/mapScopes/index.js": 1918,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/pause/mapScopes/rangeMetadata.js": 1919,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/pause/mapScopes/findGeneratedBindingFromPosition.js": 1920,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/pause/mapScopes/getGeneratedLocationRanges.js": 1921,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/pause/mapScopes/buildGeneratedBindingList.js": 1922,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/actions/sources/newSources.js": 1923,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/actions/ast/setInScopeLines.js": 1924,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/actions/sources/select.js": 1925,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/editor/get-token-location.js": 1926,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/editor/token-events.js": 1927,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/editor/create-editor.js": 1928,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/location.js": 1929,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/pause/why.js": 1930,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/pause/stepping.js": 1931,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/actions/pause/setPopupObjectProperties.js": 1932,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/actions/pause/selectComponent.js": 1933,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/actions/pause/skipPausing.js": 1934,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/actions/replay.js": 1935,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/actions/preview.js": 1936,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/editor/get-expression.js": 1937,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/components/ProjectSearch.js": 1938,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/project-search.js": 1939,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/components/shared/Button/CloseButton.js": 1940,
+      "../../extract-text-webpack-plugin/dist/loader.js??ref--3-0!../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/shared/Button/styles/CloseButton.css": 1941,
+      "../../extract-text-webpack-plugin/dist/loader.js??ref--3-0!../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/shared/Button/styles/CommandBarButton.css": 1942,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/components/shared/Button/PaneToggleButton.js": 1943,
+      "../../extract-text-webpack-plugin/dist/loader.js??ref--3-0!../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/shared/Button/styles/PaneToggleButton.css": 1944,
+      "../../extract-text-webpack-plugin/dist/loader.js??ref--3-0!../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/ProjectSearch.css": 1945,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/components/PrimaryPanes/SourcesTreeItem.js": 1946,
+      "../../extract-text-webpack-plugin/dist/loader.js??ref--3-0!../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/shared/SourceIcon.css": 1947,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/components/Editor/HighlightLine.js": 1948,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/components/SecondaryPanes/Breakpoints/index.js": 1949,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/components/SecondaryPanes/Breakpoints/Breakpoint.js": 1950,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/components/SecondaryPanes/Breakpoints/BreakpointsContextMenu.js": 1951,
+      "../../extract-text-webpack-plugin/dist/loader.js??ref--3-0!../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/SecondaryPanes/Breakpoints/Breakpoints.css": 1952,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/components/SecondaryPanes/FrameworkComponent.js": 1953,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/pause/scopes/index.js": 1954,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/pause/scopes/getScope.js": 1955,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/pause/scopes/getVariables.js": 1956,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/pause/scopes/utils.js": 1957,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/components/Editor/Tab.js": 1958,
+      "../../extract-text-webpack-plugin/dist/loader.js??ref--3-0!../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/QuickOpenModal.css": 1959,
+      "../../@babel/types/lib/validators/react/isReactComponent.js": 1960,
+      "../../@babel/types/lib/validators/react/isCompatTag.js": 1961,
+      "../../@babel/types/lib/builders/react/buildChildren.js": 1962,
+      "../../@babel/types/lib/utils/react/cleanJSXElementLiteralChild.js": 1963,
+      "../../@babel/types/lib/builders/builder.js": 1964,
+      "../../lodash/isMap.js": 1965,
+      "../../lodash/_baseIsMap.js": 1966,
+      "../../lodash/isSet.js": 1967,
+      "../../lodash/_baseIsSet.js": 1968,
+      "../../@babel/types/lib/definitions/flow.js": 1969,
+      "../../@babel/types/lib/definitions/jsx.js": 1970,
+      "../../@babel/types/lib/definitions/misc.js": 1971,
+      "../../@babel/types/lib/definitions/experimental.js": 1972,
+      "../../@babel/types/lib/definitions/typescript.js": 1973,
+      "../../@babel/types/lib/asserts/assertNode.js": 1974,
+      "../../@babel/types/lib/asserts/generated/index.js": 1975,
+      "../../@babel/types/lib/builders/flow/createTypeAnnotationBasedOnTypeof.js": 1976,
+      "../../@babel/types/lib/builders/flow/createUnionTypeAnnotation.js": 1977,
+      "../../@babel/types/lib/clone/cloneDeep.js": 1978,
+      "../../@babel/types/lib/clone/cloneWithoutLoc.js": 1979,
+      "../../@babel/types/lib/comments/addComment.js": 1980,
+      "../../@babel/types/lib/comments/removeComments.js": 1981,
+      "../../@babel/types/lib/constants/generated/index.js": 1982,
+      "../../@babel/types/lib/converters/ensureBlock.js": 1983,
+      "../../@babel/types/lib/converters/toBindingIdentifierName.js": 1984,
+      "../../@babel/types/lib/converters/toComputedKey.js": 1985,
+      "../../@babel/types/lib/converters/toExpression.js": 1986,
+      "../../@babel/types/lib/converters/toKeyAlias.js": 1987,
+      "../../@babel/types/lib/converters/toSequenceExpression.js": 1988,
+      "../../@babel/types/lib/converters/gatherSequenceExpressions.js": 1989,
+      "../../@babel/types/lib/converters/toStatement.js": 1990,
+      "../../@babel/types/lib/converters/valueToNode.js": 1991,
+      "../../@babel/types/lib/modifications/appendToMemberExpression.js": 1992,
+      "../../@babel/types/lib/modifications/inherits.js": 1993,
+      "../../@babel/types/lib/modifications/prependToMemberExpression.js": 1994,
+      "../../@babel/types/lib/retrievers/getOuterBindingIdentifiers.js": 1995,
+      "../../@babel/types/lib/traverse/traverse.js": 1996,
+      "../../@babel/types/lib/validators/isBinding.js": 1997,
+      "../../@babel/types/lib/validators/isBlockScoped.js": 1998,
+      "../../@babel/types/lib/validators/isImmutable.js": 1999,
+      "../../@babel/types/lib/validators/isNodesEquivalent.js": 2000,
+      "../../@babel/types/lib/validators/isReferenced.js": 2001,
+      "../../@babel/types/lib/validators/isScope.js": 2002,
+      "../../@babel/types/lib/validators/isSpecifierDefault.js": 2003,
+      "../../@babel/types/lib/validators/isValidES3Identifier.js": 2004,
+      "../../@babel/types/lib/validators/isVar.js": 2005,
+      "../../parse-script-tags/customParse.js": 2006,
+      "../../parse-script-tags/parseScriptFragment.js": 2007,
+      "../../@babel/generator/lib/source-map.js": 2008,
+      "../../@babel/generator/lib/printer.js": 2009,
+      "../../@babel/generator/lib/buffer.js": 2010,
+      "../../@babel/generator/lib/node/whitespace.js": 2011,
+      "../../@babel/generator/lib/node/parentheses.js": 2012,
+      "../../@babel/generator/lib/generators/index.js": 2013,
+      "../../@babel/generator/lib/generators/template-literals.js": 2014,
+      "../../@babel/generator/lib/generators/expressions.js": 2015,
+      "../../@babel/generator/lib/generators/statements.js": 2016,
+      "../../@babel/generator/lib/generators/classes.js": 2017,
+      "../../@babel/generator/lib/generators/methods.js": 2018,
+      "../../jsesc/jsesc.js": 2019,
+      "../../@babel/generator/lib/generators/flow.js": 2020,
+      "../../@babel/generator/lib/generators/base.js": 2021,
+      "../../@babel/generator/lib/generators/jsx.js": 2022,
+      "../../@babel/generator/lib/generators/typescript.js": 2023,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/workers/parser/getScopes/visitor.js": 2024,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/workers/parser/pausePoints.js": 2025,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/workers/parser/mapOriginalExpression.js": 2026,
+      "multi ../../../packages/devtools-source-map/src/worker.js": 2027,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-source-map/src/worker.js": 2028,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-source-map/src/source-map.js": 2029,
+      "../../../packages/devtools-source-map/node_modules/source-map/lib/base64.js": 2030,
+      "../../../packages/devtools-source-map/node_modules/source-map/lib/mapping-list.js": 2031,
+      "../../../packages/devtools-source-map/node_modules/source-map/lib/source-map-consumer.js": 2032,
+      "../../../packages/devtools-source-map/node_modules/source-map/lib/binary-search.js": 2033,
+      "../../../packages/devtools-source-map/node_modules/source-map/lib/quick-sort.js": 2034,
+      "../../../packages/devtools-source-map/node_modules/source-map/lib/source-node.js": 2035,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-source-map/src/utils/assert.js": 2036,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-source-map/src/utils/fetchSourceMap.js": 2037,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-source-map/src/utils/wasmRemap.js": 2038,
+      "multi ../../../packages/devtools-source-map/src/index.js": 2039,
+      "multi ../../../src/vendors.js": 2040,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/vendors.js": 2041,
+      "multi ../../../packages/devtools-reps/src/index.js": 2042
     },
     "usedIds": {
       "0": 0,
@@ -22334,7 +22619,292 @@
       "1754": 1754,
       "1755": 1755,
       "1756": 1756,
-      "1757": 1757
+      "1757": 1757,
+      "1758": 1758,
+      "1759": 1759,
+      "1760": 1760,
+      "1761": 1761,
+      "1762": 1762,
+      "1763": 1763,
+      "1764": 1764,
+      "1765": 1765,
+      "1766": 1766,
+      "1767": 1767,
+      "1768": 1768,
+      "1769": 1769,
+      "1770": 1770,
+      "1771": 1771,
+      "1772": 1772,
+      "1773": 1773,
+      "1774": 1774,
+      "1775": 1775,
+      "1776": 1776,
+      "1777": 1777,
+      "1778": 1778,
+      "1779": 1779,
+      "1780": 1780,
+      "1781": 1781,
+      "1782": 1782,
+      "1783": 1783,
+      "1784": 1784,
+      "1785": 1785,
+      "1786": 1786,
+      "1787": 1787,
+      "1788": 1788,
+      "1789": 1789,
+      "1790": 1790,
+      "1791": 1791,
+      "1792": 1792,
+      "1793": 1793,
+      "1794": 1794,
+      "1795": 1795,
+      "1796": 1796,
+      "1797": 1797,
+      "1798": 1798,
+      "1799": 1799,
+      "1800": 1800,
+      "1801": 1801,
+      "1802": 1802,
+      "1803": 1803,
+      "1804": 1804,
+      "1805": 1805,
+      "1806": 1806,
+      "1807": 1807,
+      "1808": 1808,
+      "1809": 1809,
+      "1810": 1810,
+      "1811": 1811,
+      "1812": 1812,
+      "1813": 1813,
+      "1814": 1814,
+      "1815": 1815,
+      "1816": 1816,
+      "1817": 1817,
+      "1818": 1818,
+      "1819": 1819,
+      "1820": 1820,
+      "1821": 1821,
+      "1822": 1822,
+      "1823": 1823,
+      "1824": 1824,
+      "1825": 1825,
+      "1826": 1826,
+      "1827": 1827,
+      "1828": 1828,
+      "1829": 1829,
+      "1830": 1830,
+      "1831": 1831,
+      "1832": 1832,
+      "1833": 1833,
+      "1834": 1834,
+      "1835": 1835,
+      "1836": 1836,
+      "1837": 1837,
+      "1838": 1838,
+      "1839": 1839,
+      "1840": 1840,
+      "1841": 1841,
+      "1842": 1842,
+      "1843": 1843,
+      "1844": 1844,
+      "1845": 1845,
+      "1846": 1846,
+      "1847": 1847,
+      "1848": 1848,
+      "1849": 1849,
+      "1850": 1850,
+      "1851": 1851,
+      "1852": 1852,
+      "1853": 1853,
+      "1854": 1854,
+      "1855": 1855,
+      "1856": 1856,
+      "1857": 1857,
+      "1858": 1858,
+      "1859": 1859,
+      "1860": 1860,
+      "1861": 1861,
+      "1862": 1862,
+      "1863": 1863,
+      "1864": 1864,
+      "1865": 1865,
+      "1866": 1866,
+      "1867": 1867,
+      "1868": 1868,
+      "1869": 1869,
+      "1870": 1870,
+      "1871": 1871,
+      "1872": 1872,
+      "1873": 1873,
+      "1874": 1874,
+      "1875": 1875,
+      "1876": 1876,
+      "1877": 1877,
+      "1878": 1878,
+      "1879": 1879,
+      "1880": 1880,
+      "1881": 1881,
+      "1882": 1882,
+      "1883": 1883,
+      "1884": 1884,
+      "1885": 1885,
+      "1886": 1886,
+      "1887": 1887,
+      "1888": 1888,
+      "1889": 1889,
+      "1890": 1890,
+      "1891": 1891,
+      "1892": 1892,
+      "1893": 1893,
+      "1894": 1894,
+      "1895": 1895,
+      "1896": 1896,
+      "1897": 1897,
+      "1898": 1898,
+      "1899": 1899,
+      "1900": 1900,
+      "1901": 1901,
+      "1902": 1902,
+      "1903": 1903,
+      "1904": 1904,
+      "1905": 1905,
+      "1906": 1906,
+      "1907": 1907,
+      "1908": 1908,
+      "1909": 1909,
+      "1910": 1910,
+      "1911": 1911,
+      "1912": 1912,
+      "1913": 1913,
+      "1914": 1914,
+      "1915": 1915,
+      "1916": 1916,
+      "1917": 1917,
+      "1918": 1918,
+      "1919": 1919,
+      "1920": 1920,
+      "1921": 1921,
+      "1922": 1922,
+      "1923": 1923,
+      "1924": 1924,
+      "1925": 1925,
+      "1926": 1926,
+      "1927": 1927,
+      "1928": 1928,
+      "1929": 1929,
+      "1930": 1930,
+      "1931": 1931,
+      "1932": 1932,
+      "1933": 1933,
+      "1934": 1934,
+      "1935": 1935,
+      "1936": 1936,
+      "1937": 1937,
+      "1938": 1938,
+      "1939": 1939,
+      "1940": 1940,
+      "1941": 1941,
+      "1942": 1942,
+      "1943": 1943,
+      "1944": 1944,
+      "1945": 1945,
+      "1946": 1946,
+      "1947": 1947,
+      "1948": 1948,
+      "1949": 1949,
+      "1950": 1950,
+      "1951": 1951,
+      "1952": 1952,
+      "1953": 1953,
+      "1954": 1954,
+      "1955": 1955,
+      "1956": 1956,
+      "1957": 1957,
+      "1958": 1958,
+      "1959": 1959,
+      "1960": 1960,
+      "1961": 1961,
+      "1962": 1962,
+      "1963": 1963,
+      "1964": 1964,
+      "1965": 1965,
+      "1966": 1966,
+      "1967": 1967,
+      "1968": 1968,
+      "1969": 1969,
+      "1970": 1970,
+      "1971": 1971,
+      "1972": 1972,
+      "1973": 1973,
+      "1974": 1974,
+      "1975": 1975,
+      "1976": 1976,
+      "1977": 1977,
+      "1978": 1978,
+      "1979": 1979,
+      "1980": 1980,
+      "1981": 1981,
+      "1982": 1982,
+      "1983": 1983,
+      "1984": 1984,
+      "1985": 1985,
+      "1986": 1986,
+      "1987": 1987,
+      "1988": 1988,
+      "1989": 1989,
+      "1990": 1990,
+      "1991": 1991,
+      "1992": 1992,
+      "1993": 1993,
+      "1994": 1994,
+      "1995": 1995,
+      "1996": 1996,
+      "1997": 1997,
+      "1998": 1998,
+      "1999": 1999,
+      "2000": 2000,
+      "2001": 2001,
+      "2002": 2002,
+      "2003": 2003,
+      "2004": 2004,
+      "2005": 2005,
+      "2006": 2006,
+      "2007": 2007,
+      "2008": 2008,
+      "2009": 2009,
+      "2010": 2010,
+      "2011": 2011,
+      "2012": 2012,
+      "2013": 2013,
+      "2014": 2014,
+      "2015": 2015,
+      "2016": 2016,
+      "2017": 2017,
+      "2018": 2018,
+      "2019": 2019,
+      "2020": 2020,
+      "2021": 2021,
+      "2022": 2022,
+      "2023": 2023,
+      "2024": 2024,
+      "2025": 2025,
+      "2026": 2026,
+      "2027": 2027,
+      "2028": 2028,
+      "2029": 2029,
+      "2030": 2030,
+      "2031": 2031,
+      "2032": 2032,
+      "2033": 2033,
+      "2034": 2034,
+      "2035": 2035,
+      "2036": 2036,
+      "2037": 2037,
+      "2038": 2038,
+      "2039": 2039,
+      "2040": 2040,
+      "2041": 2041,
+      "2042": 2042
     }
   },
   "chunks": {
@@ -22344,14 +22914,20 @@
       "pretty-print-worker": 2,
       "source-map-worker": 3,
       "parser-worker": 4,
-      "search-worker": 5
+      "search-worker": 5,
+      "vendors": 1,
+      "reps": 3,
+      "source-map-index": 6
     },
     "byBlocks": {},
     "usedIds": {
       "0": 0,
+      "1": 1,
       "2": 2,
+      "3": 3,
       "4": 4,
-      "5": 5
+      "5": 5,
+      "6": 6
     }
   },
   "extract-text-webpack-plugin ../../extract-text-webpack-plugin/dist ../../css-loader/index.js??ref--4-2!../../postcss-loader/lib/index.js??ref--4-3!../../../src/components/variables.css": [
@@ -25530,18 +26106,20 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/variables.css": 0,
-          "../../css-loader/lib/css-base.js": 1
+          "../../css-loader/lib/css-base.js": 1,
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/variables.css": 2
         },
         "usedIds": {
           "0": 0,
-          "1": 1
+          "1": 1,
+          "2": 2
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "1": 1
+          "0": 0
         }
       }
     }
@@ -25551,18 +26129,20 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/App.css": 0,
-          "../../css-loader/lib/css-base.js": 1
+          "../../css-loader/lib/css-base.js": 1,
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/App.css": 2
         },
         "usedIds": {
           "0": 0,
-          "1": 1
+          "1": 1,
+          "2": 2
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "1": 1
+          "0": 0
         }
       }
     }
@@ -25572,18 +26152,20 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/shared/menu.css": 0,
-          "../../css-loader/lib/css-base.js": 1
+          "../../css-loader/lib/css-base.js": 1,
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/shared/menu.css": 2
         },
         "usedIds": {
           "0": 0,
-          "1": 1
+          "1": 1,
+          "2": 2
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "1": 1
+          "0": 0
         }
       }
     }
@@ -25593,18 +26175,20 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/shared/reps.css": 0,
-          "../../css-loader/lib/css-base.js": 1
+          "../../css-loader/lib/css-base.js": 1,
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/shared/reps.css": 2
         },
         "usedIds": {
           "0": 0,
-          "1": 1
+          "1": 1,
+          "2": 2
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "1": 1
+          "0": 0
         }
       }
     }
@@ -25635,18 +26219,20 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/shared/SearchInput.css": 0,
-          "../../css-loader/lib/css-base.js": 1
+          "../../css-loader/lib/css-base.js": 1,
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/shared/SearchInput.css": 2
         },
         "usedIds": {
           "0": 0,
-          "1": 1
+          "1": 1,
+          "2": 2
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "1": 1
+          "0": 0
         }
       }
     }
@@ -25677,18 +26263,20 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/shared/Svg.css": 0,
-          "../../css-loader/lib/css-base.js": 1
+          "../../css-loader/lib/css-base.js": 1,
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/shared/Svg.css": 2
         },
         "usedIds": {
           "0": 0,
-          "1": 1
+          "1": 1,
+          "2": 2
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "1": 1
+          "0": 0
         }
       }
     }
@@ -25698,18 +26286,20 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/shared/Modal.css": 0,
-          "../../css-loader/lib/css-base.js": 1
+          "../../css-loader/lib/css-base.js": 1,
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/shared/Modal.css": 2
         },
         "usedIds": {
           "0": 0,
-          "1": 1
+          "1": 1,
+          "2": 2
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "1": 1
+          "0": 0
         }
       }
     }
@@ -25719,18 +26309,20 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/shared/ResultList.css": 0,
-          "../../css-loader/lib/css-base.js": 1
+          "../../css-loader/lib/css-base.js": 1,
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/shared/ResultList.css": 2
         },
         "usedIds": {
           "0": 0,
-          "1": 1
+          "1": 1,
+          "2": 2
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "1": 1
+          "0": 0
         }
       }
     }
@@ -25740,18 +26332,20 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/Editor/Tabs.css": 0,
-          "../../css-loader/lib/css-base.js": 1
+          "../../css-loader/lib/css-base.js": 1,
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/Editor/Tabs.css": 2
         },
         "usedIds": {
           "0": 0,
-          "1": 1
+          "1": 1,
+          "2": 2
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "1": 1
+          "0": 0
         }
       }
     }
@@ -25761,18 +26355,20 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/shared/Dropdown.css": 0,
-          "../../css-loader/lib/css-base.js": 1
+          "../../css-loader/lib/css-base.js": 1,
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/shared/Dropdown.css": 2
         },
         "usedIds": {
           "0": 0,
-          "1": 1
+          "1": 1,
+          "2": 2
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "1": 1
+          "0": 0
         }
       }
     }
@@ -25803,18 +26399,20 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/WelcomeBox.css": 0,
-          "../../css-loader/lib/css-base.js": 1
+          "../../css-loader/lib/css-base.js": 1,
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/WelcomeBox.css": 2
         },
         "usedIds": {
           "0": 0,
-          "1": 1
+          "1": 1,
+          "2": 2
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "1": 1
+          "0": 0
         }
       }
     }
@@ -25824,18 +26422,20 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/SecondaryPanes/SecondaryPanes.css": 0,
-          "../../css-loader/lib/css-base.js": 1
+          "../../css-loader/lib/css-base.js": 1,
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/SecondaryPanes/SecondaryPanes.css": 2
         },
         "usedIds": {
           "0": 0,
-          "1": 1
+          "1": 1,
+          "2": 2
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "1": 1
+          "0": 0
         }
       }
     }
@@ -25845,18 +26445,20 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/SecondaryPanes/Scopes.css": 0,
-          "../../css-loader/lib/css-base.js": 1
+          "../../css-loader/lib/css-base.js": 1,
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/SecondaryPanes/Scopes.css": 2
         },
         "usedIds": {
           "0": 0,
-          "1": 1
+          "1": 1,
+          "2": 2
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "1": 1
+          "0": 0
         }
       }
     }
@@ -25908,18 +26510,20 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/shared/ManagedTree.css": 0,
-          "../../css-loader/lib/css-base.js": 1
+          "../../css-loader/lib/css-base.js": 1,
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/shared/ManagedTree.css": 2
         },
         "usedIds": {
           "0": 0,
-          "1": 1
+          "1": 1,
+          "2": 2
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "1": 1
+          "0": 0
         }
       }
     }
@@ -25929,18 +26533,20 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/SecondaryPanes/CommandBar.css": 0,
-          "../../css-loader/lib/css-base.js": 1
+          "../../css-loader/lib/css-base.js": 1,
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/SecondaryPanes/CommandBar.css": 2
         },
         "usedIds": {
           "0": 0,
-          "1": 1
+          "1": 1,
+          "2": 2
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "1": 1
+          "0": 0
         }
       }
     }
@@ -25950,18 +26556,20 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/shared/Accordion.css": 0,
-          "../../css-loader/lib/css-base.js": 1
+          "../../css-loader/lib/css-base.js": 1,
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/shared/Accordion.css": 2
         },
         "usedIds": {
           "0": 0,
-          "1": 1
+          "1": 1,
+          "2": 2
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "1": 1
+          "0": 0
         }
       }
     }
@@ -25971,18 +26579,20 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/SecondaryPanes/Workers.css": 0,
-          "../../css-loader/lib/css-base.js": 1
+          "../../css-loader/lib/css-base.js": 1,
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/SecondaryPanes/Workers.css": 2
         },
         "usedIds": {
           "0": 0,
-          "1": 1
+          "1": 1,
+          "2": 2
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "1": 1
+          "0": 0
         }
       }
     }
@@ -25992,18 +26602,20 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/SecondaryPanes/EventListeners.css": 0,
-          "../../css-loader/lib/css-base.js": 1
+          "../../css-loader/lib/css-base.js": 1,
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/SecondaryPanes/EventListeners.css": 2
         },
         "usedIds": {
           "0": 0,
-          "1": 1
+          "1": 1,
+          "2": 2
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "1": 1
+          "0": 0
         }
       }
     }
@@ -26013,18 +26625,20 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/SecondaryPanes/Frames/Frames.css": 0,
-          "../../css-loader/lib/css-base.js": 1
+          "../../css-loader/lib/css-base.js": 1,
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/SecondaryPanes/Frames/Frames.css": 2
         },
         "usedIds": {
           "0": 0,
-          "1": 1
+          "1": 1,
+          "2": 2
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "1": 1
+          "0": 0
         }
       }
     }
@@ -26034,18 +26648,20 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/SecondaryPanes/Frames/WhyPaused.css": 0,
-          "../../css-loader/lib/css-base.js": 1
+          "../../css-loader/lib/css-base.js": 1,
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/SecondaryPanes/Frames/WhyPaused.css": 2
         },
         "usedIds": {
           "0": 0,
-          "1": 1
+          "1": 1,
+          "2": 2
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "1": 1
+          "0": 0
         }
       }
     }
@@ -26055,18 +26671,20 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/SecondaryPanes/Frames/Group.css": 0,
-          "../../css-loader/lib/css-base.js": 1
+          "../../css-loader/lib/css-base.js": 1,
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/SecondaryPanes/Frames/Group.css": 2
         },
         "usedIds": {
           "0": 0,
-          "1": 1
+          "1": 1,
+          "2": 2
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "1": 1
+          "0": 0
         }
       }
     }
@@ -26076,18 +26694,20 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/SecondaryPanes/Expressions.css": 0,
-          "../../css-loader/lib/css-base.js": 1
+          "../../css-loader/lib/css-base.js": 1,
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/SecondaryPanes/Expressions.css": 2
         },
         "usedIds": {
           "0": 0,
-          "1": 1
+          "1": 1,
+          "2": 2
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "1": 1
+          "0": 0
         }
       }
     }
@@ -26118,18 +26738,20 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/Editor/Editor.css": 0,
-          "../../css-loader/lib/css-base.js": 1
+          "../../css-loader/lib/css-base.js": 1,
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/Editor/Editor.css": 2
         },
         "usedIds": {
           "0": 0,
-          "1": 1
+          "1": 1,
+          "2": 2
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "1": 1
+          "0": 0
         }
       }
     }
@@ -26139,18 +26761,20 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/Editor/Highlight.css": 0,
-          "../../css-loader/lib/css-base.js": 1
+          "../../css-loader/lib/css-base.js": 1,
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/Editor/Highlight.css": 2
         },
         "usedIds": {
           "0": 0,
-          "1": 1
+          "1": 1,
+          "2": 2
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "1": 1
+          "0": 0
         }
       }
     }
@@ -26160,18 +26784,20 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/Editor/ConditionalPanel.css": 0,
-          "../../css-loader/lib/css-base.js": 1
+          "../../css-loader/lib/css-base.js": 1,
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/Editor/ConditionalPanel.css": 2
         },
         "usedIds": {
           "0": 0,
-          "1": 1
+          "1": 1,
+          "2": 2
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "1": 1
+          "0": 0
         }
       }
     }
@@ -26202,18 +26828,20 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/Editor/CallSite.css": 0,
-          "../../css-loader/lib/css-base.js": 1
+          "../../css-loader/lib/css-base.js": 1,
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/Editor/CallSite.css": 2
         },
         "usedIds": {
           "0": 0,
-          "1": 1
+          "1": 1,
+          "2": 2
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "1": 1
+          "0": 0
         }
       }
     }
@@ -26223,18 +26851,20 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/Editor/Preview/Popup.css": 0,
-          "../../css-loader/lib/css-base.js": 1
+          "../../css-loader/lib/css-base.js": 1,
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/Editor/Preview/Popup.css": 2
         },
         "usedIds": {
           "0": 0,
-          "1": 1
+          "1": 1,
+          "2": 2
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "1": 1
+          "0": 0
         }
       }
     }
@@ -26244,18 +26874,20 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/shared/PreviewFunction.css": 0,
-          "../../css-loader/lib/css-base.js": 1
+          "../../css-loader/lib/css-base.js": 1,
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/shared/PreviewFunction.css": 2
         },
         "usedIds": {
           "0": 0,
-          "1": 1
+          "1": 1,
+          "2": 2
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "1": 1
+          "0": 0
         }
       }
     }
@@ -26265,18 +26897,20 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/shared/Popover.css": 0,
-          "../../css-loader/lib/css-base.js": 1
+          "../../css-loader/lib/css-base.js": 1,
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/shared/Popover.css": 2
         },
         "usedIds": {
           "0": 0,
-          "1": 1
+          "1": 1,
+          "2": 2
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "1": 1
+          "0": 0
         }
       }
     }
@@ -26286,18 +26920,20 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/shared/BracketArrow.css": 0,
-          "../../css-loader/lib/css-base.js": 1
+          "../../css-loader/lib/css-base.js": 1,
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/shared/BracketArrow.css": 2
         },
         "usedIds": {
           "0": 0,
-          "1": 1
+          "1": 1,
+          "2": 2
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "1": 1
+          "0": 0
         }
       }
     }
@@ -26307,18 +26943,20 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/Editor/SearchBar.css": 0,
-          "../../css-loader/lib/css-base.js": 1
+          "../../css-loader/lib/css-base.js": 1,
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/Editor/SearchBar.css": 2
         },
         "usedIds": {
           "0": 0,
-          "1": 1
+          "1": 1,
+          "2": 2
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "1": 1
+          "0": 0
         }
       }
     }
@@ -26328,18 +26966,20 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/Editor/Footer.css": 0,
-          "../../css-loader/lib/css-base.js": 1
+          "../../css-loader/lib/css-base.js": 1,
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/Editor/Footer.css": 2
         },
         "usedIds": {
           "0": 0,
-          "1": 1
+          "1": 1,
+          "2": 2
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "1": 1
+          "0": 0
         }
       }
     }
@@ -26349,18 +26989,20 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/PrimaryPanes/Sources.css": 0,
-          "../../css-loader/lib/css-base.js": 1
+          "../../css-loader/lib/css-base.js": 1,
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/PrimaryPanes/Sources.css": 2
         },
         "usedIds": {
           "0": 0,
-          "1": 1
+          "1": 1,
+          "2": 2
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "1": 1
+          "0": 0
         }
       }
     }
@@ -26370,18 +27012,20 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/PrimaryPanes/Outline.css": 0,
-          "../../css-loader/lib/css-base.js": 1
+          "../../css-loader/lib/css-base.js": 1,
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/PrimaryPanes/Outline.css": 2
         },
         "usedIds": {
           "0": 0,
-          "1": 1
+          "1": 1,
+          "2": 2
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "1": 1
+          "0": 0
         }
       }
     }
@@ -26454,18 +27098,20 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../devtools-splitter/src/SplitBox.css": 0,
-          "../../css-loader/lib/css-base.js": 1
+          "../../css-loader/lib/css-base.js": 1,
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../devtools-splitter/src/SplitBox.css": 2
         },
         "usedIds": {
           "0": 0,
-          "1": 1
+          "1": 1,
+          "2": 2
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "1": 1
+          "0": 0
         }
       }
     }
@@ -26475,18 +27121,20 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/ShortcutsModal.css": 0,
-          "../../css-loader/lib/css-base.js": 1
+          "../../css-loader/lib/css-base.js": 1,
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/ShortcutsModal.css": 2
         },
         "usedIds": {
           "0": 0,
-          "1": 1
+          "1": 1,
+          "2": 2
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "1": 1
+          "0": 0
         }
       }
     }
@@ -26496,18 +27144,20 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!components/Root.css": 0,
-          "../../css-loader/lib/css-base.js": 1
+          "../../css-loader/lib/css-base.js": 1,
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!components/Root.css": 2
         },
         "usedIds": {
           "0": 0,
-          "1": 1
+          "1": 1,
+          "2": 2
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "1": 1
+          "0": 0
         }
       }
     }
@@ -26517,18 +27167,20 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../devtools-contextmenu/menu.css": 0,
-          "../../css-loader/lib/css-base.js": 1
+          "../../css-loader/lib/css-base.js": 1,
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../devtools-contextmenu/menu.css": 2
         },
         "usedIds": {
           "0": 0,
-          "1": 1
+          "1": 1,
+          "2": 2
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "1": 1
+          "0": 0
         }
       }
     }
@@ -26601,6 +27253,29 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/shared/Badge.css": 0,
+          "../../css-loader/lib/css-base.js": 1,
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/shared/Badge.css": 2
+        },
+        "usedIds": {
+          "0": 0,
+          "1": 1,
+          "2": 2
+        }
+      },
+      "chunks": {
+        "byName": {},
+        "byBlocks": {},
+        "usedIds": {
+          "0": 0
+        }
+      }
+    }
+  ],
+  "extract-text-webpack-plugin ../../extract-text-webpack-plugin/dist ../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/QuickOpenModal.css": [
+    {
+      "modules": {
+        "byIdentifier": {
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/QuickOpenModal.css": 0,
           "../../css-loader/lib/css-base.js": 1
         },
         "usedIds": {
@@ -26612,7 +27287,196 @@
         "byName": {},
         "byBlocks": {},
         "usedIds": {
+          "0": 0
+        }
+      }
+    }
+  ],
+  "extract-text-webpack-plugin ../../extract-text-webpack-plugin/dist ../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/shared/Button/styles/PaneToggleButton.css": [
+    {
+      "modules": {
+        "byIdentifier": {
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/shared/Button/styles/PaneToggleButton.css": 0,
+          "../../css-loader/lib/css-base.js": 1
+        },
+        "usedIds": {
+          "0": 0,
           "1": 1
+        }
+      },
+      "chunks": {
+        "byName": {},
+        "byBlocks": {},
+        "usedIds": {
+          "0": 0
+        }
+      }
+    }
+  ],
+  "extract-text-webpack-plugin ../../extract-text-webpack-plugin/dist ../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/shared/Button/styles/CommandBarButton.css": [
+    {
+      "modules": {
+        "byIdentifier": {
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/shared/Button/styles/CommandBarButton.css": 0,
+          "../../css-loader/lib/css-base.js": 1
+        },
+        "usedIds": {
+          "0": 0,
+          "1": 1
+        }
+      },
+      "chunks": {
+        "byName": {},
+        "byBlocks": {},
+        "usedIds": {
+          "0": 0
+        }
+      }
+    }
+  ],
+  "extract-text-webpack-plugin ../../extract-text-webpack-plugin/dist ../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/shared/Button/styles/CloseButton.css": [
+    {
+      "modules": {
+        "byIdentifier": {
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/shared/Button/styles/CloseButton.css": 0,
+          "../../css-loader/lib/css-base.js": 1
+        },
+        "usedIds": {
+          "0": 0,
+          "1": 1
+        }
+      },
+      "chunks": {
+        "byName": {},
+        "byBlocks": {},
+        "usedIds": {
+          "0": 0
+        }
+      }
+    }
+  ],
+  "extract-text-webpack-plugin ../../extract-text-webpack-plugin/dist ../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/shared/SourceIcon.css": [
+    {
+      "modules": {
+        "byIdentifier": {
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/shared/SourceIcon.css": 0,
+          "../../css-loader/lib/css-base.js": 1
+        },
+        "usedIds": {
+          "0": 0,
+          "1": 1
+        }
+      },
+      "chunks": {
+        "byName": {},
+        "byBlocks": {},
+        "usedIds": {
+          "0": 0
+        }
+      }
+    }
+  ],
+  "extract-text-webpack-plugin ../../extract-text-webpack-plugin/dist ../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../packages/devtools-reps/src/object-inspector/index.css": [
+    {
+      "modules": {
+        "byIdentifier": {
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../packages/devtools-reps/src/object-inspector/index.css": 0,
+          "../../css-loader/lib/css-base.js": 1
+        },
+        "usedIds": {
+          "0": 0,
+          "1": 1
+        }
+      },
+      "chunks": {
+        "byName": {},
+        "byBlocks": {},
+        "usedIds": {
+          "0": 0
+        }
+      }
+    }
+  ],
+  "extract-text-webpack-plugin ../../extract-text-webpack-plugin/dist ../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../packages/devtools-components/src/tree.css": [
+    {
+      "modules": {
+        "byIdentifier": {
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../packages/devtools-components/src/tree.css": 0,
+          "../../css-loader/lib/css-base.js": 1
+        },
+        "usedIds": {
+          "0": 0,
+          "1": 1
+        }
+      },
+      "chunks": {
+        "byName": {},
+        "byBlocks": {},
+        "usedIds": {
+          "0": 0
+        }
+      }
+    }
+  ],
+  "extract-text-webpack-plugin ../../extract-text-webpack-plugin/dist ../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../packages/devtools-reps/src/reps/reps.css": [
+    {
+      "modules": {
+        "byIdentifier": {
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../packages/devtools-reps/src/reps/reps.css": 0,
+          "../../css-loader/lib/css-base.js": 1
+        },
+        "usedIds": {
+          "0": 0,
+          "1": 1
+        }
+      },
+      "chunks": {
+        "byName": {},
+        "byBlocks": {},
+        "usedIds": {
+          "0": 0
+        }
+      }
+    }
+  ],
+  "extract-text-webpack-plugin ../../extract-text-webpack-plugin/dist ../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/SecondaryPanes/Breakpoints/Breakpoints.css": [
+    {
+      "modules": {
+        "byIdentifier": {
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/SecondaryPanes/Breakpoints/Breakpoints.css": 0,
+          "../../css-loader/lib/css-base.js": 1
+        },
+        "usedIds": {
+          "0": 0,
+          "1": 1
+        }
+      },
+      "chunks": {
+        "byName": {},
+        "byBlocks": {},
+        "usedIds": {
+          "0": 0
+        }
+      }
+    }
+  ],
+  "extract-text-webpack-plugin ../../extract-text-webpack-plugin/dist ../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/ProjectSearch.css": [
+    {
+      "modules": {
+        "byIdentifier": {
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/ProjectSearch.css": 0,
+          "../../css-loader/lib/css-base.js": 1
+        },
+        "usedIds": {
+          "0": 0,
+          "1": 1
+        }
+      },
+      "chunks": {
+        "byName": {},
+        "byBlocks": {},
+        "usedIds": {
+          "0": 0
         }
       }
     }

--- a/bin/copy-assets.js
+++ b/bin/copy-assets.js
@@ -274,11 +274,8 @@ function onBundleFinish({mcPath, bundlePath, projectPath}) {
     {cwd: projectPath}
   );
 
-  moveFile(
-    path.join(mcPath, bundlePath, "reps.js"),
-    path.join(mcPath, "devtools/client/shared/components/reps/reps.js"),
-    {cwd: projectPath}
-  );
+  console.log("[copy-assets] delete reps.js bundle");
+  fs.unlinkSync(path.join(mcPath, bundlePath, "reps.js"))
 
   moveFile(
     path.join(mcPath, bundlePath, "reps.css"),

--- a/bin/copy.js
+++ b/bin/copy.js
@@ -2,6 +2,7 @@
 const copyAssets = require("./copy-assets")
 const copyModules = require("./copy-modules")
 const minimist = require("minimist");
+const path = require("path");
 
 const args = minimist(process.argv.slice(1), {
   string: ["mc"],
@@ -16,8 +17,23 @@ const assets = args.assets
 console.log(`Copying Files to ${mc} with params: `, {watch, assets, symlink})
 
 async function start() {
-  await copyAssets({ assets, mc, watch, symlink})
-  await copyModules({ mc, watch })
+  await copyAssets({ assets, mc, watch, symlink});
+
+  // Debugger
+  await copyModules({
+    source: "./src/**/*.js",
+    ignoreRegexp: /(\/fixtures|\/test|vendors\.js|types\.js|types\/)/,
+    mcPath: path.join(mc, "devtools/client/debugger/new"),
+    watch
+  });
+
+  // Reps
+  await copyModules({
+    source: "./packages/devtools-reps/src/**/*.js",
+    ignoreRegexp: /(launchpad\/|test\/|tests\/|stubs\/|types\.js)/,
+    mcPath: path.join(mc, "devtools/client/shared/components/reps/"),
+    watch
+  });
 }
 
 start();

--- a/package.json
+++ b/package.json
@@ -113,6 +113,8 @@
     "babel-plugin-syntax-trailing-function-commas": "^6.22.0",
     "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.26.0",
+    "babel-plugin-transform-require-ignore": "^0.1.1",
+    "babel-plugin-syntax-object-rest-spread": "^6.13.0",
     "babel-preset-env": "^1.6.1",
     "babel-preset-react": "^6.24.1",
     "chalk": "^2.1.0",

--- a/src/utils/editor/source-documents.js
+++ b/src/utils/editor/source-documents.js
@@ -128,8 +128,8 @@ export function showSourceText(
     const doc = getDocument(source.id);
     if (editor.codeMirror.doc === doc) {
       const mode = getMode(source, symbols);
-
-      if (doc.mode.name !== mode.name) {
+      const currentMode = editor.codeMirror.getOption("mode");
+      if (currentMode.name !== mode.name) {
         editor.setMode(mode);
       }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1703,6 +1703,10 @@ babel-plugin-transform-remove-undefined@^0.3.0:
   dependencies:
     babel-helper-evaluate-path "^0.3.0"
 
+babel-plugin-transform-require-ignore@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-require-ignore/-/babel-plugin-transform-require-ignore-0.1.1.tgz#1abb0f803cc29646dd0057f538fdb4a98d6cb8b2"
+
 babel-plugin-transform-runtime@^6.23.0, babel-plugin-transform-runtime@^6.7.5:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-runtime/-/babel-plugin-transform-runtime-6.23.0.tgz#88490d446502ea9b8e7efb0fe09ec4d99479b1ee"


### PR DESCRIPTION
Adds a new script to transpile and move Reps files to mozilla-central.
At some point, it would be nice to simply have an option in copy-modules
to handle both debugger and reps modules.
