### PR TITLE
Clicking a link in a scopes object opens link

### DIFF
--- a/src/components/SecondaryPanes/Scopes.js
+++ b/src/components/SecondaryPanes/Scopes.js
@@ -30,7 +30,8 @@ type Props = {
   generatedFrameScopes: Object,
   originalFrameScopes: Object | null,
   isLoading: boolean,
-  why: Why
+  why: Why,
+  openLink: string => void
 };
 
 type State = {
@@ -93,7 +94,7 @@ class Scopes extends PureComponent<Props, State> {
   }
 
   render() {
-    const { isPaused, isLoading } = this.props;
+    const { isPaused, isLoading, openLink } = this.props;
     const { originalScopes, generatedScopes, showOriginal } = this.state;
 
     const scopes = (showOriginal && originalScopes) || generatedScopes;
@@ -108,6 +109,7 @@ class Scopes extends PureComponent<Props, State> {
             disableWrap={true}
             focusable={false}
             dimTopLevelWindow={true}
+            openLink={openLink}
             createObjectClient={grip => createObjectClient(grip)}
           />
           {originalScopes ? (


### PR DESCRIPTION
Adding the `openLink` prop to `ObjectInspector` allows our users to open a link from the scopes pane.  Yay!

## Testing

1.  Open https://davidwalsh.name in the debugger
2.  Open and pretty-print `main.js`, add a breakpoint to line 42 (`z.isDebug && sessionStorage.clear();`)
3.  Refresh the debugee tab, wait for breakpoint to hit
4.  Expand `Window: Global` in the scopes pane
5.  Expand `z`, then `d`, then click the URL property's value.

Link should open in new window