### PR TITLE
[Editor] get mode from editor

### DIFF
--- a/src/utils/editor/source-documents.js
+++ b/src/utils/editor/source-documents.js
@@ -129,7 +129,7 @@ export function showSourceText(
     if (editor.codeMirror.doc === doc) {
       const mode = getMode(source, symbols);
       const currentMode = editor.codeMirror.getOption("mode");
-      if (currentMode.name !== mode.name) {
+      if (currentMode.name != mode.name) {
         editor.setMode(mode);
       }
 

--- a/src/utils/editor/source-documents.js
+++ b/src/utils/editor/source-documents.js
@@ -128,8 +128,8 @@ export function showSourceText(
     const doc = getDocument(source.id);
     if (editor.codeMirror.doc === doc) {
       const mode = getMode(source, symbols);
-
-      if (doc.mode.name !== mode.name) {
+      const currentMode = editor.codeMirror.getOption("mode");
+      if (currentMode.name !== mode.name) {
         editor.setMode(mode);
       }
 


### PR DESCRIPTION
Fixes Issue: #6507

### Summary of Changes

* fetch editor mode option from the editor as opposed to the doc
* this should speed up stepping large documents that might have had a big syntax highlighting component

### Test Plan

lets write a jest unit test to assert that we don't call setMode more than once