### PR TITLE
Fix breakpoints panel context menu items

### DIFF
--- a/src/components/SecondaryPanes/Breakpoints/Breakpoint.js
+++ b/src/components/SecondaryPanes/Breakpoints/Breakpoint.js
@@ -43,7 +43,12 @@ type Props = {
   frame: ?Frame,
   enableBreakpoint: typeof actions.enableBreakpoint,
   removeBreakpoint: typeof actions.removeBreakpoint,
+  removeBreakpoints: typeof actions.removeBreakpoints,
+  removeAllBreakpoints: typeof actions.removeAllBreakpoints,
   disableBreakpoint: typeof actions.disableBreakpoint,
+  toggleAllBreakpoints: typeof actions.toggleAllBreakpoints,
+  toggleBreakpoints: typeof actions.toggleBreakpoints,
+  openConditionalPanel: typeof actions.openConditionalPanel,
   selectSpecificLocation: typeof actions.selectSpecificLocation
 };
 
@@ -188,6 +193,12 @@ const mapStateToProps = state => ({
 export default connect(mapStateToProps, {
   enableBreakpoint: actions.enableBreakpoint,
   removeBreakpoint: actions.removeBreakpoint,
+  removeBreakpoints: actions.removeBreakpoints,
+  removeAllBreakpoints: actions.removeAllBreakpoints,
   disableBreakpoint: actions.disableBreakpoint,
-  selectSpecificLocation: actions.selectSpecificLocation
+  selectSpecificLocation: actions.selectSpecificLocation,
+  selectLocation: actions.selectLocation,
+  toggleAllBreakpoints: actions.toggleAllBreakpoints,
+  toggleBreakpoints: actions.toggleBreakpoints,
+  openConditionalPanel: actions.openConditionalPanel
 })(Breakpoint);

--- a/src/components/SecondaryPanes/Breakpoints/BreakpointsContextMenu.js
+++ b/src/components/SecondaryPanes/Breakpoints/BreakpointsContextMenu.js
@@ -12,7 +12,7 @@ export default function showContextMenu(props) {
     toggleBreakpoints,
     toggleAllBreakpoints,
     toggleDisabledBreakpoint,
-    selectLocation,
+    selectSpecificLocation,
     setBreakpointCondition,
     openConditionalPanel,
     breakpoints,
@@ -168,7 +168,7 @@ export default function showContextMenu(props) {
     label: addConditionLabel,
     accesskey: addConditionKey,
     click: () => {
-      selectLocation(breakpoint.location);
+      selectSpecificLocation(breakpoint.location);
       openConditionalPanel(breakpoint.location.line);
     }
   };
@@ -178,7 +178,7 @@ export default function showContextMenu(props) {
     label: editConditionLabel,
     accesskey: editConditionKey,
     click: () => {
-      selectLocation(breakpoint.location);
+      selectSpecificLocation(breakpoint.location);
       openConditionalPanel(breakpoint.location.line);
     }
   };


### PR DESCRIPTION
Most of the breakpoints context menu items are broken because those props aren't provided to the context menu.

Note: We should add tests but I'm hoping a contributor can help with those.