### PR TITLE
Fix 6718 - Allow scrolling in sources tree and outline panes

### DIFF
--- a/src/components/PrimaryPanes/Sources.css
+++ b/src/components/PrimaryPanes/Sources.css
@@ -189,6 +189,7 @@
 
 .source-outline-panel {
   flex: 1;
+  overflow: auto;
 }
 
 .sources-list .managed-tree .tree .node img.blackBox {


### PR DESCRIPTION
Fixes Issue: #6718 

## Testing

1.  Open the sources pane so that there should be scrollbars.  Ensure there's only one scrollbar for vertical and one for horizontal.  Same for Outline pane.

2.  Set a directory root.  Ensure there's only one scrollbar for vertical and one for horizontal.  Same for outline pane.