### PR TITLE
 Instrument object expansion with telemetry

### DIFF
--- a/packages/devtools-reps/src/launchpad/components/Result.js
+++ b/packages/devtools-reps/src/launchpad/components/Result.js
@@ -100,7 +100,10 @@ class Result extends Component {
         onInspectIconClick: nodeFront =>
           console.log("inspectIcon click", { nodeFront }),
         onViewSourceInDebugger: location =>
-          console.log("onViewSourceInDebugger", { location })
+          console.log("onViewSourceInDebugger", { location }),
+        recordTelemetryEvent: (eventName, extra = {}) => {
+          console.log("📊", eventName, "📊", extra);
+        }
       })
     );
   }

--- a/packages/devtools-reps/src/object-inspector/component.js
+++ b/packages/devtools-reps/src/object-inspector/component.js
@@ -192,7 +192,8 @@ class ObjectInspector extends Component<Props> {
       loadedProperties,
       nodeExpand,
       nodeCollapse,
-      roots
+      recordTelemetryEvent,
+      roots,
     } = this.props;
 
     if (expand === true) {
@@ -212,6 +213,10 @@ class ObjectInspector extends Component<Props> {
         createObjectClient,
         createLongStringClient
       );
+
+      if (recordTelemetryEvent) {
+        recordTelemetryEvent("object_expanded");
+      }
     } else {
       nodeCollapse(item);
     }


### PR DESCRIPTION
This calls recordTelemetry event with the object_expanded event name
when the object inspector is expanded.
A test is added to make sure this works as expected.

Also, we now pass a recordTelemetryEvent prop to the ObjectInspector in the reps-launchpad for manual testing sake.