### PR TITLE
Allow for clicking and copying scopes information

### DIFF
--- a/src/components/SecondaryPanes/SecondaryPanes.css
+++ b/src/components/SecondaryPanes/SecondaryPanes.css
@@ -8,8 +8,6 @@
   flex-direction: column;
   flex: 1;
   white-space: nowrap;
-  -moz-user-select: none;
-  user-select: none;
   --breakpoint-expression-right-clear-space: 36px;
   --breakpoint-expression-height: 2.4em;
 }


### PR DESCRIPTION
Fixes Issue: #6478

Allows users to copy scope properties and values.  This declaration was overly broad.

## Testing
- Set a breakpoint, refresh your source page, wait for breakpoint to hit
- Hover over and copy values in the Scopes' pane tree

## Bonus
- @digitarald will be very happy when this is in