### PR TITLE
breakpoints set on pretty source visible on reload

### DIFF
--- a/src/actions/sources/newSources.js
+++ b/src/actions/sources/newSources.js
@@ -109,7 +109,8 @@ function checkSelectedSource(sourceId: string) {
 
     if (rawPendingUrl === source.url) {
       if (isPrettyURL(pendingUrl)) {
-        return await dispatch(togglePrettyPrint(source.id));
+        const prettySource = await dispatch(togglePrettyPrint(source.id));
+        return dispatch(checkPendingBreakpoints(prettySource.id));
       }
 
       await dispatch(

--- a/src/actions/sources/prettyPrint.js
+++ b/src/actions/sources/prettyPrint.js
@@ -116,8 +116,10 @@ export function togglePrettyPrint(sourceId: string) {
     await dispatch(setPausePoints(newPrettySource.id));
     await dispatch(setSymbols(newPrettySource.id));
 
-    return dispatch(
+    dispatch(
       selectLocation({ ...options.location, sourceId: newPrettySource.id })
     );
+
+    return newPrettySource;
   };
 }


### PR DESCRIPTION
Fixes Issue: #6704 

Since `addSources` doesn't gets called for pretty sources, so we missed checking for pending breakpoints.
