### PR TITLE
allow update always

### DIFF
--- a/src/components/Editor/Breakpoint.js
+++ b/src/components/Editor/Breakpoint.js
@@ -71,18 +71,6 @@ class Breakpoint extends Component<Props> {
     }
   };
 
-  shouldComponentUpdate(nextProps: any) {
-    const { editor, breakpoint, selectedSource } = this.props;
-    return (
-      editor !== nextProps.editor ||
-      breakpoint.disabled !== nextProps.breakpoint.disabled ||
-      breakpoint.hidden !== nextProps.breakpoint.hidden ||
-      breakpoint.condition !== nextProps.breakpoint.condition ||
-      breakpoint.loading !== nextProps.breakpoint.loading ||
-      selectedSource !== nextProps.selectedSource
-    );
-  }
-
   componentDidMount() {
     this.addBreakpoint();
   }


### PR DESCRIPTION
Fixes Issue: #6355

### Summary of Changes

* remove `shouldComponentUpdate` in Breakpoint.js

If the editor is not ready before the breakpoint tries to render, the breakpoint never gets shown.
`shouldComponentUpdate` stops the breakpoint from updating after the editor is ready.

**Note:** One concern was the possible performance hit, but i don't think that is an issue because it still feels instant, as i think react figures out how to not re-render the breakpoints. see (after screenshot)

### Test Plan

-  debug http://firefox-dev.tools/debugger-examples/examples/todomvc/
- open `backbone.js` in the debugger
- set breakpoint on line 12
- close `backbone.js`
- refresh the debugger
- click to open `backbone.js` from the source tree

AR:
No breakpoint set on line 12 in the editor

ER:
Breakpoint should be set on line 12

### Screenshots/Videos (OPTIONAL)

#### Before
On reload & reopening `backbone.js`  the breakpoints do not show up.

![](http://g.recordit.co/LlcEUfb4N1.gif)

#### After
On reload & reopening `backbone.js` the breakpoints now show up.

![](http://g.recordit.co/bPCNzB83Uu.gif)