### PR TITLE
Fix bug in Error stacktrace generation when stacktrace is a longString.

### DIFF
--- a/packages/devtools-reps/src/reps/stubs/error.js
+++ b/packages/devtools-reps/src/reps/stubs/error.js
@@ -235,4 +235,30 @@ stubs.set("longString stack Error", {
   }
 });
 
+stubs.set("longString stack Error - cut-off location", {
+  type: "object",
+  actor: "server1.conn1.child1/obj33",
+  class: "Error",
+  extensible: true,
+  frozen: false,
+  sealed: false,
+  ownPropertyLength: 6,
+  preview: {
+    kind: "Error",
+    name: "InternalError",
+    message: "too much recursion",
+    stack: {
+      type: "longString",
+      initial:
+        "execute/AppComponent</AppComponent.prototype.doStuff@https://angular-3eqab4.stackblitz.io/tmp/appfiles/src/app/app.component.ts:32:1\nexecute/AppComponent</AppComponent.prototype.doStuff@https://angular-3eqab4.stackblitz.io/tmp/appfiles/src/app/app.component.ts:33:21\nexecute/AppComponent</AppComponent.prototype.doStuff@https://angular-3eqab4.stackblitz.io/tmp/appfiles/src/app/app.component.ts:33:21\nexecute/AppComponent</AppComponent.prototype.doStuff@https://angular-3eqab4.stackblitz.io/tmp/appfiles/src/app/app.component.ts:33:21\nexecute/AppComponent</AppComponent.prototype.doStuff@https://angular-3eqab4.stackblitz.io/tmp/appfiles/src/app/app.component.ts:33:21\nexecute/AppComponent</AppComponent.prototype.doStuff@https://angular-3eqab4.stackblitz.io/tmp/appfiles/src/app/app.component.ts:33:21\nexecute/AppComponent</AppComponent.prototype.doStuff@https://angular-3eqab4.stackblitz.io/tmp/appfiles/src/app/app.component.ts:33:21\nexecute/AppComponent</AppComponent.prototype.doStuff@https://an",
+      length: 17151,
+      actor: "server1.conn1.child1/longString27"
+    },
+    fileName:
+      "https://c.staticblitz.com/assets/engineblock-bc7b07e99ec5c6739c766b4898e4cff5acfddc137ccb7218377069c32731f1d0.js line 1 > eval",
+    lineNumber: 32,
+    columnNumber: 1
+  }
+});
+
 module.exports = stubs;

--- a/packages/devtools-reps/src/reps/tests/__snapshots__/error.js.snap
+++ b/packages/devtools-reps/src/reps/tests/__snapshots__/error.js.snap
@@ -394,6 +394,127 @@ exports[`Error - base-loader.js renders as expected without mode 1`] = `
 </span>
 `;
 
+exports[`Error - longString stacktrace - cut-off location renders as expected 1`] = `
+<span
+  className="objectBox-stackTrace"
+  data-link-actor-id="server1.conn1.child1/obj33"
+>
+  InternalError: "too much recursion"
+  
+
+  <span
+    className="objectBox-stackTrace-grid"
+    key="stack"
+  >
+    	
+    <span
+      className="objectBox-stackTrace-fn"
+      key="fn0"
+    >
+      doStuff
+    </span>
+    <span
+      className="objectBox-stackTrace-location"
+      key="location0"
+    >
+      https://angular-3eqab4.stackblitz.io/tmp/appfiles/src/app/app.component.ts:32:1
+    </span>
+    
+
+    	
+    <span
+      className="objectBox-stackTrace-fn"
+      key="fn1"
+    >
+      doStuff
+    </span>
+    <span
+      className="objectBox-stackTrace-location"
+      key="location1"
+    >
+      https://angular-3eqab4.stackblitz.io/tmp/appfiles/src/app/app.component.ts:33:21
+    </span>
+    
+
+    	
+    <span
+      className="objectBox-stackTrace-fn"
+      key="fn2"
+    >
+      doStuff
+    </span>
+    <span
+      className="objectBox-stackTrace-location"
+      key="location2"
+    >
+      https://angular-3eqab4.stackblitz.io/tmp/appfiles/src/app/app.component.ts:33:21
+    </span>
+    
+
+    	
+    <span
+      className="objectBox-stackTrace-fn"
+      key="fn3"
+    >
+      doStuff
+    </span>
+    <span
+      className="objectBox-stackTrace-location"
+      key="location3"
+    >
+      https://angular-3eqab4.stackblitz.io/tmp/appfiles/src/app/app.component.ts:33:21
+    </span>
+    
+
+    	
+    <span
+      className="objectBox-stackTrace-fn"
+      key="fn4"
+    >
+      doStuff
+    </span>
+    <span
+      className="objectBox-stackTrace-location"
+      key="location4"
+    >
+      https://angular-3eqab4.stackblitz.io/tmp/appfiles/src/app/app.component.ts:33:21
+    </span>
+    
+
+    	
+    <span
+      className="objectBox-stackTrace-fn"
+      key="fn5"
+    >
+      doStuff
+    </span>
+    <span
+      className="objectBox-stackTrace-location"
+      key="location5"
+    >
+      https://angular-3eqab4.stackblitz.io/tmp/appfiles/src/app/app.component.ts:33:21
+    </span>
+    
+
+    	
+    <span
+      className="objectBox-stackTrace-fn"
+      key="fn6"
+    >
+      doStuff
+    </span>
+    <span
+      className="objectBox-stackTrace-location"
+      key="location6"
+    >
+      https://angular-3eqab4.stackblitz.io/tmp/appfiles/src/app/app.component.ts:33:21
+    </span>
+    
+
+  </span>
+</span>
+`;
+
 exports[`Error - longString stacktrace renders as expected 1`] = `
 <span
   className="objectBox-stackTrace"
@@ -556,13 +677,6 @@ exports[`Error - longString stacktrace renders as expected 1`] = `
     </span>
     
 
-    	
-    <span
-      className="objectBox-stackTrace-fn"
-      key="fn10"
-    >
-      node_modules
-    </span>
   </span>
 </span>
 `;

--- a/packages/devtools-reps/src/reps/tests/error.js
+++ b/packages/devtools-reps/src/reps/tests/error.js
@@ -391,6 +391,20 @@ describe("Error - longString stacktrace", () => {
   });
 });
 
+describe("Error - longString stacktrace - cut-off location", () => {
+  const stub = stubs.get("longString stack Error - cut-off location");
+
+  it("renders as expected", () => {
+    const renderedComponent = shallow(
+      ErrorRep.rep({
+        object: stub
+      })
+    );
+
+    expect(renderedComponent).toMatchSnapshot();
+  });
+});
+
 describe("Error - stacktrace location click", () => {
   it("Calls onViewSourceInDebugger with the expected arguments", () => {
     const onViewSourceInDebugger = jest.fn();


### PR DESCRIPTION
In order to build the stacktrace we parse the string we
receive from the server. In some cases, the stacktrace
can be very long and a longString is sent instead of a
string. This means that the property that we check might
have a cut-off location at the end.
Due to a placement error in an if, it could happen that
this last cut-off element would throw.
The fix is made by correctly guarding the property we
are checking.
We take this as an opportunity to change how we handle
the last frame (we don't include it in the stack array
we build, instead of putting it and then removing it).
A snapshot test is added to make sure everything is
working as expected.
