### PR TITLE
[release] switch to copyModules.run

### DIFF
--- a/bin/copy.js
+++ b/bin/copy.js
@@ -17,7 +17,7 @@ console.log(`Copying Files to ${mc} with params: `, {watch, assets, symlink})
 
 async function start() {
   await copyAssets({ assets, mc, watch, symlink})
-  await copyModules({ mc, watch })
+  await copyModules.run({ mc, watch })
 }
 
 start();


### PR DESCRIPTION
### Summary of Changes

looks like we broke copy with the work to update transformModule for devtools-modules