### PR TITLE
[Preview] Recognize React.Component as a parent class.

### DIFF
--- a/src/actions/tests/__snapshots__/preview.spec.js.snap
+++ b/src/actions/tests/__snapshots__/preview.spec.js.snap
@@ -46,7 +46,14 @@ exports[`setPreview react instance 1`] = `
 Object {
   "cursorPos": undefined,
   "expression": "this",
-  "extra": Object {},
+  "extra": Object {
+    "react": Object {
+      "componentStack": Array [
+        "Foo",
+      ],
+      "displayName": "FixtureComponent",
+    },
+  },
   "location": Object {
     "end": Object {
       "column": 18,

--- a/src/actions/tests/__snapshots__/preview.spec.js.snap
+++ b/src/actions/tests/__snapshots__/preview.spec.js.snap
@@ -46,14 +46,7 @@ exports[`setPreview react instance 1`] = `
 Object {
   "cursorPos": undefined,
   "expression": "this",
-  "extra": Object {
-    "react": Object {
-      "componentStack": Array [
-        "Foo",
-      ],
-      "displayName": "FixtureComponent",
-    },
-  },
+  "extra": Object {},
   "location": Object {
     "end": Object {
       "column": 18,

--- a/src/actions/tests/preview.spec.js
+++ b/src/actions/tests/preview.spec.js
@@ -8,7 +8,6 @@ import {
   actions,
   makeSource
 } from "../../utils/test-head";
-import I from "immutable";
 import readFixture from "./helpers/readFixture";
 import { prefs } from "../../utils/prefs";
 
@@ -53,7 +52,7 @@ describe("setPreview", () => {
 
     const source = makeSource(fileName);
     await dispatch(actions.newSource(source));
-    await dispatch(actions.loadSourceText(I.Map({ id: fileName })));
+    await dispatch(actions.loadSourceText({ id: fileName }));
 
     await dispatch(actions.selectLocation({ sourceId: fileName }));
     await dispatch(actions.setSymbols(fileName));

--- a/src/selectors/inComponent.js
+++ b/src/selectors/inComponent.js
@@ -40,11 +40,7 @@ export function inComponent(state: State) {
 
   const inReactFile = sourceMetaData.framework == "React";
   const { parent } = closestClass;
-  const isComponent =
-    parent &&
-    parent.name.includes &&
-    (parent.name.includes("Component") ||
-      parent.name.includes("PureComponent"));
+  const isComponent = parent && parent.name.includes("Component");
 
   if (inReactFile && isComponent) {
     return closestClass.name;

--- a/src/selectors/inComponent.js
+++ b/src/selectors/inComponent.js
@@ -39,9 +39,12 @@ export function inComponent(state: State) {
   }
 
   const inReactFile = sourceMetaData.framework == "React";
+  const { parent } = closestClass;
   const isComponent =
-    closestClass.parent &&
-    ["Component", "PureComponent"].includes(closestClass.parent.name);
+    parent &&
+    parent.name.includes &&
+    (parent.name.includes("Component") ||
+      parent.name.includes("PureComponent"));
 
   if (inReactFile && isComponent) {
     return closestClass.name;

--- a/src/workers/parser/getSymbols.js
+++ b/src/workers/parser/getSymbols.js
@@ -16,7 +16,8 @@ import {
   getObjectExpressionValue,
   getVariableNames,
   getComments,
-  getSpecifiers
+  getSpecifiers,
+  getCode
 } from "./utils/helpers";
 
 import { inferClassName } from "./utils/inferClassName";
@@ -33,9 +34,10 @@ export type SymbolDeclaration = {
 };
 
 export type ClassDeclaration = SymbolDeclaration & {
-  parent: {
-    name: string
-  }
+  parent: ?{|
+    name: string,
+    location: AstLocation
+  |}
 };
 
 export type FunctionDeclaration = SymbolDeclaration & {
@@ -146,10 +148,18 @@ function extractSymbol(path: SimplePath, symbols) {
   }
 
   if (t.isClassDeclaration(path)) {
+    const { loc, superClass } = path.node;
     symbols.classes.push({
       name: path.node.id.name,
-      parent: path.node.superClass,
-      location: path.node.loc
+      parent: superClass
+        ? {
+            name: t.isMemberExpression(superClass)
+              ? getCode(superClass)
+              : superClass,
+            location: superClass.loc
+          }
+        : null,
+      location: loc
     });
   }
 

--- a/src/workers/parser/getSymbols.js
+++ b/src/workers/parser/getSymbols.js
@@ -155,7 +155,7 @@ function extractSymbol(path: SimplePath, symbols) {
         ? {
             name: t.isMemberExpression(superClass)
               ? getCode(superClass)
-              : superClass,
+              : superClass.name,
             location: superClass.loc
           }
         : null,

--- a/src/workers/parser/utils/helpers.js
+++ b/src/workers/parser/utils/helpers.js
@@ -62,6 +62,10 @@ export function getObjectExpressionValue(node: Node) {
   return shouldWrap ? `(${code})` : code;
 }
 
+export function getCode(node: Node) {
+  return generate(node).code;
+}
+
 export function getVariableNames(path: SimplePath): SymbolDeclaration[] {
   if (t.isObjectProperty(path.node) && !isFunction(path.node.value)) {
     if (path.node.key.type === "StringLiteral") {


### PR DESCRIPTION
Fixes Issue: #6331 

### Summary of Changes

* Pretty much followed @jasonLaster comments on the issue. 

### Test Plan
- Open https://firefox-debugger-example-react-js.glitch.me/ debugger test page
- Select parse-worker from workers
- Command-P opens the panel and look for getSymbols.js
- Put a breakpoint in line 148
- Reload the target debug page
- It'll hit the breakpoint, then step over
- `symbols.classes` array has the `UnorderedList` object with the parent as shown in the screenshot

### Screenshots/Videos
Object in parser-worker.js, parent added as React.Component
![image](https://user-images.githubusercontent.com/3975603/41015892-82ba2bb8-6909-11e8-89ec-2377d0896976.png)
