### PR TITLE
[Editor] do not update highlight line by default

### DIFF
--- a/src/components/Editor/HighlightLine.js
+++ b/src/components/Editor/HighlightLine.js
@@ -66,7 +66,14 @@ export class HighlightLine extends Component<Props> {
       return false;
     }
 
-    return true;
+    if (
+      editorLine !== this.previousEditorLine ||
+      this.props.selectedSource !== selectedSource
+    ) {
+      return true;
+    }
+
+    return false;
   }
 
   componentDidUpdate(prevProps: Props) {

--- a/src/components/Editor/HighlightLine.js
+++ b/src/components/Editor/HighlightLine.js
@@ -48,6 +48,7 @@ function isDocumentReady(selectedSource, selectedLocation) {
 export class HighlightLine extends Component<Props> {
   isStepping: boolean = false;
   previousEditorLine: ?number = null;
+  shouldHighlight: boolean = false;
 
   shouldComponentUpdate(nextProps: Props) {
     const { selectedLocation, selectedSource } = nextProps;
@@ -70,6 +71,11 @@ export class HighlightLine extends Component<Props> {
       editorLine !== this.previousEditorLine ||
       this.props.selectedSource !== selectedSource
     ) {
+      if (!this.shouldHighlight) {
+        this.shouldHighlight = true;
+        return false;
+      }
+
       return true;
     }
 
@@ -103,6 +109,7 @@ export class HighlightLine extends Component<Props> {
     if (!this.shouldSetHighlightLine(selectedLocation, selectedSource)) {
       return;
     }
+
     this.isStepping = false;
     const editorLine = toEditorLine(sourceId, line);
     this.previousEditorLine = editorLine;


### PR DESCRIPTION
Fixes Issue: #6588

### Summary of Changes

Previously we were updating the highlight line if two conditions were not met. Now, we update it if those conditions are not met and a some others are. This will prevent spurious re-renders.