### PR TITLE
Fix vendoring of lodash-move

### DIFF
--- a/src/reducers/sources.js
+++ b/src/reducers/sources.js
@@ -10,7 +10,7 @@
  */
 
 import { createSelector } from "reselect";
-import { move } from "lodash-move";
+import move from "lodash-move";
 import { getPrettySourceURL } from "../utils/source";
 import { originalToGeneratedId, isOriginalId } from "devtools-source-map";
 import { find } from "lodash";

--- a/src/vendors.js
+++ b/src/vendors.js
@@ -25,11 +25,11 @@ import * as fuzzaldrinPlus from "fuzzaldrin-plus";
 import * as transition from "react-transition-group/Transition";
 import * as reselect from "reselect";
 import * as url from "url";
-import * as lodashMove from "lodash-move";
 
 // Modules imported without destructuring
 import classnames from "classnames";
 import devtoolsSplitter from "devtools-splitter";
+import move from "lodash-move";
 import Svg from "./components/shared/Svg";
 
 // We cannot directly export literals containing special characters
@@ -46,7 +46,7 @@ export const vendored = {
   "devtools-splitter": devtoolsSplitter,
   "devtools-utils": devtoolsUtils,
   "fuzzaldrin-plus": fuzzaldrinPlus,
-  "lodash-move": lodashMove,
+  "lodash-move": move,
   "react-transition-group/Transition": transition,
   reselect,
   // Svg is required via relative paths, so the key is not imported path.


### PR DESCRIPTION
Fixes Issue: #6640

### Summary of Changes

* import lodash-move as `import move from "lodash-move"`
* import without destructuring in vendors.js

