### PR TITLE
Implement componentDidCatch to prevent complete app breakage

### DIFF
--- a/src/components/App.css
+++ b/src/components/App.css
@@ -28,10 +28,6 @@ button:focus {
     padding: 20px;
 }
 
-.debugger-error details {
-  white-space: pre-wrap;
-}
-
 .editor-pane {
   display: flex;
   position: relative;

--- a/src/components/App.css
+++ b/src/components/App.css
@@ -23,6 +23,15 @@ button:focus {
   height: 100%;
 }
 
+.debugger-error {
+    display: block;
+    padding: 20px;
+}
+
+.debugger-error details {
+  white-space: pre-wrap;
+}
+
 .editor-pane {
   display: flex;
   position: relative;

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -66,7 +66,9 @@ type Props = {
 type State = {
   shortcutsModalEnabled: boolean,
   startPanelSize: number,
-  endPanelSize: number
+  endPanelSize: number,
+  error: string,
+  errorInfo: Object
 };
 
 class App extends Component<Props, State> {
@@ -83,7 +85,9 @@ class App extends Component<Props, State> {
     this.state = {
       shortcutsModalEnabled: false,
       startPanelSize: 0,
-      endPanelSize: 0
+      endPanelSize: 0,
+      error: "",
+      errorInfo: null
     };
   }
 
@@ -131,6 +135,12 @@ class App extends Component<Props, State> {
     shortcuts.off(L10N.getStr("gotoLineModal.key2"), this.toggleQuickOpenModal);
 
     shortcuts.off("Escape", this.onEscape);
+  }
+
+  componentDidCatch(error, errorInfo) {
+    // TODO:  Add telemetry to send this information to us for analysis
+    console.log("App: ", error, errorInfo);
+    this.setState({ error, errorInfo });
   }
 
   onEscape = (_, e) => {
@@ -291,6 +301,21 @@ class App extends Component<Props, State> {
 
   render() {
     const { quickOpenEnabled } = this.props;
+    const { error } = this.state;
+
+    if (error) {
+      return (
+        <div className="debugger debugger-error">
+          <h1>Debugger Error</h1>
+          <p>
+            An error in the debugger has prevented the debugger from working
+            properly:
+          </p>
+          <pre>{error.toString()}</pre>
+        </div>
+      );
+    }
+
     return (
       <div className="debugger">
         {this.renderLayout()}


### PR DESCRIPTION
Fixes Issue: #6384

This is a discussion/kickoff PR to implementing overall error handling for the component.  The alternative to `componentDidCatch` (i.e. what we have right now) is an error completely bricking the debugger and nothing being shown in that Firefox panel.  Yuck.

## Questions
-  How does this look as a general rule?
-  How can we send the error data via Telemetry?  (@MikeRatcliffe)

## Testing
-  In any component, add `throw new Error("blah blah")`
-  Refresh the debugger page
-  See something like this:

<img width="1277" alt="errorpane" src="https://user-images.githubusercontent.com/46655/40800202-5254a774-64d5-11e8-8a83-d9ca511ff75d.png">


All thoughts welcome