### PR TITLE
Reverts 6485; Restore breakpoint arrow calculation

### DIFF
--- a/src/components/Editor/Editor.css
+++ b/src/components/Editor/Editor.css
@@ -62,7 +62,7 @@ html[dir="rtl"] .editor-mount {
 :not(.empty-line):not(.new-breakpoint) > .CodeMirror-gutter-wrapper:hover {
   width: 60px;
   height: 13px;
-  margin-left: -25px;
+  left: -55px !important;
   background-color: var(--gutter-hover-background-color) !important;
   mask: url(/images/breakpoint.svg) no-repeat;
   mask-size: 100%;


### PR DESCRIPTION
While my #6485 works well for most JS files, it doesn't look good in WASM, so we should revert and try again.