### PR TITLE
Prevent :formatted from tab names, only show mappedSource footer for original sources

### DIFF
--- a/src/components/Editor/Footer.js
+++ b/src/components/Editor/Footer.js
@@ -155,7 +155,7 @@ class SourceFooter extends PureComponent<Props> {
 
   renderSourceSummary() {
     const { mappedSource, jumpToMappedLocation, selectedSource } = this.props;
-    if (mappedSource) {
+    if (mappedSource && mappedSource != selectedSource) {
       const filename = getFilename(mappedSource);
       const tooltip = L10N.getFormatStr(
         "sourceFooter.mappedSourceTooltip",

--- a/src/components/Editor/Tab.js
+++ b/src/components/Editor/Tab.js
@@ -192,7 +192,9 @@ class Tab extends PureComponent<Props> {
           source={source}
           shouldHide={icon => ["file", "javascript"].includes(icon)}
         />
-        <div className="filename">{getTruncatedFileName(source)}</div>
+        <div className="filename">
+          {getRawSourceURL(getTruncatedFileName(source))}
+        </div>
         <CloseButton
           handleClick={onClickClose}
           tooltip={L10N.getStr("sourceTabs.closeTabButtonTooltip")}


### PR DESCRIPTION
Fixes these issues:

<img width="717" alt="bugz" src="https://user-images.githubusercontent.com/46655/42522995-27c5022a-8432-11e8-8305-6ba42e6cc66d.png">
