### PR TITLE
fix(search): highlight stays after deleting a search string

### DIFF
--- a/src/actions/file-search.js
+++ b/src/actions/file-search.js
@@ -5,6 +5,7 @@
 // @flow
 
 import {
+  clearSearch,
   find,
   findNext,
   findPrev,
@@ -94,17 +95,17 @@ export function searchContents(query: string, editor: Object) {
     const modifiers = getFileSearchModifiers(getState());
     const selectedSource = getSelectedSource(getState());
 
-    if (
-      !query ||
-      !editor ||
-      !selectedSource ||
-      !selectedSource.text ||
-      !modifiers
-    ) {
+    if (!editor || !selectedSource || !selectedSource.text || !modifiers) {
       return;
     }
 
     const ctx = { ed: editor, cm: editor.codeMirror };
+
+    if (!query) {
+      clearSearch(ctx.cm, query);
+      return;
+    }
+
     const _modifiers = modifiers.toJS();
     const matches = await getMatches(query, selectedSource.text, _modifiers);
 

--- a/src/actions/tests/file-search.spec.js
+++ b/src/actions/tests/file-search.spec.js
@@ -48,4 +48,14 @@ describe("file text search", () => {
     fileSearchModState = getFileSearchModifiers(getState());
     expect(fileSearchModState.get("caseSensitive")).toBe(true);
   });
+
+  it("should toggle a file search query cleaning", () => {
+    const { dispatch, getState } = createStore();
+    dispatch(actions.setFileSearchQuery("foobar"));
+    let fileSearchQueryState = getFileSearchQuery(getState());
+    expect(fileSearchQueryState).toBe("foobar");
+    dispatch(actions.setFileSearchQuery(""));
+    fileSearchQueryState = getFileSearchQuery(getState());
+    expect(fileSearchQueryState).toBe("");
+  });
 });

--- a/src/utils/editor/source-search.js
+++ b/src/utils/editor/source-search.js
@@ -274,7 +274,7 @@ export function removeOverlay(ctx: any, query: string) {
  * @memberof utils/source-search
  * @static
  */
-export function clearSearch(cm, query: string) {
+export function clearSearch(cm: any, query: string) {
   const state = getSearchState(cm, query);
 
   state.results = [];

--- a/src/utils/editor/source-search.js
+++ b/src/utils/editor/source-search.js
@@ -274,7 +274,7 @@ export function removeOverlay(ctx: any, query: string) {
  * @memberof utils/source-search
  * @static
  */
-function clearSearch(cm, query: string) {
+export function clearSearch(cm, query: string) {
   const state = getSearchState(cm, query);
 
   state.results = [];


### PR DESCRIPTION
Fixes Issue: #6608

### Summary of Changes

During the file search, instead of simply ignoring the case where the search string is empty, I call the clearSearch function which is imported from source-search.js.

### Test Plan

- [x] Open a source
- [x] Open the search bar
- [x] Type a word that can be found in the file
- [x] Delete it
- [x] Highlights are gone