### PR TITLE
[Sources] remove get shim

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
   global:
     - DISPLAY=':99.0'
     - YARN_VERSION='0.24.5'
-    - MC_COMMIT='9c7bb8874337'  # https://hg.mozilla.org/mozilla-central/shortlog
+    - MC_COMMIT='3d20b0701781'  # https://hg.mozilla.org/mozilla-central/shortlog
 
 notifications:
   slack:

--- a/src/reducers/sources.js
+++ b/src/reducers/sources.js
@@ -13,7 +13,6 @@ import { createSelector } from "reselect";
 import { move } from "lodash-move";
 import { getPrettySourceURL } from "../utils/source";
 import { originalToGeneratedId, isOriginalId } from "devtools-source-map";
-import { isTesting } from "devtools-environment";
 import { find } from "lodash";
 import { prefs } from "../utils/prefs";
 
@@ -416,15 +415,7 @@ export const getSelectedSource = createSelector(
       return;
     }
 
-    const source = sources[selectedLocation.sourceId];
-
-    // TODO: remove this when the immutable refactor lands in m-c
-    if (isTesting()) {
-      const testSource: any = { ...source, get: field => source[field] };
-      return testSource;
-    }
-
-    return source;
+    return sources[selectedLocation.sourceId];
   }
 );
 

--- a/src/test/mochitest/browser_dbg-search-project.js
+++ b/src/test/mochitest/browser_dbg-search-project.js
@@ -56,5 +56,5 @@ add_task(async function() {
   is(dbg.selectors.getActiveSearch(dbg.getState()), null);
 
   const selectedSource = dbg.selectors.getSelectedSource(dbg.getState());
-  ok(selectedSource.get("url").includes("switching-01"));
+  ok(selectedSource.url.includes("switching-01"));
 });

--- a/src/test/mochitest/browser_dbg-sources.js
+++ b/src/test/mochitest/browser_dbg-sources.js
@@ -49,7 +49,7 @@ add_task(async function() {
 
   const focusedNode = findElementWithSelector(dbg, ".sources-list .focused");
   const fourthNode = findElement(dbg, "sourceNode", 4);
-  const selectedSource = getSelectedSource(getState()).get("url");
+  const selectedSource = getSelectedSource(getState()).url;
 
   ok(fourthNode.classList.contains("focused"), "4th node is focused");
   ok(selectedSource.includes("nested-source.js"), "nested-source is selected");


### PR DESCRIPTION
### Summary of Changes

this is a shim we added so that one of the console mochitests would still pass. We should remove it now that we've landed the immutable work and can easily update the MC mochitest.