### PR TITLE
[scopes] Handle Webpack 2-style ESM identity wrapper fn

### DIFF
--- a/src/utils/pause/mapScopes/findGeneratedBindingFromPosition.js
+++ b/src/utils/pause/mapScopes/findGeneratedBindingFromPosition.js
@@ -329,7 +329,12 @@ async function mapImportReferenceToDescriptor({
   //       ^^^           // binding
   // vs
   //
-  //   Object(foo.bar)() // Webpack
+  //   __webpack_require__.i(foo.bar)() // Webpack 2
+  //   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   // mapping
+  //                         ^^^        // binding
+  // vs
+  //
+  //   Object(foo.bar)() // Webpack >= 3
   //   ^^^^^^^^^^^^^^^   // mapping
   //          ^^^        // binding
   //
@@ -342,6 +347,18 @@ async function mapImportReferenceToDescriptor({
   //   ^                 // wrapped to column 0 of next line
 
   if (!mappingContains(range, binding.loc)) {
+    return null;
+  }
+
+  // Webpack 2's import declarations wrap calls with an identity fn, so we
+  // need to make sure to skip that binding because it is mapped to the
+  // location of the original binding usage.
+  if (
+    binding.name === "__webpack_require__" &&
+    binding.loc.meta &&
+    binding.loc.meta.type === "member" &&
+    binding.loc.meta.property === "i"
+  ) {
     return null;
   }
 

--- a/src/workers/parser/getScopes/visitor.js
+++ b/src/workers/parser/getScopes/visitor.js
@@ -867,10 +867,14 @@ function buildMetaBindings(
     };
   }
 
-  // Consider "Object(foo)" to be equivalent to "foo"
+  // Consider "Object(foo)", and "__webpack_require__.i(foo)" to be
+  // equivalent to "foo" since they are essentially identity functions.
   if (
     t.isCallExpression(parent) &&
-    t.isIdentifier(parent.callee, { name: "Object" }) &&
+    (t.isIdentifier(parent.callee, { name: "Object" }) ||
+      (t.isMemberExpression(parent.callee, { computed: false }) &&
+        t.isIdentifier(parent.callee.object, { name: "__webpack_require__" }) &&
+        t.isIdentifier(parent.callee.property, { name: "i" }))) &&
     parent.arguments.length === 1 &&
     parent.arguments[0] === node
   ) {

--- a/src/workers/parser/tests/__snapshots__/getScopes.spec.js.snap
+++ b/src/workers/parser/tests/__snapshots__/getScopes.spec.js.snap
@@ -15172,6 +15172,74 @@ Array [
             },
             "type": "ref",
           },
+          Object {
+            "end": Object {
+              "column": 25,
+              "line": 6,
+              "sourceId": "scopes/expressions/originalSource-1",
+            },
+            "meta": Object {
+              "end": Object {
+                "column": 29,
+                "line": 6,
+                "sourceId": "scopes/expressions/originalSource-1",
+              },
+              "parent": Object {
+                "end": Object {
+                  "column": 30,
+                  "line": 6,
+                  "sourceId": "scopes/expressions/originalSource-1",
+                },
+                "parent": Object {
+                  "end": Object {
+                    "column": 32,
+                    "line": 6,
+                    "sourceId": "scopes/expressions/originalSource-1",
+                  },
+                  "parent": Object {
+                    "end": Object {
+                      "column": 36,
+                      "line": 6,
+                      "sourceId": "scopes/expressions/originalSource-1",
+                    },
+                    "parent": null,
+                    "property": "baz",
+                    "start": Object {
+                      "column": 0,
+                      "line": 6,
+                      "sourceId": "scopes/expressions/originalSource-1",
+                    },
+                    "type": "member",
+                  },
+                  "start": Object {
+                    "column": 0,
+                    "line": 6,
+                    "sourceId": "scopes/expressions/originalSource-1",
+                  },
+                  "type": "call",
+                },
+                "start": Object {
+                  "column": 0,
+                  "line": 6,
+                  "sourceId": "scopes/expressions/originalSource-1",
+                },
+                "type": "inherit",
+              },
+              "property": "bar",
+              "start": Object {
+                "column": 22,
+                "line": 6,
+                "sourceId": "scopes/expressions/originalSource-1",
+              },
+              "type": "member",
+            },
+            "start": Object {
+              "column": 22,
+              "line": 6,
+              "sourceId": "scopes/expressions/originalSource-1",
+            },
+            "type": "ref",
+          },
         ],
         "type": "const",
       },
@@ -15179,7 +15247,7 @@ Array [
     "displayName": "Lexical Global",
     "end": Object {
       "column": 0,
-      "line": 6,
+      "line": 7,
       "sourceId": "scopes/expressions/originalSource-1",
     },
     "start": Object {
@@ -15210,6 +15278,39 @@ Array [
         ],
         "type": "global",
       },
+      "__webpack_require__": Object {
+        "refs": Array [
+          Object {
+            "end": Object {
+              "column": 19,
+              "line": 6,
+              "sourceId": "scopes/expressions/originalSource-1",
+            },
+            "meta": Object {
+              "end": Object {
+                "column": 21,
+                "line": 6,
+                "sourceId": "scopes/expressions/originalSource-1",
+              },
+              "parent": null,
+              "property": "i",
+              "start": Object {
+                "column": 0,
+                "line": 6,
+                "sourceId": "scopes/expressions/originalSource-1",
+              },
+              "type": "member",
+            },
+            "start": Object {
+              "column": 0,
+              "line": 6,
+              "sourceId": "scopes/expressions/originalSource-1",
+            },
+            "type": "ref",
+          },
+        ],
+        "type": "global",
+      },
       "this": Object {
         "refs": Array [],
         "type": "implicit",
@@ -15218,7 +15319,7 @@ Array [
     "displayName": "Global",
     "end": Object {
       "column": 0,
-      "line": 6,
+      "line": 7,
       "sourceId": "scopes/expressions/originalSource-1",
     },
     "start": Object {

--- a/src/workers/parser/tests/fixtures/scopes/expressions.js
+++ b/src/workers/parser/tests/fixtures/scopes/expressions.js
@@ -3,3 +3,4 @@ const foo = {};
 foo.bar().baz;
 (0, foo.bar)().baz;
 Object(foo.bar)().baz;
+__webpack_require__.i(foo.bar)().baz;


### PR DESCRIPTION
Refs Issue: #6400

### Summary of Changes

* Ignore matching import bindings to `__webpack_require__.i` to handle Webpack 2

This approach isn't the best since it'll fail for code that has been minified, but I'm struggling to think of any other way for us to handle it with the way things are now.

In the future it'd be awesome if we could rely on Spidermonkey itself to have a "speculative execute" to get a value without side-effects, but until that happens, this seems like the only way.