### PR TITLE
Enable code-folding and always show markers

### DIFF
--- a/assets/panel/prefs.js
+++ b/assets/panel/prefs.js
@@ -57,7 +57,7 @@ pref("devtools.debugger.features.remove-command-bar-options", false);
 pref("devtools.debugger.features.workers", true);
 pref("devtools.debugger.features.code-coverage", false);
 pref("devtools.debugger.features.event-listeners", false);
-pref("devtools.debugger.features.code-folding", false);
+pref("devtools.debugger.features.code-folding", true);
 pref("devtools.debugger.features.outline", true);
 pref("devtools.debugger.features.replay", false);
 pref("devtools.debugger.features.pause-points", true);

--- a/src/components/Editor/Editor.css
+++ b/src/components/Editor/Editor.css
@@ -218,10 +218,6 @@ debug-expression-error {
   }
 }
 
-.CodeMirror-guttermarker-subtle {
-  visibility: hidden;
-}
-
 .visible {
   visibility: visible;
 }

--- a/src/utils/editor/tests/__snapshots__/create-editor.spec.js.snap
+++ b/src/utils/editor/tests/__snapshots__/create-editor.spec.js.snap
@@ -31,7 +31,7 @@ Object {
 
 exports[`createEditor Returns a SourceEditor 1`] = `
 Object {
-  "enableCodeFolding": false,
+  "enableCodeFolding": true,
   "extraKeys": Object {
     "Cmd-F": false,
     "Cmd-G": false,
@@ -39,11 +39,12 @@ Object {
     "Ctrl-G": false,
     "Esc": false,
   },
-  "foldGutter": false,
+  "foldGutter": true,
   "gutters": Array [
     "breakpoints",
     "hit-markers",
     "CodeMirror-linenumbers",
+    "CodeMirror-foldgutter",
   ],
   "lineNumbers": true,
   "lineWrapping": false,

--- a/src/utils/prefs.js
+++ b/src/utils/prefs.js
@@ -48,7 +48,7 @@ if (isDevelopment()) {
   pref("devtools.debugger.features.remove-command-bar-options", true);
   pref("devtools.debugger.features.code-coverage", false);
   pref("devtools.debugger.features.event-listeners", false);
-  pref("devtools.debugger.features.code-folding", false);
+  pref("devtools.debugger.features.code-folding", true);
   pref("devtools.debugger.features.outline", true);
   pref("devtools.debugger.features.column-breakpoints", true);
   pref("devtools.debugger.features.replay", true);


### PR DESCRIPTION
I did a very scientific poll and people seem to like this feature:

https://twitter.com/davidwalshblog/status/1017040616025452544

This PR enables code-folding and always shows markers.  The default behavior is to only show when the row is hovered over, but the hit area on the arrow is small so it flickers.

My only beef with folding enabled is that the gutter now feels "noisy".  We could make the arrows .5 opacity to grey them out until hovered, but let's take this as a starting point:

<img width="373" alt="folding" src="https://user-images.githubusercontent.com/46655/42643658-5073de9c-85bf-11e8-91db-d1af7a8e0532.png">
