### PR TITLE
Web replay tweaks

### DIFF
--- a/src/components/SecondaryPanes/CommandBar.js
+++ b/src/components/SecondaryPanes/CommandBar.js
@@ -179,11 +179,10 @@ class CommandBar extends Component<Props> {
   renderPauseButton() {
     const { isPaused, breakOnNext, isWaitingOnBreak, canRewind } = this.props;
 
-    if (canRewind) {
-      return;
-    }
-
     if (isPaused) {
+      if (canRewind) {
+        return null;
+      }
       return debugBtn(
         () => this.resume(),
         "resume",
@@ -227,7 +226,7 @@ class CommandBar extends Component<Props> {
       debugBtn(this.props.rewind, "rewind", "active", "Rewind Execution"),
 
       debugBtn(
-        () => this.props.resume,
+        this.props.resume,
         "resume",
         "active",
         L10N.getFormatStr("resumeButtonTooltip", formatKey("resume"))


### PR DESCRIPTION
### Summary of Changes

* When recording/replaying, fix bug where pressing resume when paused has no effect.
* When recording/replaying, always show pause button when unpaused.  Per email discussion this is nice to have to interrupt an execution and start rewinding (or interrupt a rewinding execution and pause or play forward).
