### PR TITLE
Bug 1463780 - Set cursor style to element-node rep

### DIFF
--- a/packages/devtools-reps/src/reps/element-node.js
+++ b/packages/devtools-reps/src/reps/element-node.js
@@ -50,7 +50,8 @@ function ElementNode(props) {
   if (isInTree) {
     if (onDOMNodeClick) {
       Object.assign(baseConfig, {
-        onClick: _ => onDOMNodeClick(object)
+        onClick: _ => onDOMNodeClick(object),
+        className: `${baseConfig.className} clickable`
       });
     }
 

--- a/packages/devtools-reps/src/reps/reps.css
+++ b/packages/devtools-reps/src/reps/reps.css
@@ -142,6 +142,10 @@
   padding: 0 2px;
 }
 
+.objectBox-node.clickable {
+  cursor: pointer;
+}
+
 /******************************************************************************/
 
 .objectBox-event,
@@ -248,6 +252,7 @@ button.open-inspector {
   height: 16px;
   margin-left: 0.25em;
   vertical-align: middle;
+  cursor: pointer;
 }
 
 .objectBox-node:hover .open-inspector,


### PR DESCRIPTION
### Summary of Changes

* Set pointer cursor to `.objectBox-node` element in case of the element was clickable
* Set pointer cursor to `.open-inspector` element

This changes are for https://bugzilla.mozilla.org/show_bug.cgi?id=1463780

### Test Plan

Please run yarn test