### PR TITLE
accordion accessibility #4080 Need to be able to collapse expand headers with keyboard

### DIFF
--- a/src/components/shared/Accordion.js
+++ b/src/components/shared/Accordion.js
@@ -48,11 +48,11 @@ class Accordion extends Component<Props, State> {
     // would not re-render
     this.forceUpdate();
   }
-  
+
   onHandleHeaderKeyPress(e, i) {
-  	if (e && (e.key === " " || e.key === "Enter")) {
-  		this.handleHeaderClick(i);
-  	}
+    if (e && (e.key === " " || e.key === "Enter")) {
+      this.handleHeaderClick(i);
+    }
   }
 
   renderContainer = (item: AccordionItem, i: number) => {

--- a/src/components/shared/Accordion.js
+++ b/src/components/shared/Accordion.js
@@ -49,7 +49,10 @@ class Accordion extends Component<Props, State> {
     this.forceUpdate();
   }
 
-  onHandleHeaderKeyPress(e, i) {
+  onHandleHeaderKeyDown(
+  e: SyntheticKeyboardEvent<HTMLHeadingElement>,
+  i: number
+  ) {
     if (e && (e.key === " " || e.key === "Enter")) {
       this.handleHeaderClick(i);
     }
@@ -63,7 +66,7 @@ class Accordion extends Component<Props, State> {
         <h2
           className="_header"
           tabIndex="0"
-          onKeyPress={e => this.onHandleHeaderKeyPress(e, i)}
+          onKeyPress={e => this.onHandleHeaderKeyDown(e, i)}
           onClick={() => this.handleHeaderClick(i)}
         >
           <Svg name="arrow" className={opened ? "expanded" : ""} />

--- a/src/components/shared/Accordion.js
+++ b/src/components/shared/Accordion.js
@@ -48,6 +48,12 @@ class Accordion extends Component<Props, State> {
     // would not re-render
     this.forceUpdate();
   }
+  
+  onHandleHeaderKeyPress(e, i) {
+  	if (e && (e.key === " " || e.key === "Enter")) {
+  		this.handleHeaderClick(i);
+  	}
+  }
 
   renderContainer = (item: AccordionItem, i: number) => {
     const { opened } = item;
@@ -57,6 +63,7 @@ class Accordion extends Component<Props, State> {
         <h2
           className="_header"
           tabIndex="0"
+          onKeyPress={e => this.onHandleHeaderKeyPress(e, i)}
           onClick={() => this.handleHeaderClick(i)}
         >
           <Svg name="arrow" className={opened ? "expanded" : ""} />

--- a/src/components/shared/Accordion.js
+++ b/src/components/shared/Accordion.js
@@ -50,8 +50,8 @@ class Accordion extends Component<Props, State> {
   }
 
   onHandleHeaderKeyDown(
-  e: SyntheticKeyboardEvent<HTMLHeadingElement>,
-  i: number
+    e: SyntheticKeyboardEvent<HTMLHeadingElement>,
+    i: number
   ) {
     if (e && (e.key === " " || e.key === "Enter")) {
       this.handleHeaderClick(i);
@@ -66,7 +66,7 @@ class Accordion extends Component<Props, State> {
         <h2
           className="_header"
           tabIndex="0"
-          onKeyPress={e => this.onHandleHeaderKeyDown(e, i)}
+          onKeyDown={e => this.onHandleHeaderKeyDown(e, i)}
           onClick={() => this.handleHeaderClick(i)}
         >
           <Svg name="arrow" className={opened ? "expanded" : ""} />

--- a/src/components/shared/tests/__snapshots__/Accordion.spec.js.snap
+++ b/src/components/shared/tests/__snapshots__/Accordion.spec.js.snap
@@ -13,7 +13,7 @@ exports[`Accordion basic render 1`] = `
     <h2
       className="_header"
       onClick={[Function]}
-      onKeyPress={[Function]}
+      onKeyDown={[Function]}
       tabIndex="0"
     >
       <Svg
@@ -36,7 +36,7 @@ exports[`Accordion basic render 1`] = `
     <h2
       className="_header"
       onClick={[Function]}
-      onKeyPress={[Function]}
+      onKeyDown={[Function]}
       tabIndex="0"
     >
       <Svg
@@ -60,7 +60,7 @@ exports[`Accordion basic render 1`] = `
     <h2
       className="_header"
       onClick={[Function]}
-      onKeyPress={[Function]}
+      onKeyDown={[Function]}
       tabIndex="0"
     >
       <Svg

--- a/src/components/shared/tests/__snapshots__/Accordion.spec.js.snap
+++ b/src/components/shared/tests/__snapshots__/Accordion.spec.js.snap
@@ -13,6 +13,7 @@ exports[`Accordion basic render 1`] = `
     <h2
       className="_header"
       onClick={[Function]}
+      onKeyPress={[Function]}
       tabIndex="0"
     >
       <Svg
@@ -35,6 +36,7 @@ exports[`Accordion basic render 1`] = `
     <h2
       className="_header"
       onClick={[Function]}
+      onKeyPress={[Function]}
       tabIndex="0"
     >
       <Svg
@@ -58,6 +60,7 @@ exports[`Accordion basic render 1`] = `
     <h2
       className="_header"
       onClick={[Function]}
+      onKeyPress={[Function]}
       tabIndex="0"
     >
       <Svg


### PR DESCRIPTION
Fixes Issue: # 4080 (Expand/Collapse headers with Keyboard)

Here's the Pull Request Doc
https://devtools-html.github.io/debugger.html/CONTRIBUTING.html#pull-requests

**Summary of Changes**

- We have a bug fix though the we can expand and collapse the headers with the spacebar and Enter key only.

**Test Plan**

- Going though the debugger panel we can shift to the next object with tab when landing on the headers "Watch Expressions" and "Breeakpoints" we can then expand and collapse them with using the space bar and Enter key only, other keys do not do anything.