### PR TITLE
Improve breakpoint alignment

### DIFF
--- a/src/components/SecondaryPanes/Breakpoints/Breakpoints.css
+++ b/src/components/SecondaryPanes/Breakpoints/Breakpoints.css
@@ -154,7 +154,7 @@ html[dir="rtl"] .breakpoints-list .breakpoint .breakpoint-line {
   flex-grow: 1;
   text-overflow: ellipsis;
   overflow: hidden;
-  padding-top: 3px;
+  padding-top: 2px;
   font-size: 11px;
 }
 

--- a/src/components/SecondaryPanes/Breakpoints/Breakpoints.css
+++ b/src/components/SecondaryPanes/Breakpoints/Breakpoints.css
@@ -131,7 +131,6 @@ html .breakpoints-list .breakpoint.paused {
   color: var(--theme-comment);
   min-width: 16px;
   text-align: right;
-  margin-top: -1px;
 }
 
 html[dir="rtl"] .breakpoints-list .breakpoint .breakpoint-line {


### PR DESCRIPTION
A few breakpoint alignment modifications; the breakpoint text looked low on both Mac and Windows, while the line number looked too high.

<img width="297" alt="breakpointheights" src="https://user-images.githubusercontent.com/46655/40941257-ebfe7b38-680f-11e8-9807-26524594468e.png">
