### PR TITLE
Extract "excluded" mc mappings to dedicated object

### DIFF
--- a/configs/mozilla-central-mappings.js
+++ b/configs/mozilla-central-mappings.js
@@ -2,7 +2,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
-module.exports = {
+// The excluded files below should not be required while the Debugger runs
+// in Firefox. Here, "devtools/shared/flags" is used as a dummy module.
+const EXCLUDED_FILES = {
+  "../assets/panel/debugger.properties": "devtools/shared/flags",
+  "devtools-connection": "devtools/shared/flags",
+  "chrome-remote-interface": "devtools/shared/flags",
+  "devtools-launchpad": "devtools/shared/flags",
+};
+
+module.exports = Object.assign({
   "./source-editor": "devtools/client/sourceeditor/editor",
   "../editor/source-editor": "devtools/client/sourceeditor/editor",
   "./test-flag": "devtools/shared/flags",
@@ -19,11 +28,5 @@ module.exports = {
   "wasmparser/dist/WasmParser": "devtools/client/shared/vendor/WasmParser",
   "wasmparser/dist/WasmDis": "devtools/client/shared/vendor/WasmDis",
 
-  // The excluded files below should not be required while the Debugger runs
-  // in Firefox. Here, "devtools/shared/flags" is used as a dummy module.
-  "../assets/panel/debugger.properties": "devtools/shared/flags",
-  "devtools-connection": "devtools/shared/flags",
-  "chrome-remote-interface": "devtools/shared/flags",
-  "devtools-launchpad": "devtools/shared/flags",
-  "devtools-services": "Services"
-};
+  "devtools-services": "Services",
+}, EXCLUDED_FILES);


### PR DESCRIPTION
This is really a nit, but this should make it easier to isolate the hacky usage of devtools/shared/flags.