### PR TITLE
[Breakpoints] Switch Pending BPs from Immutable to Pojo

### DIFF
--- a/src/actions/breakpoints/tests/__snapshots__/syncing.spec.js.snap
+++ b/src/actions/breakpoints/tests/__snapshots__/syncing.spec.js.snap
@@ -77,7 +77,7 @@ Object {
 `;
 
 exports[`reloading debuggee syncs with changed source and an existing disabled BP 1`] = `
-Immutable.Map {
+Object {
   "http://localhost:8000/examples/magic.js:3:": Object {
     "astLocation": Object {
       "name": undefined,

--- a/src/actions/breakpoints/tests/syncing.spec.js
+++ b/src/actions/breakpoints/tests/syncing.spec.js
@@ -272,9 +272,7 @@ describe("reloading debuggee", () => {
     await dispatch(
       actions.syncBreakpoint(
         reloadedSource.id,
-        pendingBreakpoint({
-          disabled: true
-        })
+        pendingBreakpoint({ disabled: true })
       )
     );
 

--- a/src/actions/sources/newSources.js
+++ b/src/actions/sources/newSources.js
@@ -129,16 +129,15 @@ function checkPendingBreakpoints(sourceId: string) {
       source.url
     );
 
-    if (!pendingBreakpoints.size) {
+    if (pendingBreakpoints.length === 0) {
       return;
     }
 
     // load the source text if there is a pending breakpoint for it
     await dispatch(loadSourceText(source));
 
-    const breakpoints = pendingBreakpoints.valueSeq().toJS();
     await Promise.all(
-      breakpoints.map(bp => dispatch(syncBreakpoint(sourceId, bp)))
+      pendingBreakpoints.map(bp => dispatch(syncBreakpoint(sourceId, bp)))
     );
   };
 }

--- a/src/actions/tests/pending-breakpoints.spec.js
+++ b/src/actions/tests/pending-breakpoints.spec.js
@@ -57,8 +57,9 @@ describe("when adding breakpoints", () => {
 
     await dispatch(actions.addBreakpoint(bp.location));
     const pendingBps = selectors.getPendingBreakpoints(getState());
-    expect(pendingBps.size).toBe(2);
-    expect(pendingBps.get(id)).toMatchSnapshot();
+
+    expect(selectors.getPendingBreakpointList(getState())).toHaveLength(2);
+    expect(pendingBps[id]).toMatchSnapshot();
   });
 
   describe("adding and deleting breakpoints", () => {
@@ -87,8 +88,8 @@ describe("when adding breakpoints", () => {
       await dispatch(actions.addBreakpoint(breakpoint2.location));
 
       const pendingBps = selectors.getPendingBreakpoints(getState());
-      expect(pendingBps.get(breakpointLocationId1)).toMatchSnapshot();
-      expect(pendingBps.get(breakpointLocationId2)).toMatchSnapshot();
+      expect(pendingBps[breakpointLocationId1]).toMatchSnapshot();
+      expect(pendingBps[breakpointLocationId2]).toMatchSnapshot();
     });
 
     it("hidden breakponts do not create pending bps", async () => {
@@ -102,7 +103,7 @@ describe("when adding breakpoints", () => {
       );
       const pendingBps = selectors.getPendingBreakpoints(getState());
 
-      expect(pendingBps.get(breakpointLocationId1)).toBeUndefined();
+      expect(pendingBps[breakpointLocationId1]).toBeUndefined();
     });
 
     it("remove a corresponding pending breakpoint when deleting", async () => {
@@ -117,8 +118,8 @@ describe("when adding breakpoints", () => {
       await dispatch(actions.removeBreakpoint(breakpoint1.location));
 
       const pendingBps = selectors.getPendingBreakpoints(getState());
-      expect(pendingBps.has(breakpointLocationId1)).toBe(false);
-      expect(pendingBps.has(breakpointLocationId2)).toBe(true);
+      expect(pendingBps.hasOwnProperty(breakpointLocationId1)).toBe(false);
+      expect(pendingBps.hasOwnProperty(breakpointLocationId2)).toBe(true);
     });
   });
 });
@@ -143,7 +144,7 @@ describe("when changing an existing breakpoint", () => {
       actions.setBreakpointCondition(bp.location, { condition: "2" })
     );
     const bps = selectors.getPendingBreakpoints(getState());
-    const breakpoint = bps.get(id);
+    const breakpoint = bps[id];
     expect(breakpoint.condition).toBe("2");
   });
 
@@ -158,7 +159,7 @@ describe("when changing an existing breakpoint", () => {
     await dispatch(actions.addBreakpoint(bp.location));
     await dispatch(actions.disableBreakpoint(bp.location));
     const bps = selectors.getPendingBreakpoints(getState());
-    const breakpoint = bps.get(id);
+    const breakpoint = bps[id];
     expect(breakpoint.disabled).toBe(true);
   });
 
@@ -176,7 +177,7 @@ describe("when changing an existing breakpoint", () => {
       actions.setBreakpointCondition(bp.location, { condition: "2" })
     );
     const bps = selectors.getPendingBreakpoints(getState());
-    const breakpoint = bps.get(id);
+    const breakpoint = bps[id];
     expect(breakpoint.condition).toBe("2");
   });
 });
@@ -193,7 +194,7 @@ describe("initializing when pending breakpoints exist in prefs", () => {
     const { getState } = createStore(simpleMockThreadClient);
     const id = makePendingLocationId(mockedPendingBreakpoint.location);
     const bps = selectors.getPendingBreakpoints(getState());
-    const bp = bps.get(id);
+    const bp = bps[id];
     expect(bp).toMatchSnapshot();
   });
 
@@ -205,8 +206,8 @@ describe("initializing when pending breakpoints exist in prefs", () => {
 
     await dispatch(actions.addBreakpoint(bar.location));
 
-    const bps = selectors.getPendingBreakpoints(getState());
-    expect(bps.size).toBe(1);
+    const bps = selectors.getPendingBreakpointList(getState());
+    expect(bps).toHaveLength(1);
   });
 
   it("adding bps doesn't remove existing pending breakpoints", async () => {
@@ -218,8 +219,8 @@ describe("initializing when pending breakpoints exist in prefs", () => {
 
     await dispatch(actions.addBreakpoint(bp.location));
 
-    const bps = selectors.getPendingBreakpoints(getState());
-    expect(bps.size).toBe(2);
+    const bps = selectors.getPendingBreakpointList(getState());
+    expect(bps).toHaveLength(2);
   });
 });
 
@@ -329,7 +330,7 @@ describe("invalid breakpoint location", () => {
 
     await dispatch(actions.addBreakpoint(bp.location));
     const pendingBps = selectors.getPendingBreakpoints(getState());
-    const pendingBp = pendingBps.get(correctedPendingId);
+    const pendingBp = pendingBps[correctedPendingId];
     expect(pendingBp).toMatchSnapshot();
   });
 });

--- a/src/reducers/pending-breakpoints.js
+++ b/src/reducers/pending-breakpoints.js
@@ -9,9 +9,6 @@
  * @module reducers/pending-breakpoints
  */
 
-import * as I from "immutable";
-import makeRecord from "../utils/makeRecord";
-
 import {
   createPendingBreakpoint,
   makePendingLocationId
@@ -21,7 +18,6 @@ import { prefs } from "../utils/prefs";
 
 import type { PendingBreakpoint } from "../types";
 import type { Action, DonePromiseAction } from "../actions/types";
-import type { Record } from "../utils/makeRecord";
 
 export type PendingBreakpointsState = { [string]: PendingBreakpoint };
 

--- a/src/reducers/types.js
+++ b/src/reducers/types.js
@@ -26,7 +26,7 @@ export type State = {
   expressions: Record<ExpressionState>,
   fileSearch: Record<FileSearchState>,
   pause: PauseState,
-  pendingBreakpoints: Record<PendingBreakpointsState>,
+  pendingBreakpoints: PendingBreakpointsState,
   projectTextSearch: Record<ProjectTextSearchState>,
   sources: SourcesState,
   ui: Record<UIState>

--- a/src/utils/bootstrap.js
+++ b/src/utils/bootstrap.js
@@ -92,10 +92,15 @@ export function bootstrapApp(store: any) {
   }
 }
 
+let currentPendingBreakpoints;
 function updatePrefs(state: any) {
-  const pendingBreakpoints = selectors.getPendingBreakpoints(state);
+  let previousPendingBreakpoints = currentPendingBreakpoints;
+  currentPendingBreakpoints = selectors.getPendingBreakpoints(state);
 
-  if (prefs.pendingBreakpoints !== pendingBreakpoints) {
-    prefs.pendingBreakpoints = pendingBreakpoints;
+  if (
+    previousPendingBreakpoints &&
+    currentPendingBreakpoints !== previousPendingBreakpoints
+  ) {
+    prefs.pendingBreakpoints = currentPendingBreakpoints;
   }
 }


### PR DESCRIPTION
issue: #6279

### Summary of Changes

* switches pending breakpoints to a plain object
* this will make it easier to persist / serialize 
* it also will help us flow type breakpoints

### Test Plan

flow and jest were clutch here