### PR TITLE
Add breakpoint hover effect in gutter

### DIFF
--- a/src/components/Editor/Editor.css
+++ b/src/components/Editor/Editor.css
@@ -59,22 +59,29 @@ html[dir="rtl"] .editor-mount {
   --gutter-hover-background-color: #414141;
 }
 
-:not(.empty-line):not(.new-breakpoint) > .CodeMirror-gutter-wrapper:hover {
-  width: 48px;
+:not(.empty-line):not(.new-breakpoint)
+  > .CodeMirror-gutter-wrapper:hover
+  > .CodeMirror-linenumber {
   height: 13px;
-  background-color: var(--gutter-hover-background-color) !important;
-  mask: url(/images/breakpoint.svg) no-repeat;
-  mask-size: 60px 14px;
-  mask-position: -13px 0px;
+  color: var(--theme-body-color);
+  /* Add 1px offset to the background to match it
+    with the actual breakpoint image dimensions */
+  background: linear-gradient(to bottom, transparent 1px, var(--gutter-hover-background-color) 0);
 }
 
 :not(.empty-line):not(.new-breakpoint)
   > .CodeMirror-gutter-wrapper:hover
-  > .CodeMirror-linenumber {
-  left: auto !important;
-  right: 6px;
-  color: var(--theme-body-color);
-}
+  > .CodeMirror-linenumber::after {
+    content: '';
+    position: absolute;
+    top: 1px;
+    height: 12px;
+    width: 9px;
+    background-color: var(--gutter-hover-background-color);
+    mask: url('/images/breakpoint.svg') no-repeat;
+    mask-size: auto 12px;
+    mask-position: right;
+  }
 
 .editor-wrapper .breakpoints {
   position: absolute;

--- a/src/components/Editor/Editor.css
+++ b/src/components/Editor/Editor.css
@@ -51,6 +51,31 @@ html[dir="rtl"] .editor-mount {
   direction: ltr;
 }
 
+.theme-light {
+  --gutter-hover-background-color: #dde1e4;
+}
+
+.theme-dark {
+  --gutter-hover-background-color: #414141;
+}
+
+:not(.empty-line):not(.new-breakpoint) > .CodeMirror-gutter-wrapper:hover {
+  width: 48px;
+  height: 13px;
+  background-color: var(--gutter-hover-background-color) !important;
+  mask: url(/images/breakpoint.svg) no-repeat;
+  mask-size: 60px 14px;
+  mask-position: -13px 0px;
+}
+
+:not(.empty-line):not(.new-breakpoint)
+  > .CodeMirror-gutter-wrapper:hover
+  > .CodeMirror-linenumber {
+  left: auto !important;
+  right: 6px;
+  color: var(--theme-body-color);
+}
+
 .editor-wrapper .breakpoints {
   position: absolute;
   top: 0;
@@ -96,6 +121,11 @@ html[dir="rtl"] .editor-mount {
   border-radius: 5px;
   border-color: blue;
   border: 1px solid #00b6ff;
+}
+
+.editor .breakpoint {
+    position: absolute;
+    right: -2px;
 }
 
 .editor.new-breakpoint.folding-enabled svg {


### PR DESCRIPTION
Fixes Issue: #5603, #6627

Here's the Pull Request Doc
https://firefox-dev.tools/debugger.html/docs/pull-requests.html

### Summary of Changes
Add grey hover effect to the breakpoints in gutter

### Test Plan

* Open a JS file.
* Hover over the gutter line numbers.
* Line numbers should be highlighted.
* Empty lines shouldn't be highlighted.
* Existing breakpoints shouldn't be highlighted.

### Screenshots/Videos

#### Before:
![before](https://user-images.githubusercontent.com/21006120/42631268-551b4a1a-85f7-11e8-998e-2763869f553f.gif)

#### After:
![ff](https://user-images.githubusercontent.com/21006120/42631299-7286e212-85f7-11e8-8f58-9cc10d9cf920.gif)


