### PR TITLE
Prevent relatedTarget.classList errors

### DIFF
--- a/src/components/Editor/Preview/Popup.js
+++ b/src/components/Editor/Preview/Popup.js
@@ -59,7 +59,8 @@ function inPreview(event) {
 
   if (
     !relatedTarget ||
-    relatedTarget.classList.contains("preview-expression")
+    (relatedTarget.classList &&
+      relatedTarget.classList.contains("preview-expression"))
   ) {
     return true;
   }


### PR DESCRIPTION
Saw this while testing for https://github.com/devtools-html/debugger.html/issues/5986

<img width="1261" alt="relatedtargeterror" src="https://user-images.githubusercontent.com/46655/41052434-5e1b2760-697e-11e8-9dfc-192d7e777290.png">
