### PR TITLE
Don't show the blackbox button for a pretty printed source

### DIFF
--- a/src/components/Editor/Footer.js
+++ b/src/components/Editor/Footer.js
@@ -69,7 +69,7 @@ class SourceFooter extends PureComponent<Props> {
     const { selectedSource, toggleBlackBox } = this.props;
     const sourceLoaded = selectedSource && isLoaded(selectedSource);
 
-    if (!sourceLoaded) {
+    if (!sourceLoaded || selectedSource.isPrettyPrinted) {
       return;
     }
 


### PR DESCRIPTION
We don't allow blackboxing for pretty-printed sources so there's no reason to show a button that does nothing.