### PR TITLE
Perform the line-range check later so that we still search for applicable bindings for (optimized out) handling.

### DIFF
--- a/src/test/mochitest/browser_dbg-sourcemapped-scopes.js
+++ b/src/test/mochitest/browser_dbg-sourcemapped-scopes.js
@@ -722,7 +722,7 @@ async function testTypescriptClasses(dbg) {
     "webpack3",
     "rollup",
   ]) {
-    const { rollupOptimized } = targetToFlags(target);
+    const { isRollup, rollupOptimized } = targetToFlags(target);
 
     await breakpointScopes(dbg, target, "typescript-classes", { line: 50, column: 2 }, [
       "Module",
@@ -733,7 +733,10 @@ async function testTypescriptClasses(dbg) {
       rollupOptimized ? ["ExportedOther", rollupOptimized] : "ExportedOther()",
       rollupOptimized ? ["ExpressionClass", rollupOptimized] : "ExpressionClass:Foo()",
       "fn()",
-      ["ns", rollupOptimized || "{\u2026}"],
+      // Rollup optimizes out the 'ns' reference here, but when it does, it leave a mapping
+      // pointed at a location that is super weird, so it ends up being unmapped instead
+      // be "(optimized out)".
+      ["ns", isRollup ? "(unmapped)" : "{\u2026}"],
       "SubDecl()",
       "SubVar:SubExpr()"
     ]);
@@ -910,30 +913,33 @@ async function testWebpackFunctions(dbg) {
 }
 
 async function testESModules(dbg) {
-  // TODO: The behavior on Webpack 3 seems to be broken.
   await breakpointScopes(
     dbg,
     "webpack3",
     "esmodules",
     { line: 20, column: 0 },
     [
-      "Module",
-      ["aDefault", "(optimized away)"],
-      ["aDefault2", "(optimized away)"],
-      ["aDefault3", "(optimized away)"],
-      ["anAliased", "(optimized away)"],
-      ["anAliased2", "(optimized away)"],
-      ["anAliased3", "(optimized away)"],
-      ["aNamed", "(optimized away)"],
-      ["aNamed2", "(optimized away)"],
-      ["aNamed3", "(optimized away)"],
-      ["aNamespace", "(optimized away)"],
-      ["anotherNamed", "(optimized away)"],
-      ["anotherNamed2", "(optimized away)"],
-      ["anotherNamed3", "(optimized away)"],
-      ["example", "(unmapped)"],
-      ["optimizedOut", "(optimized away)"],
-      ["root", "(unmapped)"]
+      "Block",
+      ["<this>", "Window"],
+      ["arguments", "Arguments"],
+      pairToFnName("webpack3", "esmodules"),
+      "__webpack_exports__",
+      "__WEBPACK_IMPORTED_MODULE_0__src_mod1__",
+      "__WEBPACK_IMPORTED_MODULE_1__src_mod2__",
+      "__WEBPACK_IMPORTED_MODULE_10__src_optimized_out__",
+      "__WEBPACK_IMPORTED_MODULE_2__src_mod3__",
+      "__WEBPACK_IMPORTED_MODULE_3__src_mod4__",
+      "__WEBPACK_IMPORTED_MODULE_4__src_mod5__",
+      "__WEBPACK_IMPORTED_MODULE_5__src_mod6__",
+      "__WEBPACK_IMPORTED_MODULE_6__src_mod7__",
+      "__WEBPACK_IMPORTED_MODULE_7__src_mod9__",
+      "__WEBPACK_IMPORTED_MODULE_8__src_mod10__",
+      "__WEBPACK_IMPORTED_MODULE_9__src_mod11__",
+      "__webpack_require__",
+      "arguments",
+      "example",
+      "module",
+      "root()",
     ]
   );
 
@@ -1004,30 +1010,33 @@ async function testESModules(dbg) {
 
 
 async function testESModulesCJS(dbg) {
-  // TODO: The behavior on Webpack 3 seems to be broken.
   await breakpointScopes(
     dbg,
     "webpack3",
     "esmodules-cjs",
     { line: 20, column: 0 },
     [
-      "Module",
-      ["aDefault", "(optimized away)"],
-      ["aDefault2", "(optimized away)"],
-      ["aDefault3", "(optimized away)"],
-      ["anAliased", "(optimized away)"],
-      ["anAliased2", "(optimized away)"],
-      ["anAliased3", "(optimized away)"],
-      ["aNamed", "(optimized away)"],
-      ["aNamed2", "(optimized away)"],
-      ["aNamed3", "(optimized away)"],
-      ["aNamespace", "(optimized away)"],
-      ["anotherNamed", "(optimized away)"],
-      ["anotherNamed2", "(optimized away)"],
-      ["anotherNamed3", "(optimized away)"],
-      ["example", "(unmapped)"],
-      ["optimizedOut", "(optimized away)"],
-      ["root", "(unmapped)"]
+      "Block",
+      ["<this>", "Window"],
+      ["arguments", "Arguments"],
+      pairToFnName("webpack3", "esmodules-cjs"),
+      "__webpack_exports__",
+      "__WEBPACK_IMPORTED_MODULE_0__src_mod1__",
+      "__WEBPACK_IMPORTED_MODULE_1__src_mod2__",
+      "__WEBPACK_IMPORTED_MODULE_10__src_optimized_out__",
+      "__WEBPACK_IMPORTED_MODULE_2__src_mod3__",
+      "__WEBPACK_IMPORTED_MODULE_3__src_mod4__",
+      "__WEBPACK_IMPORTED_MODULE_4__src_mod5__",
+      "__WEBPACK_IMPORTED_MODULE_5__src_mod6__",
+      "__WEBPACK_IMPORTED_MODULE_6__src_mod7__",
+      "__WEBPACK_IMPORTED_MODULE_7__src_mod9__",
+      "__WEBPACK_IMPORTED_MODULE_8__src_mod10__",
+      "__WEBPACK_IMPORTED_MODULE_9__src_mod11__",
+      "__webpack_require__",
+      "arguments",
+      "example",
+      "module",
+      "root()",
     ]
   );
 
@@ -1064,30 +1073,33 @@ async function testESModulesCJS(dbg) {
 }
 
 async function testESModulesES6(dbg) {
-  // TODO: The behavior on Webpack 3 seems to be broken.
   await breakpointScopes(
     dbg,
     "webpack3",
     "esmodules-es6",
     { line: 20, column: 0 },
     [
-      "Module",
-      ["aDefault", "(optimized away)"],
-      ["aDefault2", "(optimized away)"],
-      ["aDefault3", "(optimized away)"],
-      ["anAliased", "(optimized away)"],
-      ["anAliased2", "(optimized away)"],
-      ["anAliased3", "(optimized away)"],
-      ["aNamed", "(optimized away)"],
-      ["aNamed2", "(optimized away)"],
-      ["aNamed3", "(optimized away)"],
-      ["aNamespace", "(optimized away)"],
-      ["anotherNamed", "(optimized away)"],
-      ["anotherNamed2", "(optimized away)"],
-      ["anotherNamed3", "(optimized away)"],
-      ["example", "(unmapped)"],
-      ["optimizedOut", "(optimized away)"],
-      ["root", "(unmapped)"]
+      "Block",
+      ["<this>", "Window"],
+      ["arguments", "Arguments"],
+      pairToFnName("webpack3", "esmodules-es6"),
+      "__webpack_exports__",
+      "__WEBPACK_IMPORTED_MODULE_0__src_mod1__",
+      "__WEBPACK_IMPORTED_MODULE_1__src_mod2__",
+      "__WEBPACK_IMPORTED_MODULE_10__src_optimized_out__",
+      "__WEBPACK_IMPORTED_MODULE_2__src_mod3__",
+      "__WEBPACK_IMPORTED_MODULE_3__src_mod4__",
+      "__WEBPACK_IMPORTED_MODULE_4__src_mod5__",
+      "__WEBPACK_IMPORTED_MODULE_5__src_mod6__",
+      "__WEBPACK_IMPORTED_MODULE_6__src_mod7__",
+      "__WEBPACK_IMPORTED_MODULE_7__src_mod9__",
+      "__WEBPACK_IMPORTED_MODULE_8__src_mod10__",
+      "__WEBPACK_IMPORTED_MODULE_9__src_mod11__",
+      "__webpack_require__",
+      "arguments",
+      "example",
+      "module",
+      "root()",
     ]
   );
 

--- a/src/utils/pause/mapScopes/getApplicableBindingsForOriginalPosition.js
+++ b/src/utils/pause/mapScopes/getApplicableBindingsForOriginalPosition.js
@@ -62,50 +62,18 @@ export async function getApplicableBindingsForOriginalPosition(
 ): Promise<Array<ApplicableBinding>> {
   const ranges = await sourceMaps.getGeneratedRanges(start, source);
 
-  const resultRanges = ranges.reduce((acc, mapRange) => {
-    // Some tooling creates ranges that map a line as a whole, which is useful
-    // for step-debugging, but can easily lead to finding the wrong binding.
-    // To avoid these false-positives, we entirely ignore ranges that cover
-    // full lines.
-    if (
-      locationType === "ref" &&
-      mapRange.columnStart === 0 &&
-      mapRange.columnEnd === Infinity
-    ) {
-      return acc;
+  const resultRanges = ranges.map(mapRange => ({
+    start: {
+      line: mapRange.line,
+      column: mapRange.columnStart
+    },
+    end: {
+      line: mapRange.line,
+      // SourceMapConsumer's 'lastColumn' is inclusive, so we add 1 to make
+      // it exclusive like all other locations.
+      column: mapRange.columnEnd + 1
     }
-
-    const range = {
-      start: {
-        line: mapRange.line,
-        column: mapRange.columnStart
-      },
-      end: {
-        line: mapRange.line,
-        // SourceMapConsumer's 'lastColumn' is inclusive, so we add 1 to make
-        // it exclusive like all other locations.
-        column: mapRange.columnEnd + 1
-      }
-    };
-
-    const previous = acc[acc.length - 1];
-
-    if (
-      previous &&
-      ((previous.end.line === range.start.line &&
-        previous.end.column === range.start.column) ||
-        (previous.end.line + 1 === range.start.line &&
-          previous.end.column === Infinity &&
-          range.start.column === 0))
-    ) {
-      previous.end.line = range.end.line;
-      previous.end.column = range.end.column;
-    } else {
-      acc.push(range);
-    }
-
-    return acc;
-  }, []);
+  }));
 
   // When searching for imports, we expand the range to up to the next available
   // mapping to allow for import declarations that are composed of multiple

--- a/src/utils/pause/mapScopes/index.js
+++ b/src/utils/pause/mapScopes/index.js
@@ -360,6 +360,16 @@ async function findGeneratedBinding(
     if (applicableBindings.length > 0) {
       hadApplicableBindings = true;
     }
+    if (locationType === "ref") {
+      // Some tooling creates ranges that map a line as a whole, which is useful
+      // for step-debugging, but can easily lead to finding the wrong binding.
+      // To avoid these false-positives, we entirely ignore bindings matched
+      // by ranges that cover full lines.
+      applicableBindings = applicableBindings.filter(
+        ({ range }) =>
+          !(range.start.column === 0 && range.end.column === Infinity)
+      );
+    }
     if (
       locationType !== "ref" &&
       !(await originalRangeStartsInside(source, pos, sourceMaps))


### PR DESCRIPTION
Refs Issue: #6400

cc @jasonLaster 

### Summary of Changes

* Remove the range-merging logic so we work directly with the ranges from the sourcemap, since I don't think it's actually doing anything useful.
* Move the full-line range test to _after_ we assign `hadApplicableBindings` so that bindings in full-line ranges properly cause a binding to not count as `(optimized out)`.
