### PR TITLE
Added haxe syntax highlighting support

### DIFF
--- a/src/utils/editor/source-editor.js
+++ b/src/utils/editor/source-editor.js
@@ -16,6 +16,7 @@ require("codemirror/mode/coffeescript/coffeescript");
 require("codemirror/mode/jsx/jsx");
 require("codemirror/mode/elm/elm");
 require("codemirror/mode/clojure/clojure");
+require("codemirror/mode/haxe/haxe");
 require("codemirror/addon/search/searchcursor");
 require("codemirror/addon/fold/foldcode");
 require("codemirror/addon/fold/brace-fold");

--- a/src/utils/source.js
+++ b/src/utils/source.js
@@ -277,7 +277,8 @@ export function getMode(
     { ext: ".kt", mode: "text/x-kotlin" },
     { ext: ".cpp", mode: "text/x-c++src" },
     { ext: ".m", mode: "text/x-objectivec" },
-    { ext: ".rs", mode: "text/x-rustsrc" }
+    { ext: ".rs", mode: "text/x-rustsrc" },
+    { ext: ".hx", mode: "text/x-haxe" }
   ];
 
   // check for C and other non JS languages

--- a/src/utils/tests/source.spec.js
+++ b/src/utils/tests/source.spec.js
@@ -219,6 +219,14 @@ describe("sources", () => {
       expect(getMode(source)).toEqual({ name: "jsx" });
     });
 
+    it("returns text/x-haxe if the file extension is .hx", () => {
+      const source = {
+        text: "function foo(){}",
+        url: "myComponent.hx"
+      };
+      expect(getMode(source)).toEqual({ name: "text/x-haxe" });
+    });
+
     it("typescript", () => {
       const source = {
         contentType: "text/typescript",


### PR DESCRIPTION
Fixes Issue: #6445

### Summary of Changes

* Added syntax highlighting for Haxe (.hx) files within the debugger.
* I've implemented this by simply matching against the .hx file extension in the url. I felt I could not use content type to match against as it was always reported as text/plain for haxe files.

### Test Plan

I've added a unit test to source.spec.js for the getMode function. 
I've also noticed that the test style is a bit inconsistent among the suites. 
I prefer the it("should...") style but I kept it consistent with tests in the same suite. 
I would like to know If a test cleanup would ever be on the table.
I'd be happy to help with that.

### Screenshots/Videos

Before:
![before](https://user-images.githubusercontent.com/13178548/40855437-dfab6e0a-65d4-11e8-9720-e2546277a258.png)

After:
![after](https://user-images.githubusercontent.com/13178548/40855457-ed1fb424-65d4-11e8-9350-8ac5f61961df.png)

