### PR TITLE
[flow] add types for reselect

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,8 +1,8 @@
 [ignore]
 .*node_modules/documentation.*
-.*node_modules/devtools-reps/src/object-inspector/index.js
 .*node_modules/devtools-mc-assets/.*
 .*node_modules/immutable/dist/immutable.js.flow
+.*node_modules/reselect/lib/reselect.d.ts
 .*node_modules/stylelint.*
 <PROJECT_ROOT>/firefox/.*
 .*mozilla-central/.*

--- a/flow-typed/npm/reselect_v3.x.x.js
+++ b/flow-typed/npm/reselect_v3.x.x.js
@@ -1,0 +1,895 @@
+// flow-typed signature: 84ab000391e0f17dd212d57ed0b180f5
+// flow-typed version: 5d8678f464/reselect_v3.x.x/flow_>=v0.47.x
+
+type ExtractReturnType = <Return>((...rest: any[]) => Return) => Return;
+
+declare module "reselect" {
+  declare type InputSelector<-TState, TProps, TResult> =
+    (state: TState, props: TProps, ...rest: any[]) => TResult
+
+  declare type OutputSelector<-TState, TProps, TResult> =
+    & InputSelector<TState, TProps, TResult>
+    & {
+      recomputations(): number,
+      resetRecomputations(): void,
+      resultFunc(state: TState, props: TProps, ...rest: Array<any>): TResult,
+    };
+
+  declare type SelectorCreator = {
+    <TState, TProps, TResult, T1>(
+      selector1: InputSelector<TState, TProps, T1>,
+      resultFunc: (arg1: T1) => TResult
+    ): OutputSelector<TState, TProps, TResult>,
+    <TState, TProps, TResult, T1>(
+      selectors: [InputSelector<TState, TProps, T1>],
+      resultFunc: (arg1: T1) => TResult
+    ): OutputSelector<TState, TProps, TResult>,
+
+    <TState, TProps, TResult, T1, T2>(
+      selector1: InputSelector<TState, TProps, T1>,
+      selector2: InputSelector<TState, TProps, T2>,
+      resultFunc: (arg1: T1, arg2: T2) => TResult
+    ): OutputSelector<TState, TProps, TResult>,
+    <TState, TProps, TResult, T1, T2>(
+      selectors: [InputSelector<TState, TProps, T1>, InputSelector<TState, TProps, T2>],
+      resultFunc: (arg1: T1, arg2: T2) => TResult
+    ): OutputSelector<TState, TProps, TResult>,
+
+    <TState, TProps, TResult, T1, T2, T3>(
+      selector1: InputSelector<TState, TProps, T1>,
+      selector2: InputSelector<TState, TProps, T2>,
+      selector3: InputSelector<TState, TProps, T3>,
+      resultFunc: (arg1: T1, arg2: T2, arg3: T3) => TResult
+    ): OutputSelector<TState, TProps, TResult>,
+    <TState, TProps, TResult, T1, T2, T3>(
+      selectors: [
+        InputSelector<TState, TProps, T1>,
+        InputSelector<TState, TProps, T2>,
+        InputSelector<TState, TProps, T3>
+      ],
+      resultFunc: (arg1: T1, arg2: T2, arg3: T3) => TResult
+    ): OutputSelector<TState, TProps, TResult>,
+
+    <TState, TProps, TResult, T1, T2, T3, T4>(
+      selector1: InputSelector<TState, TProps, T1>,
+      selector2: InputSelector<TState, TProps, T2>,
+      selector3: InputSelector<TState, TProps, T3>,
+      selector4: InputSelector<TState, TProps, T4>,
+      resultFunc: (arg1: T1, arg2: T2, arg3: T3, arg4: T4) => TResult
+    ): OutputSelector<TState, TProps, TResult>,
+    <TState, TProps, TResult, T1, T2, T3, T4>(
+      selectors: [
+        InputSelector<TState, TProps, T1>,
+        InputSelector<TState, TProps, T2>,
+        InputSelector<TState, TProps, T3>,
+        InputSelector<TState, TProps, T4>
+      ],
+      resultFunc: (arg1: T1, arg2: T2, arg3: T3, arg4: T4) => TResult
+    ): OutputSelector<TState, TProps, TResult>,
+
+    <TState, TProps, TResult, T1, T2, T3, T4, T5>(
+      selector1: InputSelector<TState, TProps, T1>,
+      selector2: InputSelector<TState, TProps, T2>,
+      selector3: InputSelector<TState, TProps, T3>,
+      selector4: InputSelector<TState, TProps, T4>,
+      selector5: InputSelector<TState, TProps, T5>,
+      resultFunc: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5) => TResult
+    ): OutputSelector<TState, TProps, TResult>,
+    <TState, TProps, TResult, T1, T2, T3, T4, T5>(
+      selectors: [
+        InputSelector<TState, TProps, T1>,
+        InputSelector<TState, TProps, T2>,
+        InputSelector<TState, TProps, T3>,
+        InputSelector<TState, TProps, T4>,
+        InputSelector<TState, TProps, T5>
+      ],
+      resultFunc: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5) => TResult
+    ): OutputSelector<TState, TProps, TResult>,
+
+    <TState, TProps, TResult, T1, T2, T3, T4, T5, T6>(
+      selector1: InputSelector<TState, TProps, T1>,
+      selector2: InputSelector<TState, TProps, T2>,
+      selector3: InputSelector<TState, TProps, T3>,
+      selector4: InputSelector<TState, TProps, T4>,
+      selector5: InputSelector<TState, TProps, T5>,
+      selector6: InputSelector<TState, TProps, T6>,
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6
+      ) => TResult
+    ): OutputSelector<TState, TProps, TResult>,
+    <TState, TProps, TResult, T1, T2, T3, T4, T5, T6>(
+      selectors: [
+        InputSelector<TState, TProps, T1>,
+        InputSelector<TState, TProps, T2>,
+        InputSelector<TState, TProps, T3>,
+        InputSelector<TState, TProps, T4>,
+        InputSelector<TState, TProps, T5>,
+        InputSelector<TState, TProps, T6>
+      ],
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6
+      ) => TResult
+    ): OutputSelector<TState, TProps, TResult>,
+
+    <TState, TProps, TResult, T1, T2, T3, T4, T5, T6, T7>(
+      selector1: InputSelector<TState, TProps, T1>,
+      selector2: InputSelector<TState, TProps, T2>,
+      selector3: InputSelector<TState, TProps, T3>,
+      selector4: InputSelector<TState, TProps, T4>,
+      selector5: InputSelector<TState, TProps, T5>,
+      selector6: InputSelector<TState, TProps, T6>,
+      selector7: InputSelector<TState, TProps, T7>,
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6,
+        arg7: T7
+      ) => TResult
+    ): OutputSelector<TState, TProps, TResult>,
+    <TState, TProps, TResult, T1, T2, T3, T4, T5, T6, T7>(
+      selectors: [
+        InputSelector<TState, TProps, T1>,
+        InputSelector<TState, TProps, T2>,
+        InputSelector<TState, TProps, T3>,
+        InputSelector<TState, TProps, T4>,
+        InputSelector<TState, TProps, T5>,
+        InputSelector<TState, TProps, T6>,
+        InputSelector<TState, TProps, T7>
+      ],
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6,
+        arg7: T7
+      ) => TResult
+    ): OutputSelector<TState, TProps, TResult>,
+
+    <TState, TProps, TResult, T1, T2, T3, T4, T5, T6, T7, T8>(
+      selector1: InputSelector<TState, TProps, T1>,
+      selector2: InputSelector<TState, TProps, T2>,
+      selector3: InputSelector<TState, TProps, T3>,
+      selector4: InputSelector<TState, TProps, T4>,
+      selector5: InputSelector<TState, TProps, T5>,
+      selector6: InputSelector<TState, TProps, T6>,
+      selector7: InputSelector<TState, TProps, T7>,
+      selector8: InputSelector<TState, TProps, T8>,
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6,
+        arg7: T7,
+        arg8: T8
+      ) => TResult
+    ): OutputSelector<TState, TProps, TResult>,
+    <TState, TProps, TResult, T1, T2, T3, T4, T5, T6, T7, T8>(
+      selectors: [
+        InputSelector<TState, TProps, T1>,
+        InputSelector<TState, TProps, T2>,
+        InputSelector<TState, TProps, T3>,
+        InputSelector<TState, TProps, T4>,
+        InputSelector<TState, TProps, T5>,
+        InputSelector<TState, TProps, T6>,
+        InputSelector<TState, TProps, T7>,
+        InputSelector<TState, TProps, T8>
+      ],
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6,
+        arg7: T7,
+        arg8: T8
+      ) => TResult
+    ): OutputSelector<TState, TProps, TResult>,
+
+    <TState, TProps, TResult, T1, T2, T3, T4, T5, T6, T7, T8, T9>(
+      selector1: InputSelector<TState, TProps, T1>,
+      selector2: InputSelector<TState, TProps, T2>,
+      selector3: InputSelector<TState, TProps, T3>,
+      selector4: InputSelector<TState, TProps, T4>,
+      selector5: InputSelector<TState, TProps, T5>,
+      selector6: InputSelector<TState, TProps, T6>,
+      selector7: InputSelector<TState, TProps, T7>,
+      selector8: InputSelector<TState, TProps, T8>,
+      selector9: InputSelector<TState, TProps, T9>,
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6,
+        arg7: T7,
+        arg8: T8,
+        arg9: T9
+      ) => TResult
+    ): OutputSelector<TState, TProps, TResult>,
+    <TState, TProps, TResult, T1, T2, T3, T4, T5, T6, T7, T8, T9>(
+      selectors: [
+        InputSelector<TState, TProps, T1>,
+        InputSelector<TState, TProps, T2>,
+        InputSelector<TState, TProps, T3>,
+        InputSelector<TState, TProps, T4>,
+        InputSelector<TState, TProps, T5>,
+        InputSelector<TState, TProps, T6>,
+        InputSelector<TState, TProps, T7>,
+        InputSelector<TState, TProps, T8>,
+        InputSelector<TState, TProps, T9>
+      ],
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6,
+        arg7: T7,
+        arg8: T8,
+        arg9: T9
+      ) => TResult
+    ): OutputSelector<TState, TProps, TResult>,
+
+    <TState, TProps, TResult, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(
+      selector1: InputSelector<TState, TProps, T1>,
+      selector2: InputSelector<TState, TProps, T2>,
+      selector3: InputSelector<TState, TProps, T3>,
+      selector4: InputSelector<TState, TProps, T4>,
+      selector5: InputSelector<TState, TProps, T5>,
+      selector6: InputSelector<TState, TProps, T6>,
+      selector7: InputSelector<TState, TProps, T7>,
+      selector8: InputSelector<TState, TProps, T8>,
+      selector9: InputSelector<TState, TProps, T9>,
+      selector10: InputSelector<TState, TProps, T10>,
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6,
+        arg7: T7,
+        arg8: T8,
+        arg9: T9,
+        arg10: T10
+      ) => TResult
+    ): OutputSelector<TState, TProps, TResult>,
+    <TState, TProps, TResult, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(
+      selectors: [
+        InputSelector<TState, TProps, T1>,
+        InputSelector<TState, TProps, T2>,
+        InputSelector<TState, TProps, T3>,
+        InputSelector<TState, TProps, T4>,
+        InputSelector<TState, TProps, T5>,
+        InputSelector<TState, TProps, T6>,
+        InputSelector<TState, TProps, T7>,
+        InputSelector<TState, TProps, T8>,
+        InputSelector<TState, TProps, T9>,
+        InputSelector<TState, TProps, T10>
+      ],
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6,
+        arg7: T7,
+        arg8: T8,
+        arg9: T9,
+        arg10: T10
+      ) => TResult
+    ): OutputSelector<TState, TProps, TResult>,
+
+    <TState, TProps, TResult, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(
+      selector1: InputSelector<TState, TProps, T1>,
+      selector2: InputSelector<TState, TProps, T2>,
+      selector3: InputSelector<TState, TProps, T3>,
+      selector4: InputSelector<TState, TProps, T4>,
+      selector5: InputSelector<TState, TProps, T5>,
+      selector6: InputSelector<TState, TProps, T6>,
+      selector7: InputSelector<TState, TProps, T7>,
+      selector8: InputSelector<TState, TProps, T8>,
+      selector9: InputSelector<TState, TProps, T9>,
+      selector10: InputSelector<TState, TProps, T10>,
+      selector11: InputSelector<TState, TProps, T11>,
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6,
+        arg7: T7,
+        arg8: T8,
+        arg9: T9,
+        arg10: T10,
+        arg11: T11
+      ) => TResult
+    ): OutputSelector<TState, TProps, TResult>,
+    <TState, TProps, TResult, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(
+      selectors: [
+        InputSelector<TState, TProps, T1>,
+        InputSelector<TState, TProps, T2>,
+        InputSelector<TState, TProps, T3>,
+        InputSelector<TState, TProps, T4>,
+        InputSelector<TState, TProps, T5>,
+        InputSelector<TState, TProps, T6>,
+        InputSelector<TState, TProps, T7>,
+        InputSelector<TState, TProps, T8>,
+        InputSelector<TState, TProps, T9>,
+        InputSelector<TState, TProps, T10>,
+        InputSelector<TState, TProps, T11>
+      ],
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6,
+        arg7: T7,
+        arg8: T8,
+        arg9: T9,
+        arg10: T10,
+        arg11: T11
+      ) => TResult
+    ): OutputSelector<TState, TProps, TResult>,
+
+    <
+      TState,
+      TProps,
+      TResult,
+      T1,
+      T2,
+      T3,
+      T4,
+      T5,
+      T6,
+      T7,
+      T8,
+      T9,
+      T10,
+      T11,
+      T12
+    >(
+      selector1: InputSelector<TState, TProps, T1>,
+      selector2: InputSelector<TState, TProps, T2>,
+      selector3: InputSelector<TState, TProps, T3>,
+      selector4: InputSelector<TState, TProps, T4>,
+      selector5: InputSelector<TState, TProps, T5>,
+      selector6: InputSelector<TState, TProps, T6>,
+      selector7: InputSelector<TState, TProps, T7>,
+      selector8: InputSelector<TState, TProps, T8>,
+      selector9: InputSelector<TState, TProps, T9>,
+      selector10: InputSelector<TState, TProps, T10>,
+      selector11: InputSelector<TState, TProps, T11>,
+      selector12: InputSelector<TState, TProps, T12>,
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6,
+        arg7: T7,
+        arg8: T8,
+        arg9: T9,
+        arg10: T10,
+        arg11: T11,
+        arg12: T12
+      ) => TResult
+    ): OutputSelector<TState, TProps, TResult>,
+    <
+      TState,
+      TProps,
+      TResult,
+      T1,
+      T2,
+      T3,
+      T4,
+      T5,
+      T6,
+      T7,
+      T8,
+      T9,
+      T10,
+      T11,
+      T12
+    >(
+      selectors: [
+        InputSelector<TState, TProps, T1>,
+        InputSelector<TState, TProps, T2>,
+        InputSelector<TState, TProps, T3>,
+        InputSelector<TState, TProps, T4>,
+        InputSelector<TState, TProps, T5>,
+        InputSelector<TState, TProps, T6>,
+        InputSelector<TState, TProps, T7>,
+        InputSelector<TState, TProps, T8>,
+        InputSelector<TState, TProps, T9>,
+        InputSelector<TState, TProps, T10>,
+        InputSelector<TState, TProps, T11>,
+        InputSelector<TState, TProps, T12>
+      ],
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6,
+        arg7: T7,
+        arg8: T8,
+        arg9: T9,
+        arg10: T10,
+        arg11: T11,
+        arg12: T12
+      ) => TResult
+    ): OutputSelector<TState, TProps, TResult>,
+
+    <
+      TState,
+      TProps,
+      TResult,
+      T1,
+      T2,
+      T3,
+      T4,
+      T5,
+      T6,
+      T7,
+      T8,
+      T9,
+      T10,
+      T11,
+      T12,
+      T13
+    >(
+      selector1: InputSelector<TState, TProps, T1>,
+      selector2: InputSelector<TState, TProps, T2>,
+      selector3: InputSelector<TState, TProps, T3>,
+      selector4: InputSelector<TState, TProps, T4>,
+      selector5: InputSelector<TState, TProps, T5>,
+      selector6: InputSelector<TState, TProps, T6>,
+      selector7: InputSelector<TState, TProps, T7>,
+      selector8: InputSelector<TState, TProps, T8>,
+      selector9: InputSelector<TState, TProps, T9>,
+      selector10: InputSelector<TState, TProps, T10>,
+      selector11: InputSelector<TState, TProps, T11>,
+      selector12: InputSelector<TState, TProps, T12>,
+      selector13: InputSelector<TState, TProps, T13>,
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6,
+        arg7: T7,
+        arg8: T8,
+        arg9: T9,
+        arg10: T10,
+        arg11: T11,
+        arg12: T12,
+        arg13: T13
+      ) => TResult
+    ): OutputSelector<TState, TProps, TResult>,
+    <
+      TState,
+      TProps,
+      TResult,
+      T1,
+      T2,
+      T3,
+      T4,
+      T5,
+      T6,
+      T7,
+      T8,
+      T9,
+      T10,
+      T11,
+      T12,
+      T13
+    >(
+      selectors: [
+        InputSelector<TState, TProps, T1>,
+        InputSelector<TState, TProps, T2>,
+        InputSelector<TState, TProps, T3>,
+        InputSelector<TState, TProps, T4>,
+        InputSelector<TState, TProps, T5>,
+        InputSelector<TState, TProps, T6>,
+        InputSelector<TState, TProps, T7>,
+        InputSelector<TState, TProps, T8>,
+        InputSelector<TState, TProps, T9>,
+        InputSelector<TState, TProps, T10>,
+        InputSelector<TState, TProps, T11>,
+        InputSelector<TState, TProps, T12>,
+        InputSelector<TState, TProps, T13>
+      ],
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6,
+        arg7: T7,
+        arg8: T8,
+        arg9: T9,
+        arg10: T10,
+        arg11: T11,
+        arg12: T12,
+        arg13: T13
+      ) => TResult
+    ): OutputSelector<TState, TProps, TResult>,
+
+    <
+      TState,
+      TProps,
+      TResult,
+      T1,
+      T2,
+      T3,
+      T4,
+      T5,
+      T6,
+      T7,
+      T8,
+      T9,
+      T10,
+      T11,
+      T12,
+      T13,
+      T14
+    >(
+      selector1: InputSelector<TState, TProps, T1>,
+      selector2: InputSelector<TState, TProps, T2>,
+      selector3: InputSelector<TState, TProps, T3>,
+      selector4: InputSelector<TState, TProps, T4>,
+      selector5: InputSelector<TState, TProps, T5>,
+      selector6: InputSelector<TState, TProps, T6>,
+      selector7: InputSelector<TState, TProps, T7>,
+      selector8: InputSelector<TState, TProps, T8>,
+      selector9: InputSelector<TState, TProps, T9>,
+      selector10: InputSelector<TState, TProps, T10>,
+      selector11: InputSelector<TState, TProps, T11>,
+      selector12: InputSelector<TState, TProps, T12>,
+      selector13: InputSelector<TState, TProps, T13>,
+      selector14: InputSelector<TState, TProps, T14>,
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6,
+        arg7: T7,
+        arg8: T8,
+        arg9: T9,
+        arg10: T10,
+        arg11: T11,
+        arg12: T12,
+        arg13: T13,
+        arg14: T14
+      ) => TResult
+    ): OutputSelector<TState, TProps, TResult>,
+    <
+      TState,
+      TProps,
+      TResult,
+      T1,
+      T2,
+      T3,
+      T4,
+      T5,
+      T6,
+      T7,
+      T8,
+      T9,
+      T10,
+      T11,
+      T12,
+      T13,
+      T14
+    >(
+      selectors: [
+        InputSelector<TState, TProps, T1>,
+        InputSelector<TState, TProps, T2>,
+        InputSelector<TState, TProps, T3>,
+        InputSelector<TState, TProps, T4>,
+        InputSelector<TState, TProps, T5>,
+        InputSelector<TState, TProps, T6>,
+        InputSelector<TState, TProps, T7>,
+        InputSelector<TState, TProps, T8>,
+        InputSelector<TState, TProps, T9>,
+        InputSelector<TState, TProps, T10>,
+        InputSelector<TState, TProps, T11>,
+        InputSelector<TState, TProps, T12>,
+        InputSelector<TState, TProps, T13>,
+        InputSelector<TState, TProps, T14>
+      ],
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6,
+        arg7: T7,
+        arg8: T8,
+        arg9: T9,
+        arg10: T10,
+        arg11: T11,
+        arg12: T12,
+        arg13: T13,
+        arg14: T14
+      ) => TResult
+    ): OutputSelector<TState, TProps, TResult>,
+
+    <
+      TState,
+      TProps,
+      TResult,
+      T1,
+      T2,
+      T3,
+      T4,
+      T5,
+      T6,
+      T7,
+      T8,
+      T9,
+      T10,
+      T11,
+      T12,
+      T13,
+      T14,
+      T15
+    >(
+      selector1: InputSelector<TState, TProps, T1>,
+      selector2: InputSelector<TState, TProps, T2>,
+      selector3: InputSelector<TState, TProps, T3>,
+      selector4: InputSelector<TState, TProps, T4>,
+      selector5: InputSelector<TState, TProps, T5>,
+      selector6: InputSelector<TState, TProps, T6>,
+      selector7: InputSelector<TState, TProps, T7>,
+      selector8: InputSelector<TState, TProps, T8>,
+      selector9: InputSelector<TState, TProps, T9>,
+      selector10: InputSelector<TState, TProps, T10>,
+      selector11: InputSelector<TState, TProps, T11>,
+      selector12: InputSelector<TState, TProps, T12>,
+      selector13: InputSelector<TState, TProps, T13>,
+      selector14: InputSelector<TState, TProps, T14>,
+      selector15: InputSelector<TState, TProps, T15>,
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6,
+        arg7: T7,
+        arg8: T8,
+        arg9: T9,
+        arg10: T10,
+        arg11: T11,
+        arg12: T12,
+        arg13: T13,
+        arg14: T14,
+        arg15: T15
+      ) => TResult
+    ): OutputSelector<TState, TProps, TResult>,
+    <
+      TState,
+      TProps,
+      TResult,
+      T1,
+      T2,
+      T3,
+      T4,
+      T5,
+      T6,
+      T7,
+      T8,
+      T9,
+      T10,
+      T11,
+      T12,
+      T13,
+      T14,
+      T15
+    >(
+      selectors: [
+        InputSelector<TState, TProps, T1>,
+        InputSelector<TState, TProps, T2>,
+        InputSelector<TState, TProps, T3>,
+        InputSelector<TState, TProps, T4>,
+        InputSelector<TState, TProps, T5>,
+        InputSelector<TState, TProps, T6>,
+        InputSelector<TState, TProps, T7>,
+        InputSelector<TState, TProps, T8>,
+        InputSelector<TState, TProps, T9>,
+        InputSelector<TState, TProps, T10>,
+        InputSelector<TState, TProps, T11>,
+        InputSelector<TState, TProps, T12>,
+        InputSelector<TState, TProps, T13>,
+        InputSelector<TState, TProps, T14>,
+        InputSelector<TState, TProps, T15>
+      ],
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6,
+        arg7: T7,
+        arg8: T8,
+        arg9: T9,
+        arg10: T10,
+        arg11: T11,
+        arg12: T12,
+        arg13: T13,
+        arg14: T14,
+        arg15: T15
+      ) => TResult
+    ): OutputSelector<TState, TProps, TResult>,
+
+    <
+      TState,
+      TProps,
+      TResult,
+      T1,
+      T2,
+      T3,
+      T4,
+      T5,
+      T6,
+      T7,
+      T8,
+      T9,
+      T10,
+      T11,
+      T12,
+      T13,
+      T14,
+      T15,
+      T16
+    >(
+      selector1: InputSelector<TState, TProps, T1>,
+      selector2: InputSelector<TState, TProps, T2>,
+      selector3: InputSelector<TState, TProps, T3>,
+      selector4: InputSelector<TState, TProps, T4>,
+      selector5: InputSelector<TState, TProps, T5>,
+      selector6: InputSelector<TState, TProps, T6>,
+      selector7: InputSelector<TState, TProps, T7>,
+      selector8: InputSelector<TState, TProps, T8>,
+      selector9: InputSelector<TState, TProps, T9>,
+      selector10: InputSelector<TState, TProps, T10>,
+      selector11: InputSelector<TState, TProps, T11>,
+      selector12: InputSelector<TState, TProps, T12>,
+      selector13: InputSelector<TState, TProps, T13>,
+      selector14: InputSelector<TState, TProps, T14>,
+      selector15: InputSelector<TState, TProps, T15>,
+      selector16: InputSelector<TState, TProps, T16>,
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6,
+        arg7: T7,
+        arg8: T8,
+        arg9: T9,
+        arg10: T10,
+        arg11: T11,
+        arg12: T12,
+        arg13: T13,
+        arg14: T14,
+        arg15: T15,
+        arg16: T16
+      ) => TResult
+    ): OutputSelector<TState, TProps, TResult>,
+    <
+      TState,
+      TProps,
+      TResult,
+      T1,
+      T2,
+      T3,
+      T4,
+      T5,
+      T6,
+      T7,
+      T8,
+      T9,
+      T10,
+      T11,
+      T12,
+      T13,
+      T14,
+      T15,
+      T16
+    >(
+      selectors: [
+        InputSelector<TState, TProps, T1>,
+        InputSelector<TState, TProps, T2>,
+        InputSelector<TState, TProps, T3>,
+        InputSelector<TState, TProps, T4>,
+        InputSelector<TState, TProps, T5>,
+        InputSelector<TState, TProps, T6>,
+        InputSelector<TState, TProps, T7>,
+        InputSelector<TState, TProps, T8>,
+        InputSelector<TState, TProps, T9>,
+        InputSelector<TState, TProps, T10>,
+        InputSelector<TState, TProps, T11>,
+        InputSelector<TState, TProps, T12>,
+        InputSelector<TState, TProps, T13>,
+        InputSelector<TState, TProps, T14>,
+        InputSelector<TState, TProps, T15>,
+        InputSelector<TState, TProps, T16>
+      ],
+      resultFunc: (
+        arg1: T1,
+        arg2: T2,
+        arg3: T3,
+        arg4: T4,
+        arg5: T5,
+        arg6: T6,
+        arg7: T7,
+        arg8: T8,
+        arg9: T9,
+        arg10: T10,
+        arg11: T11,
+        arg12: T12,
+        arg13: T13,
+        arg14: T14,
+        arg15: T15,
+        arg16: T16
+      ) => TResult
+    ): OutputSelector<TState, TProps, TResult>
+  };
+
+  declare type Reselect = {
+    createSelector: SelectorCreator,
+
+    defaultMemoize: <TFunc: Function>(
+      func: TFunc,
+      equalityCheck?: (a: any, b: any) => boolean
+    ) => TFunc,
+
+    createSelectorCreator: (
+      memoize: Function,
+      ...memoizeOptions: any[]
+    ) => SelectorCreator,
+
+    createStructuredSelector: <TState, TProps, InputSelectors: {[k: string | number]: InputSelector<TState, TProps, any>}>(
+      inputSelectors: InputSelectors,
+      selectorCreator?: SelectorCreator
+    ) => OutputSelector<TState, TProps, $ObjMap<InputSelectors, ExtractReturnType>>
+  };
+
+  declare module.exports: Reselect;
+}

--- a/src/actions/ast.js
+++ b/src/actions/ast.js
@@ -61,13 +61,11 @@ export function setSymbols(sourceId: SourceId) {
       return;
     }
 
-    await dispatch(
-      ({
-        type: "SET_SYMBOLS",
-        sourceId,
-        [PROMISE]: getSymbols(sourceId)
-      }: Action)
-    );
+    await dispatch({
+      type: "SET_SYMBOLS",
+      sourceId,
+      [PROMISE]: getSymbols(sourceId)
+    });
 
     if (isPaused(getState())) {
       await dispatch(fetchExtra());

--- a/src/actions/breakpoints.js
+++ b/src/actions/breakpoints.js
@@ -85,18 +85,11 @@ export function addBreakpoint(
 ) {
   const breakpoint = createBreakpoint(location, { condition, hidden });
   return ({ dispatch, getState, sourceMaps, client }: ThunkArgs) => {
-    return dispatch(
-      ({
-        type: "ADD_BREAKPOINT",
-        breakpoint,
-        [PROMISE]: addBreakpointPromise(
-          getState,
-          client,
-          sourceMaps,
-          breakpoint
-        )
-      }: Action)
-    );
+    return dispatch({
+      type: "ADD_BREAKPOINT",
+      breakpoint,
+      [PROMISE]: addBreakpointPromise(getState, client, sourceMaps, breakpoint)
+    });
   };
 }
 
@@ -139,14 +132,12 @@ export function removeBreakpoint(location: Location) {
       );
     }
 
-    return dispatch(
-      ({
-        type: "REMOVE_BREAKPOINT",
-        breakpoint: bp,
-        disabled: false,
-        [PROMISE]: client.removeBreakpoint(bp.generatedLocation)
-      }: Action)
-    );
+    return dispatch({
+      type: "REMOVE_BREAKPOINT",
+      breakpoint: bp,
+      disabled: false,
+      [PROMISE]: client.removeBreakpoint(bp.generatedLocation)
+    });
   };
 }
 
@@ -171,18 +162,11 @@ export function enableBreakpoint(location: Location) {
       disabled: false
     };
 
-    return dispatch(
-      ({
-        type: "ENABLE_BREAKPOINT",
-        breakpoint: enabledBreakpoint,
-        [PROMISE]: addBreakpointPromise(
-          getState,
-          client,
-          sourceMaps,
-          breakpoint
-        )
-      }: Action)
-    );
+    return dispatch({
+      type: "ENABLE_BREAKPOINT",
+      breakpoint: enabledBreakpoint,
+      [PROMISE]: addBreakpointPromise(getState, client, sourceMaps, breakpoint)
+    });
   };
 }
 
@@ -374,12 +358,13 @@ export function setBreakpointCondition(
 
 export function toggleBreakpoint(line: ?number, column?: number) {
   return ({ dispatch, getState, client, sourceMaps }: ThunkArgs) => {
-    if (!line) {
+    const state = getState();
+    const selectedSource = getSelectedSource(state);
+
+    if (!line || !selectedSource) {
       return;
     }
 
-    const state = getState();
-    const selectedSource = getSelectedSource(state);
     const bp = getBreakpointAtLocation(state, { line, column });
     const isEmptyLine = isEmptyLineInSource(state, line, selectedSource.id);
 
@@ -411,11 +396,12 @@ export function toggleBreakpoint(line: ?number, column?: number) {
 
 export function addOrToggleDisabledBreakpoint(line: ?number, column?: number) {
   return ({ dispatch, getState, client, sourceMaps }: ThunkArgs) => {
-    if (!line) {
+    const selectedSource = getSelectedSource(getState());
+
+    if (!line || !selectedSource) {
       return;
     }
 
-    const selectedSource = getSelectedSource(getState());
     const bp = getBreakpointAtLocation(getState(), { line, column });
 
     if (bp && bp.loading) {
@@ -431,8 +417,8 @@ export function addOrToggleDisabledBreakpoint(line: ?number, column?: number) {
 
     return dispatch(
       addBreakpoint({
-        sourceId: selectedSource.get("id"),
-        sourceUrl: selectedSource.get("url"),
+        sourceId: selectedSource.id,
+        sourceUrl: selectedSource.url,
         line: line,
         column: column
       })

--- a/src/actions/pause/continueToHere.js
+++ b/src/actions/pause/continueToHere.js
@@ -6,7 +6,6 @@
 
 import {
   getSelectedSource,
-  isPaused,
   getSelectedFrame,
   getCanRewind
 } from "../../selectors";
@@ -18,12 +17,12 @@ import type { ThunkArgs } from "../types";
 export function continueToHere(line: number) {
   return async function({ dispatch, getState }: ThunkArgs) {
     const selectedSource = getSelectedSource(getState());
+    const selectedFrame = getSelectedFrame(getState());
 
-    if (!isPaused(getState()) || !selectedSource) {
+    if (!selectedFrame || !selectedSource) {
       return;
     }
 
-    const selectedFrame = getSelectedFrame(getState());
     const debugLine = selectedFrame.location.line;
     if (debugLine == line) {
       return;

--- a/src/actions/pause/extra.js
+++ b/src/actions/pause/extra.js
@@ -70,6 +70,10 @@ async function getExtraProps(getState, expression, result, evaluate) {
 export function fetchExtra() {
   return async function({ dispatch, getState }: ThunkArgs) {
     const frame = getSelectedFrame(getState());
+    if (!frame) {
+      return;
+    }
+
     const extra = await dispatch(getExtra("this;", frame.this));
     dispatch({
       type: "ADD_EXTRA",

--- a/src/actions/pause/paused.js
+++ b/src/actions/pause/paused.js
@@ -76,9 +76,10 @@ export function paused(pauseInfo: Pause) {
 
     if (selectedFrame) {
       const visibleFrame = getVisibleSelectedFrame(getState());
-      const location = isGeneratedId(visibleFrame.location.sourceId)
-        ? selectedFrame.generatedLocation
-        : selectedFrame.location;
+      const location =
+        visibleFrame && isGeneratedId(visibleFrame.location.sourceId)
+          ? selectedFrame.generatedLocation
+          : selectedFrame.location;
       await dispatch(selectLocation(location));
     }
 

--- a/src/actions/preview.js
+++ b/src/actions/preview.js
@@ -77,44 +77,46 @@ export function setPreview(
   cursorPos: ClientRect
 ) {
   return async ({ dispatch, getState, client, sourceMaps }: ThunkArgs) => {
-    await dispatch(
-      ({
-        type: "SET_PREVIEW",
-        [PROMISE]: (async function() {
-          const source = getSelectedSource(getState());
-          const sourceId = source.id;
-          const selectedFrame = getSelectedFrame(getState());
+    await dispatch({
+      type: "SET_PREVIEW",
+      [PROMISE]: (async function() {
+        const source = getSelectedSource(getState());
+        if (!source) {
+          return;
+        }
 
-          if (location && !isGeneratedId(sourceId)) {
-            expression = await dispatch(getMappedExpression(expression));
-          }
+        const sourceId = source.id;
+        const selectedFrame = getSelectedFrame(getState());
 
-          if (!selectedFrame) {
-            return;
-          }
+        if (location && !isGeneratedId(sourceId)) {
+          expression = await dispatch(getMappedExpression(expression));
+        }
 
-          const { result } = await client.evaluateInFrame(
-            expression,
-            selectedFrame.id
-          );
+        if (!selectedFrame) {
+          return;
+        }
 
-          if (result === undefined) {
-            return;
-          }
+        const { result } = await client.evaluateInFrame(
+          expression,
+          selectedFrame.id
+        );
 
-          const extra = await dispatch(getExtra(expression, result));
+        if (result === undefined) {
+          return;
+        }
 
-          return {
-            expression,
-            result,
-            location,
-            tokenPos,
-            cursorPos,
-            extra
-          };
-        })()
-      }: Action)
-    );
+        const extra = await dispatch(getExtra(expression, result));
+
+        return {
+          expression,
+          result,
+          location,
+          tokenPos,
+          cursorPos,
+          extra
+        };
+      })()
+    });
   };
 }
 

--- a/src/actions/sources/blackbox.js
+++ b/src/actions/sources/blackbox.js
@@ -11,18 +11,16 @@
 
 import { PROMISE } from "../utils/middleware/promise";
 import type { Source } from "../../types";
-import type { Action, ThunkArgs } from "../types";
+import type { ThunkArgs } from "../types";
 
 export function toggleBlackBox(source: Source) {
   return async ({ dispatch, getState, client, sourceMaps }: ThunkArgs) => {
     const { isBlackBoxed, id } = source;
 
-    return dispatch(
-      ({
-        type: "BLACKBOX",
-        source,
-        [PROMISE]: client.blackBox(id, isBlackBoxed)
-      }: Action)
-    );
+    return dispatch({
+      type: "BLACKBOX",
+      source,
+      [PROMISE]: client.blackBox(id, isBlackBoxed)
+    });
   };
 }

--- a/src/actions/sources/loadSourceText.js
+++ b/src/actions/sources/loadSourceText.js
@@ -11,7 +11,8 @@ import * as parser from "../../workers/parser";
 import { isLoaded } from "../../utils/source";
 
 import defer from "../../utils/defer";
-import type { Action, ThunkArgs } from "../types";
+import type { ThunkArgs } from "../types";
+
 import type { SourceRecord } from "../../types";
 
 const requests = new Map();
@@ -56,13 +57,11 @@ export function loadSourceText(source: SourceRecord) {
     requests.set(id, deferred.promise);
 
     try {
-      await dispatch(
-        ({
-          type: "LOAD_SOURCE_TEXT",
-          sourceId: id,
-          [PROMISE]: loadSource(source, { sourceMaps, client })
-        }: Action)
-      );
+      await dispatch({
+        type: "LOAD_SOURCE_TEXT",
+        sourceId: id,
+        [PROMISE]: loadSource(source, { sourceMaps, client })
+      });
     } catch (e) {
       deferred.resolve();
       requests.delete(id);

--- a/src/actions/sources/select.js
+++ b/src/actions/sources/select.js
@@ -227,6 +227,10 @@ export function jumpToMappedLocation(location: Location) {
 export function jumpToMappedSelectedLocation() {
   return async function({ dispatch, getState }: ThunkArgs) {
     const location = getSelectedLocation(getState());
+    if (!location) {
+      return;
+    }
+
     await dispatch(jumpToMappedLocation(location));
   };
 }

--- a/src/actions/types/SourceAction.js
+++ b/src/actions/types/SourceAction.js
@@ -7,7 +7,15 @@
 import type { Location, Source } from "../../types";
 import type { PromiseAction } from "../utils/middleware/promise";
 
+export type LoadSourceAction = PromiseAction<
+  {|
+    +type: "LOAD_SOURCE_TEXT",
+    +sourceId: string
+  |},
+  Source
+>;
 export type SourceAction =
+  | LoadSourceAction
   | {|
       +type: "ADD_SOURCE",
       +source: Source
@@ -30,13 +38,6 @@ export type SourceAction =
       +url: string,
       +line: ?number
     |}
-  | PromiseAction<
-      {|
-        +type: "LOAD_SOURCE_TEXT",
-        +sourceId: string
-      |},
-      Source
-    >
   | {| type: "CLEAR_SELECTED_LOCATION" |}
   | PromiseAction<
       {|

--- a/src/actions/utils/middleware/promise.js
+++ b/src/actions/utils/middleware/promise.js
@@ -30,13 +30,27 @@ export type ErrorPromiseAction = {|
   +error: any
 |};
 
-export type PromiseAction<Action, Value = any> = {|
-  ...BasePromiseAction,
-  ...Action,
-  +status?: "start" | "done" | "error",
-  +value?: Value,
-  +error?: any
-|};
+export type PromiseAction<Action, Value = any> =
+  // | {| ...Action, "@@dispatch/promise": Promise<Object> |}
+  | {|
+      ...BasePromiseAction,
+      ...Action,
+      +status: "start",
+      value: void
+    |}
+  | {|
+      ...BasePromiseAction,
+      ...Action,
+      +status: "done",
+      +value: Value
+    |}
+  | {|
+      ...BasePromiseAction,
+      ...Action,
+      +status: "error",
+      +error?: any,
+      value: void
+    |};
 
 let seqIdVal = 1;
 

--- a/src/reducers/ast.js
+++ b/src/reducers/ast.js
@@ -156,7 +156,7 @@ function update(
 // https://github.com/devtools-html/debugger.html/blob/master/src/reducers/sources.js#L179-L185
 type OuterState = { ast: Record<ASTState> };
 
-export function getSymbols(state: OuterState, source: Source): ?Symbols {
+export function getSymbols(state: OuterState, source?: Source): ?Symbols {
   if (!source) {
     return null;
   }

--- a/src/reducers/debuggee.js
+++ b/src/reducers/debuggee.js
@@ -9,7 +9,6 @@
  * @module reducers/debuggee
  */
 
-import { createSelector } from "reselect";
 import { List } from "immutable";
 import type { Record } from "../utils/makeRecord";
 import type { Worker } from "../types";
@@ -40,11 +39,7 @@ export default function debuggee(
   }
 }
 
-const getDebuggeeWrapper = state => state.debuggee;
-
-export const getWorkers = createSelector(getDebuggeeWrapper, debuggeeState =>
-  debuggeeState.get("workers")
-);
+export const getWorkers = (state: OuterState) => state.debuggee.workers;
 
 type OuterState = { debuggee: DebuggeeState };
 

--- a/src/reducers/pause.js
+++ b/src/reducers/pause.js
@@ -17,6 +17,7 @@ import { getSelectedSource } from "./sources";
 
 import type { OriginalScope } from "../utils/pause/mapScopes";
 import type { Action } from "../actions/types";
+import type { State } from "./types";
 import type { Why, Scope, SourceId, FrameId, MappedLocation } from "../types";
 
 export type Command =
@@ -299,7 +300,7 @@ function getPauseLocation(state, action) {
 // top-level app state, so we'd have to "wrap" them to automatically
 // pick off the piece of state we're interested in. It's impossible
 // (right now) to type those wrapped functions.
-type OuterState = { pause: PauseState };
+type OuterState = State;
 
 const getPauseState = state => state.pause;
 
@@ -453,6 +454,7 @@ export const getSelectedFrame = createSelector(
     if (!frames) {
       return null;
     }
+
     return frames.find(frame => frame.id == selectedFrameId);
   }
 );

--- a/src/reducers/replay.js
+++ b/src/reducers/replay.js
@@ -65,8 +65,8 @@ function update(
   return state;
 }
 
-function addScopes(state: ReplayState, action: any) {
-  const { frame, status, value } = action;
+function addScopes(state: ReplayState, action) {
+  const { frame, status } = action;
   const selectedFrameId = frame.id;
   const instance = state.history[state.position];
 
@@ -75,13 +75,20 @@ function addScopes(state: ReplayState, action: any) {
   }
 
   const pausedInst = instance.paused;
+  const scopeValue =
+    status === "done"
+      ? {
+          pending: false,
+          scope: action.value
+        }
+      : {
+          pending: true,
+          scope: null
+        };
 
   const generated = {
     ...pausedInst.frameScopes.generated,
-    [selectedFrameId]: {
-      pending: status !== "done",
-      scope: value
-    }
+    [selectedFrameId]: scopeValue
   };
 
   const newPaused = {

--- a/src/reducers/sources.js
+++ b/src/reducers/sources.js
@@ -18,12 +18,13 @@ import { prefs } from "../utils/prefs";
 
 import type { Map, List } from "immutable";
 import type { Source, Location, SourceRecord } from "../types";
-import type { SelectedLocation, PendingSelectedLocation } from "./types";
+import type { SelectedLocation, PendingSelectedLocation, State } from "./types";
 import type { Action, DonePromiseAction } from "../actions/types";
 import type { Record } from "../utils/makeRecord";
+import type { LoadSourceAction } from "../actions/types/SourceAction";
 
 type Tab = string;
-export type SourcesMap = Map<string, SourceRecord>;
+export type SourcesMap = Map<string, Source>;
 export type TabList = List<Tab>;
 
 export type SourcesState = {
@@ -34,7 +35,9 @@ export type SourcesState = {
   tabs: TabList
 };
 
-export function initialSourcesState(): Record<SourcesState> {
+type SourcesStateRecord = Record<SourcesState>;
+
+export function initialSourcesState(): SourcesStateRecord {
   return makeRecord(
     ({
       sources: I.Map(),
@@ -158,7 +161,10 @@ function update(
       break;
 
     case "NAVIGATE":
-      const source = getSelectedSource({ sources: state });
+      const source =
+        state.selectedLocation &&
+        state.sources.get(state.selectedLocation.sourceId);
+
       const url = source && source.url;
 
       if (!url) {
@@ -171,8 +177,8 @@ function update(
   return state;
 }
 
-function getTextPropsFromAction(action: any) {
-  const { value, sourceId } = action;
+function getTextPropsFromAction(action) {
+  const { sourceId } = action;
 
   if (action.status === "start") {
     return { id: sourceId, loadedState: "loading" };
@@ -181,9 +187,9 @@ function getTextPropsFromAction(action: any) {
   }
 
   return {
-    text: value.text,
+    text: action.value.text,
     id: sourceId,
-    contentType: value.contentType,
+    contentType: action.value.contentType,
     loadedState: "loaded"
   };
 }
@@ -192,7 +198,10 @@ function getTextPropsFromAction(action: any) {
 // asynchronous actions is wrong. The `value` may be null for the
 // "start" and "error" states but we don't type it like that. We need
 // to rethink how we type async actions.
-function setSourceTextProps(state, action: any): Record<SourcesState> {
+function setSourceTextProps(
+  state,
+  action: LoadSourceAction
+): Record<SourcesState> {
   const text = getTextPropsFromAction(action);
   return updateSource(state, text);
 }
@@ -274,7 +283,7 @@ export function getBlackBoxList() {
  */
 export function getNewSelectedSourceId(
   state: OuterState,
-  availableTabs: any
+  availableTabs: TabList
 ): string {
   const selectedLocation = state.sources.selectedLocation;
   if (!selectedLocation) {
@@ -326,9 +335,9 @@ export function getNewSelectedSourceId(
 // top-level app state, so we'd have to "wrap" them to automatically
 // pick off the piece of state we're interested in. It's impossible
 // (right now) to type those wrapped functions.
-type OuterState = { sources: Record<SourcesState> };
+type OuterState = State;
 
-const getSourcesState = state => state.sources;
+const getSourcesState = (state: OuterState) => state.sources;
 
 export function getSource(state: OuterState, id: string) {
   return getSourceInSources(getSources(state), id);
@@ -381,10 +390,7 @@ export function getSourceInSources(
   return sources.get(id);
 }
 
-export const getSources = createSelector(
-  getSourcesState,
-  sources => sources.sources
-);
+export const getSources = (sources: OuterState) => sources.sources.sources;
 
 export const getTabs = createSelector(getSourcesState, sources => sources.tabs);
 
@@ -418,15 +424,6 @@ export const getSelectedSource = createSelector(
     }
 
     return sources.get(selectedLocation.sourceId);
-  }
-);
-
-export const getSelectedSourceText = createSelector(
-  getSelectedSource,
-  getSourcesState,
-  (selectedSource, sources) => {
-    const id = selectedSource.id;
-    return id ? sources.sourcesText.get(id) : null;
   }
 );
 

--- a/src/selectors/inComponent.js
+++ b/src/selectors/inComponent.js
@@ -12,6 +12,10 @@ import type { State } from "../reducers/types";
 
 export function inComponent(state: State) {
   const selectedFrame = getSelectedFrame(state);
+  if (!selectedFrame) {
+    return;
+  }
+
   const source = getSource(state, selectedFrame.location.sourceId);
   const symbols = getSymbols(state, source);
 


### PR DESCRIPTION
Fixes Issue: #5122 

### Summary of Changes

This adds flow type definitions for reselect, which is important for validating PropTypes and improving our redux action and selector coverage