### PR TITLE
Rollback PR #6335.

### DIFF
--- a/packages/devtools-components/src/tree.js
+++ b/packages/devtools-components/src/tree.js
@@ -823,14 +823,14 @@ class Tree extends Component {
             return;
           }
 
-          const { relatedTarget } = nativeEvent;
+          const { explicitOriginalTarget } = nativeEvent;
 
           // Only set default focus to the first tree node if the focus came
           // from outside the tree (e.g. by tabbing to the tree from other
           // external elements).
           if (
-            relatedTarget !== this.treeRef &&
-            !this.treeRef.contains(relatedTarget)
+            explicitOriginalTarget !== this.treeRef &&
+            !this.treeRef.contains(explicitOriginalTarget)
           ) {
             this._focus(traversal[0].item);
           }


### PR DESCRIPTION
This introduced a regression in the ObjectInspector (see [Bug 1469959](https://bugzilla.mozilla.org/show_bug.cgi\?id\=1469959)).
Let's see how to handle the removal of explicitOriginalTarget later.