### PR TITLE
handle search for wasm files

### DIFF
--- a/src/actions/file-search.js
+++ b/src/actions/file-search.js
@@ -11,6 +11,7 @@ import {
   removeOverlay,
   searchSourceForHighlight
 } from "../utils/editor";
+import { isWasm, renderWasmText } from "../utils/wasm";
 import { getMatches } from "../workers/search";
 import type { Action, FileTextSearchModifier, ThunkArgs } from "./types";
 
@@ -106,7 +107,11 @@ export function searchContents(query: string, editor: Object) {
 
     const ctx = { ed: editor, cm: editor.codeMirror };
     const _modifiers = modifiers.toJS();
-    const matches = await getMatches(query, selectedSource.text, _modifiers);
+    const sourceId = selectedSource.id;
+    const text = isWasm(sourceId)
+      ? renderWasmText(sourceId, selectedSource.text).join("\n")
+      : selectedSource.text;
+    const matches = await getMatches(query, text, _modifiers);
 
     const res = find(ctx, query, true, _modifiers);
     if (!res) {

--- a/src/actions/file-search.js
+++ b/src/actions/file-search.js
@@ -111,6 +111,7 @@ export function searchContents(query: string, editor: Object) {
     const text = isWasm(sourceId)
       ? renderWasmText(sourceId, selectedSource.text).join("\n")
       : selectedSource.text;
+
     const matches = await getMatches(query, text, _modifiers);
 
     const res = find(ctx, query, true, _modifiers);

--- a/src/utils/wasm.js
+++ b/src/utils/wasm.js
@@ -137,7 +137,7 @@ export function clearWasmStates() {
   wasmStates = (Object.create(null): any);
 }
 
-export function renderWasmText(sourceId: string, { binary }: Object) {
+export function renderWasmText(sourceId: string, { binary }: any) {
   // binary does not survive as Uint8Array, converting from string
   const data = new Uint8Array(binary.length);
   for (let i = 0; i < data.length; i++) {


### PR DESCRIPTION
Fixes Issue: #6584

Quick fix

### Summary of Changes

* handle wasm sources

### Test Plan

Tell us a little a bit about how you tested your patch.

Example test plan:

1) Load http://janodvarko.cz/test/wasm/basic1/
2) Press `Load Module & Execute Exported Function` button
3) Go to the debugger and select `test.wasm` file
4) Press Ctrl+F (win) or ⌘⇧F (mac) to open an input field for searching in the current file
5) Type `module`
6) There is no result and the text turns red eve though the text is there -> BUG

### Screenshots/Videos (OPTIONAL)

![](http://g.recordit.co/0TuTQIuCbF.gif)