### PR TITLE
Solves issue 6005 - files with same filename

### DIFF
--- a/src/components/Editor/Tab.js
+++ b/src/components/Editor/Tab.js
@@ -21,7 +21,7 @@ import {
   getFileURL,
   getRawSourceURL,
   getTruncatedFileName,
-  getPath,
+  getDisplayPath,
   isPretty
 } from "../../utils/source";
 import { copyToTheClipboard } from "../../utils/clipboard";
@@ -195,7 +195,7 @@ class Tab extends PureComponent<Props> {
           shouldHide={icon => ["file", "javascript"].includes(icon)}
         />
         <div className="filename">
-          {[getTruncatedFileName(source), getPath(source, tabSources)]
+          {[getTruncatedFileName(source), getDisplayPath(source, tabSources)]
             .filter(Boolean)
             .join("\u2014")}
         </div>

--- a/src/components/Editor/Tab.js
+++ b/src/components/Editor/Tab.js
@@ -20,7 +20,7 @@ import actions from "../../actions";
 import {
   getFileURL,
   getRawSourceURL,
-  getTruncatedFileName,
+  getUniqueFileName,
   isPretty
 } from "../../utils/source";
 import { copyToTheClipboard } from "../../utils/clipboard";
@@ -149,7 +149,8 @@ class Tab extends PureComponent<Props> {
       selectedSource,
       selectSpecificSource,
       closeTab,
-      source
+      source,
+      tabSources
     } = this.props;
     const sourceId = source.id;
     const active =
@@ -192,7 +193,7 @@ class Tab extends PureComponent<Props> {
           source={source}
           shouldHide={icon => ["file", "javascript"].includes(icon)}
         />
-        <div className="filename">{getTruncatedFileName(source)}</div>
+        <div className="filename">{getUniqueFileName(source, tabSources)}</div>
         <CloseButton
           handleClick={onClickClose}
           tooltip={L10N.getStr("sourceTabs.closeTabButtonTooltip")}

--- a/src/components/Editor/Tab.js
+++ b/src/components/Editor/Tab.js
@@ -198,7 +198,7 @@ class Tab extends PureComponent<Props> {
         />
         <div className="filename">
           {getTruncatedFileName(source)}
-          {path && <span>{`../${getDisplayPath(source, tabSources)}/..`}</span>}
+          {path && <span>{`../${path}/..`}</span>}
         </div>
         <CloseButton
           handleClick={onClickClose}

--- a/src/components/Editor/Tab.js
+++ b/src/components/Editor/Tab.js
@@ -20,7 +20,8 @@ import actions from "../../actions";
 import {
   getFileURL,
   getRawSourceURL,
-  getUniqueFileName,
+  getTruncatedFileName,
+  getPath,
   isPretty
 } from "../../utils/source";
 import { copyToTheClipboard } from "../../utils/clipboard";
@@ -193,7 +194,11 @@ class Tab extends PureComponent<Props> {
           source={source}
           shouldHide={icon => ["file", "javascript"].includes(icon)}
         />
-        <div className="filename">{getUniqueFileName(source, tabSources)}</div>
+        <div className="filename">
+          {[getTruncatedFileName(source), getPath(source, tabSources)]
+            .filter(Boolean)
+            .join("\u2014")}
+        </div>
         <CloseButton
           handleClick={onClickClose}
           tooltip={L10N.getStr("sourceTabs.closeTabButtonTooltip")}

--- a/src/components/Editor/Tab.js
+++ b/src/components/Editor/Tab.js
@@ -182,6 +182,8 @@ class Tab extends PureComponent<Props> {
       pretty: isPrettyCode
     });
 
+    const path = getDisplayPath(source, tabSources);
+
     return (
       <div
         className={className}
@@ -195,9 +197,8 @@ class Tab extends PureComponent<Props> {
           shouldHide={icon => ["file", "javascript"].includes(icon)}
         />
         <div className="filename">
-          {[getTruncatedFileName(source), getDisplayPath(source, tabSources)]
-            .filter(Boolean)
-            .join("\u2014")}
+          {getTruncatedFileName(source)}
+          {path && <span>{`../${getDisplayPath(source, tabSources)}/..`}</span>}
         </div>
         <CloseButton
           handleClick={onClickClose}

--- a/src/components/Editor/Tabs.css
+++ b/src/components/Editor/Tabs.css
@@ -131,6 +131,11 @@ html[dir="rtl"] img.moreTabs {
   align-self: center;
 }
 
+.source-tab .filename span {
+  opacity: 0.7;
+  padding-left: 4px;
+}
+
 .source-tab .close-btn {
   visibility: hidden;
   line-height: 0;

--- a/src/components/SecondaryPanes/Breakpoints/Breakpoints.css
+++ b/src/components/SecondaryPanes/Breakpoints/Breakpoints.css
@@ -22,6 +22,12 @@
   align-items: center;
 }
 
+.breakpoints-list .breakpoint-heading .filename span {
+  opacity: 0.7;
+  padding-left: 4px;
+}
+
+
 /* temporary until we refactor the sources tree and tab icon styles */
 .breakpoints-list .breakpoint-heading .source-icon.file {
   top: 0;

--- a/src/components/SecondaryPanes/Breakpoints/Breakpoints.css
+++ b/src/components/SecondaryPanes/Breakpoints/Breakpoints.css
@@ -27,7 +27,6 @@
   padding-left: 4px;
 }
 
-
 /* temporary until we refactor the sources tree and tab icon styles */
 .breakpoints-list .breakpoint-heading .source-icon.file {
   top: 0;

--- a/src/components/SecondaryPanes/Breakpoints/index.js
+++ b/src/components/SecondaryPanes/Breakpoints/index.js
@@ -112,7 +112,9 @@ class Breakpoints extends Component<Props> {
             />
             <div className="filename">
               {getTruncatedFileName(source)}
-              {path && <span>{`../${getDisplayPath(source, sources)}/..`}</span>}
+              {path && (
+                <span>{`../${getDisplayPath(source, sources)}/..`}</span>
+              )}
             </div>
           </div>,
           ...breakpoints.map(breakpoint => (

--- a/src/components/SecondaryPanes/Breakpoints/index.js
+++ b/src/components/SecondaryPanes/Breakpoints/index.js
@@ -14,7 +14,7 @@ import SourceIcon from "../../shared/SourceIcon";
 import actions from "../../../actions";
 import {
   getTruncatedFileName,
-  getPath,
+  getDisplayPath,
   getRawSourceURL
 } from "../../../utils/source";
 import { makeLocationId } from "../../../utils/breakpoint";
@@ -108,7 +108,7 @@ class Breakpoints extends Component<Props> {
             source={source}
             shouldHide={icon => ["file", "javascript"].includes(icon)}
           />
-          {[getTruncatedFileName(source), getPath(source, sources)]
+          {[getTruncatedFileName(source), getDisplayPath(source, sources)]
             .filter(Boolean)
             .join("\u2014")}
         </div>,

--- a/src/components/SecondaryPanes/Breakpoints/index.js
+++ b/src/components/SecondaryPanes/Breakpoints/index.js
@@ -97,29 +97,33 @@ class Breakpoints extends Component<Props> {
     ];
 
     return [
-      ...breakpointSources.map(({ source, breakpoints }) => [
-        <div
-          className="breakpoint-heading"
-          title={getRawSourceURL(source.url)}
-          key={source.url}
-          onClick={() => this.props.selectSource(source.id)}
-        >
-          <SourceIcon
-            source={source}
-            shouldHide={icon => ["file", "javascript"].includes(icon)}
-          />
-          {[getTruncatedFileName(source), getDisplayPath(source, sources)]
-            .filter(Boolean)
-            .join("\u2014")}
-        </div>,
-        ...breakpoints.map(breakpoint => (
-          <Breakpoint
-            breakpoint={breakpoint}
-            source={source}
-            key={makeLocationId(breakpoint.location)}
-          />
-        ))
-      ])
+      ...breakpointSources.map(({ source, breakpoints, i }) => {
+        const path = getDisplayPath(source, sources);
+        return [
+          <div
+            className="breakpoint-heading"
+            title={getRawSourceURL(source.url)}
+            key={source.url}
+            onClick={() => this.props.selectSource(source.id)}
+          >
+            <SourceIcon
+              source={source}
+              shouldHide={icon => ["file", "javascript"].includes(icon)}
+            />
+            <div className="filename">
+              {getTruncatedFileName(source)}
+              {path && <span>{`../${getDisplayPath(source, sources)}/..`}</span>}
+            </div>
+          </div>,
+          ...breakpoints.map(breakpoint => (
+            <Breakpoint
+              breakpoint={breakpoint}
+              source={source}
+              key={makeLocationId(breakpoint.location)}
+            />
+          ))
+        ];
+      })
     ];
   }
 

--- a/src/components/SecondaryPanes/Breakpoints/index.js
+++ b/src/components/SecondaryPanes/Breakpoints/index.js
@@ -12,7 +12,11 @@ import Breakpoint from "./Breakpoint";
 import SourceIcon from "../../shared/SourceIcon";
 
 import actions from "../../../actions";
-import { getUniqueFileName, getRawSourceURL } from "../../../utils/source";
+import {
+  getTruncatedFileName,
+  getPath,
+  getRawSourceURL
+} from "../../../utils/source";
 import { makeLocationId } from "../../../utils/breakpoint";
 
 import { getSelectedSource, getBreakpointSources } from "../../../selectors";
@@ -104,7 +108,9 @@ class Breakpoints extends Component<Props> {
             source={source}
             shouldHide={icon => ["file", "javascript"].includes(icon)}
           />
-          {getUniqueFileName(source, sources)}
+          {[getTruncatedFileName(source), getPath(source, sources)]
+            .filter(Boolean)
+            .join("\u2014")}
         </div>,
         ...breakpoints.map(breakpoint => (
           <Breakpoint

--- a/src/components/SecondaryPanes/Breakpoints/index.js
+++ b/src/components/SecondaryPanes/Breakpoints/index.js
@@ -112,9 +112,7 @@ class Breakpoints extends Component<Props> {
             />
             <div className="filename">
               {getTruncatedFileName(source)}
-              {path && (
-                <span>{`../${getDisplayPath(source, sources)}/..`}</span>
-              )}
+              {path && <span>{`../${path}/..`}</span>}
             </div>
           </div>,
           ...breakpoints.map(breakpoint => (

--- a/src/components/SecondaryPanes/Breakpoints/index.js
+++ b/src/components/SecondaryPanes/Breakpoints/index.js
@@ -12,7 +12,7 @@ import Breakpoint from "./Breakpoint";
 import SourceIcon from "../../shared/SourceIcon";
 
 import actions from "../../../actions";
-import { getTruncatedFileName, getRawSourceURL } from "../../../utils/source";
+import { getUniqueFileName, getRawSourceURL } from "../../../utils/source";
 import { makeLocationId } from "../../../utils/breakpoint";
 
 import { getSelectedSource, getBreakpointSources } from "../../../selectors";
@@ -88,6 +88,9 @@ class Breakpoints extends Component<Props> {
 
   renderBreakpoints() {
     const { breakpointSources } = this.props;
+    const sources = [
+      ...breakpointSources.map(({ source, breakpoints }) => source)
+    ];
 
     return [
       ...breakpointSources.map(({ source, breakpoints }) => [
@@ -101,7 +104,7 @@ class Breakpoints extends Component<Props> {
             source={source}
             shouldHide={icon => ["file", "javascript"].includes(icon)}
           />
-          {getTruncatedFileName(source)}
+          {getUniqueFileName(source, sources)}
         </div>,
         ...breakpoints.map(breakpoint => (
           <Breakpoint

--- a/src/reducers/sources.js
+++ b/src/reducers/sources.js
@@ -10,7 +10,7 @@
  */
 
 import { createSelector } from "reselect";
-import move from "lodash-move";
+import { move } from "lodash-move";
 import { getPrettySourceURL } from "../utils/source";
 import { originalToGeneratedId, isOriginalId } from "devtools-source-map";
 import { find } from "lodash";

--- a/src/reducers/sources.js
+++ b/src/reducers/sources.js
@@ -10,7 +10,7 @@
  */
 
 import { createSelector } from "reselect";
-import { move } from "lodash-move";
+import move from "lodash-move";
 import { getPrettySourceURL } from "../utils/source";
 import { originalToGeneratedId, isOriginalId } from "devtools-source-map";
 import { find } from "lodash";

--- a/src/utils/source.js
+++ b/src/utils/source.js
@@ -176,7 +176,7 @@ export function getTruncatedFileName(source: Source, length: number = 30) {
  * @static
  */
 
-export function getUniqueFileName(mySource: Source, sources: Sources) {
+export function getUniqueFileName(mySource: Source, sources: Source[]) {
   const myFileName = getFilename(mySource);
 
   let myPathSegments;

--- a/src/utils/source.js
+++ b/src/utils/source.js
@@ -182,6 +182,9 @@ export function getUniqueFileName(mySource: Source, sources: Source[]) {
   let myPathSegments;
   const openEditorPathSegmentsWithSameFilename = [];
   for (const source of sources) {
+    if (!source.url) {
+      continue;
+    }
     const fileName = getFilename(source);
     if (fileName === myFileName) {
       const idx = source.url.lastIndexOf("/");

--- a/src/utils/source.js
+++ b/src/utils/source.js
@@ -169,6 +169,51 @@ export function getTruncatedFileName(source: Source, length: number = 30) {
   return truncateMiddleText(getFilename(source), length);
 }
 
+/* Show a source url's unique filename for editor tabs, breakpoints, etc.
+ * Pass the url of file, and the list of file urls
+ *
+ * @memberof utils/source
+ * @static
+ */
+
+export function getUniqueFileName(mySource: Source, sources: Sources) {
+  const myFileName = getFilename(mySource);
+
+  let myPathSegments;
+  const openEditorPathSegmentsWithSameFilename = [];
+  for (const source of sources) {
+    const fileName = getFilename(source);
+    if (fileName === myFileName) {
+      const idx = source.url.lastIndexOf("/");
+      const pathSegments = source.url.slice(0, idx).split("/");
+      openEditorPathSegmentsWithSameFilename.push(pathSegments);
+      if (source.url === mySource.url) {
+        myPathSegments = pathSegments;
+      }
+    }
+  }
+
+  if (!myPathSegments || openEditorPathSegmentsWithSameFilename.length === 1) {
+    return myFileName;
+  }
+
+  let commonPathSegmentCount;
+  for (let i = 0, { length } = myPathSegments; i < length; i++) {
+    const myPathSegment = myPathSegments[i];
+    if (
+      openEditorPathSegmentsWithSameFilename.some(
+        segments => segments.length === i + 1 || segments[i] !== myPathSegment
+      )
+    ) {
+      commonPathSegmentCount = i;
+      break;
+    }
+  }
+  return `${myFileName} \u2014 ${[
+    ...myPathSegments.slice(commonPathSegmentCount + 1)
+  ].join("/")}`;
+}
+
 /**
  * Gets a readable source URL for display purposes.
  * If the source does not have a URL, the source ID will be returned instead.

--- a/src/utils/source.js
+++ b/src/utils/source.js
@@ -169,52 +169,52 @@ export function getTruncatedFileName(source: Source, length: number = 30) {
   return truncateMiddleText(getFilename(source), length);
 }
 
-/* Show a source url's unique filename for editor tabs, breakpoints, etc.
- * Pass the url of file, and the list of file urls
+/* Gets path for files with same filename for editor tabs, breakpoints, etc.
+ * Pass the source, and list of other sources
  *
  * @memberof utils/source
  * @static
  */
 
-export function getUniqueFileName(mySource: Source, sources: Source[]) {
+export function getPath(mySource: Source, sources: Source[]) {
   const myFileName = getFilename(mySource);
-
+  const myUrl = mySource.url;
   let myPathSegments;
-  const openEditorPathSegmentsWithSameFilename = [];
+  const pathSegmentsWithSameFilename = [];
+
   for (const source of sources) {
-    if (!source.url) {
+    const { url } = source;
+    if (!url) {
       continue;
     }
     const fileName = getFilename(source);
     if (fileName === myFileName) {
-      const idx = source.url.lastIndexOf("/");
-      const pathSegments = source.url.slice(0, idx).split("/");
-      openEditorPathSegmentsWithSameFilename.push(pathSegments);
-      if (source.url === mySource.url) {
+      const idx = url.lastIndexOf("/");
+      const pathSegments = url.slice(0, idx).split("/");
+      pathSegmentsWithSameFilename.push(pathSegments);
+      if (url === myUrl) {
         myPathSegments = pathSegments;
       }
     }
   }
 
-  if (!myPathSegments || openEditorPathSegmentsWithSameFilename.length === 1) {
-    return myFileName;
+  if (!myPathSegments || pathSegmentsWithSameFilename.length === 1) {
+    return;
   }
 
   let commonPathSegmentCount;
   for (let i = 0, { length } = myPathSegments; i < length; i++) {
-    const myPathSegment = myPathSegments[i];
     if (
-      openEditorPathSegmentsWithSameFilename.some(
-        segments => segments.length === i + 1 || segments[i] !== myPathSegment
+      pathSegmentsWithSameFilename.some(
+        segments =>
+          segments.length === i + 1 || segments[i] !== myPathSegments[i]
       )
     ) {
       commonPathSegmentCount = i;
       break;
     }
   }
-  return `${myFileName} \u2014 ${[
-    ...myPathSegments.slice(commonPathSegmentCount + 1)
-  ].join("/")}`;
+  return `${[...myPathSegments.slice(commonPathSegmentCount + 1)].join("/")}`;
 }
 
 /**

--- a/src/utils/source.js
+++ b/src/utils/source.js
@@ -176,7 +176,7 @@ export function getTruncatedFileName(source: Source, length: number = 30) {
  * @static
  */
 
-export function getPath(mySource: Source, sources: Source[]) {
+export function getDisplayPath(mySource: Source, sources: Source[]) {
   const myFileName = getFilename(mySource);
   const myUrl = mySource.url;
   let myPathSegments;

--- a/src/utils/tests/source.spec.js
+++ b/src/utils/tests/source.spec.js
@@ -6,6 +6,7 @@ import {
   getFilename,
   getTruncatedFileName,
   getFileURL,
+  getDisplayPath,
   getMode,
   getSourceLineCount,
   isThirdParty,
@@ -79,6 +80,84 @@ describe("sources", () => {
           30
         )
       ).toBe("測測測測測測測測測測測測測...測測測測測測測測測.html");
+    });
+  });
+
+  describe("getDisplayPath", () => {
+    it("should give us the path for files with same name", () => {
+      expect(
+        getDisplayPath(
+          {
+            url: "http://localhost.com:7999/increment/abc/hello.html",
+            id: ""
+          },
+          [
+            {
+              url: "http://localhost.com:7999/increment/xyz/hello.html",
+              id: ""
+            },
+            {
+              url: "http://localhost.com:7999/increment/abc/hello.html",
+              id: ""
+            },
+            {
+              url: "http://localhost.com:7999/increment/hello.html",
+              id: ""
+            }
+          ]
+        )
+      ).toBe("abc");
+    });
+
+    it(`should give us the path for files with same name
+      in directories with same name`, () => {
+      expect(
+        getDisplayPath(
+          {
+            url: "http://localhost.com:7999/increment/abc/web/hello.html",
+            id: ""
+          },
+          [
+            {
+              url: "http://localhost.com:7999/increment/xyz/web/hello.html",
+              id: ""
+            },
+            {
+              url: "http://localhost.com:7999/increment/abc/web/hello.html",
+              id: ""
+            },
+            {
+              url: "http://localhost.com:7999/increment/hello.html",
+              id: ""
+            }
+          ]
+        )
+      ).toBe("abc/web");
+    });
+
+    it("should give np path for files with unique name", () => {
+      expect(
+        getDisplayPath(
+          {
+            url: "http://localhost.com:7999/increment/abc/web.html",
+            id: ""
+          },
+          [
+            {
+              url: "http://localhost.com:7999/increment/xyz.html",
+              id: ""
+            },
+            {
+              url: "http://localhost.com:7999/increment/abc.html",
+              id: ""
+            },
+            {
+              url: "http://localhost.com:7999/increment/hello.html",
+              id: ""
+            }
+          ]
+        )
+      ).toBe(undefined);
     });
   });
 


### PR DESCRIPTION
Gets unique name with path for breakpoints

Fixes Issue: #6005

Here's the Pull Request Doc
https://firefox-dev.tools/debugger.html/docs/pull-requests.html

### Summary of Changes

* Show directories for files with same names in the breakpoint list

### Test Plan

* Open a project which has files with same filenames
* Add breakpoints in line of two files with same name, and one breakpoint in a file with unique filename
* Directory should be visible with the common filenames in the breakpoint list, and should not be visible in the file with unique filename

Example test plan:

- [x] Add breakpoints
- [x] Check breakpoint list for filenames with directories

Here's the Debugger's Testing doc
https://docs.google.com/document/d/1oBMRxV8A2ag2t22YsQOxTdEv0mXKzIg0tggJjRkU1S0/edit#.
Feel free to improve it!

### Screenshots/Videos (OPTIONAL)
<img width="936" alt="screen shot 2018-07-18 at 12 05 07 pm" src="https://user-images.githubusercontent.com/8366397/42864268-81685b68-8a83-11e8-87c4-5fcc39f7fd40.png">

