### PR TITLE
include breakpoint.svg

### DIFF
--- a/src/components/Editor/Editor.css
+++ b/src/components/Editor/Editor.css
@@ -66,22 +66,26 @@ html[dir="rtl"] .editor-mount {
   color: var(--theme-body-color);
   /* Add 1px offset to the background to match it
     with the actual breakpoint image dimensions */
-  background: linear-gradient(to bottom, transparent 1px, var(--gutter-hover-background-color) 0);
+  background: linear-gradient(
+    to bottom,
+    transparent 1px,
+    var(--gutter-hover-background-color) 0
+  );
 }
 
 :not(.empty-line):not(.new-breakpoint)
   > .CodeMirror-gutter-wrapper:hover
   > .CodeMirror-linenumber::after {
-    content: '';
-    position: absolute;
-    top: 1px;
-    height: 12px;
-    width: 9px;
-    background-color: var(--gutter-hover-background-color);
-    mask: url('/images/breakpoint.svg') no-repeat;
-    mask-size: auto 12px;
-    mask-position: right;
-  }
+  content: "";
+  position: absolute;
+  top: 1px;
+  height: 12px;
+  width: 9px;
+  background-color: var(--gutter-hover-background-color);
+  mask: url(/images/breakpoint.svg) no-repeat;
+  mask-size: auto 12px;
+  mask-position: right;
+}
 
 .editor-wrapper .breakpoints {
   position: absolute;
@@ -131,8 +135,8 @@ html[dir="rtl"] .editor-mount {
 }
 
 .editor .breakpoint {
-    position: absolute;
-    right: -2px;
+  position: absolute;
+  right: -2px;
 }
 
 .editor.new-breakpoint.folding-enabled svg {

--- a/src/components/Editor/Editor.css
+++ b/src/components/Editor/Editor.css
@@ -66,7 +66,8 @@ html[dir="rtl"] .editor-mount {
   color: var(--theme-body-color);
   /* Add 1px offset to the background to match it
     with the actual breakpoint image dimensions */
-  background: linear-gradient(
+  background:
+  linear-gradient(
     to bottom,
     transparent 1px,
     var(--gutter-hover-background-color) 0


### PR DESCRIPTION
### Summary of Changes

- The quotes were keeping the svg from being copied from github ` mask: url('/images/breakpoint.svg') no-repeat;`
- the rest was just prettier