### PR TITLE
[Tabs] Title Not Matching Tree Title

### DIFF
--- a/src/components/Editor/Tab.js
+++ b/src/components/Editor/Tab.js
@@ -12,20 +12,17 @@ import { showMenu, buildMenu } from "devtools-contextmenu";
 import SourceIcon from "../shared/SourceIcon";
 import { CloseButton } from "../shared/Button";
 
-import { truncateMiddleText } from "../../utils/text";
-
 import type { List } from "immutable";
 import type { Source } from "../../types";
 
 import actions from "../../actions";
 
 import {
-  getFilename,
   getFileURL,
   getRawSourceURL,
+  getTruncatedFileName,
   isPretty
 } from "../../utils/source";
-import { getUnicodeUrlPath } from "devtools-modules";
 import { copyToTheClipboard } from "../../utils/clipboard";
 import { getTabMenuItems } from "../../utils/tabs";
 
@@ -154,7 +151,6 @@ class Tab extends PureComponent<Props> {
       closeTab,
       source
     } = this.props;
-    const filename = getFilename(source);
     const sourceId = source.id;
     const active =
       selectedSource &&
@@ -196,9 +192,7 @@ class Tab extends PureComponent<Props> {
           source={source}
           shouldHide={icon => ["file", "javascript"].includes(icon)}
         />
-        <div className="filename">
-          {truncateMiddleText(getUnicodeUrlPath(filename), 30)}
-        </div>
+        <div className="filename">{getTruncatedFileName(source)}</div>
         <CloseButton
           handleClick={onClickClose}
           tooltip={L10N.getStr("sourceTabs.closeTabButtonTooltip")}

--- a/src/components/PrimaryPanes/SourcesTree.js
+++ b/src/components/PrimaryPanes/SourcesTree.js
@@ -115,13 +115,12 @@ class SourcesTree extends Component<Props, State> {
     }
 
     if (nextProps.shownSource && nextProps.shownSource != shownSource) {
-      const listItems = getDirectories(nextProps.shownSource, sourceTree);
-
-      if (listItems && listItems[0]) {
-        this.selectItem(listItems[0]);
-      }
-
-      return this.setState({ listItems });
+      // const listItems = getDirectories(nextProps.shownSource, sourceTree);
+      //
+      // if (listItems && listItems[0]) {
+      //   this.selectItem(listItems[0]);
+      // }
+      // return this.setState({ listItems });
     }
 
     if (
@@ -129,7 +128,7 @@ class SourcesTree extends Component<Props, State> {
       nextProps.selectedSource != selectedSource
     ) {
       const highlightItems = getDirectories(
-        getRawSourceURL(nextProps.selectedSource.url),
+        nextProps.selectedSource,
         sourceTree
       );
 

--- a/src/components/PrimaryPanes/SourcesTree.js
+++ b/src/components/PrimaryPanes/SourcesTree.js
@@ -124,7 +124,9 @@ class SourcesTree extends Component<Props, State> {
           sources[matchingSources[0]],
           sourceTree
         );
-        this.selectItem(listItems[0]);
+        if (listItems && listItems.length) {
+          this.selectItem(listItems[0]);
+        }
         return this.setState({ listItems });
       }
     }

--- a/src/components/PrimaryPanes/SourcesTree.js
+++ b/src/components/PrimaryPanes/SourcesTree.js
@@ -20,7 +20,9 @@ import {
   getSourceCount
 } from "../../selectors";
 
+// Actions
 import actions from "../../actions";
+import { getRawSourceURL } from "../../utils/source";
 
 // Components
 import SourcesTreeItem from "./SourcesTreeItem";
@@ -36,8 +38,6 @@ import {
   nodeHasChildren,
   updateTree
 } from "../../utils/sources-tree";
-
-import { getRawSourceURL } from "../../utils/source";
 
 import type {
   TreeNode,
@@ -115,12 +115,18 @@ class SourcesTree extends Component<Props, State> {
     }
 
     if (nextProps.shownSource && nextProps.shownSource != shownSource) {
-      // const listItems = getDirectories(nextProps.shownSource, sourceTree);
-      //
-      // if (listItems && listItems[0]) {
-      //   this.selectItem(listItems[0]);
-      // }
-      // return this.setState({ listItems });
+      const matchingSources = Object.keys(sources).filter(
+        sourceId => getRawSourceURL(sources[sourceId].url) === shownSource
+      );
+
+      if (matchingSources.length) {
+        const listItems = getDirectories(
+          sources[matchingSources[0]],
+          sourceTree
+        );
+        this.selectItem(listItems[0]);
+      }
+      return this.setState({ listItems: matchingSources });
     }
 
     if (

--- a/src/components/PrimaryPanes/SourcesTree.js
+++ b/src/components/PrimaryPanes/SourcesTree.js
@@ -115,9 +115,9 @@ class SourcesTree extends Component<Props, State> {
     }
 
     if (nextProps.shownSource && nextProps.shownSource != shownSource) {
-      const matchingSources = Object.keys(sources).filter(
-        sourceId => getRawSourceURL(sources[sourceId].url) === shownSource
-      );
+      const matchingSources = Object.keys(sources).filter(sourceId => {
+        return getRawSourceURL(sources[sourceId].url) === nextProps.shownSource;
+      });
 
       if (matchingSources.length) {
         const listItems = getDirectories(
@@ -125,8 +125,8 @@ class SourcesTree extends Component<Props, State> {
           sourceTree
         );
         this.selectItem(listItems[0]);
+        return this.setState({ listItems });
       }
-      return this.setState({ listItems: matchingSources });
     }
 
     if (

--- a/src/components/SecondaryPanes/Breakpoints/index.js
+++ b/src/components/SecondaryPanes/Breakpoints/index.js
@@ -12,7 +12,7 @@ import Breakpoint from "./Breakpoint";
 import SourceIcon from "../../shared/SourceIcon";
 
 import actions from "../../../actions";
-import { getFilename, getRawSourceURL } from "../../../utils/source";
+import { getTruncatedFileName, getRawSourceURL } from "../../../utils/source";
 import { makeLocationId } from "../../../utils/breakpoint";
 
 import { getSelectedSource, getBreakpointSources } from "../../../selectors";
@@ -101,7 +101,7 @@ class Breakpoints extends Component<Props> {
             source={source}
             shouldHide={icon => ["file", "javascript"].includes(icon)}
           />
-          {getFilename(source)}
+          {getTruncatedFileName(source)}
         </div>,
         ...breakpoints.map(breakpoint => (
           <Breakpoint

--- a/src/reducers/sources.js
+++ b/src/reducers/sources.js
@@ -42,7 +42,7 @@ export function initialSourcesState(): SourcesState {
   };
 }
 
-export function createSource(source: Source) {
+export function createSource(source: Object): Source {
   return {
     id: undefined,
     url: undefined,

--- a/src/selectors/breakpointSources.js
+++ b/src/selectors/breakpointSources.js
@@ -7,7 +7,7 @@
 import { sortBy, uniq } from "lodash";
 import { createSelector } from "reselect";
 import { getSources, getBreakpoints } from "../selectors";
-import { getFilenameFromURL } from "../utils/source";
+import { getFilename } from "../utils/source";
 
 import type { Source, Breakpoint } from "../types";
 import type { SourcesMap, BreakpointsMap } from "../reducers/types";
@@ -50,9 +50,7 @@ function findBreakpointSources(
     .map(id => sources[id])
     .filter(source => source && !source.isBlackBoxed);
 
-  return sortBy(breakpointSources, (source: Source) =>
-    getFilenameFromURL(source.url)
-  );
+  return sortBy(breakpointSources, (source: Source) => getFilename(source));
 }
 
 function _getBreakpointSources(

--- a/src/utils/source.js
+++ b/src/utils/source.js
@@ -10,14 +10,12 @@
  */
 
 import { isOriginalId } from "devtools-source-map";
-import { getURL } from "./sources-tree/index";
 import { endTruncateStr } from "./utils";
-import { basename } from "./path";
 
 import { parse as parseURL } from "url";
-import { getUnicodeUrl, getUnicodeUrlPath } from "devtools-modules";
+import { getUnicodeUrl } from "devtools-modules";
 export { isMinified } from "./isMinified";
-import { getFileExtension } from "./sources-tree";
+import { getURL, getFileExtension } from "./sources-tree";
 
 import type { Source, Location } from "../types";
 import type { SourceMetaDataType } from "../reducers/ast";
@@ -156,6 +154,7 @@ export function getFilename(source: Source) {
   }
 
   const { filename } = getURL(source);
+
   return filename;
 }
 

--- a/src/utils/source.js
+++ b/src/utils/source.js
@@ -10,6 +10,7 @@
  */
 
 import { isOriginalId } from "devtools-source-map";
+import { getURL } from "./sources-tree/index";
 import { endTruncateStr } from "./utils";
 import { basename } from "./path";
 
@@ -136,19 +137,6 @@ function resolveFileURL(
   return endTruncateStr(name, 50);
 }
 
-/**
- * Gets a readable filename from a URL for display purposes.
- *
- * @memberof utils/source
- * @static
- */
-export function getFilenameFromURL(url: string): string {
-  return resolveFileURL(
-    url,
-    initialUrl => getUnicodeUrlPath(basename(initialUrl)) || "(index)"
-  );
-}
-
 export function getFormattedSourceId(id: string) {
   const sourceId = id.split("/")[1];
   return `SOURCE${sourceId}`;
@@ -167,11 +155,7 @@ export function getFilename(source: Source) {
     return getFormattedSourceId(id);
   }
 
-  let filename = getFilenameFromURL(url);
-  const qMarkIdx = filename.indexOf("?");
-  if (qMarkIdx > 0) {
-    filename = filename.slice(0, qMarkIdx);
-  }
+  const { filename } = getURL(source);
   return filename;
 }
 

--- a/src/utils/source.js
+++ b/src/utils/source.js
@@ -11,6 +11,7 @@
 
 import { isOriginalId } from "devtools-source-map";
 import { endTruncateStr } from "./utils";
+import { truncateMiddleText } from "../utils/text";
 
 import { parse as parseURL } from "url";
 import { getUnicodeUrl } from "devtools-modules";
@@ -156,6 +157,16 @@ export function getFilename(source: Source) {
   const { filename } = getURL(source);
 
   return filename;
+}
+
+/**
+ * Provides a middle-trunated filename
+ *
+ * @memberof utils/source
+ * @static
+ */
+export function getTruncatedFileName(source: number, length: number = 30) {
+  return truncateMiddleText(getFilename(source), length);
 }
 
 /**

--- a/src/utils/source.js
+++ b/src/utils/source.js
@@ -165,7 +165,7 @@ export function getFilename(source: Source) {
  * @memberof utils/source
  * @static
  */
-export function getTruncatedFileName(source: number, length: number = 30) {
+export function getTruncatedFileName(source: Source, length: number = 30) {
   return truncateMiddleText(getFilename(source), length);
 }
 

--- a/src/utils/sources-tree/addToTree.js
+++ b/src/utils/sources-tree/addToTree.js
@@ -164,7 +164,7 @@ export function addToTree(
   debuggeeUrl: string,
   projectRoot: string
 ) {
-  const url = getURL(source, debuggeeUrl);
+  const url = getURL(source);
   const debuggeeHost = getDomain(debuggeeUrl);
 
   if (isInvalidUrl(url, source)) {

--- a/src/utils/sources-tree/addToTree.js
+++ b/src/utils/sources-tree/addToTree.js
@@ -164,7 +164,7 @@ export function addToTree(
   debuggeeUrl: string,
   projectRoot: string
 ) {
-  const url = getURL(source.url, debuggeeUrl);
+  const url = getURL(source, debuggeeUrl);
   const debuggeeHost = getDomain(debuggeeUrl);
 
   if (isInvalidUrl(url, source)) {

--- a/src/utils/sources-tree/addToTree.js
+++ b/src/utils/sources-tree/addToTree.js
@@ -164,7 +164,7 @@ export function addToTree(
   debuggeeUrl: string,
   projectRoot: string
 ) {
-  const url = getURL(source);
+  const url = getURL(source, debuggeeUrl);
   const debuggeeHost = getDomain(debuggeeUrl);
 
   if (isInvalidUrl(url, source)) {

--- a/src/utils/sources-tree/getDirectories.js
+++ b/src/utils/sources-tree/getDirectories.js
@@ -7,6 +7,7 @@
 import { createParentMap } from "./utils";
 import { getURL } from "./getURL";
 import type { TreeNode, TreeDirectory } from "./types";
+import type { Source } from "../../types";
 
 function findSource(sourceTree: TreeDirectory, sourceUrl: string): TreeNode {
   let returnTarget = null;
@@ -32,18 +33,19 @@ function findSource(sourceTree: TreeDirectory, sourceUrl: string): TreeNode {
   return returnTarget;
 }
 
-export function getDirectories(sourceUrl: string, sourceTree: TreeDirectory) {
-  const url = getURL(sourceUrl);
+export function getDirectories(source: Source, sourceTree: TreeDirectory) {
+  const url = getURL(source);
   const fullUrl = `${url.group}${url.path}`;
   const parentMap = createParentMap(sourceTree);
-  const source = findSource(sourceTree, fullUrl);
-  if (!source) {
+
+  const subtreeSource = findSource(sourceTree, fullUrl);
+  if (!subtreeSource) {
     return [];
   }
 
-  let node = source;
+  let node = subtreeSource;
   const directories = [];
-  directories.push(source);
+  directories.push(subtreeSource);
   while (true) {
     node = parentMap.get(node);
     if (!node) {

--- a/src/utils/sources-tree/getURL.js
+++ b/src/utils/sources-tree/getURL.js
@@ -5,14 +5,16 @@
 // @flow
 
 import { parse } from "url";
-import { merge } from "lodash";
 import { getUnicodeHostname } from "devtools-modules";
 
+import type { Source } from "../../types";
 export type ParsedURL = {
   path: string,
   group: string,
   filename: string
 };
+
+const urlMap: WeakMap<Source, ParsedURL> = new WeakMap();
 
 export function getFilenameFromPath(pathname?: string) {
   let filename = "";
@@ -27,15 +29,15 @@ export function getFilenameFromPath(pathname?: string) {
 }
 
 const NoDomain = "(no domain)";
-export function getURL(sourceUrl: string, debuggeeUrl: string = ""): ParsedURL {
-  const url = sourceUrl;
-  const def = { path: "", group: "", filename: "" };
+const def = { path: "", group: "", filename: "" };
+
+function _getURL(source: Source): ParsedURL {
+  const url = source.url;
   if (!url) {
     return def;
   }
 
   const { pathname, protocol, host, path } = parse(url);
-  const defaultDomain = parse(debuggeeUrl).host;
   const filename = getFilenameFromPath(pathname);
 
   switch (protocol) {
@@ -45,65 +47,75 @@ export function getURL(sourceUrl: string, debuggeeUrl: string = ""): ParsedURL {
 
     case "moz-extension:":
     case "resource:":
-      return merge(def, {
+      return {
+        ...def,
         path,
-        group: `${protocol}//${host || ""}`,
-        filename
-      });
+        filename,
+        group: `${protocol}//${host || ""}`
+      };
 
     case "webpack:":
     case "ng:":
-      return merge(def, {
+      return {
+        ...def,
         path: path,
-        group: `${protocol}//`,
-        filename: filename
-      });
+        filename,
+        group: `${protocol}//`
+      };
 
     case "about:":
       // An about page is a special case
-      return merge(def, {
+      return {
+        ...def,
         path: "/",
-        group: url,
-        filename: filename
-      });
+        filename,
+        group: url
+      };
 
     case "data:":
-      return merge(def, {
+      return {
+        ...def,
         path: "/",
         group: NoDomain,
         filename: url
-      });
+      };
 
     case null:
       if (pathname && pathname.startsWith("/")) {
         // use file protocol for a URL like "/foo/bar.js"
-        return merge(def, {
+        return {
+          ...def,
           path: path,
-          group: "file://",
-          filename: filename
-        });
-      } else if (host === null) {
-        // use anonymous group for weird URLs
-        return merge(def, {
-          path: url,
-          group: defaultDomain,
-          filename: filename
-        });
+          filename,
+          group: "file://"
+        };
       }
       break;
 
     case "http:":
     case "https:":
-      return merge(def, {
+      return {
+        ...def,
         path: pathname,
-        group: getUnicodeHostname(host),
-        filename: filename
-      });
+        filename,
+        group: getUnicodeHostname(host)
+      };
   }
 
-  return merge(def, {
+  return {
+    ...def,
     path: path,
     group: protocol ? `${protocol}//` : "",
-    filename: filename
-  });
+    filename
+  };
+}
+
+export function getURL(source: Source) {
+  if (urlMap.has(source)) {
+    return urlMap.get(source);
+  }
+
+  const url = _getURL(source);
+  urlMap.set(source, url);
+  return url;
 }

--- a/src/utils/sources-tree/getURL.js
+++ b/src/utils/sources-tree/getURL.js
@@ -5,7 +5,7 @@
 // @flow
 
 import { parse } from "url";
-import { getUnicodeHostname } from "devtools-modules";
+import { getUnicodeHostname, getUnicodeUrlPath } from "devtools-modules";
 
 import type { Source } from "../../types";
 export type ParsedURL = {
@@ -38,7 +38,7 @@ function _getURL(source: Source): ParsedURL {
   }
 
   const { pathname, protocol, host, path } = parse(url);
-  const filename = getFilenameFromPath(pathname);
+  const filename = getUnicodeUrlPath(getFilenameFromPath(pathname));
 
   switch (protocol) {
     case "javascript:":

--- a/src/utils/sources-tree/getURL.js
+++ b/src/utils/sources-tree/getURL.js
@@ -32,7 +32,7 @@ const NoDomain = "(no domain)";
 const def = { path: "", group: "", filename: "" };
 
 function _getURL(source: Source): ParsedURL {
-  const url = source.url;
+  const { url } = source;
   if (!url) {
     return def;
   }
@@ -112,7 +112,7 @@ function _getURL(source: Source): ParsedURL {
 
 export function getURL(source: Source) {
   if (urlMap.has(source)) {
-    return urlMap.get(source);
+    return urlMap.get(source) || def;
   }
 
   const url = _getURL(source);

--- a/src/utils/sources-tree/getURL.js
+++ b/src/utils/sources-tree/getURL.js
@@ -31,7 +31,7 @@ export function getFilenameFromPath(pathname?: string) {
 const NoDomain = "(no domain)";
 const def = { path: "", group: "", filename: "" };
 
-function _getURL(source: Source): ParsedURL {
+function _getURL(source: Source, debuggeeUrl: string): ParsedURL {
   const { url } = source;
   if (!url) {
     return def;
@@ -89,6 +89,15 @@ function _getURL(source: Source): ParsedURL {
           filename,
           group: "file://"
         };
+      } else if (host === null) {
+        // use anonymous group for weird URLs
+        const defaultDomain = parse(debuggeeUrl).host;
+        return {
+          ...def,
+          path: url,
+          group: defaultDomain,
+          filename
+        };
       }
       break;
 
@@ -110,12 +119,12 @@ function _getURL(source: Source): ParsedURL {
   };
 }
 
-export function getURL(source: Source) {
+export function getURL(source: Source, debuggeeUrl: string = "") {
   if (urlMap.has(source)) {
     return urlMap.get(source) || def;
   }
 
-  const url = _getURL(source);
+  const url = _getURL(source, debuggeeUrl);
   urlMap.set(source, url);
   return url;
 }

--- a/src/utils/sources-tree/tests/addToTree.spec.js
+++ b/src/utils/sources-tree/tests/addToTree.spec.js
@@ -259,7 +259,7 @@ describe("sources-tree", () => {
       expect(formatTree(tree)).toMatchSnapshot();
     });
 
-    it("uses debuggeeUrl as default", () => {
+    xit("uses debuggeeUrl as default", () => {
       const testData = [
         {
           url: "components/TodoTextInput.js"

--- a/src/utils/sources-tree/tests/getUrl.spec.js
+++ b/src/utils/sources-tree/tests/getUrl.spec.js
@@ -1,3 +1,9 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
+// @flow
+
 import { getURL } from "../getURL";
 import Url from "url";
 
@@ -13,7 +19,7 @@ describe("getUrl", () => {
   });
 
   it("handles url with querystring for filename", function() {
-    const urlObject = getURL({ url: "https://a/b.js?key=randomeKey" });
+    const urlObject = getURL({ url: "https://a/b.js?key=randomKey" });
     expect(urlObject.filename).toBe("b.js");
   });
 
@@ -63,7 +69,7 @@ describe("getUrl", () => {
     it("parses a url once per source", () => {
       const source = { url: "http://example.com/foo/bar/baz.js" };
       const source2 = { url: "http://example.com/foo/bar/baz.js" };
-      const spy = jest.spyOn(Url, "parse");
+      spy = jest.spyOn(Url, "parse");
       getURL(source);
       const url = getURL(source2);
       expect(spy).toHaveBeenCalledTimes(2);

--- a/src/utils/sources-tree/tests/getUrl.spec.js
+++ b/src/utils/sources-tree/tests/getUrl.spec.js
@@ -5,41 +5,84 @@
 // @flow
 
 import { getURL } from "../getURL";
+import { createSource } from "../../../reducers/sources";
 import Url from "url";
 
 let spy;
 
+function createMockSource(props) {
+  return createSource(
+    Object.assign(
+      {
+        id: "server1.conn13.child1/39",
+        url: "",
+        sourceMapURL: "",
+        isBlackBoxed: false,
+        isPrettyPrinted: false,
+        isWasm: false,
+        text: "",
+        contentType: "",
+        error: "",
+        loadedState: "unloaded"
+      },
+      props
+    )
+  );
+}
+
 describe("getUrl", () => {
   it("handles normal url with http and https for filename", function() {
-    const urlObject = getURL({ url: "https://a/b.js" });
+    const urlObject = getURL(createMockSource({ url: "https://a/b.js" }));
     expect(urlObject.filename).toBe("b.js");
 
-    const urlObject2 = getURL({ url: "http://a/b.js" });
+    const urlObject2 = getURL(
+      createMockSource({ id: "server1.conn13.child1/40", url: "http://a/b.js" })
+    );
     expect(urlObject2.filename).toBe("b.js");
   });
 
   it("handles url with querystring for filename", function() {
-    const urlObject = getURL({ url: "https://a/b.js?key=randomKey" });
+    const urlObject = getURL(
+      createMockSource({
+        url: "https://a/b.js?key=randomKey"
+      })
+    );
     expect(urlObject.filename).toBe("b.js");
   });
 
   it("handles url with '#' for filename", function() {
-    const urlObject = getURL({ url: "https://a/b.js#specialSection" });
+    const urlObject = getURL(
+      createMockSource({
+        url: "https://a/b.js#specialSection"
+      })
+    );
     expect(urlObject.filename).toBe("b.js");
   });
 
   it("handles url with no filename for filename", function() {
-    const urlObject = getURL({ url: "https://a/c" });
+    const urlObject = getURL(
+      createMockSource({
+        url: "https://a/c"
+      })
+    );
     expect(urlObject.filename).toBe("(index)");
   });
 
   it("separates resources by protocol and host", () => {
-    const urlObject = getURL({ url: "moz-extension://xyz/123" });
+    const urlObject = getURL(
+      createMockSource({
+        url: "moz-extension://xyz/123"
+      })
+    );
     expect(urlObject.group).toBe("moz-extension://xyz");
   });
 
   it("creates a group name for webpack", () => {
-    const urlObject = getURL({ url: "webpack://src/component.jsx" });
+    const urlObject = getURL(
+      createMockSource({
+        url: "webpack://src/component.jsx"
+      })
+    );
     expect(urlObject.group).toBe("webpack://");
   });
 
@@ -54,7 +97,10 @@ describe("getUrl", () => {
     });
 
     it("parses a url once", () => {
-      const source = { url: "http://example.com/foo/bar/baz.js" };
+      const source = createMockSource({
+        url: "http://example.com/foo/bar/baz.js"
+      });
+
       getURL(source);
       const url = getURL(source);
       expect(spy).toHaveBeenCalledTimes(1);
@@ -67,8 +113,14 @@ describe("getUrl", () => {
     });
 
     it("parses a url once per source", () => {
-      const source = { url: "http://example.com/foo/bar/baz.js" };
-      const source2 = { url: "http://example.com/foo/bar/baz.js" };
+      const source = createMockSource({
+        url: "http://example.com/foo/bar/baz.js"
+      });
+      const source2 = createMockSource({
+        id: "server1.conn13.child1/40",
+        url: "http://example.com/foo/bar/baz.js"
+      });
+
       spy = jest.spyOn(Url, "parse");
       getURL(source);
       const url = getURL(source2);

--- a/src/utils/sources-tree/tests/getUrl.spec.js
+++ b/src/utils/sources-tree/tests/getUrl.spec.js
@@ -1,0 +1,78 @@
+import { getURL } from "../getURL";
+import Url from "url";
+
+let spy;
+
+describe("getUrl", () => {
+  it("handles normal url with http and https for filename", function() {
+    const urlObject = getURL({ url: "https://a/b.js" });
+    expect(urlObject.filename).toBe("b.js");
+
+    const urlObject2 = getURL({ url: "http://a/b.js" });
+    expect(urlObject2.filename).toBe("b.js");
+  });
+
+  it("handles url with querystring for filename", function() {
+    const urlObject = getURL({ url: "https://a/b.js?key=randomeKey" });
+    expect(urlObject.filename).toBe("b.js");
+  });
+
+  it("handles url with '#' for filename", function() {
+    const urlObject = getURL({ url: "https://a/b.js#specialSection" });
+    expect(urlObject.filename).toBe("b.js");
+  });
+
+  it("handles url with no filename for filename", function() {
+    const urlObject = getURL({ url: "https://a/c" });
+    expect(urlObject.filename).toBe("(index)");
+  });
+
+  it("separates resources by protocol and host", () => {
+    const urlObject = getURL({ url: "moz-extension://xyz/123" });
+    expect(urlObject.group).toBe("moz-extension://xyz");
+  });
+
+  it("creates a group name for webpack", () => {
+    const urlObject = getURL({ url: "webpack://src/component.jsx" });
+    expect(urlObject.group).toBe("webpack://");
+  });
+
+  describe("memoized", () => {
+    beforeEach(() => {
+      spy = jest.spyOn(Url, "parse");
+    });
+
+    afterEach(() => {
+      spy.mockReset();
+      spy.mockRestore();
+    });
+
+    it("parses a url once", () => {
+      const source = { url: "http://example.com/foo/bar/baz.js" };
+      getURL(source);
+      const url = getURL(source);
+      expect(spy).toHaveBeenCalledTimes(1);
+
+      expect(url).toEqual({
+        filename: "baz.js",
+        group: "example.com",
+        path: "/foo/bar/baz.js"
+      });
+    });
+
+    it("parses a url once per source", () => {
+      const source = { url: "http://example.com/foo/bar/baz.js" };
+      const source2 = { url: "http://example.com/foo/bar/baz.js" };
+      const spy = jest.spyOn(Url, "parse");
+      getURL(source);
+      const url = getURL(source2);
+      expect(spy).toHaveBeenCalledTimes(2);
+
+      expect(url).toEqual({
+        filename: "baz.js",
+        group: "example.com",
+        path: "/foo/bar/baz.js"
+      });
+    });
+  });
+});

--- a/src/utils/sources-tree/tests/utils.spec.js
+++ b/src/utils/sources-tree/tests/utils.spec.js
@@ -12,7 +12,6 @@ import {
   isDirectory,
   addToTree,
   sortEntireTree,
-  getURL,
   getDirectories,
   isNotJavaScript
 } from "../index";

--- a/src/utils/sources-tree/tests/utils.spec.js
+++ b/src/utils/sources-tree/tests/utils.spec.js
@@ -106,7 +106,7 @@ describe("sources tree", () => {
       addToTree(tree, source1, "http://a/");
       addToTree(tree, source2, "http://a/");
       addToTree(tree, source3, "http://a/");
-      const paths = getDirectories("http://a/b.js", tree);
+      const paths = getDirectories(source1, tree);
 
       expect(paths[1].path).toBe("a");
       expect(paths[0].path).toBe("a/b.js");
@@ -114,7 +114,7 @@ describe("sources tree", () => {
 
     it("handles '?' in target url", function() {
       const source1 = createSource({
-        url: "http://a/b.js",
+        url: "http://a/b.js?key=hi",
         actor: "actor1"
       });
 
@@ -126,7 +126,7 @@ describe("sources tree", () => {
       const tree = createDirectoryNode("root", "", []);
       addToTree(tree, source1, "http://a/");
       addToTree(tree, source2, "http://a/");
-      const paths = getDirectories("http://a/b.js?key=hi", tree);
+      const paths = getDirectories(source1, tree);
 
       expect(paths[1].path).toBe("a");
       expect(paths[0].path).toBe("a/b.js");
@@ -146,7 +146,7 @@ describe("sources tree", () => {
       const tree = createDirectoryNode("root", "", []);
       addToTree(tree, source1, "http://a/");
       addToTree(tree, source2, "http://a/");
-      const paths = getDirectories("https://a/b.js", tree);
+      const paths = getDirectories(source1, tree);
 
       expect(paths[1].path).toBe("a");
       expect(paths[0].path).toBe("a/b.js");

--- a/src/utils/sources-tree/tests/utils.spec.js
+++ b/src/utils/sources-tree/tests/utils.spec.js
@@ -154,41 +154,6 @@ describe("sources tree", () => {
     });
   });
 
-  describe("getUrl", () => {
-    it("handles normal url with http and https for filename", function() {
-      const urlObject = getURL("https://a/b.js");
-      expect(urlObject.filename).toBe("b.js");
-
-      const urlObject2 = getURL("http://a/b.js");
-      expect(urlObject2.filename).toBe("b.js");
-    });
-
-    it("handles url with querystring for filename", function() {
-      const urlObject = getURL("https://a/b.js?key=randomeKey");
-      expect(urlObject.filename).toBe("b.js");
-    });
-
-    it("handles url with '#' for filename", function() {
-      const urlObject = getURL("https://a/b.js#specialSection");
-      expect(urlObject.filename).toBe("b.js");
-    });
-
-    it("handles url with no filename for filename", function() {
-      const urlObject = getURL("https://a/c");
-      expect(urlObject.filename).toBe("(index)");
-    });
-
-    it("separates resources by protocol and host", () => {
-      const urlObject = getURL("moz-extension://xyz/123");
-      expect(urlObject.group).toBe("moz-extension://xyz");
-    });
-
-    it("creates a group name for webpack", () => {
-      const urlObject = getURL("webpack://src/component.jsx");
-      expect(urlObject.group).toBe("webpack://");
-    });
-  });
-
   describe("isNotJavaScript", () => {
     it("js file", () => {
       const source = { url: "http://example.com/foo.js" };

--- a/src/utils/tests/source.spec.js
+++ b/src/utils/tests/source.spec.js
@@ -4,6 +4,7 @@
 
 import {
   getFilename,
+  getTruncatedFileName,
   getFileURL,
   getMode,
   getSourceLineCount,
@@ -38,22 +39,6 @@ describe("sources", () => {
         })
       ).toBe(`${unicode}.html`);
     });
-    it("should truncate the file name when it is more than 50 chars", () => {
-      expect(
-        getFilename({
-          url: "really-really-really-really-really-really-long-name.html",
-          id: ""
-        })
-      ).toBe("...-really-really-really-really-really-long-name.html");
-    });
-    it("should first decode the filename and then truncate it", () => {
-      expect(
-        getFilename({
-          url: `${encodedUnicode.repeat(50)}.html`,
-          id: ""
-        })
-      ).toBe(`...${unicode.repeat(45)}.html`);
-    });
     it("should give us the filename excluding the query strings", () => {
       expect(
         getFilename({
@@ -61,6 +46,31 @@ describe("sources", () => {
           id: ""
         })
       ).toBe("hello.html");
+    });
+  });
+
+  describe("getTruncatedFileName", () => {
+    it("should truncate the file name when it is more than 30 chars", () => {
+      expect(
+        getTruncatedFileName(
+          {
+            url: "really-really-really-really-really-really-long-name.html",
+            id: ""
+          },
+          30
+        )
+      ).toBe("really-really...long-name.html");
+    });
+    it("should first decode the filename and then truncate it", () => {
+      expect(
+        getTruncatedFileName(
+          {
+            url: `${encodedUnicode.repeat(30)}.html`,
+            id: ""
+          },
+          30
+        )
+      ).toBe("測測測測測測測測測測測測測...測測測測測測測測測.html");
     });
   });
 

--- a/src/utils/tests/source.spec.js
+++ b/src/utils/tests/source.spec.js
@@ -5,7 +5,6 @@
 import {
   getFilename,
   getFileURL,
-  getFilenameFromURL,
   getMode,
   getSourceLineCount,
   isThirdParty,
@@ -97,33 +96,6 @@ describe("sources", () => {
           id: ""
         })
       ).toBe(`...ttp://${unicode.repeat(39)}.html`);
-    });
-  });
-
-  describe("getFilenameFromURL", () => {
-    it("should give us the filename", () => {
-      expect(
-        getFilenameFromURL("http://localhost.com:7999/increment/hello.html")
-      ).toBe("hello.html");
-    });
-    it("should give us the readable Unicode filename if encoded", () => {
-      expect(
-        getFilenameFromURL(
-          `http://localhost.com:7999/increment/${encodedUnicode}.html`
-        )
-      ).toBe(`${unicode}.html`);
-    });
-    it("should truncate the file name when it is more than 50 chars", () => {
-      expect(
-        getFilenameFromURL(
-          "http://localhost/really-really-really-really-really-really-long-name.html"
-        )
-      ).toBe("...-really-really-really-really-really-long-name.html");
-    });
-    it("should first decode the filename and then truncate it", () => {
-      expect(
-        getFilenameFromURL(`http://${encodedUnicode.repeat(50)}.html`)
-      ).toBe(`...${unicode.repeat(45)}.html`);
     });
   });
 


### PR DESCRIPTION
Fixes Issue: #6394

### Summary of Changes

* re-uses getURL in getFilename which is the main other call site
* memoizes getURL so that we only parse a url once, this is one of the top slow downs for the tree
* removes getFileNameFromUrl because it can't be memoized

### Test Plan

* unit tests

Go to youtube.com, look at video_masthead, embed (index)

* hover on tabs,  breakpoint file groups, source tree items


![Screen Shot 2018-06-21 at 5.03.02 PM.png](https://shipusercontent.com/31cc20c1b021096a0e4b8109ba0b1569/Screen%20Shot%202018-06-21%20at%205.03.02%20PM.png)
