### PR TITLE
[Telemetry] Add recordTelemetryEvent() helper to debugger util fixes #6529

### DIFF
--- a/src/utils/telemetry.js
+++ b/src/utils/telemetry.js
@@ -1,0 +1,68 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
+/**
+ * Usage:
+ *
+ * import { recordEvent } from "src/utils/telemetry";
+ *
+ * // Event without extra properties
+ * recordEvent("add_breakpoint");
+ *
+ * // Event with extra properties
+ * recordEvent("pause", {
+ *   "reason": "debugger-statement",
+ *   "collapsed_callstacks": 1
+ * });
+ *
+ * // If the properties are in multiple code paths and you can't send them all
+ * // in one go you will need to use the full telemetry API.
+ *
+ * import { Telemetry } from "devtools-modules";
+ *
+ * const telemetry = new Telemetry();
+ *
+ * // Prepare the event and define which properties to expect.
+ * //
+ * // NOTE: You CAN send properties before preparing the event.
+ * //
+ * telemetry.preparePendingEvent("devtools.main", "pause", "debugger", null, [
+ *   "reason", "collapsed_callstacks"
+ * ]);
+ *
+ * // Elsewhere in another codepath send the reason property
+ * telemetry.addEventProperty(
+ *   "devtools.main", "pause", "debugger", null, "reason", "debugger-statement"
+ * );
+ *
+ * // Elsewhere in another codepath send the collapsed_callstacks property
+ * telemetry.addEventProperty(
+ *   "devtools.main", "pause", "debugger", null, "collapsed_callstacks", 1
+ * );
+ */
+
+// @flow
+
+import { Telemetry } from "devtools-modules";
+
+const telemetry = new Telemetry();
+
+/**
+ * @memberof utils/telemetry
+ * @static
+ */
+export function recordEvent(eventName: string, fields: {} = {}) {
+  let sessionId = -1;
+
+  if (typeof window === "object" && window.parent.frameElement) {
+    sessionId = window.parent.frameElement.getAttribute("session_id");
+  }
+
+  /* eslint-disable camelcase */
+  telemetry.recordEvent("devtools.main", eventName, "debugger", null, {
+    session_id: sessionId,
+    ...fields
+  });
+  /* eslint-enable camelcase */
+}

--- a/src/utils/tests/telemetry.spec.js
+++ b/src/utils/tests/telemetry.spec.js
@@ -1,0 +1,36 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
+jest.mock("devtools-modules", () => {
+  function MockTelemetry() {}
+  MockTelemetry.prototype.recordEvent = jest.fn();
+
+  return {
+    Telemetry: MockTelemetry
+  };
+});
+
+import { Telemetry } from "devtools-modules";
+import { recordEvent } from "../telemetry";
+
+const telemetry = new Telemetry();
+
+describe("telemetry.recordEvent()", () => {
+  it("Receives the correct telemetry information", () => {
+    recordEvent("foo", {
+      bar: 1
+    });
+
+    expect(telemetry.recordEvent).toHaveBeenCalledWith(
+      "devtools.main",
+      "foo",
+      "debugger",
+      null,
+      {
+        session_id: -1,
+        bar: 1
+      }
+    );
+  });
+});


### PR DESCRIPTION
# requires: https://github.com/devtools-html/debugger.html/pull/6567

This greatly simplifies debugger telemetry... of course, the appropriate events need to be present inside `Events.yaml` for them to work.

### Usage

```js
import { recordEvent } from "src/utils/telemetry"; // Correct the path as appropriate

// Event without extra properties
recordEvent("add_breakpoint");

// Event with extra properties
recordEvent("pause", {
  "reason": "debugger-statement",
  "collapsed_callstacks": 1
});
```
