### PR TITLE
 Fix Travis intermittent failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+sudo: required
+dist: precise
 language: python
   - "3.6"
 

--- a/bin/ci/clone-gecko.sh
+++ b/bin/ci/clone-gecko.sh
@@ -1,9 +1,12 @@
 #!/bin/bash
-
+python --version
 hg --version
+df -h 
+
 rm -rf firefox/
 hg clone https://hg.mozilla.org/mozilla-unified/ firefox
 
 cd firefox
+hg update --clean
 hg co $MC_COMMIT
 cd ..


### PR DESCRIPTION
### Summary of Changes

We have been seeing intermittent travis failures for the past month or so. David noticed early on that it looks like it is an out of memory issue. 

This PR tries to fix that by doubling our RAM from 4gb to 7.5gb (i think). [link](https://docs.travis-ci.com/user/reference/overview/).


I think I have some evidence to show that we have an OOM issue:

A recent build had this output for the `hg clone`. The `killed!` output is weird, but I think the important thing is the `137` exit code which looks like a standard linux and docker code for memory issues.

<img width="1155" alt="screen shot 2018-06-17 at 2 18 44 am" src="https://user-images.githubusercontent.com/254562/41505337-de3e7830-71d4-11e8-8e86-063d64ac71fb.png">

Another indicator that the clone failed is when the update includes the message `untracked file differs` and has this error message `abort: untracked files in working directory differ from files in requested revision`


<img width="1071" alt="screen shot 2018-06-17 at 2 23 26 am" src="https://user-images.githubusercontent.com/254562/41505355-75ac11e6-71d5-11e8-89f9-b9c4c664f61f.png">


