### PR TITLE
Use Promise.all for checkPendingBreakpoints

### DIFF
--- a/src/actions/sources/newSources.js
+++ b/src/actions/sources/newSources.js
@@ -137,9 +137,11 @@ function checkPendingBreakpoints(sourceId: string) {
     await dispatch(loadSourceText(source));
 
     const pendingBreakpointsArray = pendingBreakpoints.valueSeq().toJS();
-    for (const pendingBreakpoint of pendingBreakpointsArray) {
-      await dispatch(syncBreakpoint(sourceId, pendingBreakpoint));
-    }
+    await Promise.all(
+      pendingBreakpointsArray.map(pendingBreakpoint =>
+        dispatch(syncBreakpoint(sourceId, pendingBreakpoint))
+      )
+    );
   };
 }
 


### PR DESCRIPTION
I can't think of a reason these needs to be synced in any order so throwing this out there.