### PR TITLE
Conditionally show focus indicators

### DIFF
--- a/src/components/A11yIntention.css
+++ b/src/components/A11yIntention.css
@@ -1,0 +1,3 @@
+.A11y-mouse :focus {
+  outline: 0;
+}

--- a/src/components/A11yIntention.js
+++ b/src/components/A11yIntention.js
@@ -19,15 +19,11 @@ export default class A11yIntention extends React.Component<Props, State> {
   state = { keyboard: false };
 
   handleKeyDown = () => {
-    if (!this.state.keyboard) {
-      this.setState({ keyboard: true });
-    }
+    this.setState({ keyboard: true });
   };
 
   handleMouseDown = () => {
-    if (this.state.keyboard) {
-      this.setState({ keyboard: false });
-    }
+    this.setState({ keyboard: false });
   };
 
   render() {

--- a/src/components/A11yIntention.js
+++ b/src/components/A11yIntention.js
@@ -1,0 +1,39 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
+// @flow
+import React from "react";
+import "./A11yIntention.css";
+
+type State = {
+  keyboard: boolean
+};
+
+export default class A11yIntention extends React.Component<*, State> {
+  state = { keyboard: false };
+
+  handleKeyDown = () => {
+    if (!this.state.keyboard) {
+      this.setState({ keyboard: true });
+    }
+  };
+
+  handleMouseDown = () => {
+    if (this.state.keyboard) {
+      this.setState({ keyboard: false });
+    }
+  };
+
+  render() {
+    return (
+      <div
+        className={this.state.keyboard ? "A11y-keyboard" : "A11y-mouse"}
+        onKeyDown={this.handleKeyDown}
+        onMouseDown={this.handleMouseDown}
+      >
+        {this.props.children}
+      </div>
+    );
+  }
+}

--- a/src/components/A11yIntention.js
+++ b/src/components/A11yIntention.js
@@ -4,13 +4,18 @@
 
 // @flow
 import React from "react";
+import type { Node } from "react";
 import "./A11yIntention.css";
+
+type Props = {
+  children?: Node
+};
 
 type State = {
   keyboard: boolean
 };
 
-export default class A11yIntention extends React.Component<*, State> {
+export default class A11yIntention extends React.Component<Props, State> {
   state = { keyboard: false };
 
   handleKeyDown = () => {

--- a/src/components/App.css
+++ b/src/components/App.css
@@ -8,7 +8,6 @@
 
 button {
   background: transparent;
-  outline: none;
   border: none;
 }
 

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -8,6 +8,7 @@ import React, { Component } from "react";
 import { connect } from "react-redux";
 import { features } from "../utils/prefs";
 import actions from "../actions";
+import A11yIntention from "./A11yIntention";
 import { ShortcutsModal } from "./ShortcutsModal";
 
 import {
@@ -297,14 +298,16 @@ class App extends Component<Props, State> {
     const { quickOpenEnabled } = this.props;
     return (
       <div className="debugger">
-        {this.renderLayout()}
-        {quickOpenEnabled === true && (
-          <QuickOpenModal
-            shortcutsModalEnabled={this.state.shortcutsModalEnabled}
-            toggleShortcutsModal={() => this.toggleShortcutsModal()}
-          />
-        )}
-        {this.renderShortcutsModal()}
+        <A11yIntention>
+          {this.renderLayout()}
+          {quickOpenEnabled === true && (
+            <QuickOpenModal
+              shortcutsModalEnabled={this.state.shortcutsModalEnabled}
+              toggleShortcutsModal={() => this.toggleShortcutsModal()}
+            />
+          )}
+          {this.renderShortcutsModal()}
+        </A11yIntention>
       </div>
     );
   }

--- a/src/components/Editor/Footer.css
+++ b/src/components/Editor/Footer.css
@@ -49,10 +49,6 @@
   background: var(--theme-toolbar-background-hover);
 }
 
-.source-footer > .commands > button.action:focus {
-  outline: none;
-}
-
 :root.theme-dark .source-footer > .commands > .action {
   fill: var(--theme-body-color);
 }

--- a/src/components/Editor/SearchBar.css
+++ b/src/components/Editor/SearchBar.css
@@ -32,10 +32,6 @@
   padding: 0 13px;
 }
 
-.search-bottom-bar button:focus {
-  outline: none;
-}
-
 .search-bottom-bar .search-modifiers {
   display: flex;
   align-items: center;
@@ -69,10 +65,6 @@
   background: var(--theme-toolbar-background-hover);
 }
 
-.search-bottom-bar .search-modifiers button:active {
-  outline: none;
-}
-
 .search-bottom-bar .search-modifiers button.active svg {
   fill: var(--theme-selection-background);
 }
@@ -93,10 +85,6 @@
   border: none;
   background: transparent;
   color: var(--theme-comment);
-}
-
-.search-bottom-bar .search-type-toggles .search-type-btn:active {
-  outline: none;
 }
 
 .search-bottom-bar .search-type-toggles .search-type-btn.active {

--- a/src/components/PrimaryPanes/Sources.css
+++ b/src/components/PrimaryPanes/Sources.css
@@ -72,10 +72,6 @@
   overflow: hidden;
 }
 
-.sources-list .tree:focus {
-  outline: none;
-}
-
 .sources-list .managed-tree {
   flex: 1;
   display: flex;

--- a/src/components/SecondaryPanes/Expressions.css
+++ b/src/components/SecondaryPanes/Expressions.css
@@ -37,7 +37,6 @@
 }
 
 .input-expression:focus {
-  outline: none;
   cursor: text;
 }
 
@@ -117,8 +116,4 @@
 
 .expression-input {
   max-width: 50%;
-}
-
-.expressions-list .tree:focus {
-  outline: none;
 }

--- a/src/components/SecondaryPanes/Frames/Frames.css
+++ b/src/components/SecondaryPanes/Frames/Frames.css
@@ -56,7 +56,6 @@
 .frames ul li:hover,
 .frames ul li:focus {
   background-color: var(--theme-toolbar-background-alt);
-  outline: none;
 }
 
 .theme-dark .frames ul li:focus {

--- a/src/components/SecondaryPanes/Scopes.css
+++ b/src/components/SecondaryPanes/Scopes.css
@@ -37,10 +37,6 @@ html[dir="rtl"] .object-node {
   overflow: auto;
 }
 
-.scopes-list .tree:focus {
-  outline: none;
-}
-
 .scopes-list .function-signature {
   display: inline-block;
 }

--- a/src/components/shared/Accordion.css
+++ b/src/components/shared/Accordion.css
@@ -64,7 +64,6 @@
   display: flex;
   margin-left: auto;
   padding-right: 5px;
-  outline: 0;
 }
 
 .accordion .header-buttons .add-button {
@@ -77,7 +76,6 @@
   color: var(--theme-body-color);
   border: none;
   background: none;
-  outline: 0;
   padding: 0;
   width: 16px;
   height: 16px;

--- a/src/components/shared/Button/styles/CloseButton.css
+++ b/src/components/shared/Button/styles/CloseButton.css
@@ -14,10 +14,6 @@
   padding: 0;
 }
 
-.close-btn:focus {
-  outline: none;
-}
-
 .close-btn .close {
   mask: url(/images/close.svg) no-repeat;
   mask-size: 100%;

--- a/src/components/shared/Button/styles/CommandBarButton.css
+++ b/src/components/shared/Button/styles/CommandBarButton.css
@@ -13,10 +13,6 @@
   fill: currentColor;
 }
 
-.command-bar-button:focus {
-  outline: none;
-}
-
 .command-bar-button:disabled {
   opacity: 0.8;
   cursor: default;

--- a/src/components/shared/SearchInput.css
+++ b/src/components/shared/SearchInput.css
@@ -57,10 +57,6 @@
   line-height: 40px;
 }
 
-.search-field input:focus {
-  outline: none;
-}
-
 .theme-dark .search-field input {
   color: var(--theme-body-color-inactive);
 }

--- a/src/components/test/A11yIntention.spec.js
+++ b/src/components/test/A11yIntention.spec.js
@@ -1,0 +1,24 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
+import React from "react";
+import { shallow } from "enzyme";
+import A11yIntention from "../A11yIntention";
+
+function render() {
+  return shallow(<A11yIntention />);
+}
+
+describe("A11yIntention", () => {
+  it("toggles between indicating keyboard and mouse usage", () => {
+    const component = render();
+    expect(component.prop("className")).toEqual("A11y-mouse");
+
+    component.simulate("keyDown");
+    expect(component.prop("className")).toEqual("A11y-keyboard");
+
+    component.simulate("mouseDown");
+    expect(component.prop("className")).toEqual("A11y-mouse");
+  });
+});

--- a/src/components/test/A11yIntention.spec.js
+++ b/src/components/test/A11yIntention.spec.js
@@ -7,10 +7,19 @@ import { shallow } from "enzyme";
 import A11yIntention from "../A11yIntention";
 
 function render() {
-  return shallow(<A11yIntention />);
+  return shallow(
+    <A11yIntention>
+      <span>hello world</span>
+    </A11yIntention>
+  );
 }
 
 describe("A11yIntention", () => {
+  it("renders its children", () => {
+    const component = render();
+    expect(component).toMatchSnapshot();
+  });
+
   it("indicates that the mouse or keyboard is being used", () => {
     const component = render();
     expect(component.prop("className")).toEqual("A11y-mouse");

--- a/src/components/test/A11yIntention.spec.js
+++ b/src/components/test/A11yIntention.spec.js
@@ -11,7 +11,7 @@ function render() {
 }
 
 describe("A11yIntention", () => {
-  it("toggles between indicating keyboard and mouse usage", () => {
+  it("indicates that the mouse or keyboard is being used", () => {
     const component = render();
     expect(component.prop("className")).toEqual("A11y-mouse");
 

--- a/src/components/test/__snapshots__/A11yIntention.spec.js.snap
+++ b/src/components/test/__snapshots__/A11yIntention.spec.js.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`A11yIntention renders its children 1`] = `
+<div
+  className="A11y-mouse"
+  onKeyDown={[Function]}
+  onMouseDown={[Function]}
+>
+  <span>
+    hello world
+  </span>
+</div>
+`;


### PR DESCRIPTION
Fixes Issue: #6628 

### Summary of Changes

* Introduces a React component which detects keyboard vs mouse interaction
* Applies a class indicating what mode of interaction is being used
* Styles focus outlines so that they only show up when the keyboard is being used
* Removes `outline: 0` from everywhere else, so that keyboard users can see what has focus

### Screenshots/Videos

Coming soon...
