### PR TITLE
[Breakpoints] Enable skip all pausing button in dev

### DIFF
--- a/assets/panel/prefs.js
+++ b/assets/panel/prefs.js
@@ -63,4 +63,4 @@ pref("devtools.debugger.features.replay", false);
 pref("devtools.debugger.features.pause-points", true);
 pref("devtools.debugger.features.component-pane", false);
 pref("devtools.debugger.features.async-stepping", true);
-pref("devtools.debugger.features.skip-pausing", false);
+pref("devtools.debugger.features.skip-pausing", true);

--- a/src/actions/pause/skipPausing.js
+++ b/src/actions/pause/skipPausing.js
@@ -14,10 +14,7 @@ import { getSkipPausing } from "../../selectors";
 export function toggleSkipPausing() {
   return async ({ dispatch, client, getState, sourceMaps }: ThunkArgs) => {
     const skipPausing = !getSkipPausing(getState());
-
-    // NOTE: enable this when we land the endpoint in m-c
-    // await client.setSkipPausing(skipPausing);
-
+    await client.setSkipPausing(skipPausing);
     dispatch({ type: "TOGGLE_SKIP_PAUSING", skipPausing });
   };
 }

--- a/src/client/firefox/commands.js
+++ b/src/client/firefox/commands.js
@@ -329,7 +329,7 @@ async function setSkipPausing(shouldSkip: boolean) {
   return threadClient.request({
     skip: shouldSkip,
     to: threadClient.actor,
-    type: "skipPausing"
+    type: "skipBreakpoints"
   });
 }
 

--- a/src/components/SecondaryPanes/CommandBar.js
+++ b/src/components/SecondaryPanes/CommandBar.js
@@ -340,9 +340,13 @@ class CommandBar extends Component<Props> {
 
     return (
       <button
-        className={classnames("command-bar-button", {
-          active: skipPausing
-        })}
+        className={classnames(
+          "command-bar-button",
+          "command-bar-skip-pausing",
+          {
+            active: skipPausing
+          }
+        )}
         title={L10N.getStr("skipPausingTooltip")}
         onClick={toggleSkipPausing}
       >

--- a/src/test/mochitest/browser.ini
+++ b/src/test/mochitest/browser.ini
@@ -159,6 +159,7 @@ skip-if = ccov # Bug 1441545
 [browser_dbg-sourcemapped-preview.js]
 skip-if = (os == "win" && ccov) || (os == "win" && !debug) # Bug 1448523, Bug 1448450
 [browser_dbg-breaking.js]
+[browser_dbg-breakpoint-skipping.js]
 [browser_dbg-breaking-from-console.js]
 [browser_dbg-breakpoints.js]
 [browser_dbg-breakpoints-reloading.js]

--- a/src/test/mochitest/browser_dbg-breakpoint-skipping.js
+++ b/src/test/mochitest/browser_dbg-breakpoint-skipping.js
@@ -1,0 +1,29 @@
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
+
+add_task(async function() {
+  await pushPref("devtools.features.skip-pausing", true);
+
+  let dbg = await initDebugger("doc-scripts.html");
+
+  await selectSource(dbg, "simple3");
+  await addBreakpoint(dbg, "simple3", 2);
+  await addBreakpoint(dbg, "simple3", 3);
+
+  let syncedBps = waitForDispatch(dbg, "SYNC_BREAKPOINT", 2);
+  await reload(dbg, "simple3");
+  await waitForSelectedSource(dbg, "simple3");
+  await syncedBps;
+
+  assertNotPaused(dbg);
+
+  // Turn "skip pausing" on
+  clickElementWithSelector(dbg, ".command-bar-skip-pausing");
+
+  syncedBps = waitForDispatch(dbg, "SYNC_BREAKPOINT", 2);
+  await reload(dbg, "simple3");
+  await waitForSelectedSource(dbg, "simple3");
+  await syncedBps;
+
+  assertPaused(dbg);
+});

--- a/src/test/mochitest/browser_dbg-breakpoint-skipping.js
+++ b/src/test/mochitest/browser_dbg-breakpoint-skipping.js
@@ -2,28 +2,28 @@
  * http://creativecommons.org/publicdomain/zero/1.0/ */
 
 add_task(async function() {
-  await pushPref("devtools.features.skip-pausing", true);
+  await pushPref("devtools.debugger.skip-pausing", true);
+  await pushPref("devtools.debugger.features.skip-pausing", true);
 
   let dbg = await initDebugger("doc-scripts.html");
 
   await selectSource(dbg, "simple3");
   await addBreakpoint(dbg, "simple3", 2);
   await addBreakpoint(dbg, "simple3", 3);
+  await waitForDispatch(dbg, "SYNC_BREAKPOINT", 2);
 
-  let syncedBps = waitForDispatch(dbg, "SYNC_BREAKPOINT", 2);
-  await reload(dbg, "simple3");
-  await waitForSelectedSource(dbg, "simple3");
-  await syncedBps;
+  // Click the button to trigger breakpoints
+  //findElementWithSelector(dbg, "button").click();
+  invokeInTab("simple");
 
-  assertNotPaused(dbg);
+  assertPaused(dbg);
 
   // Turn "skip pausing" on
   clickElementWithSelector(dbg, ".command-bar-skip-pausing");
 
-  syncedBps = waitForDispatch(dbg, "SYNC_BREAKPOINT", 2);
-  await reload(dbg, "simple3");
-  await waitForSelectedSource(dbg, "simple3");
-  await syncedBps;
+  // Click the button to trigger breakpoints
+  //findElementWithSelector(dbg, "button").click();
+  invokeInTab("simple");
 
-  assertPaused(dbg);
+  assertNotPaused(dbg);
 });

--- a/src/test/mochitest/browser_dbg-breakpoint-skipping.js
+++ b/src/test/mochitest/browser_dbg-breakpoint-skipping.js
@@ -1,29 +1,16 @@
 /* Any copyright is dedicated to the Public Domain.
  * http://creativecommons.org/publicdomain/zero/1.0/ */
 
-add_task(async function() {
-  await pushPref("devtools.debugger.skip-pausing", true);
-  await pushPref("devtools.debugger.features.skip-pausing", true);
-
-  let dbg = await initDebugger("doc-scripts.html");
-
-  await selectSource(dbg, "simple3");
-  await addBreakpoint(dbg, "simple3", 2);
-  await addBreakpoint(dbg, "simple3", 3);
-  await waitForDispatch(dbg, "SYNC_BREAKPOINT", 2);
-
-  // Click the button to trigger breakpoints
-  //findElementWithSelector(dbg, "button").click();
-  invokeInTab("simple");
-
-  assertPaused(dbg);
-
-  // Turn "skip pausing" on
+function skipPausing(dbg) {
   clickElementWithSelector(dbg, ".command-bar-skip-pausing");
+  return waitForState(dbg, state => dbg.selectors.getSkipPausing(state))
+}
 
-  // Click the button to trigger breakpoints
-  //findElementWithSelector(dbg, "button").click();
-  invokeInTab("simple");
+add_task(async function() {
+  let dbg = await initDebugger("doc-scripts.html");
+  await addBreakpoint(dbg, "simple3", 2);
 
-  assertNotPaused(dbg);
+  await skipPausing(dbg);
+  const res = await invokeInTab("simple")
+  is(res, 3, "simple() successfully completed")
 });

--- a/src/test/mochitest/helpers.js
+++ b/src/test/mochitest/helpers.js
@@ -494,6 +494,7 @@ function clearDebuggerPreferences() {
   Services.prefs.clearUserPref("devtools.debugger.expressions");
   Services.prefs.clearUserPref("devtools.debugger.call-stack-visible");
   Services.prefs.clearUserPref("devtools.debugger.scopes-visible");
+  Services.prefs.clearUserPref("devtools.debugger.skip-pausing");
 }
 
 /**
@@ -896,7 +897,7 @@ function invokeInTab(fnc, ...args) {
     fnc,
     args
   }) {
-    content.wrappedJSObject[fnc](...args); // eslint-disable-line mozilla/no-cpows-in-tests, max-len
+    return content.wrappedJSObject[fnc](...args); // eslint-disable-line mozilla/no-cpows-in-tests, max-len
   });
 }
 

--- a/src/utils/prefs.js
+++ b/src/utils/prefs.js
@@ -54,7 +54,7 @@ if (isDevelopment()) {
   pref("devtools.debugger.features.replay", true);
   pref("devtools.debugger.features.pause-points", true);
   pref("devtools.debugger.features.component-pane", false);
-  pref("devtools.debugger.features.skip-pausing", false);
+  pref("devtools.debugger.features.skip-pausing", true);
 }
 
 export const prefs = new PrefsHelper("devtools", {


### PR DESCRIPTION
Fixes Issue: #6512

## Testing
- `yarn copy`
- `cd firefox && ./mach build faster`
- `./mach run`
- Go into `about:config` and turn on `debugger.features.skip-pausing`
- Restart Firefox (`./mach run`)
- Toggle on and off the button and ensure breakpoints are either hit or not.
