### PR TITLE
[sources] fix isTesting

### DIFF
--- a/src/reducers/sources.js
+++ b/src/reducers/sources.js
@@ -419,7 +419,7 @@ export const getSelectedSource = createSelector(
     const source = sources[selectedLocation.sourceId];
 
     // TODO: remove this when the immutable refactor lands in m-c
-    if (isTesting) {
+    if (isTesting()) {
       const testSource: any = { ...source, get: field => source[field] };
       return testSource;
     }


### PR DESCRIPTION
### Summary of Changes

When we removed immutable we added a `get` shim for a test. The shim had bug, which we should fix now because it is causing sources to always be different. We should then try to remove the shim as soon as possible here #6600 