### PR TITLE
[flow] type react-redux

### DIFF
--- a/flow-typed/npm/react-redux_v5.x.x.js
+++ b/flow-typed/npm/react-redux_v5.x.x.js
@@ -1,3 +1,192 @@
-declare module 'react-redux' {
-  declare module.exports: any;
+// flow-typed signature: d4e793bc07ef1dc9906a244b12960f7b
+// flow-typed version: cf33ff8762/react-redux_v5.x.x/flow_>=v0.63.0
+
+import type { Dispatch, Store } from "redux";
+
+declare module "react-redux" {
+  import type { ComponentType, ElementConfig } from 'react';
+
+  declare export class Provider<S, A> extends React$Component<{
+    store: Store<S, A>,
+    children?: any
+  }> {}
+
+  declare export function createProvider(
+    storeKey?: string,
+    subKey?: string
+  ): Provider<*, *>;
+
+  /*
+
+  S = State
+  A = Action
+  OP = OwnProps
+  SP = StateProps
+  DP = DispatchProps
+  MP = Merge props
+  MDP = Map dispatch to props object
+  RSP = Returned state props
+  RDP = Returned dispatch props
+  RMP = Returned merge props
+  CP = Props for returned component
+  Com = React Component
+  */
+
+  declare type MapStateToProps<S: Object, SP: Object, RSP: Object> = (state: S, props: SP) => RSP;
+
+  declare type MapDispatchToProps<A, OP: Object, RDP: Object> = (dispatch: Dispatch<A>, ownProps: OP) => RDP;
+
+  declare type MergeProps<SP: Object, DP: Object, MP: Object, RMP: Object> = (
+    stateProps: SP,
+    dispatchProps: DP,
+    ownProps: MP
+  ) => RMP;
+
+  declare type ConnectOptions<S: Object, OP: Object, RSP: Object, RMP: Object> = {|
+    pure?: boolean,
+    withRef?: boolean,
+    areStatesEqual?: (next: S, prev: S) => boolean,
+    areOwnPropsEqual?: (next: OP, prev: OP) => boolean,
+    areStatePropsEqual?: (next: RSP, prev: RSP) => boolean,
+    areMergedPropsEqual?: (next: RMP, prev: RMP) => boolean,
+    storeKey?: string
+  |};
+
+  declare type OmitDispatch<Component> = $Diff<Component, {dispatch: Dispatch<*>}>;
+
+  declare export function connect<
+    Com: ComponentType<*>,
+    S: Object,
+    DP: Object,
+    RSP: Object,
+    CP: $Diff<OmitDispatch<ElementConfig<Com>>, RSP>
+    >(
+    mapStateToProps: MapStateToProps<S, DP, RSP>,
+    mapDispatchToProps?: null
+  ): (component: Com) => ComponentType<CP & DP>;
+
+  declare export function connect<Com: ComponentType<*>>(
+    mapStateToProps?: null,
+    mapDispatchToProps?: null
+  ): (component: Com) => ComponentType<OmitDispatch<ElementConfig<Com>>>;
+
+  declare export function connect<
+    Com: ComponentType<*>,
+    A,
+    S: Object,
+    DP: Object,
+    SP: Object,
+    RSP: Object,
+    RDP: Object,
+    CP: $Diff<$Diff<ElementConfig<Com>, RSP>, RDP>
+    >(
+    mapStateToProps: MapStateToProps<S, SP, RSP>,
+    mapDispatchToProps: MapDispatchToProps<A, DP, RDP>
+  ): (component: Com) => ComponentType<CP & SP & DP>;
+
+  declare export function connect<
+    Com: ComponentType<*>,
+    A,
+    OP: Object,
+    DP: Object,
+    PR: Object,
+    CP: $Diff<ElementConfig<Com>, DP>
+    >(
+    mapStateToProps?: null,
+    mapDispatchToProps: MapDispatchToProps<A, OP, DP>
+  ): (Com) => ComponentType<CP & OP>;
+
+  declare export function connect<
+    Com: ComponentType<*>,
+    MDP: Object
+    >(
+    mapStateToProps?: null,
+    mapDispatchToProps: MDP
+  ): (component: Com) => ComponentType<$Diff<ElementConfig<Com>, MDP>>;
+
+  declare export function connect<
+    Com: ComponentType<*>,
+    S: Object,
+    SP: Object,
+    RSP: Object,
+    MDP: Object,
+    CP: $Diff<ElementConfig<Com>, RSP>
+    >(
+    mapStateToProps: MapStateToProps<S, SP, RSP>,
+    mapDispatchToPRops: MDP
+  ): (component: Com) => ComponentType<$Diff<CP, MDP> & SP>;
+
+  declare export function connect<
+    Com: ComponentType<*>,
+    A,
+    S: Object,
+    DP: Object,
+    SP: Object,
+    RSP: Object,
+    RDP: Object,
+    MP: Object,
+    RMP: Object,
+    CP: $Diff<ElementConfig<Com>, RMP>
+    >(
+    mapStateToProps: MapStateToProps<S, SP, RSP>,
+    mapDispatchToProps: ?MapDispatchToProps<A, DP, RDP>,
+    mergeProps: MergeProps<RSP, RDP, MP, RMP>
+  ): (component: Com) => ComponentType<CP & SP & DP & MP>;
+
+  declare export function connect<
+    Com: ComponentType<*>,
+    A,
+    S: Object,
+    DP: Object,
+    SP: Object,
+    RSP: Object,
+    RDP: Object,
+    MDP: Object,
+    MP: Object,
+    RMP: Object,
+    CP: $Diff<ElementConfig<Com>, RMP>
+    >(
+    mapStateToProps: MapStateToProps<S, SP, RSP>,
+    mapDispatchToProps: MDP,
+    mergeProps: MergeProps<RSP, RDP, MP, RMP>
+  ): (component: Com) => ComponentType<CP & SP & DP & MP>;
+
+  declare export function connect<Com: ComponentType<*>,
+    A,
+    S: Object,
+    DP: Object,
+    SP: Object,
+    RSP: Object,
+    RDP: Object,
+    MP: Object,
+    RMP: Object
+    >(
+    mapStateToProps: ?MapStateToProps<S, SP, RSP>,
+    mapDispatchToProps: ?MapDispatchToProps<A, DP, RDP>,
+    mergeProps: ?MergeProps<RSP, RDP, MP, RMP>,
+    options: ConnectOptions<S, SP & DP & MP, RSP, RMP>
+  ): (component: Com) => ComponentType<$Diff<ElementConfig<Com>, RMP> & SP & DP & MP>;
+
+  declare export function connect<Com: ComponentType<*>,
+    A,
+    S: Object,
+    DP: Object,
+    SP: Object,
+    RSP: Object,
+    RDP: Object,
+    MDP: Object,
+    MP: Object,
+    RMP: Object
+    >(
+    mapStateToProps: ?MapStateToProps<S, SP, RSP>,
+    mapDispatchToProps: ?MapDispatchToProps<A, DP, RDP>,
+    mergeProps: MDP,
+    options: ConnectOptions<S, SP & DP & MP, RSP, RMP>
+  ): (component: Com) => ComponentType<$Diff<ElementConfig<Com>, RMP> & SP & DP & MP>;
+
+  declare export default {
+    Provider: typeof Provider,
+    createProvider: typeof createProvider,
+    connect: typeof connect,
+  };
 }

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -320,4 +320,11 @@ const mapStateToProps = state => ({
   orientation: getOrientation(state)
 });
 
-export default connect(mapStateToProps, actions)(App);
+export default connect(mapStateToProps, {
+  setActiveSearch: actions.setActiveSearch,
+  closeActiveSearch: actions.closeActiveSearch,
+  closeProjectSearch: actions.closeProjectSearch,
+  openQuickOpen: actions.openQuickOpen,
+  closeQuickOpen: actions.closeQuickOpen,
+  setOrientation: actions.setOrientation
+})(App);

--- a/src/components/Editor/Footer.js
+++ b/src/components/Editor/Footer.js
@@ -28,13 +28,13 @@ type Props = {
   selectedSource: Source,
   mappedSource: Source,
   editor: any,
+  endPanelCollapsed: boolean,
+  horizontal: boolean,
   togglePrettyPrint: string => void,
   toggleBlackBox: Object => void,
   jumpToMappedLocation: (Source: any) => void,
   recordCoverage: () => void,
-  togglePaneCollapse: () => void,
-  endPanelCollapsed: boolean,
-  horizontal: boolean
+  togglePaneCollapse: () => void
 };
 
 class SourceFooter extends PureComponent<Props> {
@@ -209,4 +209,10 @@ const mapStateToProps = state => {
   };
 };
 
-export default connect(mapStateToProps, actions)(SourceFooter);
+export default connect(mapStateToProps, {
+  togglePrettyPrint: actions.togglePrettyPrint,
+  toggleBlackBox: actions.toggleBlackBox,
+  jumpToMappedLocation: actions.jumpToMappedLocation,
+  recordCoverage: actions.recordCoverage,
+  togglePaneCollapse: actions.togglePaneCollapse
+})(SourceFooter);

--- a/src/components/Editor/Preview/index.js
+++ b/src/components/Editor/Preview/index.js
@@ -13,22 +13,19 @@ import { getPreview, getSelectedSource, getIsPaused } from "../../../selectors";
 import actions from "../../../actions";
 import { toEditorRange } from "../../../utils/editor";
 
-import type { Source, Location } from "../../../types";
+import type { Source } from "../../../types";
 
 import type { Preview as PreviewType } from "../../../reducers/ast";
 
 type Props = {
-  setPopupObjectProperties: Object => void,
-  addExpression: (string, ?Object) => void,
-  loadedObjects: Object,
   editor: any,
   editorRef: ?HTMLDivElement,
   selectedSource: Source,
-  selectedLocation: ?Location,
-  clearPreview: () => void,
   preview: PreviewType,
   isPaused: Boolean,
-  selectedFrameVisible: boolean,
+  clearPreview: () => void,
+  setPopupObjectProperties: Object => void,
+  addExpression: (string, ?Object) => void,
   updatePreview: (any, any, any) => void
 };
 
@@ -179,18 +176,9 @@ const mapStateToProps = state => ({
   selectedSource: getSelectedSource(state)
 });
 
-const {
-  addExpression,
-  setPopupObjectProperties,
-  updatePreview,
-  clearPreview
-} = actions;
-
-const mapDispatchToProps = {
-  addExpression,
-  setPopupObjectProperties,
-  updatePreview,
-  clearPreview
-};
-
-export default connect(mapStateToProps, mapDispatchToProps)(Preview);
+export default connect(mapStateToProps, {
+  clearPreview: actions.clearPreview,
+  setPopupObjectProperties: actions.setPopupObjectProperties,
+  addExpression: actions.addExpression,
+  updatePreview: actions.updatePreview
+})(Preview);

--- a/src/components/Editor/SearchBar.js
+++ b/src/components/Editor/SearchBar.js
@@ -57,16 +57,16 @@ type State = {
 type Props = {
   editor?: SourceEditor,
   selectedSource?: Source,
-  searchOn?: boolean,
+  searchOn: boolean,
+  searchResults: SearchResults,
+  modifiers: Modifiers,
+  query: string,
+  toggleFileSearchModifier: string => any,
+  setFileSearchQuery: string => any,
   setActiveSearch: (?ActiveSearchType) => any,
   closeFileSearch: SourceEditor => void,
   doSearch: (string, SourceEditor) => void,
   traverseResults: (boolean, SourceEditor) => void,
-  searchResults: SearchResults,
-  modifiers: Modifiers,
-  toggleFileSearchModifier: string => any,
-  query: string,
-  setFileSearchQuery: string => any,
   updateSearchResults: ({ count: number, index?: number }) => any
 };
 
@@ -345,4 +345,12 @@ const mapStateToProps = state => ({
   searchResults: getFileSearchResults(state)
 });
 
-export default connect(mapStateToProps, actions)(SearchBar);
+export default connect(mapStateToProps, {
+  toggleFileSearchModifier: actions.toggleFileSearchModifier,
+  setFileSearchQuery: actions.setFileSearchQuery,
+  setActiveSearch: actions.setActiveSearch,
+  closeFileSearch: actions.closeFileSearch,
+  doSearch: actions.doSearch,
+  traverseResults: actions.traverseResults,
+  updateSearchResults: actions.updateSearchResults
+})(SearchBar);

--- a/src/components/Editor/Tab.js
+++ b/src/components/Editor/Tab.js
@@ -41,14 +41,14 @@ type SourcesList = List<Source>;
 
 type Props = {
   tabSources: SourcesList,
-  selectSpecificSource: string => void,
   selectedSource: Source,
+  source: Source,
+  activeSearch: string,
+  selectSpecificSource: string => void,
   closeTab: string => void,
   closeTabs: (List<string>) => void,
   togglePrettyPrint: string => void,
-  showSource: string => void,
-  source: Source,
-  activeSearch: string
+  showSource: string => void
 };
 
 class Tab extends PureComponent<Props> {
@@ -218,4 +218,10 @@ const mapStateToProps = (state, { source }) => {
   };
 };
 
-export default connect(mapStateToProps, actions)(Tab);
+export default connect(mapStateToProps, {
+  selectSpecificSource: actions.selectSpecificSource,
+  closeTab: actions.closeTab,
+  closeTabs: actions.closeTabs,
+  togglePrettyPrint: actions.togglePrettyPrint,
+  showSource: actions.showSource
+})(Tab);

--- a/src/components/Editor/Tabs.js
+++ b/src/components/Editor/Tabs.js
@@ -28,14 +28,14 @@ type SourcesList = Source[];
 type Props = {
   tabSources: SourcesList,
   selectedSource: ?Source,
-  selectSpecificSource: string => void,
+  horizontal: boolean,
+  startPanelCollapsed: boolean,
+  endPanelCollapsed: boolean,
   moveTab: (string, number) => void,
   closeTab: string => void,
   togglePaneCollapse: () => void,
   showSource: string => void,
-  horizontal: boolean,
-  startPanelCollapsed: boolean,
-  endPanelCollapsed: boolean
+  selectSpecificSource: string => void
 };
 
 type State = {
@@ -202,4 +202,10 @@ const mapStateToProps = state => ({
   tabSources: getSourcesForTabs(state)
 });
 
-export default connect(mapStateToProps, actions)(Tabs);
+export default connect(mapStateToProps, {
+  selectSpecificSource: actions.selectSpecificSource,
+  moveTab: actions.moveTab,
+  closeTab: actions.closeTab,
+  togglePaneCollapse: actions.togglePaneCollapse,
+  showSource: actions.showSource
+})(Tabs);

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -613,4 +613,13 @@ const mapStateToProps = state => {
   };
 };
 
-export default connect(mapStateToProps, actions)(Editor);
+export default connect(mapStateToProps, {
+  openConditionalPanel: actions.openConditionalPanel,
+  closeConditionalPanel: actions.closeConditionalPanel,
+  setContextMenu: actions.setContextMenu,
+  continueToHere: actions.continueToHere,
+  toggleBreakpoint: actions.toggleBreakpoint,
+  addOrToggleDisabledBreakpoint: actions.addOrToggleDisabledBreakpoint,
+  jumpToMappedLocation: actions.jumpToMappedLocation,
+  traverseResults: actions.traverseResults
+})(Editor);

--- a/src/components/PrimaryPanes/Outline.js
+++ b/src/components/PrimaryPanes/Outline.js
@@ -32,13 +32,13 @@ import type { Source } from "../../types";
 
 type Props = {
   symbols: SymbolDeclarations,
-  selectLocation: ({ sourceId: string, line: number }) => void,
   selectedSource: ?Source,
-  onAlphabetizeClick: Function,
   alphabetizeOutline: boolean,
+  onAlphabetizeClick: Function,
+  selectedLocation: any,
+  selectLocation: ({ sourceId: string, line: number }) => void,
   getFunctionText: Function,
-  flashLineRange: Function,
-  selectedLocation: any
+  flashLineRange: Function
 };
 
 export class Outline extends Component<Props> {
@@ -221,4 +221,8 @@ const mapStateToProps = state => {
   };
 };
 
-export default connect(mapStateToProps, actions)(Outline);
+export default connect(mapStateToProps, {
+  selectLocation: actions.selectLocation,
+  getFunctionText: actions.getFunctionText,
+  flashLineRange: actions.flashLineRange
+})(Outline);

--- a/src/components/PrimaryPanes/SourcesTree.js
+++ b/src/components/PrimaryPanes/SourcesTree.js
@@ -20,13 +20,7 @@ import {
   getSourceCount
 } from "../../selectors";
 
-// Actions
-import { setExpandedState } from "../../actions/source-tree";
-import { selectSource } from "../../actions/sources";
-import {
-  setProjectDirectoryRoot,
-  clearProjectDirectoryRoot
-} from "../../actions/ui";
+import actions from "../../actions";
 
 // Components
 import SourcesTreeItem from "./SourcesTreeItem";
@@ -55,17 +49,17 @@ import type { SourcesMap } from "../../reducers/types";
 import type { Item } from "../shared/ManagedTree";
 
 type Props = {
-  selectSource: string => void,
-  setExpandedState: (Set<string>) => void,
-  setProjectDirectoryRoot: string => void,
-  clearProjectDirectoryRoot: void => void,
   sources: SourcesMap,
   sourceCount: number,
   shownSource?: string,
   selectedSource?: Source,
   debuggeeUrl: string,
   projectRoot: string,
-  expanded?: boolean
+  expanded?: boolean,
+  selectSource: string => mixed,
+  setExpandedState: (Set<string>) => mixed,
+  setProjectDirectoryRoot: string => void,
+  clearProjectDirectoryRoot: () => void
 };
 
 type State = {
@@ -379,11 +373,9 @@ const mapStateToProps = state => {
   };
 };
 
-const actionCreators = {
-  setExpandedState,
-  selectSource,
-  setProjectDirectoryRoot,
-  clearProjectDirectoryRoot
-};
-
-export default connect(mapStateToProps, actionCreators)(SourcesTree);
+export default connect(mapStateToProps, {
+  selectSource: actions.selectSource,
+  setExpandedState: actions.setExpandedState,
+  setProjectDirectoryRoot: actions.setProjectDirectoryRoot,
+  clearProjectDirectoryRoot: actions.clearProjectDirectoryRoot
+})(SourcesTree);

--- a/src/components/PrimaryPanes/index.js
+++ b/src/components/PrimaryPanes/index.js
@@ -28,14 +28,13 @@ type State = {
 
 type Props = {
   selectedTab: string,
-  setPrimaryPaneTab: string => void,
   sources: SourcesMap,
-  selectLocation: Object => void,
   horizontal: boolean,
-  setActiveSearch: string => void,
-  closeActiveSearch: () => void,
   sourceSearchOn: boolean,
-  alphabetizeOutline: boolean
+  setPrimaryPaneTab: string => void,
+  selectLocation: Object => void,
+  setActiveSearch: string => void,
+  closeActiveSearch: () => void
 };
 
 class PrimaryPanes extends Component<Props, State> {
@@ -145,4 +144,9 @@ const mapStateToProps = state => ({
   sourceSearchOn: getActiveSearch(state) === "source"
 });
 
-export default connect(mapStateToProps, actions)(PrimaryPanes);
+export default connect(mapStateToProps, {
+  setPrimaryPaneTab: actions.setPrimaryPaneTab,
+  selectLocation: actions.selectLocation,
+  setActiveSearch: actions.setActiveSearch,
+  closeActiveSearch: actions.closeActiveSearch
+})(PrimaryPanes);

--- a/src/components/ProjectSearch.js
+++ b/src/components/ProjectSearch.js
@@ -65,11 +65,11 @@ type Props = {
   results: List<Result>,
   status: StatusType,
   activeSearch: ActiveSearchType,
-  setActiveSearch: (activeSearch?: ActiveSearchType) => void,
   closeProjectSearch: () => void,
   searchSources: (query: string) => void,
   clearSearch: () => void,
   selectLocation: (location: Location, tabIndex?: string) => void,
+  setActiveSearch: (activeSearch?: ActiveSearchType) => void,
   doSearchForHighlight: (
     query: string,
     editor: Editor,
@@ -341,4 +341,11 @@ const mapStateToProps = state => ({
   status: getTextSearchStatus(state)
 });
 
-export default connect(mapStateToProps, actions)(ProjectSearch);
+export default connect(mapStateToProps, {
+  closeProjectSearch: actions.closeProjectSearch,
+  searchSources: actions.searchSources,
+  clearSearch: actions.clearSearch,
+  selectLocation: actions.selectLocation,
+  setActiveSearch: actions.setActiveSearch,
+  doSearchForHighlight: actions.doSearchForHighlight
+})(ProjectSearch);

--- a/src/components/QuickOpenModal.js
+++ b/src/components/QuickOpenModal.js
@@ -49,11 +49,11 @@ type Props = {
   symbols: FormattedSymbolDeclarations,
   symbolsLoading: boolean,
   tabs: string[],
+  shortcutsModalEnabled: boolean,
   selectLocation: Location => void,
   setQuickOpenQuery: (query: string) => void,
   highlightLineRange: ({ start: number, end: number }) => void,
   closeQuickOpen: () => void,
-  shortcutsModalEnabled: boolean,
   toggleShortcutsModal: () => void
 };
 
@@ -444,4 +444,11 @@ function mapStateToProps(state) {
 }
 
 /* istanbul ignore next: ignoring testing of redux connection stuff */
-export default connect(mapStateToProps, actions)(QuickOpenModal);
+export default connect(mapStateToProps, {
+  shortcutsModalEnabled: actions.shortcutsModalEnabled,
+  selectLocation: actions.selectLocation,
+  setQuickOpenQuery: actions.setQuickOpenQuery,
+  highlightLineRange: actions.highlightLineRange,
+  closeQuickOpen: actions.closeQuickOpen,
+  toggleShortcutsModal: actions.toggleShortcutsModal
+})(QuickOpenModal);

--- a/src/components/SecondaryPanes/Breakpoints/Breakpoint.js
+++ b/src/components/SecondaryPanes/Breakpoints/Breakpoint.js
@@ -39,12 +39,12 @@ type Props = {
   breakpoint: BreakpointType,
   breakpoints: BreakpointsMap,
   selectedSource: ?Source,
-  disableBreakpoint: Function,
-  enableBreakpoint: Function,
-  removeBreakpoint: Function,
-  selectSpecificLocation: Function,
   source: Source,
-  frame: ?Frame
+  frame: ?Frame,
+  enableBreakpoint: typeof actions.enableBreakpoint,
+  removeBreakpoint: typeof actions.removeBreakpoint,
+  disableBreakpoint: typeof actions.disableBreakpoint,
+  selectSpecificLocation: typeof actions.selectSpecificLocation
 };
 
 function getMappedLocation(mappedLocation: MappedLocation, selectedSource) {
@@ -185,4 +185,9 @@ const mapStateToProps = state => ({
   selectedSource: getSelectedSource(state)
 });
 
-export default connect(mapStateToProps, actions)(Breakpoint);
+export default connect(mapStateToProps, {
+  enableBreakpoint: actions.enableBreakpoint,
+  removeBreakpoint: actions.removeBreakpoint,
+  disableBreakpoint: actions.disableBreakpoint,
+  selectSpecificLocation: actions.selectSpecificLocation
+})(Breakpoint);

--- a/src/components/SecondaryPanes/Breakpoints/index.js
+++ b/src/components/SecondaryPanes/Breakpoints/index.js
@@ -25,10 +25,10 @@ import "./Breakpoints.css";
 type Props = {
   breakpointSources: BreakpointSources,
   selectedSource: Source,
-  selectSource: string => void,
   shouldPauseOnExceptions: boolean,
   shouldPauseOnCaughtExceptions: boolean,
-  pauseOnExceptions: Function
+  pauseOnExceptions: Function,
+  selectSource: string => void
 };
 
 function createExceptionOption(
@@ -129,4 +129,7 @@ const mapStateToProps = state => ({
   selectedSource: getSelectedSource(state)
 });
 
-export default connect(mapStateToProps, actions)(Breakpoints);
+export default connect(mapStateToProps, {
+  pauseOnExceptions: actions.pauseOnExceptions,
+  selectSource: actions.selectSource
+})(Breakpoints);

--- a/src/components/SecondaryPanes/CommandBar.js
+++ b/src/components/SecondaryPanes/CommandBar.js
@@ -27,9 +27,6 @@ import "./CommandBar.css";
 import { Services } from "devtools-modules";
 const { appinfo } = Services;
 
-import type { SourcesMap } from "../../reducers/sources";
-import type { Source } from "../../types";
-
 const isMacOS = appinfo.OS === "Darwin";
 
 const COMMANDS = ["resume", "stepOver", "stepIn", "stepOut"];
@@ -80,8 +77,15 @@ function formatKey(action) {
 }
 
 type Props = {
-  sources: SourcesMap,
-  selectedSource: Source,
+  historyPosition: number,
+  history: any,
+  isPaused: boolean,
+  isWaitingOnBreak: boolean,
+  horizontal: boolean,
+  canRewind: boolean,
+  skipPausing: boolean,
+  timeTravelTo: number => void,
+  clearHistory: () => void,
   resume: () => void,
   stepIn: () => void,
   stepOut: () => void,
@@ -91,18 +95,7 @@ type Props = {
   reverseStepIn: () => void,
   reverseStepOut: () => void,
   reverseStepOver: () => void,
-  isPaused: boolean,
   pauseOnExceptions: (boolean, boolean) => void,
-  shouldPauseOnExceptions: boolean,
-  shouldPauseOnCaughtExceptions: boolean,
-  historyPosition: number,
-  history: any,
-  timeTravelTo: number => void,
-  clearHistory: () => void,
-  isWaitingOnBreak: boolean,
-  horizontal: boolean,
-  canRewind: boolean,
-  skipPausing: boolean,
   toggleSkipPausing: () => void
 };
 
@@ -389,4 +382,18 @@ const mapStateToProps = state => ({
   skipPausing: getSkipPausing(state)
 });
 
-export default connect(mapStateToProps, actions)(CommandBar);
+export default connect(mapStateToProps, {
+  timeTravelTo: actions.timeTravelTo,
+  clearHistory: actions.clearHistory,
+  resume: actions.resume,
+  stepIn: actions.stepIn,
+  stepOut: actions.stepOut,
+  stepOver: actions.stepOver,
+  breakOnNext: actions.breakOnNext,
+  rewind: actions.rewind,
+  reverseStepIn: actions.reverseStepIn,
+  reverseStepOut: actions.reverseStepOut,
+  reverseStepOver: actions.reverseStepOver,
+  pauseOnExceptions: actions.pauseOnExceptions,
+  toggleSkipPausing: actions.toggleSkipPausing
+})(CommandBar);

--- a/src/components/SecondaryPanes/EventListeners.js
+++ b/src/components/SecondaryPanes/EventListeners.js
@@ -112,4 +112,10 @@ const mapStateToProps = state => {
   return { listeners };
 };
 
-export default connect(mapStateToProps, actions)(EventListeners);
+export default connect(mapStateToProps, {
+  selectLocation: actions.selectLocation,
+  addBreakpoint: actions.addBreakpoint,
+  enableBreakpoint: actions.enableBreakpoint,
+  disableBreakpoint: actions.disableBreakpoint,
+  removeBreakpoint: actions.removeBreakpoint
+})(EventListeners);

--- a/src/components/SecondaryPanes/Expressions.js
+++ b/src/components/SecondaryPanes/Expressions.js
@@ -36,17 +36,17 @@ type State = {
 type Props = {
   expressions: List<Expression>,
   expressionError: boolean,
+  showInput: boolean,
+  autocompleteMatches: string[],
+  autocomplete: (input: string, cursor: number) => Promise<any>,
+  clearAutocomplete: () => void,
+  onExpressionAdded: () => void,
   addExpression: (input: string) => void,
   clearExpressionError: () => void,
   evaluateExpressions: () => void,
   updateExpression: (input: string, expression: Expression) => void,
   deleteExpression: (expression: Expression) => void,
-  openLink: (url: string) => void,
-  showInput: boolean,
-  onExpressionAdded: () => void,
-  autocomplete: (input: string, cursor: number) => Promise<any>,
-  clearAutocomplete: () => void,
-  autocompleteMatches: string[]
+  openLink: (url: string) => void
 };
 
 class Expressions extends Component<Props, State> {
@@ -360,4 +360,14 @@ const mapStateToProps = state => {
   };
 };
 
-export default connect(mapStateToProps, actions)(Expressions);
+export default connect(mapStateToProps, {
+  autocomplete: actions.autocomplete,
+  clearAutocomplete: actions.clearAutocomplete,
+  onExpressionAdded: actions.onExpressionAdded,
+  addExpression: actions.addExpression,
+  clearExpressionError: actions.clearExpressionError,
+  evaluateExpressions: actions.evaluateExpressions,
+  updateExpression: actions.updateExpression,
+  deleteExpression: actions.deleteExpression,
+  openLink: actions.openLink
+})(Expressions);

--- a/src/components/SecondaryPanes/Frames/index.js
+++ b/src/components/SecondaryPanes/Frames/index.js
@@ -35,12 +35,12 @@ const NUM_FRAMES_SHOWN = 7;
 type Props = {
   frames: Array<Frame>,
   frameworkGroupingOn: boolean,
-  toggleFrameworkGrouping: Function,
   selectedFrame: Object,
+  why: Why,
   selectFrame: Function,
   toggleBlackBox: Function,
-  disableFrameTruncate: boolean,
-  why: Why
+  toggleFrameworkGrouping: Function,
+  disableFrameTruncate: Function
 };
 
 type State = {
@@ -201,4 +201,9 @@ const mapStateToProps = state => ({
   pause: getIsPaused(state)
 });
 
-export default connect(mapStateToProps, actions)(Frames);
+export default connect(mapStateToProps, {
+  selectFrame: actions.selectFrame,
+  toggleBlackBox: actions.toggleBlackBox,
+  toggleFrameworkGrouping: actions.toggleFrameworkGrouping,
+  disableFrameTruncate: actions.disableFrameTruncate
+})(Frames);

--- a/src/components/SecondaryPanes/FrameworkComponent.js
+++ b/src/components/SecondaryPanes/FrameworkComponent.js
@@ -19,9 +19,9 @@ const { createNode, getChildren } = ObjectInspectorUtils.node;
 const { loadItemProperties } = ObjectInspectorUtils.loadProperties;
 
 type Props = {
-  setPopupObjectProperties: (Object, Object) => void,
   selectedFrame: Frame,
-  popupObjectProperties: Object
+  popupObjectProperties: Object,
+  setPopupObjectProperties: (Object, Object) => void
 };
 
 class FrameworkComponent extends PureComponent<Props> {
@@ -89,4 +89,6 @@ const mapStateToProps = state => ({
   popupObjectProperties: getAllPopupObjectProperties(state)
 });
 
-export default connect(mapStateToProps, actions)(FrameworkComponent);
+export default connect(mapStateToProps, {
+  setPopupObjectProperties: actions.setPopupObjectProperties
+})(FrameworkComponent);

--- a/src/components/SecondaryPanes/Scopes.js
+++ b/src/components/SecondaryPanes/Scopes.js
@@ -179,4 +179,6 @@ const mapStateToProps = state => {
   };
 };
 
-export default connect(mapStateToProps, actions)(Scopes);
+export default connect(mapStateToProps, {
+  openLink: actions.openLink
+})(Scopes);

--- a/src/components/SecondaryPanes/index.js
+++ b/src/components/SecondaryPanes/index.js
@@ -73,20 +73,20 @@ type State = {
 type Props = {
   expressions: List<Expression>,
   extra: Object,
-  evaluateExpressions: Function,
   hasFrames: boolean,
   horizontal: boolean,
   breakpoints: Object,
   breakpointsDisabled: boolean,
   breakpointsLoading: boolean,
-  toggleAllBreakpoints: Function,
-  toggleShortcutsModal: Function,
-  pauseOnExceptions: (boolean, boolean) => void,
-  breakOnNext: () => void,
-  isWaitingOnBreak: any,
+  isWaitingOnBreak: boolean,
   shouldPauseOnExceptions: boolean,
   shouldPauseOnCaughtExceptions: boolean,
-  workers: WorkersList
+  workers: WorkersList,
+  toggleAllBreakpoints: Function,
+  toggleShortcutsModal: Function,
+  evaluateExpressions: Function,
+  pauseOnExceptions: (boolean, boolean) => void,
+  breakOnNext: () => void
 };
 
 class SecondaryPanes extends Component<Props, State> {
@@ -403,4 +403,10 @@ const mapStateToProps = state => ({
   workers: getWorkers(state)
 });
 
-export default connect(mapStateToProps, actions)(SecondaryPanes);
+export default connect(mapStateToProps, {
+  toggleAllBreakpoints: actions.toggleAllBreakpoints,
+  toggleShortcutsModal: actions.toggleShortcutsModal,
+  evaluateExpressions: actions.evaluateExpressions,
+  pauseOnExceptions: actions.pauseOnExceptions,
+  breakOnNext: actions.breakOnNext
+})(SecondaryPanes);

--- a/src/components/WelcomeBox.js
+++ b/src/components/WelcomeBox.js
@@ -18,8 +18,8 @@ import "./WelcomeBox.css";
 
 type Props = {
   horizontal: boolean,
-  togglePaneCollapse: Function,
   endPanelCollapsed: boolean,
+  togglePaneCollapse: Function,
   setActiveSearch: (?ActiveSearchType) => any,
   openQuickOpen: (query?: string) => void
 };
@@ -88,4 +88,8 @@ const mapStateToProps = state => ({
   endPanelCollapsed: getPaneCollapse(state, "end")
 });
 
-export default connect(mapStateToProps, actions)(WelcomeBox);
+export default connect(mapStateToProps, {
+  togglePaneCollapse: actions.togglePaneCollapse,
+  setActiveSearch: actions.setActiveSearch,
+  openQuickOpen: actions.openQuickOpen
+})(WelcomeBox);


### PR DESCRIPTION
Fixes Issue: #5072

### Summary of Changes

* Adds flow support for react-redux
* Fixes all the ambiguous flow types - i like that one consequence is that we now only pass in the actions that we use
* This inspires me to add coverage to some components and component types that are lacking

We now catch warnings like this!

<img width="1180" alt="screen shot 2018-06-26 at 9 41 26 am" src="https://user-images.githubusercontent.com/254562/41916679-90cb333c-7926-11e8-934b-a29a70a3385f.png">
