### PR TITLE
[Breakpoints] move actions file

### DIFF
--- a/src/actions/breakpoints/index.js
+++ b/src/actions/breakpoints/index.js
@@ -9,30 +9,30 @@
  * @module actions/breakpoints
  */
 
-import { PROMISE } from "./utils/middleware/promise";
+import { PROMISE } from "../utils/middleware/promise";
 import {
   getBreakpoint,
   getBreakpoints,
   getSelectedSource,
   getBreakpointAtLocation,
   getBreakpointsAtLine
-} from "../selectors";
-import { createBreakpoint, assertBreakpoint } from "../utils/breakpoint";
-import addBreakpointPromise from "./breakpoints/addBreakpoint";
-import remapLocations from "./breakpoints/remapLocations";
-import { isEmptyLineInSource } from "../reducers/ast";
+} from "../../selectors";
+import { createBreakpoint, assertBreakpoint } from "../../utils/breakpoint";
+import addBreakpointPromise from "../breakpoints/addBreakpoint";
+import remapLocations from "../breakpoints/remapLocations";
+import { isEmptyLineInSource } from "../../reducers/ast";
 
 // this will need to be changed so that addCLientBreakpoint is removed
-import { syncClientBreakpoint } from "./breakpoints/syncBreakpoint";
+import { syncClientBreakpoint } from "../breakpoints/syncBreakpoint";
 
-import type { ThunkArgs, Action } from "./types";
+import type { ThunkArgs, Action } from "../types";
 import type {
   Breakpoint,
   SourceId,
   PendingBreakpoint,
   Location
-} from "../types";
-import type { BreakpointsMap } from "../reducers/types";
+} from "../../types";
+import type { BreakpointsMap } from "../../reducers/types";
 
 type addBreakpointOptions = {
   condition?: string,

--- a/src/actions/breakpoints/index.js
+++ b/src/actions/breakpoints/index.js
@@ -17,101 +17,26 @@ import {
   getBreakpointAtLocation,
   getBreakpointsAtLine
 } from "../../selectors";
-import { createBreakpoint, assertBreakpoint } from "../../utils/breakpoint";
-import addBreakpointPromise from "../breakpoints/addBreakpoint";
-import remapLocations from "../breakpoints/remapLocations";
+import { assertBreakpoint } from "../../utils/breakpoint";
+import {
+  addBreakpoint,
+  addHiddenBreakpoint,
+  enableBreakpoint
+} from "./addBreakpoint";
+import remapLocations from "./remapLocations";
+import { syncBreakpoint } from "./syncBreakpoint";
 import { isEmptyLineInSource } from "../../reducers/ast";
 
 // this will need to be changed so that addCLientBreakpoint is removed
-import { syncClientBreakpoint } from "../breakpoints/syncBreakpoint";
 
 import type { ThunkArgs, Action } from "../types";
-import type {
-  Breakpoint,
-  SourceId,
-  PendingBreakpoint,
-  Location
-} from "../../types";
+import type { Breakpoint, Location } from "../../types";
 import type { BreakpointsMap } from "../../reducers/types";
 
 type addBreakpointOptions = {
   condition?: string,
   hidden?: boolean
 };
-
-/**
- * Syncing a breakpoint add breakpoint information that is stored, and
- * contact the server for more data.
- *
- * @memberof actions/breakpoints
- * @static
- * @param {String} $1.sourceId String  value
- * @param {PendingBreakpoint} $1.location PendingBreakpoint  value
- */
-export function syncBreakpoint(
-  sourceId: SourceId,
-  pendingBreakpoint: PendingBreakpoint
-) {
-  return async ({ dispatch, getState, client, sourceMaps }: ThunkArgs) => {
-    const response = await syncClientBreakpoint(
-      getState,
-      client,
-      sourceMaps,
-      sourceId,
-      pendingBreakpoint
-    );
-
-    if (!response) {
-      return;
-    }
-
-    const { breakpoint, previousLocation } = response;
-
-    return dispatch(
-      ({
-        type: "SYNC_BREAKPOINT",
-        breakpoint,
-        previousLocation
-      }: Action)
-    );
-  };
-}
-
-/**
- * Add a new breakpoint
- *
- * @memberof actions/breakpoints
- * @static
- * @param {String} $1.condition Conditional breakpoint condition value
- * @param {Boolean} $1.disabled Disable value for breakpoint value
- */
-
-export function addBreakpoint(
-  location: Location,
-  { condition, hidden }: addBreakpointOptions = {}
-) {
-  const breakpoint = createBreakpoint(location, { condition, hidden });
-  return ({ dispatch, getState, sourceMaps, client }: ThunkArgs) => {
-    return dispatch({
-      type: "ADD_BREAKPOINT",
-      breakpoint,
-      [PROMISE]: addBreakpointPromise(getState, client, sourceMaps, breakpoint)
-    });
-  };
-}
-
-/**
- * Add a new hidden breakpoint
- *
- * @memberOf actions/breakpoints
- * @param location
- * @return {function(ThunkArgs)}
- */
-export function addHiddenBreakpoint(location: Location) {
-  return ({ dispatch }: ThunkArgs) => {
-    return dispatch(addBreakpoint(location, { hidden: true }));
-  };
-}
 
 /**
  * Remove a single breakpoint
@@ -144,35 +69,6 @@ export function removeBreakpoint(location: Location) {
       breakpoint: bp,
       disabled: false,
       [PROMISE]: client.removeBreakpoint(bp.generatedLocation)
-    });
-  };
-}
-
-/**
- * Enabling a breakpoint
- * will reuse the existing breakpoint information that is stored.
- *
- * @memberof actions/breakpoints
- * @static
- * @param {Location} $1.location Location  value
- */
-export function enableBreakpoint(location: Location) {
-  return async ({ dispatch, getState, client, sourceMaps }: ThunkArgs) => {
-    const breakpoint = getBreakpoint(getState(), location);
-    if (!breakpoint || breakpoint.loading) {
-      return;
-    }
-
-    // To instantly reflect in the UI, we optimistically enable the breakpoint
-    const enabledBreakpoint = {
-      ...breakpoint,
-      disabled: false
-    };
-
-    return dispatch({
-      type: "ENABLE_BREAKPOINT",
-      breakpoint: enabledBreakpoint,
-      [PROMISE]: addBreakpointPromise(getState, client, sourceMaps, breakpoint)
     });
   };
 }
@@ -484,3 +380,5 @@ export function toggleDisabledBreakpoint(line: number, column?: number) {
     return dispatch(enableBreakpoint(bp.location));
   };
 }
+
+export { addBreakpoint, addHiddenBreakpoint, enableBreakpoint, syncBreakpoint };

--- a/src/actions/breakpoints/tests/syncing.spec.js
+++ b/src/actions/breakpoints/tests/syncing.spec.js
@@ -35,7 +35,7 @@ jest.mock("../../../utils/breakpoint/astBreakpointLocation", () => ({
 // eslint-disable-next-line
 import { findScopeByName } from "../../../utils/breakpoint/astBreakpointLocation";
 
-import { syncClientBreakpoint } from "../../breakpoints/syncBreakpoint.js";
+import { syncBreakpointPromise } from "../../breakpoints/syncBreakpoint.js";
 
 function setBreakpoint(location, condition) {
   const actualLocation = { ...location, line: location.line };
@@ -124,7 +124,7 @@ describe("loading the debugger", () => {
     const breakpoints = selectors.getBreakpoints(getState());
     expect(breakpoints.size).toBe(0);
     // manually sync
-    const update = await syncClientBreakpoint(
+    const update = await syncBreakpointPromise(
       getState,
       threadClient,
       sourceMaps,
@@ -155,7 +155,7 @@ describe("loading the debugger", () => {
     const breakpoints = selectors.getBreakpoints(getState());
     expect(breakpoints.size).toBe(0);
     // manually sync
-    const update = await syncClientBreakpoint(
+    const update = await syncBreakpointPromise(
       getState,
       threadClient,
       sourceMaps,
@@ -193,7 +193,7 @@ describe("reloading debuggee", () => {
     await dispatch(actions.addBreakpoint(loc1));
 
     // manually sync
-    const update = await syncClientBreakpoint(
+    const update = await syncBreakpointPromise(
       getState,
       threadClient,
       sourceMaps,
@@ -231,7 +231,7 @@ describe("reloading debuggee", () => {
     await dispatch(actions.newSource(reloadedSource));
 
     // manually sync
-    const update = await syncClientBreakpoint(
+    const update = await syncBreakpointPromise(
       getState,
       threadClient,
       sourceMaps,


### PR DESCRIPTION
### Summary of Changes

the goal here is to organize the breakpoint actions so that it is similar to sources and pause actions where each action is in its own module.

- moves the action file into the directory so it is easier to split up going forward
- moves the add and sync actions into their appropriate files