### PR TITLE
[sources] prevent unnecessary parsing

### DIFF
--- a/src/actions/tests/ui.spec.js
+++ b/src/actions/tests/ui.spec.js
@@ -113,9 +113,7 @@ describe("setProjectDirectoryRoot", () => {
     await dispatch(actions.newSource(makeSource("js/scopes.js")));
     await dispatch(actions.newSource(makeSource("lib/vendor.js")));
 
-    dispatch(
-      actions.setProjectDirectoryRoot("http://localhost:8000/examples/js")
-    );
+    dispatch(actions.setProjectDirectoryRoot("localhost:8000/examples/js"));
 
     const filteredSources = getRelativeSources(getState());
     const firstSource = Object.values(filteredSources)[0];

--- a/src/selectors/breakpointSources.js
+++ b/src/selectors/breakpointSources.js
@@ -53,19 +53,12 @@ function findBreakpointSources(
   return sortBy(breakpointSources, (source: Source) => getFilename(source));
 }
 
-function _getBreakpointSources(
-  breakpoints: BreakpointsMap,
-  sources: SourcesMap
-): BreakpointSources {
-  const breakpointSources = findBreakpointSources(sources, breakpoints);
-  return breakpointSources.map(source => ({
-    source,
-    breakpoints: getBreakpointsForSource(source, breakpoints)
-  }));
-}
-
 export const getBreakpointSources = createSelector(
   getBreakpoints,
   getSources,
-  _getBreakpointSources
+  (breakpoints: BreakpointsMap, sources: SourcesMap) =>
+    findBreakpointSources(sources, breakpoints).map(source => ({
+      source,
+      breakpoints: getBreakpointsForSource(source, breakpoints)
+    }))
 );

--- a/src/selectors/getRelativeSources.js
+++ b/src/selectors/getRelativeSources.js
@@ -7,20 +7,22 @@
 import { getProjectDirectoryRoot, getSources } from "../selectors";
 import { chain } from "lodash";
 import type { Source, RelativeSource } from "../types";
-import { getSourcePath } from "../utils/source";
+import { getURL } from "../utils/sources-tree";
 import { createSelector } from "reselect";
 
-function getRelativeUrl(url, root) {
+function getRelativeUrl(source, root) {
+  const { group, path } = getURL(source);
   if (!root) {
-    return getSourcePath(url);
+    return path;
   }
 
   // + 1 removes the leading "/"
+  const url = group + path;
   return url.slice(url.indexOf(root) + root.length + 1);
 }
 
 function formatSource(source, root): RelativeSource {
-  return { ...source, relativeUrl: getRelativeUrl(source.url, root) };
+  return { ...source, relativeUrl: getRelativeUrl(source, root) };
 }
 
 function underRoot(source, root) {

--- a/src/utils/source.js
+++ b/src/utils/source.js
@@ -366,5 +366,5 @@ export function getSourceClassnames(
   if (source.isBlackBoxed) {
     return "blackBox";
   }
-  return sourceTypes[getFileExtension(source.url)] || defaultClassName;
+  return sourceTypes[getFileExtension(source)] || defaultClassName;
 }

--- a/src/utils/sources-tree/addToTree.js
+++ b/src/utils/sources-tree/addToTree.js
@@ -161,11 +161,10 @@ function addSourceToNode(
 export function addToTree(
   tree: TreeDirectory,
   source: Source,
-  debuggeeUrl: string,
+  debuggeeHost: ?string,
   projectRoot: string
 ) {
-  const url = getURL(source, debuggeeUrl);
-  const debuggeeHost = getDomain(debuggeeUrl);
+  const url = getURL(source, debuggeeHost);
 
   if (isInvalidUrl(url, source)) {
     return;

--- a/src/utils/sources-tree/addToTree.js
+++ b/src/utils/sources-tree/addToTree.js
@@ -12,11 +12,7 @@ import {
   createSourceNode,
   createDirectoryNode
 } from "./utils";
-import {
-  createTreeNodeMatcher,
-  findNodeInContents,
-  getDomain
-} from "./treeOrder";
+import { createTreeNodeMatcher, findNodeInContents } from "./treeOrder";
 import { getURL } from "./getURL";
 
 import type { ParsedURL } from "./getURL";

--- a/src/utils/sources-tree/createTree.js
+++ b/src/utils/sources-tree/createTree.js
@@ -7,6 +7,7 @@
 import { addToTree } from "./addToTree";
 import { collapseTree } from "./collapseTree";
 import { createDirectoryNode, createParentMap } from "./utils";
+import { getDomain } from "./treeOrder";
 
 import type { SourcesMap } from "../../reducers/types";
 import type { TreeDirectory } from "./types";
@@ -19,10 +20,11 @@ type Params = {
 
 export function createTree({ sources, debuggeeUrl, projectRoot }: Params) {
   const uncollapsedTree = createDirectoryNode("root", "", []);
+  const debuggeeHost = getDomain(debuggeeUrl);
 
   for (const sourceId in sources) {
     const source = sources[sourceId];
-    addToTree(uncollapsedTree, source, debuggeeUrl, projectRoot);
+    addToTree(uncollapsedTree, source, debuggeeHost, projectRoot);
   }
 
   const sourceTree = collapseTree((uncollapsedTree: TreeDirectory));

--- a/src/utils/sources-tree/getURL.js
+++ b/src/utils/sources-tree/getURL.js
@@ -31,7 +31,7 @@ export function getFilenameFromPath(pathname?: string) {
 const NoDomain = "(no domain)";
 const def = { path: "", group: "", filename: "" };
 
-function _getURL(source: Source, defaultDomain: ?string = ""): ParsedURL {
+function _getURL(source: Source, defaultDomain: string): ParsedURL {
   const { url } = source;
   if (!url) {
     return def;
@@ -93,7 +93,7 @@ function _getURL(source: Source, defaultDomain: ?string = ""): ParsedURL {
         return {
           ...def,
           path: url,
-          group: defaultDomain,
+          group: defaultDomain || "",
           filename
         };
       }
@@ -117,12 +117,12 @@ function _getURL(source: Source, defaultDomain: ?string = ""): ParsedURL {
   };
 }
 
-export function getURL(source: Source, debuggeeUrl: ?string = "") {
+export function getURL(source: Source, debuggeeUrl: ?string) {
   if (urlMap.has(source)) {
     return urlMap.get(source) || def;
   }
 
-  const url = _getURL(source, debuggeeUrl);
+  const url = _getURL(source, debuggeeUrl || "");
   urlMap.set(source, url);
   return url;
 }

--- a/src/utils/sources-tree/getURL.js
+++ b/src/utils/sources-tree/getURL.js
@@ -31,7 +31,7 @@ export function getFilenameFromPath(pathname?: string) {
 const NoDomain = "(no domain)";
 const def = { path: "", group: "", filename: "" };
 
-function _getURL(source: Source, defaultDomain: ?string): ParsedURL {
+function _getURL(source: Source, defaultDomain: ?string = ""): ParsedURL {
   const { url } = source;
   if (!url) {
     return def;

--- a/src/utils/sources-tree/getURL.js
+++ b/src/utils/sources-tree/getURL.js
@@ -31,7 +31,7 @@ export function getFilenameFromPath(pathname?: string) {
 const NoDomain = "(no domain)";
 const def = { path: "", group: "", filename: "" };
 
-function _getURL(source: Source, debuggeeUrl: string): ParsedURL {
+function _getURL(source: Source, defaultDomain: ?string): ParsedURL {
   const { url } = source;
   if (!url) {
     return def;
@@ -90,8 +90,6 @@ function _getURL(source: Source, debuggeeUrl: string): ParsedURL {
           group: "file://"
         };
       } else if (host === null) {
-        // use anonymous group for weird URLs
-        const defaultDomain = parse(debuggeeUrl).host;
         return {
           ...def,
           path: url,
@@ -119,7 +117,7 @@ function _getURL(source: Source, debuggeeUrl: string): ParsedURL {
   };
 }
 
-export function getURL(source: Source, debuggeeUrl: string = "") {
+export function getURL(source: Source, debuggeeUrl: ?string = "") {
   if (urlMap.has(source)) {
     return urlMap.get(source) || def;
   }

--- a/src/utils/sources-tree/updateTree.js
+++ b/src/utils/sources-tree/updateTree.js
@@ -8,6 +8,7 @@ import { addToTree } from "./addToTree";
 import { collapseTree } from "./collapseTree";
 import { createParentMap } from "./utils";
 import { difference } from "lodash";
+import { getDomain } from "./treeOrder";
 
 import type { SourcesMap } from "../../reducers/types";
 import type { TreeDirectory } from "./types";
@@ -39,9 +40,10 @@ export function updateTree({
   sourceTree
 }: Params) {
   const newSet = newSourcesSet(newSources, prevSources);
+  const debuggeeHost = getDomain(debuggeeUrl);
 
   for (const source of newSet) {
-    addToTree(uncollapsedTree, source, debuggeeUrl, projectRoot);
+    addToTree(uncollapsedTree, source, debuggeeHost, projectRoot);
   }
 
   const newSourceTree = collapseTree(uncollapsedTree);

--- a/src/utils/sources-tree/utils.js
+++ b/src/utils/sources-tree/utils.js
@@ -9,6 +9,7 @@ import { parse } from "url";
 import type { TreeNode, TreeSource, TreeDirectory, ParentMap } from "./types";
 import type { Source } from "../../types";
 import { isPretty } from "../source";
+import { getURL } from "./getURL";
 const IGNORED_URLS = ["debugger eval code", "XStringBundle"];
 
 export function nodeHasChildren(item: TreeNode): boolean {
@@ -49,16 +50,16 @@ export function isSource(item: TreeNode) {
   return item.type === "source";
 }
 
-export function getFileExtension(url: string = ""): string {
-  const parsedUrl = parse(url).pathname;
+export function getFileExtension(source: Source): string {
+  const parsedUrl = getURL(source).path;
   if (!parsedUrl) {
     return "";
   }
   return parsedUrl.split(".").pop();
 }
 
-export function isNotJavaScript(source: Object): boolean {
-  return ["css", "svg", "png"].includes(getFileExtension(source.url));
+export function isNotJavaScript(source: Source): boolean {
+  return ["css", "svg", "png"].includes(getFileExtension(source));
 }
 
 export function isInvalidUrl(url: Object, source: Source) {


### PR DESCRIPTION
### Summary of Changes

This is a really nice performance win I saw by looking at perf.html and I thought that I'd get the win while i could. Last week we switched to memoizing getURL, this opened up the opportunity to prevent doing a ton of unnecessary parsing:

- debuggeeHost 
- file extensions
- relative urls...


![screen shot 2018-07-06 at 2 55 40 pm](https://user-images.githubusercontent.com/254562/42396700-cc968bac-8130-11e8-8ed0-dfb4774f70e1.png)
