### PR TITLE
Prevent extra from being undefined

### DIFF
--- a/src/actions/pause/extra.js
+++ b/src/actions/pause/extra.js
@@ -82,7 +82,7 @@ export function getExtra(expression: string, result: Object) {
   return async ({ dispatch, getState, client, sourceMaps }: ThunkArgs) => {
     const selectedFrame = getSelectedFrame(getState());
     if (!selectedFrame) {
-      return;
+      return {};
     }
 
     const extra = await getExtraProps(getState, expression, result, expr =>


### PR DESCRIPTION
Fixes Issue: #6315

@gregtatum didn't have STR but tracing through our code, `getExtra` can return `undefined` if there's no `selectedFrame`.  Instead of requiring a check for `if(extra && extra.whatever)` everywhere, I think we should return an empty object in this case.