### PR TITLE
Add top-level await support

### DIFF
--- a/assets/panel/prefs.js
+++ b/assets/panel/prefs.js
@@ -66,3 +66,9 @@ pref("devtools.debugger.features.async-stepping", true);
 pref("devtools.debugger.features.skip-pausing", true);
 pref("devtools.debugger.features.autocomplete-expressions", false);
 pref("devtools.debugger.features.map-expression-bindings", true);
+
+#if defined(RELEASE_OR_BETA)
+pref("devtools.debugger.features.map-await-expression", false);
+#else
+pref("devtools.debugger.features.map-await-expression", true);
+#endif

--- a/flow-typed/npm/@babel/template_vx.x.x.js
+++ b/flow-typed/npm/@babel/template_vx.x.x.js
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
+declare module "@babel/template" {
+  declare module.exports: any;
+}

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "@babel/core": "^7.0.0-beta.55",
     "@babel/parser": "^7.0.0-beta.55",
     "@babel/plugin-proposal-object-rest-spread": "^7.0.0-beta.55",
+    "@babel/template": "^7.0.0-beta.55",
     "@babel/types": "^7.0.0-beta.55",
     "babel-plugin-transform-imports": "^1.5.0",
     "codemirror": "^5.28.0",

--- a/src/actions/expressions.js
+++ b/src/actions/expressions.js
@@ -174,8 +174,9 @@ export function getMappedExpression(expression: string) {
     return parser.mapExpression(
       expression,
       mappings,
-      bindings,
-      features.mapExpressionBindings
+      bindings || [],
+      features.mapExpressionBindings,
+      features.mapAwaitExpression
     );
   };
 }

--- a/src/actions/expressions.js
+++ b/src/actions/expressions.js
@@ -167,7 +167,7 @@ export function getMappedExpression(expression: string) {
     const mappings = getSelectedScopeMappings(getState());
     const bindings = getSelectedFrameBindings(getState());
 
-    if (!mappings && !bindings) {
+    if (!mappings && !bindings && !expression.includes("await")) {
       return expression;
     }
 

--- a/src/test/mochitest/browser.ini
+++ b/src/test/mochitest/browser.ini
@@ -655,6 +655,7 @@ skip-if = !e10s || verify # This test is only valid in e10s
 skip-if = (verify && !debug && (os == 'linux'))
 [browser_dbg-chrome-debugging.js]
 [browser_dbg-console.js]
+[browser_dbg-console-async.js]
 [browser_dbg-console-link.js]
 [browser_dbg-console-map-bindings.js]
 [browser_dbg-content-script-sources.js]

--- a/src/test/mochitest/browser_dbg-console-async.js
+++ b/src/test/mochitest/browser_dbg-console-async.js
@@ -1,0 +1,52 @@
+// Return a promise with a reference to jsterm, opening the split
+// console if necessary.  This cleans up the split console pref so
+// it won't pollute other tests.
+function getSplitConsole(dbg) {
+  const { toolbox, win } = dbg;
+
+  if (!win) {
+    win = toolbox.win;
+  }
+
+  if (!toolbox.splitConsole) {
+    pressKey(dbg, "Escape");
+  }
+
+  return new Promise(resolve => {
+    toolbox.getPanelWhenReady("webconsole").then(() => {
+      ok(toolbox.splitConsole, "Split console is shown.");
+      let jsterm = toolbox.getPanel("webconsole").hud.jsterm;
+      resolve(jsterm);
+    });
+  });
+}
+
+function findMessages(win, query) {
+  return Array.prototype.filter.call(
+    win.document.querySelectorAll(".message"),
+    e => e.innerText.includes(query)
+  )
+}
+
+add_task(async function() {
+  Services.prefs.setBoolPref("devtools.toolbox.splitconsoleEnabled", true);
+  const dbg = await initDebugger("doc-script-switching.html");
+
+  await selectSource(dbg, "switching-01");
+
+  // open the console
+  await getSplitConsole(dbg);
+  ok(dbg.toolbox.splitConsole, "Split console is shown.");
+
+  const webConsole = await dbg.toolbox.getPanel("webconsole")
+  const jsterm = webConsole.hud.jsterm;
+
+  await jsterm.execute(`let sleep = async (time, v) => new Promise(
+    res => setTimeout(() => res(v+'!!!'), time)
+  )`);
+
+  await jsterm.execute(`await sleep(200, "DONE")`)
+
+  await waitFor(async () => findMessages(webConsole._frameWindow, "DONE!!!").length > 0)
+
+});

--- a/src/utils/prefs.js
+++ b/src/utils/prefs.js
@@ -59,6 +59,7 @@ if (isDevelopment()) {
   pref("devtools.debugger.features.component-pane", false);
   pref("devtools.debugger.features.autocomplete-expressions", false);
   pref("devtools.debugger.features.map-expression-bindings", true);
+  pref("devtools.debugger.features.map-await-expression", true);
 }
 
 export const prefs = new PrefsHelper("devtools", {
@@ -108,6 +109,7 @@ export const features = new PrefsHelper("devtools.debugger.features", {
   skipPausing: ["Bool", "skip-pausing"],
   autocompleteExpression: ["Bool", "autocomplete-expressions"],
   mapExpressionBindings: ["Bool", "map-expression-bindings"],
+  mapAwaitExpression: ["Bool", "map-await-expression"],
   componentPane: ["Bool", "component-pane"]
 });
 

--- a/src/workers/parser/mapAwaitExpression.js
+++ b/src/workers/parser/mapAwaitExpression.js
@@ -1,0 +1,44 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
+// @flow
+
+import template from "@babel/template";
+import generate from "@babel/generator";
+import * as t from "@babel/types";
+
+import { parse, hasNode } from "./utils/ast";
+import { isTopLevel } from "./utils/helpers";
+
+function hasTopLevelAwait(expression: string) {
+  const ast = parse(expression, { allowAwaitOutsideFunction: true });
+  const hasAwait = hasNode(
+    ast,
+    (node, ancestors, b) => t.isAwaitExpression(node) && isTopLevel(ancestors)
+  );
+
+  return hasAwait && ast;
+}
+
+function wrapExpression(ast) {
+  const statements = ast.program.body;
+  const lastStatement = statements[statements.length - 1];
+  const body = statements
+    .slice(0, -1)
+    .concat(t.returnStatement(lastStatement.expression));
+
+  const newAst = t.arrowFunctionExpression([], t.blockStatement(body), true);
+  return generate(newAst).code;
+}
+
+export default function handleTopLevelAwait(expression: string) {
+  const ast = hasTopLevelAwait(expression);
+  if (ast) {
+    const func = wrapExpression(ast);
+    return generate(template.ast(`(${func})().then(r => console.log(r));`))
+      .code;
+  }
+
+  return expression;
+}

--- a/src/workers/parser/mapBindings.js
+++ b/src/workers/parser/mapBindings.js
@@ -5,6 +5,8 @@
 // @flow
 
 import { parseScript } from "./utils/ast";
+import { isTopLevel } from "./utils/helpers";
+
 import generate from "@babel/generator";
 import * as t from "@babel/types";
 
@@ -33,10 +35,6 @@ function globalizeAssignment(node, bindings) {
   return t.assignmentExpression(node.operator, identifier, node.right);
 }
 
-function isTopLevel(ancestors) {
-  return ancestors.filter(ancestor => ancestor.key == "body").length == 1;
-}
-
 function replaceNode(ancestors, node) {
   const parent = ancestors[ancestors.length - 1];
 
@@ -59,7 +57,7 @@ export default function mapExpressionBindings(
   expression: string,
   bindings: string[] = []
 ): string {
-  const ast = parseScript(expression);
+  const ast = parseScript(expression, { allowAwaitOutsideFunction: true });
   let shouldUpdate = true;
   t.traverse(ast, (node, ancestors) => {
     const parent = ancestors[ancestors.length - 1];

--- a/src/workers/parser/mapExpression.js
+++ b/src/workers/parser/mapExpression.js
@@ -6,22 +6,7 @@
 
 import mapOriginalExpression from "./mapOriginalExpression";
 import mapExpressionBindings from "./mapBindings";
-
-import { hasSyntaxError } from "./validate";
-import { buildScopeList } from "./getScopes";
-import generate from "@babel/generator";
-import * as t from "@babel/types";
-
-function handleTopLevelAwait(expression) {
-  if (hasSyntaxError(expression) && expression.match(/await/)) {
-    const newExpression = `(async () => { return ${expression} })().then(r => console.log(r))`;
-    if (!hasSyntaxError(newExpression)) {
-      return newExpression;
-    }
-  }
-
-  return expression;
-}
+import handleTopLevelAwait from "./mapAwaitExpression";
 
 export default function mapExpression(
   expression: string,
@@ -29,9 +14,9 @@ export default function mapExpression(
     [string]: string | null
   },
   bindings: string[],
-  shouldMapBindings: boolean = true
+  shouldMapBindings: boolean = true,
+  shouldMapAwait: boolean = true
 ): string {
-  expression = handleTopLevelAwait(expression);
   try {
     if (mappings) {
       expression = mapOriginalExpression(expression, mappings);
@@ -39,6 +24,10 @@ export default function mapExpression(
 
     if (shouldMapBindings) {
       expression = mapExpressionBindings(expression, bindings);
+    }
+
+    if (shouldMapAwait) {
+      expression = handleTopLevelAwait(expression);
     }
   } catch (e) {
     console.log(e);

--- a/src/workers/parser/mapOriginalExpression.js
+++ b/src/workers/parser/mapOriginalExpression.js
@@ -40,7 +40,7 @@ export default function mapOriginalExpression(
     [string]: string | null
   }
 ): string {
-  const ast = parseScript(expression);
+  const ast = parseScript(expression, { allowAwaitOutsideFunction: true });
   const scopes = buildScopeList(ast, "");
 
   const nodes = new Map();

--- a/src/workers/parser/tests/mapExpression.spec.js
+++ b/src/workers/parser/tests/mapExpression.spec.js
@@ -20,13 +20,50 @@ function test({
   ).toEqual(format(newExpression, { parser: "babylon" }));
 }
 
+function formatAwait(body) {
+  return `(async () => {
+    ${body}
+  })().then(r => console.log(r));`;
+}
+
 describe("mapExpression", () => {
   cases("mapExpressions", test, [
     {
       name: "await",
       expression: "await a()",
-      newExpression:
-        "(async () => { return await a()})().then(r => console.log(r));",
+      newExpression: formatAwait("return await a()"),
+      bindings: [],
+      mappings: {},
+      shouldMapExpression: true
+    },
+    {
+      name: "await (multiple statements)",
+      expression: "const x = await a(); x + x",
+      newExpression: formatAwait("self.x = await a(); return x + x;"),
+      bindings: [],
+      mappings: {},
+      shouldMapExpression: true
+    },
+    {
+      name: "await (inner)",
+      expression: "async () => await a();",
+      newExpression: "async () => await a();",
+      bindings: [],
+      mappings: {},
+      shouldMapExpression: true
+    },
+    {
+      name: "await (multiple awaits)",
+      expression: "const x = await a(); await b(x)",
+      newExpression: formatAwait("self.x = await a(); return await b(x);"),
+      bindings: [],
+      mappings: {},
+      shouldMapExpression: true
+    },
+    {
+      name: "await (assignment)",
+      expression: "let x = await sleep(100, 2)",
+      newExpression: formatAwait("return (self.x = await sleep(100, 2))"),
       bindings: [],
       mappings: {},
       shouldMapExpression: true

--- a/src/workers/parser/tests/mapExpression.spec.js
+++ b/src/workers/parser/tests/mapExpression.spec.js
@@ -23,6 +23,15 @@ function test({
 describe("mapExpression", () => {
   cases("mapExpressions", test, [
     {
+      name: "await",
+      expression: "await a()",
+      newExpression:
+        "(async () => { return await a()})().then(r => console.log(r));",
+      bindings: [],
+      mappings: {},
+      shouldMapExpression: true
+    },
+    {
       name: "simple",
       expression: "a",
       newExpression: "a",

--- a/src/workers/parser/utils/ast.js
+++ b/src/workers/parser/utils/ast.js
@@ -46,7 +46,7 @@ const sourceOptions = {
   }
 };
 
-function parse(text: ?string, opts?: Object) {
+export function parse(text: ?string, opts?: Object): any {
   let ast;
   if (!text) {
     return;
@@ -158,4 +158,21 @@ export function traverseAst<T>(sourceId: string, visitor: Visitor, state?: T) {
 
   t.traverse(ast, visitor, state);
   return ast;
+}
+
+export function hasNode(rootNode: Node, predicate: Function) {
+  try {
+    t.traverse(rootNode, {
+      enter: (node, ancestors) => {
+        if (predicate(node, ancestors)) {
+          throw new Error("MATCH");
+        }
+      }
+    });
+  } catch (e) {
+    if (e.message === "MATCH") {
+      return true;
+    }
+  }
+  return false;
 }

--- a/src/workers/parser/utils/helpers.js
+++ b/src/workers/parser/utils/helpers.js
@@ -185,3 +185,9 @@ export function getVariables(dec: Node) {
     }
   ];
 }
+
+// Top Level checks the number of "body" nodes in the ancestor chain
+// if the node is top-level, then it shoul only have one body.
+export function isTopLevel(ancestors: Node[]) {
+  return ancestors.filter(ancestor => ancestor.key == "body").length == 1;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -151,7 +151,7 @@
     babylon "7.0.0-beta.44"
     lodash "^4.2.0"
 
-"@babel/template@7.0.0-beta.55":
+"@babel/template@7.0.0-beta.55", "@babel/template@^7.0.0-beta.55":
   version "7.0.0-beta.55"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.0.0-beta.55.tgz#c6cab0e2722ba5e33fe034073b6d31673aba326e"
   dependencies:


### PR DESCRIPTION
CC https://bugzilla.mozilla.org/show_bug.cgi?id=1410820

### Summary of Changes

- Adds client-side top-level await support. 
- returns the pending promise and logs the return value when it is complete
- relies on the fact that babel fails to parse top-level awaits, and attempts to wrap top level awaits in an async iife. We probably could do better than that :)


### Test Cases

 ✅  `await sleep(10)` => `10`
  ✅   `let x = await sleep(10); x + x` => `20`

#### Top Level Awaits
![](http://g.recordit.co/KTkgjovUO0.gif)

#### Top Level Awaits with Bindings
![](http://g.recordit.co/5wCoWg1r6k.gif)