### PR TITLE
fix(popover) hitting esc closes popover

### DIFF
--- a/src/components/Editor/Preview/Popup.js
+++ b/src/components/Editor/Preview/Popup.js
@@ -124,6 +124,12 @@ export class Popup extends Component<Props, State> {
     }
   };
 
+  onKeyDown = (e: KeyboardEvent) => {
+    if (e.key === "Escape") {
+      this.props.onClose();
+    }
+  };
+
   getRoot() {
     const { expression, value, extra } = this.props;
 
@@ -331,6 +337,7 @@ export class Popup extends Component<Props, State> {
       <Popover
         targetPosition={popoverPos}
         onMouseLeave={this.onMouseLeave}
+        onKeyDown={this.onKeyDown}
         type={type}
         onPopoverCoords={this.onPopoverCoords}
         editorRef={editorRef}

--- a/src/components/shared/Popover.js
+++ b/src/components/shared/Popover.js
@@ -15,6 +15,7 @@ type Props = {
   children: ?React$Element<any>,
   onPopoverCoords: Function,
   onMouseLeave: (e: SyntheticMouseEvent<HTMLDivElement>) => void,
+  onKeyDown: (e: KeyboardEvent) => void,
   type?: "popover" | "tooltip"
 };
 
@@ -47,6 +48,7 @@ class Popover extends Component<Props, State> {
   static defaultProps = {
     onMouseLeave: () => {},
     onPopoverCoords: () => {},
+    onKeyDown: () => {},
     type: "popover"
   };
 
@@ -227,6 +229,7 @@ class Popover extends Component<Props, State> {
 
   renderPopover() {
     const { top, left, orientation, targetMid } = this.state.coords;
+    const { onMouseLeave, onKeyDown } = this.props;
     const arrow = this.getPopoverArrow(orientation, targetMid.x, targetMid.y);
 
     return (
@@ -234,7 +237,8 @@ class Popover extends Component<Props, State> {
         className={classNames("popover", `orientation-${orientation}`, {
           up: orientation === "up"
         })}
-        onMouseLeave={this.props.onMouseLeave}
+        onMouseLeave={onMouseLeave}
+        onKeyDown={onKeyDown}
         style={{ top, left }}
         ref={c => (this.$popover = c)}
       >
@@ -245,13 +249,13 @@ class Popover extends Component<Props, State> {
   }
 
   renderTooltip() {
-    const { onMouseLeave } = this.props;
     const { top, left } = this.state.coords;
-
+    const { onMouseLeave, onKeyDown } = this.props;
     return (
       <div
         className="tooltip"
         onMouseLeave={onMouseLeave}
+        onKeyDown={onKeyDown}
         style={{ top, left }}
         ref={c => (this.$tooltip = c)}
       >

--- a/src/components/shared/tests/Popover.spec.js
+++ b/src/components/shared/tests/Popover.spec.js
@@ -61,7 +61,10 @@ describe("Popover", () => {
 
   const event = { currentTarget: div };
 
-  beforeEach(() => onMouseLeave.mockClear(), onKeyDown.mockClear());
+  beforeEach(() => {
+    onMouseLeave.mockClear();
+    onKeyDown.mockClear();
+  });
 
   it("render", () => expect(popover).toMatchSnapshot());
 
@@ -83,12 +86,12 @@ describe("Popover", () => {
   });
 
   it("calls keyDown", () => {
-    popover.find(".popover").simulate("keyDown", { key: "Escape" });
+    popover.find(".popover").simulate("keydown", { key: "Escape" });
     expect(onKeyDown).toHaveBeenCalled();
   });
 
   it("calls keyDown (tooltip)", () => {
-    tooltip.find(".tooltip").simulate("keyDown", { key: "Escape" });
+    tooltip.find(".tooltip").simulate("keydown", { key: "Escape" });
     expect(onKeyDown).toHaveBeenCalled();
   });
 

--- a/src/components/shared/tests/Popover.spec.js
+++ b/src/components/shared/tests/Popover.spec.js
@@ -9,6 +9,7 @@ import Popover from "../Popover";
 
 describe("Popover", () => {
   const onMouseLeave = jest.fn();
+  const onKeyDown = jest.fn();
   const editorRef = {
     getBoundingClientRect() {
       return {
@@ -36,6 +37,7 @@ describe("Popover", () => {
   const popover = mount(
     <Popover
       onMouseLeave={onMouseLeave}
+      onKeyDown={onKeyDown}
       editorRef={editorRef}
       targetPosition={targetPosition}
     >
@@ -47,6 +49,7 @@ describe("Popover", () => {
     <Popover
       type="tooltip"
       onMouseLeave={onMouseLeave}
+      onKeyDown={onKeyDown}
       editorRef={editorRef}
       targetPosition={targetPosition}
     >
@@ -58,7 +61,7 @@ describe("Popover", () => {
 
   const event = { currentTarget: div };
 
-  beforeEach(() => onMouseLeave.mockClear());
+  beforeEach(() => onMouseLeave.mockClear(), onKeyDown.mockClear());
 
   it("render", () => expect(popover).toMatchSnapshot());
 
@@ -79,10 +82,21 @@ describe("Popover", () => {
     expect(onMouseLeave).not.toHaveBeenCalled();
   });
 
+  it("calls keyDown", () => {
+    popover.find(".popover").simulate("keyDown", { key: "Escape" });
+    expect(onKeyDown).toHaveBeenCalled();
+  });
+
+  it("calls keyDown (tooltip)", () => {
+    tooltip.find(".tooltip").simulate("keyDown", { key: "Escape" });
+    expect(onKeyDown).toHaveBeenCalled();
+  });
+
   it("mount popover", () => {
     const mountedPopover = mount(
       <Popover
         onMouseLeave={onMouseLeave}
+        onKeyDown={onKeyDown}
         editorRef={editorRef}
         targetPosition={targetPosition}
       >
@@ -97,6 +111,7 @@ describe("Popover", () => {
       <Popover
         type="tooltip"
         onMouseLeave={onMouseLeave}
+        onKeyDown={onKeyDown}
         editorRef={editorRef}
         targetPosition={targetPosition}
       >
@@ -132,6 +147,7 @@ describe("Popover", () => {
       <Popover
         type="tooltip"
         onMouseLeave={onMouseLeave}
+        onKeyDown={onKeyDown}
         editorRef={editor}
         targetPosition={target}
       >
@@ -169,6 +185,7 @@ describe("Popover", () => {
       <Popover
         type="tooltip"
         onMouseLeave={onMouseLeave}
+        onKeyDown={onKeyDown}
         editorRef={editor}
         targetPosition={target}
       >

--- a/src/components/shared/tests/__snapshots__/Popover.spec.js.snap
+++ b/src/components/shared/tests/__snapshots__/Popover.spec.js.snap
@@ -9,6 +9,7 @@ exports[`Popover mount popover 1`] = `
   }
   onMouseLeave={[MockFunction]}
   onPopoverCoords={[Function]}
+  onKeyDown={[MockFunction]}
   targetPosition={
     Object {
       "bottom": 0,
@@ -26,6 +27,7 @@ exports[`Popover mount popover 1`] = `
   <div
     className="popover orientation-right"
     onMouseLeave={[MockFunction]}
+    onKeyDown={[MockFunction]}
     style={
       Object {
         "left": 510,
@@ -69,6 +71,7 @@ exports[`Popover mount tooltip 1`] = `
   }
   onMouseLeave={[MockFunction]}
   onPopoverCoords={[Function]}
+  onKeyDown={[MockFunction]}
   targetPosition={
     Object {
       "bottom": 0,
@@ -86,6 +89,7 @@ exports[`Popover mount tooltip 1`] = `
   <div
     className="tooltip"
     onMouseLeave={[MockFunction]}
+    onKeyDown={[MockFunction]}
     style={
       Object {
         "left": -8,
@@ -108,6 +112,7 @@ exports[`Popover render (tooltip) 1`] = `
 <div
   className="tooltip"
   onMouseLeave={[MockFunction]}
+  onKeyDown={[MockFunction]}
   style={
     Object {
       "left": 0,
@@ -134,6 +139,7 @@ exports[`Popover render 1`] = `
   }
   onMouseLeave={[MockFunction]}
   onPopoverCoords={[Function]}
+  onKeyDown={[MockFunction]}
   targetPosition={
     Object {
       "bottom": 0,
@@ -151,6 +157,7 @@ exports[`Popover render 1`] = `
   <div
     className="popover orientation-right"
     onMouseLeave={[MockFunction]}
+    onKeyDown={[MockFunction]}
     style={
       Object {
         "left": 510,

--- a/src/components/shared/tests/__snapshots__/Popover.spec.js.snap
+++ b/src/components/shared/tests/__snapshots__/Popover.spec.js.snap
@@ -7,9 +7,9 @@ exports[`Popover mount popover 1`] = `
       "getBoundingClientRect": [Function],
     }
   }
+  onKeyDown={[MockFunction]}
   onMouseLeave={[MockFunction]}
   onPopoverCoords={[Function]}
-  onKeyDown={[MockFunction]}
   targetPosition={
     Object {
       "bottom": 0,
@@ -26,8 +26,8 @@ exports[`Popover mount popover 1`] = `
 >
   <div
     className="popover orientation-right"
-    onMouseLeave={[MockFunction]}
     onKeyDown={[MockFunction]}
+    onMouseLeave={[MockFunction]}
     style={
       Object {
         "left": 510,
@@ -69,9 +69,9 @@ exports[`Popover mount tooltip 1`] = `
       "getBoundingClientRect": [Function],
     }
   }
+  onKeyDown={[MockFunction]}
   onMouseLeave={[MockFunction]}
   onPopoverCoords={[Function]}
-  onKeyDown={[MockFunction]}
   targetPosition={
     Object {
       "bottom": 0,
@@ -88,8 +88,8 @@ exports[`Popover mount tooltip 1`] = `
 >
   <div
     className="tooltip"
-    onMouseLeave={[MockFunction]}
     onKeyDown={[MockFunction]}
+    onMouseLeave={[MockFunction]}
     style={
       Object {
         "left": -8,
@@ -111,8 +111,8 @@ exports[`Popover mount tooltip 1`] = `
 exports[`Popover render (tooltip) 1`] = `
 <div
   className="tooltip"
-  onMouseLeave={[MockFunction]}
   onKeyDown={[MockFunction]}
+  onMouseLeave={[MockFunction]}
   style={
     Object {
       "left": 0,
@@ -137,9 +137,9 @@ exports[`Popover render 1`] = `
       "getBoundingClientRect": [Function],
     }
   }
+  onKeyDown={[MockFunction]}
   onMouseLeave={[MockFunction]}
   onPopoverCoords={[Function]}
-  onKeyDown={[MockFunction]}
   targetPosition={
     Object {
       "bottom": 0,
@@ -156,8 +156,8 @@ exports[`Popover render 1`] = `
 >
   <div
     className="popover orientation-right"
-    onMouseLeave={[MockFunction]}
     onKeyDown={[MockFunction]}
+    onMouseLeave={[MockFunction]}
     style={
       Object {
         "left": 510,


### PR DESCRIPTION
Fixes Issue: #6648 

### Summary of Changes

A keyDown event listener has been added to the component popover so that it closes on "esc" key press.

### Test Plan

- [x] Go to the line where a breakpoint has paused
- [x] Put the mouse over a variable
- [x] Click on a tree element in the preview popup
- [x] Hitting "ESC" key shoud close the preview popup
