### PR TITLE
[Breakpoints] fix missing redux prop

### DIFF
--- a/src/components/SecondaryPanes/Breakpoints/Breakpoint.js
+++ b/src/components/SecondaryPanes/Breakpoints/Breakpoint.js
@@ -20,6 +20,8 @@ import { getLocationWithoutColumn } from "../../../utils/breakpoint";
 import { features } from "../../../utils/prefs";
 import { getEditor } from "../../../utils/editor";
 
+import type { BreakpointsMap } from "../../../reducers/types";
+
 import type {
   Frame,
   Source,
@@ -27,10 +29,15 @@ import type {
   MappedLocation
 } from "../../../types";
 
-import { getSelectedSource, getTopFrame } from "../../../selectors";
+import {
+  getBreakpoints,
+  getSelectedSource,
+  getTopFrame
+} from "../../../selectors";
 
 type Props = {
   breakpoint: BreakpointType,
+  breakpoints: BreakpointsMap,
   selectedSource: ?Source,
   disableBreakpoint: Function,
   enableBreakpoint: Function,
@@ -173,6 +180,7 @@ class Breakpoint extends PureComponent<Props> {
 }
 
 const mapStateToProps = state => ({
+  breakpoints: getBreakpoints(state),
   frame: getTopFrame(state),
   selectedSource: getSelectedSource(state)
 });

--- a/src/test/mochitest/browser.ini
+++ b/src/test/mochitest/browser.ini
@@ -159,13 +159,14 @@ skip-if = ccov # Bug 1441545
 [browser_dbg-sourcemapped-preview.js]
 skip-if = (os == "win" && ccov) || (os == "win" && !debug) # Bug 1448523, Bug 1448450
 [browser_dbg-breaking.js]
-[browser_dbg-breakpoint-skipping.js]
 [browser_dbg-breaking-from-console.js]
 [browser_dbg-breakpoints.js]
-[browser_dbg-breakpoints-reloading.js]
+[browser_dbg-breakpoints-actions.js]
 [browser_dbg-breakpoints-cond.js]
 [browser_dbg-browser-content-toolbox.js]
 skip-if = !e10s # This test is only valid in e10s
+[browser_dbg-breakpoints-reloading.js]
+[browser_dbg-breakpoint-skipping.js]
 [browser_dbg-call-stack.js]
 [browser_dbg-scopes.js]
 [browser_dbg-chrome-create.js]

--- a/src/test/mochitest/browser_dbg-breakpoints-actions.js
+++ b/src/test/mochitest/browser_dbg-breakpoints-actions.js
@@ -1,0 +1,21 @@
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
+
+async function removeBreakpoint(dbg) {
+  rightClickElement(dbg, "breakpointItem", 3)
+  selectMenuItem(dbg, 1);
+}
+
+
+// Tests to see if we can trigger a breakpoint action via the context menu
+add_task(async function() {
+  const dbg = await initDebugger("doc-scripts.html");
+  await selectSource(dbg, "simple2");
+  await waitForSelectedSource(dbg, "simple2");
+
+  await addBreakpoint(dbg, "simple2", 3);
+  await removeBreakpoint(dbg);
+
+  await waitForState(dbg, state => dbg.selectors.getBreakpoints(state).size == 0)
+  ok("successfully removed the breakpoint")
+});

--- a/src/test/mochitest/helpers.js
+++ b/src/test/mochitest/helpers.js
@@ -1026,7 +1026,7 @@ const selectors = {
   expressionInput: ".expressions-list  input.input-expression",
   expressionNodes: ".expressions-list .tree-node",
   scopesHeader: ".scopes-pane ._header",
-  breakpointItem: i => `.breakpoints-list .breakpoint:nth-of-type(${i})`,
+  breakpointItem: i => `.breakpoints-list div:nth-of-type(${i})`,
   breakpointItems: `.breakpoints-list .breakpoint`,
   scopes: ".scopes-list",
   scopeNode: i => `.scopes-list .tree-node:nth-child(${i}) .object-label`,


### PR DESCRIPTION
Fixes Issue: #6519 

### Summary of Changes

* Add a breakpoints prop to Breakpoint compnent that gets data from redux selector

### Test Plan

Ran the debugger as a web app and set some breakpoints.  Then I right clicked on a breakpoint and verified the context menu displayed and the error did not come up in the console anymore.  I tried the features of the context menu and they all seemed to work properly.  

**Note:** after thinking about this I realized the data from the selector I chose might not be what the component is expecting.  Someone more familiar with the design of the component might want to verify this is the correct data for the breakpoints prop.


