### PR TITLE
Fix 1463117 - Add telemetry for pause on (caught) exceptions

### DIFF
--- a/src/actions/pause/pauseOnExceptions.js
+++ b/src/actions/pause/pauseOnExceptions.js
@@ -5,6 +5,7 @@
 // @flow
 
 import { PROMISE } from "../utils/middleware/promise";
+import { recordEvent } from "../../utils/telemetry";
 import type { ThunkArgs } from "../types";
 
 /**
@@ -17,6 +18,14 @@ export function pauseOnExceptions(
   shouldPauseOnCaughtExceptions: boolean
 ) {
   return ({ dispatch, client }: ThunkArgs) => {
+    /* eslint-disable camelcase */
+    recordEvent("pause_on_exceptions", {
+      exceptions: shouldPauseOnExceptions,
+      // There's no "n" in the key below (#1463117)
+      caught_exceptio: shouldPauseOnCaughtExceptions
+    });
+    /* eslint-enable camelcase */
+
     return dispatch({
       type: "PAUSE_ON_EXCEPTIONS",
       shouldPauseOnExceptions,

--- a/src/actions/pause/tests/__snapshots__/pauseOnExceptions.spec.js.snap
+++ b/src/actions/pause/tests/__snapshots__/pauseOnExceptions.spec.js.snap
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`pauseOnExceptions should track telemetry for pauseOnException changes 1`] = `
+Array [
+  Object {
+    "caught_exceptio": false,
+    "exceptions": true,
+  },
+]
+`;

--- a/src/actions/pause/tests/pauseOnExceptions.spec.js
+++ b/src/actions/pause/tests/pauseOnExceptions.spec.js
@@ -1,0 +1,26 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
+import {
+  actions,
+  createStore,
+  getTelemetryEvents
+} from "../../../utils/test-head";
+
+describe("pauseOnExceptions", () => {
+  it("should track telemetry for pauseOnException changes", async () => {
+    const { dispatch } = createStore({ pauseOnExceptions: () => {} });
+    dispatch(actions.pauseOnExceptions(true, false));
+
+    const pauseTelemetry = getTelemetryEvents("pause_on_exceptions");
+
+    expect(pauseTelemetry).toHaveLength(1);
+    /* eslint-disable camelcase */
+    expect(pauseTelemetry[0]).toEqual({
+      exceptions: true,
+      caught_exceptio: false
+    });
+    /* eslint-enable camelcase */
+  });
+});

--- a/src/actions/pause/tests/pauseOnExceptions.spec.js
+++ b/src/actions/pause/tests/pauseOnExceptions.spec.js
@@ -12,15 +12,6 @@ describe("pauseOnExceptions", () => {
   it("should track telemetry for pauseOnException changes", async () => {
     const { dispatch } = createStore({ pauseOnExceptions: () => {} });
     dispatch(actions.pauseOnExceptions(true, false));
-
-    const pauseTelemetry = getTelemetryEvents("pause_on_exceptions");
-
-    expect(pauseTelemetry).toHaveLength(1);
-    /* eslint-disable camelcase */
-    expect(pauseTelemetry[0]).toEqual({
-      exceptions: true,
-      caught_exceptio: false
-    });
-    /* eslint-enable camelcase */
+    expect(getTelemetryEvents("pause_on_exceptions")).toMatchSnapshot();
   });
 });

--- a/src/actions/pause/tests/pauseOnExceptions.spec.js
+++ b/src/actions/pause/tests/pauseOnExceptions.spec.js
@@ -8,10 +8,17 @@ import {
   getTelemetryEvents
 } from "../../../utils/test-head";
 
+import {
+  getShouldPauseOnExceptions,
+  getShouldPauseOnCaughtExceptions
+} from "../../../reducers/pause";
+
 describe("pauseOnExceptions", () => {
   it("should track telemetry for pauseOnException changes", async () => {
-    const { dispatch } = createStore({ pauseOnExceptions: () => {} });
+    const { dispatch, getState } = createStore({ pauseOnExceptions: () => {} });
     dispatch(actions.pauseOnExceptions(true, false));
     expect(getTelemetryEvents("pause_on_exceptions")).toMatchSnapshot();
+    expect(getShouldPauseOnExceptions(getState())).toBe(true);
+    expect(getShouldPauseOnCaughtExceptions(getState())).toBe(false);
   });
 });


### PR DESCRIPTION
Fixes Issue: https://bugzilla.mozilla.org/show_bug.cgi?id=1463117

## ToDo
- [x] Add test

We should wait on https://github.com/devtools-html/debugger.html/pull/6671 being merged first