### PR TITLE
Log event to telemetry on jump to definition click

### DIFF
--- a/packages/devtools-reps/src/reps/function.js
+++ b/packages/devtools-reps/src/reps/function.js
@@ -24,7 +24,7 @@ FunctionRep.propTypes = {
 };
 
 function FunctionRep(props) {
-  const { object: grip, onViewSourceInDebugger } = props;
+  const { object: grip, onViewSourceInDebugger, recordTelemetryEvent } = props;
 
   let jumpToDefinitionButton;
   if (
@@ -41,6 +41,9 @@ function FunctionRep(props) {
         // Stop the event propagation so we don't trigger ObjectInspector
         // expand/collapse.
         e.stopPropagation();
+        if (recordTelemetryEvent) {
+          recordTelemetryEvent("jump_to_definition");
+        }
         onViewSourceInDebugger(grip.location);
       }
     });

--- a/packages/devtools-reps/src/reps/tests/function.js
+++ b/packages/devtools-reps/src/reps/tests/function.js
@@ -316,6 +316,26 @@ describe("Function - Jump to definition", () => {
     expect(onViewSourceInDebugger.mock.calls[0][0]).toEqual(object.location);
   });
 
+  it("calls recordTelemetryEvent when jump to definition icon clicked", () => {
+    const onViewSourceInDebugger = jest.fn();
+    const recordTelemetryEvent = jest.fn();
+    const object = stubs.get("getRandom");
+    const renderedComponent = renderRep(object, {
+      onViewSourceInDebugger,
+      recordTelemetryEvent,
+    });
+
+    const node = renderedComponent.find(".jump-definition");
+    node.simulate("click", {
+      type: "click",
+      stopPropagation: () => {}
+    });
+
+    expect(node.exists()).toBeTruthy();
+    expect(recordTelemetryEvent.mock.calls).toHaveLength(1);
+    expect(recordTelemetryEvent.mock.calls[0][0]).toEqual("jump_to_definition");
+  });
+
   it("no icon when onViewSourceInDebugger props not provided", () => {
     const object = stubs.get("getRandom");
     const renderedComponent = renderRep(object);


### PR DESCRIPTION
Add a test to make sure the props does get called when provided.