### PR TITLE
fix(sources): Make self sourcemapped urls unique

### DIFF
--- a/packages/devtools-source-map/src/source-map.js
+++ b/packages/devtools-source-map/src/source-map.js
@@ -259,7 +259,7 @@ async function getOriginalLocation(
   }
 
   return {
-    sourceId: generatedToOriginalId(location.sourceId, sourceUrl),
+    sourceId: generatedToOriginalId(location.sourceId, formatUrl(location.sourceUrl, sourceUrl)),
     sourceUrl: formatUrl(location.sourceUrl, sourceUrl),
     line,
     column

--- a/packages/devtools-source-map/src/source-map.js
+++ b/packages/devtools-source-map/src/source-map.js
@@ -259,7 +259,10 @@ async function getOriginalLocation(
   }
 
   return {
-    sourceId: generatedToOriginalId(location.sourceId, formatUrl(location.sourceUrl, sourceUrl)),
+    sourceId: generatedToOriginalId(
+      location.sourceId,
+      formatUrl(location.sourceUrl, sourceUrl)
+    ),
     sourceUrl: formatUrl(location.sourceUrl, sourceUrl),
     line,
     column

--- a/packages/devtools-source-map/src/tests/fixtures/Hello.js
+++ b/packages/devtools-source-map/src/tests/fixtures/Hello.js
@@ -1,0 +1,3 @@
+import React from "react";
+
+export default ({ name }) => <h1>Hello {name}!</h1>;

--- a/packages/devtools-source-map/src/tests/fixtures/Hello.js.map
+++ b/packages/devtools-source-map/src/tests/fixtures/Hello.js.map
@@ -1,0 +1,14 @@
+{
+  "version": 3,
+  "sources": [
+    "/Hello.js"
+  ],
+  "names": [
+    "name"
+  ],
+  "mappings": ";;;;;;AAAA;;;;;;kBAEe;AAAA,MAAGA,IAAH,QAAGA,IAAH;AAAA,SAAc;AAAA;AAAA;AAAA;AAAWA,QAAX;AAAA;AAAA,GAAd;AAAA,C",
+  "file": "Hello.js",
+  "sourcesContent": [
+    "import React from 'react';\n\nexport default ({ name }) => <h1>Hello {name}!</h1>;\n"
+  ]
+}

--- a/packages/devtools-source-map/src/tests/helpers.js
+++ b/packages/devtools-source-map/src/tests/helpers.js
@@ -23,6 +23,14 @@ function getMap(_path) {
   return fs.readFileSync(mapPath, "utf8");
 }
 
+function sourceForFixture(name) {
+  return {
+    id: `${name}.js`,
+    sourceMapURL: `${name}.js.map`,
+    url: `http://example.com/${name}.js`
+  };
+}
+
 async function setupBundleFixture(name) {
   const source = {
     id: `${name}.js`,
@@ -42,5 +50,6 @@ module.exports = {
   formatLocations,
   formatLocation,
   setupBundleFixture,
-  getMap
+  getMap,
+  sourceForFixture
 };

--- a/packages/devtools-source-map/src/tests/locations.js
+++ b/packages/devtools-source-map/src/tests/locations.js
@@ -8,6 +8,7 @@ const {
   getGeneratedLocation,
   clearSourceMaps
 } = require("../source-map");
+const md5 = require("md5");
 
 const { setupBundleFixture } = require("./helpers");
 
@@ -41,6 +42,24 @@ describe("getOriginalLocation", async () => {
     };
     const originalLocation = await getOriginalLocation(location);
     expect(originalLocation).toEqual(originalLocation);
+  });
+
+  test("source with original and generated with same url", async () => {
+    await setupBundleFixture("Hello");
+    const location = {
+      sourceId: "Hello.js",
+      line: 14,
+      sourceUrl: "http://example.com/Hello.js"
+    };
+    const originalLocation = await getOriginalLocation(location);
+    const expectedOriginalSourceUrl = "http://example.com/Hello.js [sm]";
+    const hash = md5(expectedOriginalSourceUrl);
+    expect(originalLocation).toEqual({
+      line: 3,
+      column: 15,
+      sourceUrl: expectedOriginalSourceUrl,
+      sourceId: `Hello.js/originalSource-${hash}`
+    });
   });
 });
 

--- a/packages/devtools-source-map/src/tests/source-map.js
+++ b/packages/devtools-source-map/src/tests/source-map.js
@@ -9,10 +9,11 @@ const {
   getOriginalURLs,
   hasMappedSource,
   getOriginalLocation,
+  getOriginalSourceText,
   clearSourceMaps
 } = require("../source-map");
 
-const { setupBundleFixture } = require("./helpers");
+const { setupBundleFixture, sourceForFixture } = require("./helpers");
 
 describe("source maps", () => {
   beforeEach(() => {
@@ -49,6 +50,11 @@ describe("source maps", () => {
       const urls = await setupBundleFixture("noroot2");
       expect(urls).toEqual(["http://example.com/heart.js"]);
     });
+
+    test("source with original and generated with same url", async () => {
+      const urls = await setupBundleFixture("Hello");
+      expect(urls).toEqual(["http://example.com/Hello.js [sm]"]);
+    });
   });
 
   describe("hasMappedSource", async () => {
@@ -69,6 +75,21 @@ describe("source maps", () => {
       };
       const isMapped = await hasMappedSource(location);
       expect(isMapped).toBe(false);
+    });
+  });
+
+  describe("getOriginalSourceText", () => {
+    test("source with original and generated with same url", async () => {
+      await setupBundleFixture("Hello");
+      const source = sourceForFixture("Hello");
+      source.id = `${source.id}/originalSource`;
+      source.url = `${source.url} [sm]`;
+      const { text, contentType } = await getOriginalSourceText(source);
+      expect(text).toEqual(
+        "import React from 'react';\n\n" +
+          "export default ({ name }) => <h1>Hello {name}!</h1>;\n"
+      );
+      expect(contentType).toEqual("text/javascript");
     });
   });
 

--- a/packages/devtools-source-map/src/utils/index.js
+++ b/packages/devtools-source-map/src/utils/index.js
@@ -23,12 +23,18 @@ function isGeneratedId(id: string) {
   return !isOriginalId(id);
 }
 
-function formatUrl(generatedUrl: ?string, originalUrl: string) {
+function formatUrl(generatedUrl: ?string, originalUrl: string): string {
   return originalUrl === generatedUrl ? `${originalUrl} [sm]` : originalUrl;
 }
 
-function unformatUrl(url: ?string) {
-  return (url || "").replace(" [sm]", "");
+function unformatUrl(url: ?string): string {
+  if (!url) {
+    return "";
+  }
+  if (!url.endsWith("[sm]")) {
+    return url;
+  }
+  return url.replace(/( |%20)\[sm\]$/, "");
 }
 
 /**

--- a/packages/devtools-source-map/src/utils/index.js
+++ b/packages/devtools-source-map/src/utils/index.js
@@ -23,6 +23,14 @@ function isGeneratedId(id: string) {
   return !isOriginalId(id);
 }
 
+function formatUrl(generatedUrl: ?string, originalUrl: string) {
+  return originalUrl === generatedUrl ? `${originalUrl} [sm]` : originalUrl;
+}
+
+function unformatUrl(url: ?string) {
+  return (url || "").replace(" [sm]", "");
+}
+
 /**
  * Trims the query part or reference identifier of a URL string, if necessary.
  */
@@ -79,5 +87,7 @@ module.exports = {
   isOriginalId,
   isGeneratedId,
   getContentType,
+  formatUrl,
+  unformatUrl,
   contentMapForTesting: contentMap
 };

--- a/src/actions/sources/newSources.js
+++ b/src/actions/sources/newSources.js
@@ -80,15 +80,13 @@ function loadSourceMap(sourceId: SourceId) {
 
     if (!urls) {
       // If this source doesn't have a sourcemap, enable it for pretty printing
-      dispatch(
+      return dispatch(
         ({
           type: "UPDATE_SOURCE",
           source: { ...source, sourceMapURL: "" }
         }: Action)
       );
-      return;
     }
-
     return urls.map(url => createOriginalSource(url, source, sourceMaps));
   };
 }

--- a/src/components/PrimaryPanes/SourcesTreeItem.js
+++ b/src/components/PrimaryPanes/SourcesTreeItem.js
@@ -18,7 +18,9 @@ import { features } from "../../utils/prefs";
 import type { TreeNode } from "../../utils/sources-tree/types";
 
 import type { Source } from "../../types";
-const { unformatUrl: sourceMapUnformatUrl } = require("devtools-source-map");
+const {
+  unformatUrl: sourceMapUnformatUrl
+} = require("devtools-source-map/src/utils");
 
 type Props = {
   debuggeeUrl: string,

--- a/src/components/PrimaryPanes/SourcesTreeItem.js
+++ b/src/components/PrimaryPanes/SourcesTreeItem.js
@@ -153,7 +153,8 @@ export default class SourceTreeItem extends Component<Props, State> {
       case "moz-extension://":
         return L10N.getStr("extensionsText");
       default:
-        return name;
+        // we add " [sm]" to original sources if they have same url as generated
+        return name.replace("%20[sm]", " [sm]");
     }
   }
 

--- a/src/components/PrimaryPanes/SourcesTreeItem.js
+++ b/src/components/PrimaryPanes/SourcesTreeItem.js
@@ -18,6 +18,7 @@ import { features } from "../../utils/prefs";
 import type { TreeNode } from "../../utils/sources-tree/types";
 
 import type { Source } from "../../types";
+const { unformatUrl: sourceMapUnformatUrl } = require("devtools-source-map");
 
 type Props = {
   debuggeeUrl: string,
@@ -154,7 +155,7 @@ export default class SourceTreeItem extends Component<Props, State> {
         return L10N.getStr("extensionsText");
       default:
         // we add " [sm]" to original sources if they have same url as generated
-        return name.replace("%20[sm]", " [sm]");
+        return sourceMapUnformatUrl(name);
     }
   }
 

--- a/src/components/PrimaryPanes/SourcesTreeItem.js
+++ b/src/components/PrimaryPanes/SourcesTreeItem.js
@@ -104,7 +104,7 @@ export default class SourceTreeItem extends Component<Props, State> {
           label: copySourceUri2Label,
           accesskey: copySourceUri2Key,
           disabled: false,
-          click: () => copyToTheClipboard(contents.url)
+          click: () => copyToTheClipboard(sourceMapUnformatUrl(contents.url))
         };
 
         menuOptions.push(copySourceUri2);
@@ -155,7 +155,7 @@ export default class SourceTreeItem extends Component<Props, State> {
         return L10N.getStr("extensionsText");
       default:
         // we add " [sm]" to original sources if they have same url as generated
-        return sourceMapUnformatUrl(name);
+        return name.replace("%20[sm]", " [sm]");
     }
   }
 

--- a/src/utils/sources-tree/tests/utils.spec.js
+++ b/src/utils/sources-tree/tests/utils.spec.js
@@ -12,7 +12,8 @@ import {
   isDirectory,
   addToTree,
   sortEntireTree,
-  isNotJavaScript
+  isNotJavaScript,
+  getFileExtension
 } from "../index";
 
 describe("sources tree", () => {
@@ -103,6 +104,14 @@ describe("sources tree", () => {
     it("png file", () => {
       const source = { url: "http://example.com/foo.png" };
       expect(isNotJavaScript(source)).toBe(true);
+    });
+  });
+
+  describe("getFileExtension", () => {
+    it("handles [sm] url files", () => {
+      expect(getFileExtension({ url: "http://example.com/foo.js [sm]" })).toBe(
+        "js"
+      );
     });
   });
 });

--- a/src/utils/sources-tree/utils.js
+++ b/src/utils/sources-tree/utils.js
@@ -35,7 +35,7 @@ export function isPathDirectory(path: string) {
 export function isDirectory(item: TreeNode) {
   return (
     (isPathDirectory(item.path) || item.type === "directory") &&
-    item.name != "(index)"
+    item.name !== "(index)"
   );
 }
 
@@ -51,7 +51,9 @@ export function isSource(item: TreeNode) {
 }
 
 export function getFileExtension(source: Source): string {
-  const parsedUrl = getURL(source).path;
+  const strippedUrl = source.url.replace(" [sm]", "");
+  const parsedUrl = parse(strippedUrl).pathname;
+
   if (!parsedUrl) {
     return "";
   }
@@ -64,7 +66,7 @@ export function isNotJavaScript(source: Source): boolean {
 
 export function isInvalidUrl(url: Object, source: Source) {
   return (
-    IGNORED_URLS.indexOf(url) != -1 ||
+    IGNORED_URLS.indexOf(url) !== -1 ||
     !source.url ||
     !url.group ||
     isPretty(source) ||

--- a/src/utils/sources-tree/utils.js
+++ b/src/utils/sources-tree/utils.js
@@ -5,7 +5,7 @@
 // @flow
 
 import { parse } from "../../utils/url";
-
+const { stripUrl } = require("devtools-source-map");
 import type { TreeNode, TreeSource, TreeDirectory, ParentMap } from "./types";
 import type { Source } from "../../types";
 import { isPretty } from "../source";
@@ -50,7 +50,7 @@ export function isSource(item: TreeNode) {
 }
 
 export function getFileExtension(source: Source): string {
-  const strippedUrl = source.url.replace(/ \[sm\]/, "");
+  const strippedUrl = stripUrl(source.url);
   const parsedUrl = parse(strippedUrl).pathname;
 
   if (!parsedUrl) {

--- a/src/utils/sources-tree/utils.js
+++ b/src/utils/sources-tree/utils.js
@@ -50,7 +50,7 @@ export function isSource(item: TreeNode) {
 }
 
 export function getFileExtension(source: Source): string {
-  const strippedUrl = source.url.replace(" [sm]", "");
+  const strippedUrl = source.url.replace(/ \[sm\]/, "");
   const parsedUrl = parse(strippedUrl).pathname;
 
   if (!parsedUrl) {

--- a/src/utils/sources-tree/utils.js
+++ b/src/utils/sources-tree/utils.js
@@ -5,7 +5,6 @@
 // @flow
 
 import { parse } from "../../utils/url";
-const { stripUrl } = require("devtools-source-map");
 import type { TreeNode, TreeSource, TreeDirectory, ParentMap } from "./types";
 import type { Source } from "../../types";
 import { isPretty } from "../source";
@@ -50,8 +49,7 @@ export function isSource(item: TreeNode) {
 }
 
 export function getFileExtension(source: Source): string {
-  const strippedUrl = stripUrl(source.url);
-  const parsedUrl = parse(strippedUrl).pathname;
+  const parsedUrl = parse(source.url).pathname;
 
   if (!parsedUrl) {
     return "";

--- a/src/utils/sources-tree/utils.js
+++ b/src/utils/sources-tree/utils.js
@@ -9,7 +9,6 @@ import { parse } from "../../utils/url";
 import type { TreeNode, TreeSource, TreeDirectory, ParentMap } from "./types";
 import type { Source } from "../../types";
 import { isPretty } from "../source";
-import { getURL } from "./getURL";
 const IGNORED_URLS = ["debugger eval code", "XStringBundle"];
 
 export function nodeHasChildren(item: TreeNode): boolean {

--- a/src/utils/url.js
+++ b/src/utils/url.js
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
+const { unformatUrl } = require("devtools-source-map");
 const defaultUrl = {
   hash: "",
   host: "",
@@ -20,14 +21,15 @@ const defaultUrl = {
 };
 
 export function parse(url: string): URL | object {
+  const strippedUrl = unformatUrl(url);
   try {
-    const urlObj = new URL(url);
+    const urlObj = new URL(strippedUrl);
     urlObj.path = urlObj.pathname + urlObj.search;
     return urlObj;
   } catch (err) {
     // If we're given simply a filename...
-    if (url) {
-      return { ...defaultUrl, path: url, pathname: url };
+    if (strippedUrl) {
+      return { ...defaultUrl, path: strippedUrl, pathname: strippedUrl };
     }
 
     return defaultUrl;

--- a/src/utils/url.js
+++ b/src/utils/url.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
-const { unformatUrl } = require("devtools-source-map");
+const { unformatUrl } = require("devtools-source-map/src/utils");
 const defaultUrl = {
   hash: "",
   host: "",


### PR DESCRIPTION
Fixes Issue: #5663 

### Summary of Changes

* By making the source url unique, it fixes both SourcesTree and TabsList. Maybe in the future, we need to get a better plan, but for now it's probably fine.

## ToDo:
- [x] Allow breakpoint creation for `[sm]` files; *Note*: a breakpoint is getting added to the store but the `isVisible()` function inside `getVisibleBreakpoints()` is filtering it out.
- [x] Right-clicking the tab and doing "copy to clipboard" keeps the "[sm]" in the URL
- [x] If you open a source and refresh, the editor displays as empty (never even renders) upon refresh

## Notes:
- At present, if you add a breakpoint in a `[sm]` file, it only displays when you go to the ugly file.