### PR TITLE
Add @babel/core to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "install": "prettier --write package.json"
   },
   "dependencies": {
+    "@babel/core": "^7.0.0-beta.49",
     "@babel/plugin-proposal-object-rest-spread": "^7.0.0-beta.46",
     "@babel/types": "^7.0.0-beta.39",
     "babel-plugin-transform-imports": "^1.5.0",


### PR DESCRIPTION
`node bin/copy-modules.js --mc ../firefox` fails with the message `Cannot find module '@babel/core'`:

This happens with a fresh node install and was probably missed if `@babel/core` was installed globally.

This pull request adds the missing dependency.