### PR TITLE
Don't show mapped source footer link when source is original

### DIFF
--- a/src/components/Editor/Footer.js
+++ b/src/components/Editor/Footer.js
@@ -5,6 +5,9 @@
 // @flow
 import React, { PureComponent } from "react";
 import { connect } from "react-redux";
+import { isOriginalId } from "devtools-source-map";
+import classnames from "classnames";
+
 import actions from "../../actions";
 import {
   getSelectedSource,
@@ -12,7 +15,6 @@ import {
   getPaneCollapse
 } from "../../selectors";
 
-import classnames from "classnames";
 import { features } from "../../utils/prefs";
 import { isPretty, isLoaded, getFilename } from "../../utils/source";
 import { getGeneratedSource } from "../../reducers/sources";
@@ -156,7 +158,7 @@ class SourceFooter extends PureComponent<Props> {
   renderSourceSummary() {
     const { mappedSource, jumpToMappedLocation, selectedSource } = this.props;
 
-    if (!mappedSource) {
+    if (!mappedSource || !isOriginalId(selectedSource.id)) {
       return null;
     }
 


### PR DESCRIPTION
Fixes Issue: #6643

In https://github.com/devtools-html/debugger.html/commit/8e773b9911579b4dfa114600c184b23b14612942#diff-701eb9ae1383078fc8b17995acdd81bbR341 we made a change to return the source instead of `null`, so now we need this check.