### PR TITLE
Fix Popover - Ensure top is enforced

### DIFF
--- a/src/components/shared/Popover.js
+++ b/src/components/shared/Popover.js
@@ -61,7 +61,7 @@ class Popover extends Component<Props, State> {
       this.setState({ coords });
     }
 
-    this.props.onPopoverCoords(this.state.coords);
+    this.props.onPopoverCoords(coords);
   }
 
   calculateLeft(


### PR DESCRIPTION
The top value was persistently 0, which is odd; I'm wondering if it's to do with "Do not use setState in componentDidMount (react/no-did-mount-set-state)"