### PR TITLE
Fix #6503 SourcesTree highlighting problem

### DIFF
--- a/src/utils/sources-tree/getDirectories.js
+++ b/src/utils/sources-tree/getDirectories.js
@@ -16,7 +16,7 @@ function findSource(sourceTree: TreeDirectory, sourceUrl: string): TreeNode {
         _traverse(child);
       }
     } else if (!returnTarget) {
-      if (subtree.path.replace(/http(s)?:\//, "") == sourceUrl) {
+      if (subtree.path.replace(/http(s)?:\/\//, "") == sourceUrl) {
         returnTarget = subtree;
         return;
       }


### PR DESCRIPTION
Fixes Issue: #6503

Spent too long finding this 

/me cries

So `(index)` wasn't getting highlighted because `/davidwalsh.name/` didn't match `davidwalsh.name`