### PR TITLE
[preview] check to see if we statically found a react class

### DIFF
--- a/src/components/Editor/Preview/Popup.js
+++ b/src/components/Editor/Preview/Popup.js
@@ -219,7 +219,7 @@ export class Popup extends Component<Props> {
       roots = roots.filter(r => r.type != NODE_TYPES.PROTOTYPE);
     }
 
-    if (isReactComponent(this.getObjectProperties())) {
+    if (extra.react && isReactComponent(this.getObjectProperties())) {
       header = this.renderReact(extra.react);
       roots = roots.filter(r => ["state", "props"].includes(r.name));
     }


### PR DESCRIPTION

### Summary of Changes

I noticed when a class is `class Foo extends React.Component {}` that we dynamically notice we're in react, but statically miss this. This check mandates that both checks are positive.