### PR TITLE
Use local devtools-utils, use explicit version for workspace packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "devtools-reps": "0.23.0",
     "devtools-source-map": "0.16.0",
     "devtools-splitter": "^0.0.6",
-    "devtools-utils": "0.0.13",
+    "devtools-utils": "0.0.14",
     "enzyme-adapter-react-16": "^1.1.1",
     "eslint-plugin-import": "^2.8.0",
     "fuzzaldrin-plus": "^0.6.0",

--- a/packages/devtools-source-map/package.json
+++ b/packages/devtools-source-map/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "babel-plugin-transform-async-to-generator": "^6.22.0",
     "babel-plugin-transform-flow-strip-types": "^6.22.0",
-    "devtools-utils": "^0.0.12",
+    "devtools-utils": "0.0.14",
     "md5": "^2.2.1",
     "regenerator-runtime": "^0.10.3",
     "source-map": "^0.6.1"

--- a/packages/devtools-utils/package.json
+++ b/packages/devtools-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "devtools-utils",
-  "version": "0.0.12",
+  "version": "0.0.14",
   "description": "DevTools Utils",
   "main": "index.js",
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3558,14 +3558,6 @@ devtools-sprintf-js@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/devtools-sprintf-js/-/devtools-sprintf-js-1.0.3.tgz#c2aa3c39d4047525e60410325c86770620281b87"
 
-devtools-utils@0.0.13:
-  version "0.0.13"
-  resolved "https://registry.yarnpkg.com/devtools-utils/-/devtools-utils-0.0.13.tgz#290a8a0f640e423a708933461df1862d8f253977"
-  dependencies:
-    babel-plugin-transform-flow-strip-types "^6.22.0"
-    babel-preset-stage-3 "^6.22.0"
-    jest "^20.0.4"
-
 dezalgo@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/dezalgo/-/dezalgo-1.0.3.tgz#7f742de066fc748bc8db820569dddce49bf0d456"


### PR DESCRIPTION
Should fix issue #6679 

@nchevobbe I am absolutely not sure about what I did, especially specifying "workspaces" inside of the packages themselves. The one change I would love to see in the next debugger bundle is https://github.com/devtools-html/debugger.html/commit/9048eb7e0bfc88946411bde0c7af223acc30e6f8

Have fun poking at this, mobile network is not the best to `yarn install` stuff :)