### PR TITLE
Fix #6451 - Ensure breakpoint hover is always correct

### DIFF
--- a/src/components/Editor/Editor.css
+++ b/src/components/Editor/Editor.css
@@ -62,7 +62,7 @@ html[dir="rtl"] .editor-mount {
 :not(.empty-line):not(.new-breakpoint) > .CodeMirror-gutter-wrapper:hover {
   width: 60px;
   height: 13px;
-  left: -55px !important;
+  margin-left: -25px;
   background-color: var(--gutter-hover-background-color) !important;
   mask: url(/images/breakpoint.svg) no-repeat;
   mask-size: 100%;


### PR DESCRIPTION
Fixes Issue: #6451

When you scroll the editor horizontally and then hover a line, the breakpoint hover arrow doesn't display because we aren't allowing the `left` property to change.  Setting a negative margin works much better.

## Testing
1.  Hover over a line, ensure the breakpoint arrow displays
2.  Scroll horizontally, hover over a line, ensure the breakpoint arrow displays