### PR TITLE
altered debug-expression-background for dark theme to make highlighti…

### DIFF
--- a/src/components/Editor/Editor.css
+++ b/src/components/Editor/Editor.css
@@ -13,7 +13,7 @@
 }
 
 .theme-dark .editor-wrapper {
-  --debug-expression-background: #54617e;
+  --debug-expression-background: rgba(202, 227, 255, 0.3);
   --debug-line-border: #7786a2;
 }
 


### PR DESCRIPTION
…ng breakpoint more noticeable

Fixes Issue: #6329

Here's the Pull Request Doc
https://devtools-html.github.io/debugger.html/CONTRIBUTING.html#pull-requests

### Summary of Changes

* Changed the color for .dark-theme -editor-wrapper --debug-expression-background to make it easier to see when breakpoints are highlighted.

### Test Plan

-Opened the firefox debugger.
-Switched the theme to dark theme.
-Launched firefox through the launchpad, went to Pythagorean example in debugger-examples.
-Opened the debugger through the lauchpad, set a breakpoint at line 4 in pythagorean.js
-pressed the Math button in Pythagorean example, went back to debugger and highlighted over breakpoint.

Here's the Debugger's Testing doc
https://docs.google.com/document/d/1oBMRxV8A2ag2t22YsQOxTdEv0mXKzIg0tggJjRkU1S0/edit#.
Feel free to improve it!

### Screenshots/Videos (OPTIONAL)

![image](https://user-images.githubusercontent.com/32425569/40995911-5594c8a4-68b5-11e8-8841-d668c590f6ee.png)
