### PR TITLE
Disable pretty-print when sourcemaps are enabled

### DIFF
--- a/src/utils/source.js
+++ b/src/utils/source.js
@@ -17,6 +17,7 @@ import { parse as parseURL } from "url";
 import { getUnicodeUrl } from "devtools-modules";
 export { isMinified } from "./isMinified";
 import { getURL, getFileExtension } from "./sources-tree";
+import { prefs } from './prefs';
 
 import type { Source, Location } from "../types";
 import type { SourceMetaDataType } from "../reducers/ast";
@@ -59,8 +60,11 @@ export function shouldPrettyPrint(source: Source) {
   const _isJavaScript = isJavaScript(source);
   const isOriginal = isOriginalId(source.id);
   const hasSourceMap = source.sourceMapURL;
+  const sourceMapsEnabled = prefs.clientSourceMapsEnabled;
 
-  if (_isPretty || isOriginal || hasSourceMap || !_isJavaScript) {
+  const options = [_isPretty, !_isJavaScript, isOriginal, hasSourceMap, sourceMapsEnabled];
+
+  if (options.some(Boolean)) {
     return false;
   }
 

--- a/src/utils/source.js
+++ b/src/utils/source.js
@@ -17,7 +17,7 @@ import { parse as parseURL } from "url";
 import { getUnicodeUrl } from "devtools-modules";
 export { isMinified } from "./isMinified";
 import { getURL, getFileExtension } from "./sources-tree";
-import { prefs } from './prefs';
+import { prefs } from "./prefs";
 
 import type { Source, Location } from "../types";
 import type { SourceMetaDataType } from "../reducers/ast";
@@ -62,7 +62,13 @@ export function shouldPrettyPrint(source: Source) {
   const hasSourceMap = source.sourceMapURL;
   const sourceMapsEnabled = prefs.clientSourceMapsEnabled;
 
-  const options = [_isPretty, !_isJavaScript, isOriginal, hasSourceMap, sourceMapsEnabled];
+  const options = [
+    _isPretty,
+    !_isJavaScript,
+    isOriginal,
+    hasSourceMap,
+    sourceMapsEnabled
+  ];
 
   if (options.some(Boolean)) {
     return false;


### PR DESCRIPTION
Fixes Issue: #6605

### Summary of Changes

* Add `sourceMapsEnabled` check condition pretty-print condition.

I'm confused on how to test this, I'm running the debugger locally but I can't find settings like the way we do on Firefox. CC @jasonLaster help 😂 

