### PR TITLE
[Breakpoints] show before a file is shown

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ env:
   global:
     - DISPLAY=':99.0'
     - YARN_VERSION='0.24.5'
-    - MC_COMMIT='???' # just grab the top sha from this URL --> https://hg.mozilla.org/mozilla-central/shortlog
+    - MC_COMMIT='fa5724780fe7'
 
 notifications:
   slack:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ env:
   global:
     - DISPLAY=':99.0'
     - YARN_VERSION='0.24.5'
-    - MC_COMMIT='5866d6685849' # https://hg.mozilla.org/mozilla-central/shortlog
+    - MC_COMMIT='???' # just grab the top sha from this URL --> https://hg.mozilla.org/mozilla-central/shortlog
 
 notifications:
   slack:

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -47,12 +47,11 @@ import {
   showLoading,
   showErrorMessage,
   shouldShowFooter,
-  createEditor,
+  getEditor,
   clearEditor,
   getCursorLine,
   toSourceLine,
   getDocument,
-  setEditor,
   scrollToColumn,
   toEditorPosition,
   getSourceLocationFromMouseEvent,
@@ -128,7 +127,7 @@ class Editor extends PureComponent<Props, State> {
   }
 
   setupEditor() {
-    const editor = createEditor();
+    const editor = getEditor();
 
     // disables the default search shortcuts
     // $FlowIgnore
@@ -179,7 +178,6 @@ class Editor extends PureComponent<Props, State> {
     }
 
     this.setState({ editor });
-    setEditor(editor);
     return editor;
   }
 

--- a/src/components/PrimaryPanes/SourcesTree.js
+++ b/src/components/PrimaryPanes/SourcesTree.js
@@ -211,11 +211,7 @@ class SourcesTree extends Component<Props, State> {
     }
 
     const source = this.getSource(item);
-    return (
-      <SourceIcon
-        source={source}
-      />
-    );
+    return <SourceIcon source={source} />;
   };
 
   onContextMenu = (event, item) => {

--- a/src/components/SecondaryPanes/Breakpoints/Breakpoint.js
+++ b/src/components/SecondaryPanes/Breakpoints/Breakpoint.js
@@ -18,7 +18,7 @@ import { CloseButton } from "../../shared/Button";
 import { getLocationWithoutColumn } from "../../../utils/breakpoint";
 
 import { features } from "../../../utils/prefs";
-import { getCodeMirror } from "../../../utils/editor";
+import { getEditor } from "../../../utils/editor";
 
 import type {
   Frame,
@@ -122,14 +122,14 @@ class Breakpoint extends PureComponent<Props> {
 
   highlightText() {
     const text = this.getBreakpointText();
-    const codeMirror = getCodeMirror();
+    const editor = getEditor();
 
-    if (!text || !codeMirror) {
-      return { __html: "" };
+    if (!editor.CodeMirror) {
+      return { __html: text };
     }
 
     const node = document.createElement("div");
-    codeMirror.constructor.runMode(text, "application/javascript", node);
+    editor.CodeMirror.runMode(text, "application/javascript", node);
     return { __html: node.innerHTML };
   }
 

--- a/src/components/SecondaryPanes/Breakpoints/Breakpoint.js
+++ b/src/components/SecondaryPanes/Breakpoints/Breakpoint.js
@@ -121,7 +121,7 @@ class Breakpoint extends PureComponent<Props> {
   }
 
   highlightText() {
-    const text = this.getBreakpointText();
+    const text = this.getBreakpointText() || "";
     const editor = getEditor();
 
     if (!editor.CodeMirror) {

--- a/src/utils/editor/index.js
+++ b/src/utils/editor/index.js
@@ -8,8 +8,8 @@ export * from "./source-documents";
 export * from "./get-token-location";
 export * from "./source-search";
 export * from "../ui";
-export * from "./create-editor";
 export { onMouseOver } from "./token-events";
+import { createEditor } from "./create-editor";
 
 import { shouldPrettyPrint } from "../source";
 import { findNext, findPrev } from "./source-search";
@@ -24,16 +24,13 @@ type Editor = Object;
 
 let editor: ?Editor;
 
-export function setEditor(_editor: Editor) {
-  editor = _editor;
-}
-
 export function getEditor() {
-  return editor;
-}
+  if (editor) {
+    return editor;
+  }
 
-export function getCodeMirror() {
-  return editor && editor.codeMirror;
+  editor = createEditor();
+  return editor;
 }
 
 export function removeEditor() {

--- a/src/utils/editor/source-editor.js
+++ b/src/utils/editor/source-editor.js
@@ -75,6 +75,10 @@ export default class SourceEditor {
     return this.editor;
   }
 
+  get CodeMirror() {
+    return CodeMirror;
+  }
+
   setText(str: string) {
     this.editor.setValue(str);
   }


### PR DESCRIPTION
Fixes Issue: #6439 

### Summary of Changes

* adds a new CodeMirror field to the SourceEditor so that we can use the class before an editor is intantiated 
* this will need a similar fix in the m-c SourceEditor before the tests pass
* hopefully this simplifies things too