### PR TITLE
Fix 5833 - Remove all breakpoints on a line

### DIFF
--- a/src/actions/breakpoints.js
+++ b/src/actions/breakpoints.js
@@ -429,28 +429,13 @@ export function toggleBreakpointsAtLine(line: number, column?: number) {
         addBreakpoint({
           sourceId: selectedSource.id,
           sourceUrl: selectedSource.url,
-          line: line,
-          column: column
+          line,
+          column
         })
       );
     }
 
-    const promises = bps.map(bp => {
-      if (bp.loading) {
-        return null;
-      }
-
-      return dispatch(
-        removeBreakpoint({
-          sourceId: bp.location.sourceId,
-          sourceUrl: bp.location.sourceUrl,
-          line: bp.location.line,
-          column: column || bp.location.column
-        })
-      );
-    });
-
-    return Promise.all(promises);
+    return Promise.all(bps.map(bp => dispatch(removeBreakpoint(bp.location))));
   };
 }
 

--- a/src/actions/breakpoints.js
+++ b/src/actions/breakpoints.js
@@ -14,7 +14,8 @@ import {
   getBreakpoint,
   getBreakpoints,
   getSelectedSource,
-  getBreakpointAtLocation
+  getBreakpointAtLocation,
+  getBreakpointsAtLine
 } from "../selectors";
 import { createBreakpoint, assertBreakpoint } from "../utils/breakpoint";
 import addBreakpointPromise from "./breakpoints/addBreakpoint";
@@ -404,6 +405,52 @@ export function toggleBreakpoint(line: ?number, column?: number) {
         column: column
       })
     );
+  };
+}
+
+export function toggleBreakpointsAtLine(line: number, column?: number) {
+  return ({ dispatch, getState, client, sourceMaps }: ThunkArgs) => {
+    const state = getState();
+    const selectedSource = getSelectedSource(state);
+
+    if (!line || !selectedSource) {
+      return;
+    }
+
+    const bps = getBreakpointsAtLine(state, line);
+    const isEmptyLine = isEmptyLineInSource(state, line, selectedSource.id);
+
+    if (isEmptyLine) {
+      return;
+    }
+
+    if (bps.size === 0) {
+      return dispatch(
+        addBreakpoint({
+          sourceId: selectedSource.id,
+          sourceUrl: selectedSource.url,
+          line: line,
+          column: column
+        })
+      );
+    }
+
+    const promises = bps.map(bp => {
+      if (bp.loading) {
+        return null;
+      }
+
+      return dispatch(
+        removeBreakpoint({
+          sourceId: bp.location.sourceId,
+          sourceUrl: bp.location.sourceUrl,
+          line: bp.location.line,
+          column: column || bp.location.column
+        })
+      );
+    });
+
+    return Promise.all(promises);
   };
 }
 

--- a/src/actions/breakpoints/tests/breakpoints.spec.js
+++ b/src/actions/breakpoints/tests/breakpoints.spec.js
@@ -6,8 +6,11 @@ import {
   createStore,
   selectors,
   actions,
-  makeSource
+  makeSource,
+  waitForState
 } from "../../../utils/test-head";
+
+import { generateBreakpoint } from "../../tests/helpers/breakpoints.js";
 
 import {
   simulateCorrectThreadClient,
@@ -346,5 +349,35 @@ describe("breakpoints", () => {
 
     expect(breakpoint.location.sourceUrl.includes("formatted")).toBe(true);
     expect(breakpoint).toMatchSnapshot();
+  });
+
+  describe("toggleBreakpointsAtLine", () => {
+    it("removes all breakpoints on a given line", async () => {
+      const store = createStore(simpleMockThreadClient);
+      const { dispatch } = store;
+
+      const source = makeSource("dw.js");
+      await dispatch(actions.newSources([source]));
+      await dispatch(actions.loadSourceText(makeSource("dw.js")));
+
+      await Promise.all([
+        dispatch(
+          actions.addBreakpoint(generateBreakpoint("dw.js", 5, 1).location)
+        ),
+        dispatch(
+          actions.addBreakpoint(generateBreakpoint("dw.js", 5, 2).location)
+        ),
+        dispatch(
+          actions.addBreakpoint(generateBreakpoint("dw.js", 5, 3).location)
+        )
+      ]);
+
+      await dispatch(actions.selectLocation({ sourceId: "dw.js" }));
+      await dispatch(actions.toggleBreakpointsAtLine(5));
+      await waitForState(
+        store,
+        state => selectors.getBreakpoints(state).size == 0
+      );
+    });
   });
 });

--- a/src/actions/tests/helpers/breakpoints.js
+++ b/src/actions/tests/helpers/breakpoints.js
@@ -27,12 +27,13 @@ export function mockPendingBreakpoint(overrides = {}) {
   };
 }
 
-export function generateBreakpoint(filename) {
+export function generateBreakpoint(filename, line = 5, column) {
   return {
     location: {
       sourceUrl: `http://localhost:8000/examples/${filename}`,
       sourceId: filename,
-      line: 5
+      line,
+      column
     },
     condition: null,
     disabled: false,

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -92,6 +92,7 @@ export type Props = {
   setContextMenu: (string, any) => void,
   continueToHere: (?number) => void,
   toggleBreakpoint: (?number) => void,
+  toggleBreakpointsAtLine: (?number) => void,
   addOrToggleDisabledBreakpoint: (?number) => void,
   jumpToMappedLocation: any => void,
   traverseResults: (boolean, Object) => void
@@ -335,7 +336,7 @@ class Editor extends PureComponent<Props, State> {
       conditionalPanelLine,
       closeConditionalPanel,
       addOrToggleDisabledBreakpoint,
-      toggleBreakpoint,
+      toggleBreakpointsAtLine,
       continueToHere
     } = this.props;
 
@@ -367,7 +368,7 @@ class Editor extends PureComponent<Props, State> {
       return addOrToggleDisabledBreakpoint(sourceLine);
     }
 
-    return toggleBreakpoint(sourceLine);
+    return toggleBreakpointsAtLine(sourceLine);
   };
 
   onGutterContextMenu = (event: MouseEvent) => {
@@ -628,6 +629,7 @@ export default connect(mapStateToProps, {
   setContextMenu: actions.setContextMenu,
   continueToHere: actions.continueToHere,
   toggleBreakpoint: actions.toggleBreakpoint,
+  toggleBreakpointsAtLine: actions.toggleBreakpointsAtLine,
   addOrToggleDisabledBreakpoint: actions.addOrToggleDisabledBreakpoint,
   jumpToMappedLocation: actions.jumpToMappedLocation,
   traverseResults: actions.traverseResults

--- a/src/selectors/breakpointAtLocation.js
+++ b/src/selectors/breakpointAtLocation.js
@@ -53,16 +53,6 @@ function findBreakpointAtLocation(
   });
 }
 
-function findBreakpointsAtLine(
-  breakpoints,
-  selectedSource: Source,
-  line: number
-) {
-  return breakpoints.filter(
-    breakpoint => getLocation(breakpoint, selectedSource).line === line
-  );
-}
-
 /*
  * Finds a breakpoint at a location (line, column) of the
  * selected source.
@@ -81,5 +71,7 @@ export function getBreakpointsAtLine(state: OuterState, line: number) {
   const selectedSource = getSelectedSource(state);
   const breakpoints = getBreakpointsForSource(state, selectedSource);
 
-  return findBreakpointsAtLine(breakpoints, selectedSource, line);
+  return breakpoints.filter(
+    breakpoint => getLocation(breakpoint, selectedSource).line === line
+  );
 }

--- a/src/selectors/breakpointAtLocation.js
+++ b/src/selectors/breakpointAtLocation.js
@@ -53,6 +53,16 @@ function findBreakpointAtLocation(
   });
 }
 
+function findBreakpointsAtLine(
+  breakpoints,
+  selectedSource: Source,
+  line: number
+) {
+  return breakpoints.filter(
+    breakpoint => getLocation(breakpoint, selectedSource).line === line
+  );
+}
+
 /*
  * Finds a breakpoint at a location (line, column) of the
  * selected source.
@@ -65,4 +75,11 @@ export function getBreakpointAtLocation(state, location) {
   const breakpoints = getBreakpointsForSource(state, selectedSource);
 
   return findBreakpointAtLocation(breakpoints, selectedSource, location);
+}
+
+export function getBreakpointsAtLine(state: OuterState, line: number) {
+  const selectedSource = getSelectedSource(state);
+  const breakpoints = getBreakpointsForSource(state, selectedSource);
+
+  return findBreakpointsAtLine(breakpoints, selectedSource, line);
 }

--- a/src/selectors/index.js
+++ b/src/selectors/index.js
@@ -24,7 +24,10 @@ export {
   getQuickOpenType
 } from "../reducers/quick-open";
 
-export { getBreakpointAtLocation } from "./breakpointAtLocation";
+export {
+  getBreakpointAtLocation,
+  getBreakpointsAtLine
+} from "./breakpointAtLocation";
 export { getVisibleBreakpoints } from "./visibleBreakpoints";
 export { inComponent } from "./inComponent";
 export { isSelectedFrameVisible } from "./isSelectedFrameVisible";

--- a/src/test/mochitest/browser_dbg-breakpoints-actions.js
+++ b/src/test/mochitest/browser_dbg-breakpoints-actions.js
@@ -16,6 +16,6 @@ add_task(async function() {
   await addBreakpoint(dbg, "simple2", 3);
   await removeBreakpoint(dbg);
 
-  await waitForState(dbg, state => dbg.selectors.getBreakpoints(state).size == 0)
+  await waitForState(dbg, state => dbg.selectors.getBreakpoints(state).size == 0);
   ok("successfully removed the breakpoint")
 });

--- a/src/test/mochitest/browser_dbg-editor-gutter.js
+++ b/src/test/mochitest/browser_dbg-editor-gutter.js
@@ -52,7 +52,6 @@ add_task(async function() {
   await addBreakpoint(dbg, source, 4, 1);
   await addBreakpoint(dbg, source, 4, 2);
   clickGutter(dbg, 4);
-  await waitForDispatch(dbg, "REMOVE_BREAKPOINT", 3);
-  is(getBreakpoints(getState()).size, 0, "No breakpoints exist");
+  await waitForState(dbg, state => dbg.selectors.getBreakpoints(state).size == 0);
   assertEditorBreakpoint(dbg, 4, false);
 });

--- a/src/test/mochitest/browser_dbg-editor-gutter.js
+++ b/src/test/mochitest/browser_dbg-editor-gutter.js
@@ -46,4 +46,13 @@ add_task(async function() {
   await waitForDispatch(dbg, "REMOVE_BREAKPOINT");
   is(getBreakpoints(getState()).size, 0, "No breakpoints exist");
   assertEditorBreakpoint(dbg, 4, false);
+
+  // Ensure that clicking the gutter removes all breakpoints on a given line
+  await addBreakpoint(dbg, source, 4, 0);
+  await addBreakpoint(dbg, source, 4, 1);
+  await addBreakpoint(dbg, source, 4, 2);
+  clickGutter(dbg, 4);
+  await waitForDispatch(dbg, "REMOVE_BREAKPOINT", 3);
+  is(getBreakpoints(getState()).size, 0, "No breakpoints exist");
+  assertEditorBreakpoint(dbg, 4, false);
 });


### PR DESCRIPTION
Fixes Issue: #5833

There's a fair amount of repetition here but it's a good starting off point for discussion.  

## Testing
1.  Go to https://davidwalsh.name/ , open tab for `main.js`, pretty print it
2.  Create breakpoints at various lines in the pretty printed tab
3.  Switch over to the original `main.js` tab
4.  Click the breakpoint marker on line 1
5.  All breakpoint should disappear.