### PR TITLE
[breakpoints] Fix timing issue with syncing breakpoints

### DIFF
--- a/src/actions/breakpoints.js
+++ b/src/actions/breakpoints.js
@@ -52,13 +52,19 @@ export function syncBreakpoint(
   pendingBreakpoint: PendingBreakpoint
 ) {
   return async ({ dispatch, getState, client, sourceMaps }: ThunkArgs) => {
-    const { breakpoint, previousLocation } = await syncClientBreakpoint(
+    const response = await syncClientBreakpoint(
       getState,
       client,
       sourceMaps,
       sourceId,
       pendingBreakpoint
     );
+
+    if (!response) {
+      return;
+    }
+
+    const { breakpoint, previousLocation } = response;
 
     return dispatch(
       ({

--- a/src/actions/breakpoints/syncBreakpoint.js
+++ b/src/actions/breakpoints/syncBreakpoint.js
@@ -14,7 +14,7 @@ import {
 import { getGeneratedLocation } from "../../utils/source-maps";
 import { getTextAtPosition } from "../../utils/source";
 import { originalToGeneratedId } from "devtools-source-map";
-import { getSourceFromId } from "../../selectors";
+import { getSource } from "../../selectors";
 import type {
   Location,
   ASTLocation,
@@ -76,16 +76,20 @@ export async function syncClientBreakpoint(
   sourceMaps: Object,
   sourceId: SourceId,
   pendingBreakpoint: PendingBreakpoint
-): Promise<BreakpointSyncData> {
+): Promise<BreakpointSyncData | null> {
   assertPendingBreakpoint(pendingBreakpoint);
 
-  const source = getSourceFromId(getState(), sourceId);
+  const source = getSource(getState(), sourceId);
 
   const generatedSourceId = sourceMaps.isOriginalId(sourceId)
     ? originalToGeneratedId(sourceId)
     : sourceId;
 
-  const generatedSource = getSourceFromId(getState(), generatedSourceId);
+  const generatedSource = getSource(getState(), generatedSourceId);
+
+  if (!source) {
+    return null;
+  }
 
   const { location, astLocation } = pendingBreakpoint;
   const previousLocation = { ...location, sourceId };

--- a/src/actions/sources/newSources.js
+++ b/src/actions/sources/newSources.js
@@ -136,10 +136,10 @@ function checkPendingBreakpoints(sourceId: string) {
     // load the source text if there is a pending breakpoint for it
     await dispatch(loadSourceText(source));
 
-    const pendingBreakpointsArray = pendingBreakpoints.valueSeq().toJS();
-    for (const pendingBreakpoint of pendingBreakpointsArray) {
-      await dispatch(syncBreakpoint(sourceId, pendingBreakpoint));
-    }
+    const breakpoints = pendingBreakpoints.valueSeq().toJS();
+    await Promise.all(
+      breakpoints.map(bp => dispatch(syncBreakpoint(sourceId, bp)))
+    );
   };
 }
 

--- a/src/utils/source.js
+++ b/src/utils/source.js
@@ -334,7 +334,7 @@ export function isLoading(source: Source) {
   return source.loadedState === "loading";
 }
 
-export function getTextAtPosition(source: Source, location: Location) {
+export function getTextAtPosition(source: ?Source, location: Location) {
   if (!source || !source.text || source.isWasm) {
     return "";
   }


### PR DESCRIPTION
### Summary of Changes

* fixes an intermittent with [dbg-navigation][dbg] [graph][g]
* The underlying issue is that the test does 3 navigates, the second navigate starts before we are done syncing a breakpoint, the result is that a source is not available mid-sync and the command fails. 

#### Lessons

It's hard to see a timing issue and not have some thoughts:

1. the flow types are really helpful - we should continue investing
2. the code assumes via `getSourceFromId` that we will definitely have it, that is a bit naive. It is better to be conservative.
3. it would be cool if before navigating we we could cancel in progress actions 
4. alternatively, it would be cool if we could see that there were in progress actions and wait for them to finish...

these are just thoughts... largely, i think our system is getting more stable and it is getting harder to introduce these issues

[dbg]: https://bugzilla.mozilla.org/show_bug.cgi?id=1453815
[g]: https://treeherder.mozilla.org/intermittent-failures.html#/bugdetails?startday=2018-06-18&endday=2018-06-24&tree=trunk&bug=1453815
