### PR TITLE
codeHealth(telemetry) retrieve session id from toolbox

### DIFF
--- a/assets/panel/panel.js
+++ b/assets/panel/panel.js
@@ -35,6 +35,7 @@ DebuggerPanel.prototype = {
       tabTarget: this.toolbox.target,
       debuggerClient: this.toolbox.target.client,
       sourceMaps: this.toolbox.sourceMapService,
+      sessionId: this.toolbox.session_id,
       toolboxActions: {
         // Open a link in a new browser tab.
         openLink: this.openLink.bind(this),

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -8,6 +8,7 @@ import * as firefox from "./firefox";
 
 import { prefs } from "../utils/prefs";
 import { setupHelper } from "../utils/dbg";
+import { setupTelemetry } from "../utils/telemetry";
 
 import {
   bootstrapApp,
@@ -27,7 +28,7 @@ function loadFromPrefs(actions: Object) {
 
 export async function onConnect(
   connection: Object,
-  { services, toolboxActions }: Object
+  { services, toolboxActions, sessionId }: Object
 ) {
   // NOTE: the landing page does not connect to a JS process
   if (!connection) {
@@ -40,6 +41,7 @@ export async function onConnect(
     toolboxActions
   });
 
+  setupTelemetry(sessionId);
   const workers = bootstrapWorkers();
   await firefox.onConnect(connection, actions);
   await loadFromPrefs(actions);

--- a/src/main.js
+++ b/src/main.js
@@ -25,6 +25,7 @@ if (isFirefoxPanel()) {
       tabTarget,
       debuggerClient,
       sourceMaps,
+      sessionId,
       toolboxActions
     }: any) => {
       return onConnect(
@@ -38,7 +39,8 @@ if (isFirefoxPanel()) {
         },
         {
           services: { sourceMaps },
-          toolboxActions
+          toolboxActions,
+          sessionId
         }
       );
     },

--- a/src/utils/telemetry.js
+++ b/src/utils/telemetry.js
@@ -46,23 +46,18 @@
 
 import { Telemetry } from "devtools-modules";
 
-const telemetry = new Telemetry();
+let telemetry = null;
+
+export function setupTelemetry(id: number) {
+  telemetry = new Telemetry(id);
+}
 
 /**
  * @memberof utils/telemetry
  * @static
  */
 export function recordEvent(eventName: string, fields: {} = {}) {
-  let sessionId = -1;
-
-  if (typeof window === "object" && window.parent.frameElement) {
-    sessionId = window.parent.frameElement.getAttribute("session_id");
-  }
-
   /* eslint-disable camelcase */
-  telemetry.recordEvent("devtools.main", eventName, "debugger", null, {
-    session_id: sessionId,
-    ...fields
-  });
+  telemetry.recordEvent("devtools.main", eventName, "debugger", null, fields);
   /* eslint-enable camelcase */
 }

--- a/src/utils/tests/telemetry.spec.js
+++ b/src/utils/tests/telemetry.spec.js
@@ -12,23 +12,22 @@ jest.mock("devtools-modules", () => {
 });
 
 import { Telemetry } from "devtools-modules";
-import { recordEvent } from "../telemetry";
+import { recordEvent, setupTelemetry } from "../telemetry";
 
-const telemetry = new Telemetry();
+const telemetry = new Telemetry(-1);
 
 describe("telemetry.recordEvent()", () => {
   it("Receives the correct telemetry information", () => {
+    setupTelemetry(-1);
     recordEvent("foo", {
       bar: 1
     });
-
     expect(telemetry.recordEvent).toHaveBeenCalledWith(
       "devtools.main",
       "foo",
       "debugger",
       null,
       {
-        session_id: -1,
         bar: 1
       }
     );


### PR DESCRIPTION
Fixes Issue: #6589

### Summary of Changes

I followed what jasonLaster proposed :

   1) the panel.js should get the sessionId
   2) onConnect should set the ID in the module
   3) the module should have the ID and the telemetry object
   4) telemetry instance has the ID


### Test Plan

See telemetry.spec.js : expect record event to be called without the session id.