### PR TITLE
Fix travis python modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: python
-  - "3.6"
+  - 3.5
 
 node_js: "9"
 
@@ -31,7 +31,8 @@ addons:
 before_install:
   # Ensure the correct version of Python is used; borrowed from:
   # https://github.com/pre-commit/pre-commit/commit/e3ab8902692e896da9ded42bd4d76ea4e1de359d
-  - pyenv global system 3.6
+  - PATH=$PATH.:/usr/local/lib/python
+  # - pyenv global system 3.5
 
 install:
   - pip install --user mercurial


### PR DESCRIPTION
### Summary

1/3 of our travis runs give us an ImportError

This overflow answer seems useful
https://stackoverflow.com/questions/338768/python-error-importerror-no-module-named?utm_medium=organic&utm_source=google_rich_qa&utm_campaign=google_rich_qa

![screen shot 2018-05-29 at 10 10 19 am](https://user-images.githubusercontent.com/254562/40664436-efb32e72-6328-11e8-8e71-b95cd936a997.png)
