### PR TITLE
Revert breakpoint hover effect

### DIFF
--- a/src/components/Editor/Editor.css
+++ b/src/components/Editor/Editor.css
@@ -51,32 +51,6 @@ html[dir="rtl"] .editor-mount {
   direction: ltr;
 }
 
-.theme-light {
-  --gutter-hover-background-color: #dde1e4;
-}
-
-.theme-dark {
-  --gutter-hover-background-color: #414141;
-}
-
-:not(.empty-line):not(.new-breakpoint) > .CodeMirror-gutter-wrapper:hover {
-  width: 60px;
-  height: 13px;
-  left: -55px !important;
-  background-color: var(--gutter-hover-background-color) !important;
-  mask: url(/images/breakpoint.svg) no-repeat;
-  mask-size: 100%;
-  mask-position: 0 1px;
-}
-
-:not(.empty-line):not(.new-breakpoint)
-  > .CodeMirror-gutter-wrapper:hover
-  > .CodeMirror-linenumber {
-  left: auto !important;
-  right: 6px;
-  color: var(--theme-body-color);
-}
-
 .editor-wrapper .breakpoints {
   position: absolute;
   top: 0;
@@ -122,11 +96,6 @@ html[dir="rtl"] .editor-mount {
   border-radius: 5px;
   border-color: blue;
   border: 1px solid #00b6ff;
-}
-
-.editor .breakpoint {
-  position: absolute;
-  right: -2px;
 }
 
 .editor.new-breakpoint.folding-enabled svg {


### PR DESCRIPTION
An awesome contributor made a valiant effort in creating a breakpoint hover effect in this PR:

https://github.com/devtools-html/debugger.html/pull/5979

Unfortunately it doesn't work properly when the editor is scrolled to the right (https://github.com/devtools-html/debugger.html/issues/6451) and creates a weird shifting side effect when code-folding is enabled.

Since neither the old debugger or Chrome have a hover effect, and this effect was just introduced a few months ago, I think it's safe to remove the hover effect for now and try a different solution.

