### PR TITLE
display tooltip below target when not enough space above

### DIFF
--- a/src/components/shared/Popover.js
+++ b/src/components/shared/Popover.js
@@ -192,12 +192,16 @@ class Popover extends Component<Props, State> {
       const editorRect = editor.getBoundingClientRect();
       const targetRect = this.props.targetPosition;
       const left = this.calculateLeft(targetRect, editorRect, tooltipRect);
-      const top = targetRect.top - tooltipRect.height;
+      const enoughRoomForTooltipAbove =
+        targetRect.top - editorRect.top > tooltipRect.height;
+      const top = enoughRoomForTooltipAbove
+        ? targetRect.top - tooltipRect.height
+        : targetRect.bottom;
 
       return {
         left,
         top,
-        orientation: "up",
+        orientation: enoughRoomForTooltipAbove ? "up" : "down",
         targetMid: { x: 0, y: 0 }
       };
     }

--- a/src/components/shared/tests/Popover.spec.js
+++ b/src/components/shared/tests/Popover.spec.js
@@ -105,4 +105,78 @@ describe("Popover", () => {
     );
     expect(mountedTooltip).toMatchSnapshot();
   });
+
+  it("tooltip normally displays above the target", () => {
+    const editor = {
+      getBoundingClientRect() {
+        return {
+          width: 500,
+          height: 500,
+          top: 0,
+          bottom: 500,
+          left: 0,
+          right: 500
+        };
+      }
+    };
+    const target = {
+      width: 30,
+      height: 10,
+      top: 100,
+      bottom: 110,
+      left: 20,
+      right: 50
+    };
+
+    const mountedTooltip = mount(
+      <Popover
+        type="tooltip"
+        onMouseLeave={onMouseLeave}
+        editorRef={editor}
+        targetPosition={target}
+      >
+        <h1>Toolie!</h1>
+      </Popover>
+    );
+
+    const toolTipTop = parseInt(mountedTooltip.getDOMNode().style.top, 10);
+    expect(toolTipTop).toBeLessThan(target.top);
+  });
+
+  it("tooltop won't display above the target when insufficient space", () => {
+    const editor = {
+      getBoundingClientRect() {
+        return {
+          width: 100,
+          height: 100,
+          top: 0,
+          bottom: 100,
+          left: 0,
+          right: 100
+        };
+      }
+    };
+    const target = {
+      width: 30,
+      height: 10,
+      top: 5,
+      bottom: 15,
+      left: 20,
+      right: 50
+    };
+
+    const mountedTooltip = mount(
+      <Popover
+        type="tooltip"
+        onMouseLeave={onMouseLeave}
+        editorRef={editor}
+        targetPosition={target}
+      >
+        <h1>Toolie!</h1>
+      </Popover>
+    );
+
+    const toolTipTop = parseInt(mountedTooltip.getDOMNode().style.top, 10);
+    expect(toolTipTop).toBeGreaterThan(editor.getBoundingClientRect().top);
+  });
 });

--- a/src/components/shared/tests/Popover.spec.js
+++ b/src/components/shared/tests/Popover.spec.js
@@ -140,7 +140,7 @@ describe("Popover", () => {
     );
 
     const toolTipTop = parseInt(mountedTooltip.getDOMNode().style.top, 10);
-    expect(toolTipTop).toBeLessThan(target.top);
+    expect(toolTipTop).toBeLessThanOrEqual(target.top);
   });
 
   it("tooltop won't display above the target when insufficient space", () => {
@@ -159,8 +159,8 @@ describe("Popover", () => {
     const target = {
       width: 30,
       height: 10,
-      top: 5,
-      bottom: 15,
+      top: 0,
+      bottom: 10,
       left: 20,
       right: 50
     };
@@ -177,6 +177,6 @@ describe("Popover", () => {
     );
 
     const toolTipTop = parseInt(mountedTooltip.getDOMNode().style.top, 10);
-    expect(toolTipTop).toBeGreaterThan(editor.getBoundingClientRect().top);
+    expect(toolTipTop).toBeGreaterThanOrEqual(target.bottom);
   });
 });

--- a/src/components/shared/tests/__snapshots__/Popover.spec.js.snap
+++ b/src/components/shared/tests/__snapshots__/Popover.spec.js.snap
@@ -87,17 +87,17 @@ exports[`Popover mount tooltip 1`] = `
     style={
       Object {
         "left": -8,
-        "top": 50,
+        "top": 0,
       }
     }
   >
-    <h1>
-      Toolie!
-    </h1>
     <div
       className="gap"
       key="gap"
     />
+    <h1>
+      Toolie!
+    </h1>
   </div>
 </Popover>
 `;


### PR DESCRIPTION
Fixes Issue: #6474 

### Summary of Changes

* Added code to the `getTooltipCoords` function in `Popover.js` to set the top position below the target when there is not enough room between the editor.top and target.top.
* Added 2 new test cases and updated a snapshot.

### Test Plan

**Tell us a little a bit about how you tested your patch.**
I ran the debugger and verified that tooltips for targets at the top line of the editor now show below the target and no longer extend past the editor.  I also added two unit tests but will need help getting them to work if you want to keep them.  The problem is that in the test environment [this line](https://github.com/devtools-html/debugger.html/blob/7eb88759712140709d56f6df2020396701c6bddd/src/components/shared/Popover.js#L139) reports the height of the popover as `0` which messes up the calculations. 

### Screenshots/Videos (OPTIONAL)

Before:
<img width="563" alt="before" src="https://user-images.githubusercontent.com/5035181/41382245-3725cac8-6f20-11e8-872b-be2ecdd4879c.png">

After:
<img width="513" alt="after" src="https://user-images.githubusercontent.com/5035181/41382255-3c0edd36-6f20-11e8-92fd-41abe35ea1b6.png">

