### PR TITLE
fix for issue #6495 (https://github.com/devtools-html/debugger.html/i…

### DIFF
--- a/src/components/shared/SearchInput.js
+++ b/src/components/shared/SearchInput.js
@@ -109,16 +109,16 @@ class SearchInput extends Component<Props, State> {
 
     return [
       arrowBtn(
-        handleNext,
-        "arrow-down",
-        classnames("nav-btn", "next"),
-        L10N.getFormatStr("editor.searchResults.nextResult")
-      ),
-      arrowBtn(
         handlePrev,
         "arrow-up",
         classnames("nav-btn", "prev"),
         L10N.getFormatStr("editor.searchResults.prevResult")
+      ),
+      arrowBtn(
+        handleNext,
+        "arrow-down",
+        classnames("nav-btn", "next"),
+        L10N.getFormatStr("editor.searchResults.nextResult")
       )
     ];
   }

--- a/src/components/shared/tests/__snapshots__/SearchInput.spec.js.snap
+++ b/src/components/shared/tests/__snapshots__/SearchInput.spec.js.snap
@@ -71,17 +71,6 @@ exports[`SearchInput shows nav buttons 1`] = `
       className="search-nav-buttons"
     >
       <button
-        className="nav-btn next"
-        key="arrow-down"
-        onClick={[MockFunction]}
-        title="Next result"
-        type="arrow-down"
-      >
-        <Svg
-          name="arrow-down"
-        />
-      </button>
-      <button
         className="nav-btn prev"
         key="arrow-up"
         onClick={[MockFunction]}
@@ -90,6 +79,17 @@ exports[`SearchInput shows nav buttons 1`] = `
       >
         <Svg
           name="arrow-up"
+        />
+      </button>
+      <button
+        className="nav-btn next"
+        key="arrow-down"
+        onClick={[MockFunction]}
+        title="Next result"
+        type="arrow-down"
+      >
+        <Svg
+          name="arrow-down"
         />
       </button>
     </div>
@@ -134,17 +134,6 @@ exports[`SearchInput shows svg error emoji 1`] = `
       className="search-nav-buttons"
     >
       <button
-        className="nav-btn next"
-        key="arrow-down"
-        onClick={[MockFunction]}
-        title="Next result"
-        type="arrow-down"
-      >
-        <Svg
-          name="arrow-down"
-        />
-      </button>
-      <button
         className="nav-btn prev"
         key="arrow-up"
         onClick={[MockFunction]}
@@ -153,6 +142,17 @@ exports[`SearchInput shows svg error emoji 1`] = `
       >
         <Svg
           name="arrow-up"
+        />
+      </button>
+      <button
+        className="nav-btn next"
+        key="arrow-down"
+        onClick={[MockFunction]}
+        title="Next result"
+        type="arrow-down"
+      >
+        <Svg
+          name="arrow-down"
         />
       </button>
     </div>
@@ -197,17 +197,6 @@ exports[`SearchInput shows svg magnifying glass 1`] = `
       className="search-nav-buttons"
     >
       <button
-        className="nav-btn next"
-        key="arrow-down"
-        onClick={[MockFunction]}
-        title="Next result"
-        type="arrow-down"
-      >
-        <Svg
-          name="arrow-down"
-        />
-      </button>
-      <button
         className="nav-btn prev"
         key="arrow-up"
         onClick={[MockFunction]}
@@ -216,6 +205,17 @@ exports[`SearchInput shows svg magnifying glass 1`] = `
       >
         <Svg
           name="arrow-up"
+        />
+      </button>
+      <button
+        className="nav-btn next"
+        key="arrow-down"
+        onClick={[MockFunction]}
+        title="Next result"
+        type="arrow-down"
+      >
+        <Svg
+          name="arrow-down"
         />
       </button>
     </div>


### PR DESCRIPTION
…ssues/6495) where it was suggested to match the order of the input search arrows to 'previous result' then 'next result' which is more common.

Fixes Issue: #6495

### Summary of Changes

* Updated the order of the search input arrows to follow the order "previous result" then "next result" as suggested by the issue.
* Updated the snapshots to match the swapped arrows

### Test Plan

Updated the existing snapshots

### Screenshots/Videos
<img width="736" alt="screen shot 2018-06-13 at 12 53 40 am" src="https://user-images.githubusercontent.com/16693192/41330953-5a8e83be-6ea4-11e8-9e96-db2fbe318956.png">
