### PR TITLE
Fix #6251 - Better contian the length of shortcut buttons

### DIFF
--- a/src/components/WelcomeBox.css
+++ b/src/components/WelcomeBox.css
@@ -70,12 +70,19 @@
 }
 
 .shortcutFunction {
-  flex: 1;
+  margin: 0 auto;
   color: var(--theme-comment);
+  display: table;
 }
 
 .shortcutFunction p {
-  display: flex;
+  display: table-row;
+}
+
+.shortcutFunction .shortcutKey,
+.shortcutFunction .shortcutLabel {
+  padding: 10px 5px;
+  display: table-cell;
 }
 
 html .welcomebox .toggle-button-end.collapsed {


### PR DESCRIPTION
Fixes Issue: #6251

Is no longer full length:

<img width="1356" alt="buttons" src="https://user-images.githubusercontent.com/46655/43206746-07590458-8fec-11e8-8492-2125ee69862a.png">
