### PR TITLE
[SourceTree]  Prevent index weirdness

### DIFF
--- a/src/components/shared/ManagedTree.js
+++ b/src/components/shared/ManagedTree.js
@@ -127,8 +127,14 @@ class ManagedTree extends Component<Props, State> {
       // closed folder and highlights this folder
       const index = highlightItems
         .reverse()
-        .findIndex(item => !expanded.has(this.props.getPath(item)));
-      this.focusItem(highlightItems[index]);
+        .findIndex(
+          item =>
+            !expanded.has(this.props.getPath(item)) && item.name !== "root"
+        );
+
+      if (highlightItems[index]) {
+        this.focusItem(highlightItems[index]);
+      }
     }
   }
 

--- a/src/components/test/SourcesTree.spec.js
+++ b/src/components/test/SourcesTree.spec.js
@@ -195,6 +195,17 @@ describe("SourcesTree", () => {
         .simulate("keydown", { keyCode: 13 });
       expect(props.selectSource).toHaveBeenCalledWith(item.contents.id);
     });
+
+    it("allows focus on the (index)", async () => {
+      const { component, instance, props } = render();
+      const item = createMockItem("https://davidwalsh.name/", "(index)");
+      await instance.focusItem(item);
+      await component.update();
+      await component
+        .find(".sources-list")
+        .simulate("keydown", { keyCode: 13 });
+      expect(props.selectSource).toHaveBeenCalledWith(item.contents.id);
+    });
   });
 
   describe("with custom root", () => {

--- a/src/utils/sources-tree/addToTree.js
+++ b/src/utils/sources-tree/addToTree.js
@@ -85,12 +85,10 @@ function findOrCreateNode(
  * adding new nodes along the way
  */
 function traverseTree(
-  url: Object,
+  url: ParsedURL,
   tree: TreeDirectory,
   debuggeeHost: ?string
 ): TreeNode {
-  url.path = decodeURIComponent(url.path);
-
   const parts = url.path.split("/").filter(p => p !== "");
   parts.unshift(url.group);
 

--- a/src/utils/sources-tree/tests/__snapshots__/addToTree.spec.js.snap
+++ b/src/utils/sources-tree/tests/__snapshots__/addToTree.spec.js.snap
@@ -35,10 +35,26 @@ exports[`sources-tree addToTree does not attempt to add two of the same file 1`]
 "
 `;
 
+exports[`sources-tree addToTree does not mangle encoded URLs 1`] = `
+" - root path= 
+  - example.com path=example.com 
+    - foo path=example.com/foo 
+      - B9724220.131821496;dc_ver=42.111;sz=468x60;u_sd=2;dc_adk=2020465299;ord=a53rpc;dc_rfl=1,https%3A%2F%2Fdavidwalsh.name%2F$0;xdt=1 path=example.com/foo/B9724220.131821496;dc_ver=42.111;sz=468x60;u_sd=2;dc_adk=2020465299;ord=a53rpc;dc_rfl=1,https%3A%2F%2Fdavidwalsh.name%2F$0;xdt=1 source_id=undefined 
+"
+`;
+
 exports[`sources-tree addToTree excludes javascript: URLs from the tree 1`] = `
 " - root path= 
   - example.com path=example.com 
     - source1.js path=example.com/source1.js source_id=undefined 
+"
+`;
+
+exports[`sources-tree addToTree name does not include query params 1`] = `
+" - root path= 
+  - example.com path=example.com 
+    - foo path=example.com/foo 
+      - name.js path=example.com/foo/name.js source_id=undefined 
 "
 `;
 

--- a/src/utils/sources-tree/tests/addToTree.spec.js
+++ b/src/utils/sources-tree/tests/addToTree.spec.js
@@ -75,6 +75,33 @@ describe("sources-tree", () => {
       expect(source1Node.name).toBe("source1.js");
     });
 
+    it("does not mangle encoded URLs", () => {
+      const source1 = createSourceRecord({
+        url:
+          "https://example.com/foo/B9724220.131821496;dc_ver=42.111;sz=468x60;u_sd=2;dc_adk=2020465299;ord=a53rpc;dc_rfl=1,https%3A%2F%2Fdavidwalsh.name%2F$0;xdt=1?",
+        actor: "actor1"
+      });
+      const tree = createNode("root", "", []);
+
+      addToTree(tree, source1, "http://example.com/");
+      expect(tree.contents).toHaveLength(1);
+
+      const base = tree.contents[0];
+      expect(base.name).toBe("example.com");
+      expect(base.contents).toHaveLength(1);
+
+      const fooNode = base.contents[0];
+      expect(fooNode.name).toBe("foo");
+      expect(fooNode.contents).toHaveLength(1);
+
+      const source1Node = fooNode.contents[0];
+      expect(source1Node.name).toBe(
+        "B9724220.131821496;dc_ver=42.111;sz=468x60;u_sd=2;" +
+          "dc_adk=2020465299;ord=a53rpc;dc_rfl=1" +
+          ",https%3A%2F%2Fdavidwalsh.name%2F$0;xdt=1"
+      );
+    });
+
     it("does not attempt to add two of the same directory", () => {
       const sources = [
         {


### PR DESCRIPTION
Fixes Issue: #5918

This `else` clause is causing mischief in the SourcesTree, and I don't see its value, so removing.

## Testing
1.  Go to https://davidwalsh.name
2.  Click on "(index)"; the item should highlight
3.  Expand `ad.doubleclick.net` and its subfolders; click on the oddly named files; they should also highlight

## Note
1.  This also seems to fix #6462