### PR TITLE
Add types to parser worker methods

### DIFF
--- a/packages/devtools-utils/src/worker-utils.js
+++ b/packages/devtools-utils/src/worker-utils.js
@@ -18,7 +18,7 @@ function WorkerDispatcher() {
 }
 
 WorkerDispatcher.prototype = {
-  start(url, win = window) {
+  start(url: string, win = window) {
     this.worker = new win.Worker(url);
     this.worker.onerror = () => {
       console.error(`Error in worker ${url}`);
@@ -34,7 +34,10 @@ WorkerDispatcher.prototype = {
     this.worker = null;
   },
 
-  task(method, { queue = false } = {}) {
+  task(
+    method: string,
+    { queue = false } = {}
+  ): (...args: any[]) => Promise<any> {
     const calls = [];
     const push = (args: Array<any>) => {
       return new Promise((resolve, reject) => {
@@ -91,6 +94,10 @@ WorkerDispatcher.prototype = {
     };
 
     return (...args: any) => push(args);
+  },
+
+  invoke(method: string, ...args: any[]): Promise<any> {
+    return this.task(method)(...args);
   }
 };
 

--- a/src/actions/ast.js
+++ b/src/actions/ast.js
@@ -20,7 +20,8 @@ import {
   getSymbols,
   findOutOfScopeLocations,
   getFramework,
-  getPausePoints
+  getPausePoints,
+  type AstPosition
 } from "../workers/parser";
 
 import { PROMISE } from "./utils/middleware/promise";
@@ -38,7 +39,9 @@ export function setSourceMetaData(sourceId: SourceId) {
     }
 
     const framework = await getFramework(source.id);
-    dispatch(updateTab(source, framework));
+    if (framework) {
+      dispatch(updateTab(source, framework));
+    }
 
     dispatch(
       ({
@@ -87,7 +90,10 @@ export function setOutOfScopeLocations() {
 
     let locations = null;
     if (location.line && source && !source.isWasm && isPaused(getState())) {
-      locations = await findOutOfScopeLocations(source.id, location);
+      locations = await findOutOfScopeLocations(
+        source.id,
+        ((location: any): AstPosition)
+      );
     }
 
     dispatch(
@@ -106,7 +112,7 @@ function compressPausePoints(pausePoints) {
     compressed[line] = {};
     for (const col in pausePoints[line]) {
       const point = pausePoints[line][col];
-      compressed[line][col] = (point.break && 1) | (point.step && 2);
+      compressed[line][col] = (point.break ? 1 : 0) | (point.step ? 2 : 0);
     }
   }
 

--- a/src/actions/tests/ast.spec.js
+++ b/src/actions/tests/ast.spec.js
@@ -171,7 +171,7 @@ describe("ast", () => {
         })
       );
 
-      await dispatch(actions.setOutOfScopeLocations("scopes.js"));
+      await dispatch(actions.setOutOfScopeLocations());
 
       await waitForState(store, state => getOutOfScopeLocations(state));
 

--- a/src/components/SecondaryPanes/Frames/Frame.js
+++ b/src/components/SecondaryPanes/Frames/Frame.js
@@ -28,7 +28,7 @@ type FrameLocationProps = { frame: LocalFrame };
 
 function FrameLocation({ frame }: FrameLocationProps) {
   if (!frame.source) {
-    return;
+    return null;
   }
 
   if (frame.library) {

--- a/src/reducers/ast.js
+++ b/src/reducers/ast.js
@@ -32,7 +32,7 @@ export type SymbolsMap = Map<string, Symbols>;
 export type EmptyLinesMap = Map<string, EmptyLinesType>;
 
 export type SourceMetaDataType = {
-  framework: string | void
+  framework: ?string
 };
 
 export type SourceMetaDataMap = Map<string, SourceMetaDataType>;
@@ -221,8 +221,10 @@ export function getPausePoint(
     return;
   }
 
-  const linePoints = pausePoints[line];
-  return linePoints && linePoints[column];
+  const linePoints = pausePoints[String(line)];
+  if (linePoints && column) {
+    return linePoints[String(column)];
+  }
 }
 
 export function hasPausePoints(state: OuterState, sourceId: string): boolean {

--- a/src/workers/parser/frameworks.js
+++ b/src/workers/parser/frameworks.js
@@ -2,10 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
+// @flow
+
 import * as t from "@babel/types";
 import { getSymbols } from "./getSymbols";
 
-export function getFramework(sourceId) {
+export function getFramework(sourceId: string): ?string {
   const sourceSymbols = getSymbols(sourceId);
 
   if (isReactComponent(sourceSymbols)) {

--- a/src/workers/parser/index.js
+++ b/src/workers/parser/index.js
@@ -7,30 +7,78 @@
 import { workerUtils } from "devtools-utils";
 const { WorkerDispatcher } = workerUtils;
 
-const dispatcher = new WorkerDispatcher();
-export const start = dispatcher.start.bind(dispatcher);
-export const stop = dispatcher.stop.bind(dispatcher);
+import type { AstLocation, AstPosition, PausePoints } from "./types";
+import type { Location, Source, SourceId } from "../../types";
+import type { SourceScope } from "./getScopes/visitor";
+import type { SymbolDeclarations } from "./getSymbols";
 
-export const getClosestExpression = dispatcher.task("getClosestExpression");
-export const getSymbols = dispatcher.task("getSymbols");
-export const getScopes = dispatcher.task("getScopes");
-export const findOutOfScopeLocations = dispatcher.task(
-  "findOutOfScopeLocations"
-);
-export const clearSymbols = dispatcher.task("clearSymbols");
-export const clearScopes = dispatcher.task("clearScopes");
-export const clearASTs = dispatcher.task("clearASTs");
-export const getNextStep = dispatcher.task("getNextStep");
-export const hasSource = dispatcher.task("hasSource");
-export const setSource = dispatcher.task("setSource");
-export const clearSources = dispatcher.task("clearSources");
-export const hasSyntaxError = dispatcher.task("hasSyntaxError");
-export const mapExpression = dispatcher.task("mapExpression");
-export const getFramework = dispatcher.task("getFramework");
-export const getPausePoints = dispatcher.task("getPausePoints");
-export const replaceOriginalVariableName = dispatcher.task(
-  "replaceOriginalVariableName"
-);
+const dispatcher = new WorkerDispatcher();
+export const start = (url: string) => dispatcher.start(url);
+export const stop = () => dispatcher.stop();
+
+export const findOutOfScopeLocations = async (
+  sourceId: string,
+  position: AstPosition
+): Promise<AstLocation[]> =>
+  dispatcher.invoke("findOutOfScopeLocations", sourceId, position);
+
+export const getNextStep = async (
+  sourceId: SourceId,
+  pausedPosition: AstPosition
+): Promise<?Location> =>
+  dispatcher.invoke("getNextStep", sourceId, pausedPosition);
+
+export const clearASTs = async (): Promise<void> =>
+  dispatcher.invoke("clearASTs");
+
+export const getScopes = async (location: Location): Promise<SourceScope[]> =>
+  dispatcher.invoke("getScopes", location);
+
+export const clearScopes = async (): Promise<void> =>
+  dispatcher.invoke("clearScopes");
+
+export const clearSymbols = async (): Promise<void> =>
+  dispatcher.invoke("clearSymbols");
+
+export const getSymbols = async (
+  sourceId: string
+): Promise<SymbolDeclarations> => dispatcher.invoke("getSymbols", sourceId);
+
+export const hasSource = async (sourceId: SourceId): Promise<Source> =>
+  dispatcher.invoke("hasSource", sourceId);
+
+export const setSource = async (source: Source): Promise<void> =>
+  dispatcher.invoke("setSource", source);
+
+export const clearSources = async (): Promise<void> =>
+  dispatcher.invoke("clearSources");
+
+export const hasSyntaxError = async (input: string): Promise<string | false> =>
+  dispatcher.invoke("hasSyntaxError", input);
+
+export const mapExpression = async (
+  expression: string,
+  mappings: {
+    [string]: string | null
+  } | null,
+  bindings: string[],
+  shouldMapBindings?: boolean,
+  shouldMapAwait?: boolean
+): Promise<{ expression: string }> =>
+  dispatcher.invoke(
+    "mapExpression",
+    expression,
+    mappings,
+    bindings,
+    shouldMapBindings,
+    shouldMapAwait
+  );
+
+export const getFramework = async (sourceId: string): Promise<?string> =>
+  dispatcher.invoke("getFramework", sourceId);
+
+export const getPausePoints = async (sourceId: string): Promise<PausePoints> =>
+  dispatcher.invoke("getPausePoints", sourceId);
 
 export type {
   SourceScope,

--- a/src/workers/parser/mapExpression.js
+++ b/src/workers/parser/mapExpression.js
@@ -12,7 +12,7 @@ export default function mapExpression(
   expression: string,
   mappings: {
     [string]: string | null
-  },
+  } | null,
   bindings: string[],
   shouldMapBindings: boolean = true,
   shouldMapAwait: boolean = true

--- a/src/workers/parser/pausePoints.js
+++ b/src/workers/parser/pausePoints.js
@@ -10,6 +10,7 @@ import isEqual from "lodash/isEqual";
 
 import type { BabelNode } from "@babel/types";
 import type { SimplePath } from "./utils/simple-path";
+import type { PausePoints } from "./types";
 
 const isForStatement = node =>
   t.isForStatement(node) || t.isForOfStatement(node);
@@ -69,7 +70,7 @@ function isFirstCall(node, parentNode, grandParentNode) {
   return children.find(child => isCall(child)) === node;
 }
 
-export function getPausePoints(sourceId: string) {
+export function getPausePoints(sourceId: string): PausePoints {
   const state = {};
   traverseAst(sourceId, { enter: onEnter }, state);
   return state;

--- a/src/workers/parser/steps.js
+++ b/src/workers/parser/steps.js
@@ -6,12 +6,15 @@
 
 import * as t from "@babel/types";
 import type { SimplePath } from "./utils/simple-path";
-import type { SourceId } from "../../types";
+import type { Location, SourceId } from "../../types";
 import type { AstPosition } from "./types";
 import { getClosestPath } from "./utils/closest";
 import { isAwaitExpression, isYieldExpression } from "./utils/helpers";
 
-export function getNextStep(sourceId: SourceId, pausedPosition: AstPosition) {
+export function getNextStep(
+  sourceId: SourceId,
+  pausedPosition: AstPosition
+): ?Location {
   const currentExpression = getSteppableExpression(sourceId, pausedPosition);
   if (!currentExpression) {
     return null;
@@ -53,7 +56,7 @@ function _getNextStep(
   statement: SimplePath,
   sourceId: string,
   position: AstPosition
-) {
+): ?Location {
   const nextStatement = statement.getSibling(1);
   if (nextStatement) {
     return {

--- a/src/workers/parser/types.js
+++ b/src/workers/parser/types.js
@@ -8,4 +8,4 @@ export type AstPosition = { line: number, column: number };
 export type AstLocation = { end: AstPosition, start: AstPosition };
 
 export type PausePoint = { break: boolean, step: boolean };
-export type PausePoints = { line: { column: PausePoint } };
+export type PausePoints = { [line: string]: { [column: string]: PausePoint } };

--- a/src/workers/parser/utils/simple-path.js
+++ b/src/workers/parser/utils/simple-path.js
@@ -136,7 +136,7 @@ class SimplePath {
     return this.parentPath.find(predicate);
   }
 
-  getSibling(offset: number) {
+  getSibling(offset: number): ?SimplePath {
     const { node, key, index } = this._ancestor;
 
     if (typeof index !== "number") {

--- a/src/workers/parser/validate.js
+++ b/src/workers/parser/validate.js
@@ -6,7 +6,7 @@
 
 import { parseScript } from "./utils/ast";
 
-export function hasSyntaxError(input: string) {
+export function hasSyntaxError(input: string): string | false {
   try {
     parseScript(input);
     return false;


### PR DESCRIPTION
Fixes Issue: #<issue number>

I had discussed a couple options for typing the functions. The first, using a generic `Task` type, worked fine for flow typing and was more terse but didn't give useful information to developers (e.g. the flow tooltip in vscode) because it only presented the generic (e.g. `Task<[SourceId], string>`) which required understanding of the generic.

The second option is to document the function signature explicitly (e.g. `(sourceId: SourceId) => Promise<string>`). While more verbose, the type support is identical and provides a better DX so was chosen for this PR.

### Summary of Changes

* Adds types to dispatcher tasks for the parser worker
* Fixes a few related type issues
* Removes `replaceOriginalVariableName` and `getClosestExpression` worker exports which do not appear to be exist/referenced.

### Screenshots/Videos (OPTIONAL)

From VS Code, the first line of the tooltip shows the default typing for a dispatcher task which is what would be used for a task that hadn't had typing defined for it. I'm not sure why VS code displays it here. The second line (under [Flow]) shows the actual typing for this method as seen by Flow.

<img width="620" alt="image" src="https://user-images.githubusercontent.com/788456/42574740-c39df370-84e4-11e8-91e6-60fb36f5641b.png">

