### PR TITLE
Auto-format package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,41 +18,31 @@
     "start": "node bin/dev-server",
     "start-app": "TARGET=application node bin/dev-server",
     "flow": "flow",
-    "eslint-check":
-      "eslint --print-config .eslintrc.js | eslint-config-prettier-check",
+    "eslint-check": "eslint --print-config .eslintrc.js | eslint-config-prettier-check",
     "prettier": "node bin/prettier.js",
     "license-check": "devtools-license-check",
     "links": "ls -l node_modules/ | grep ^l || echo 'no linked packages'",
     "lint": "run-p lint:css lint:js lint:md",
     "lint:css": "stylelint \"src/components/**/*.css\"",
     "lint:js": "eslint *.js \"src/**/*.js\" \"packages/*/src/**/*.js\" --fix",
-    "lint:md":
-      "remark -u devtools-linters/markdown/preset -qf *.md src configs docs",
-    "mochi":
-      "mochii --mc ./firefox --interactive --default-test-path devtools/client/debugger/new",
+    "lint:md": "remark -u devtools-linters/markdown/preset -qf *.md src configs docs",
+    "mochi": "mochii --mc ./firefox --interactive --default-test-path devtools/client/debugger/new",
     "mochid": "yarn mochi -- --jsdebugger --",
     "mochir": "yarn mochi -- --repeat 10 --",
     "mochih": "yarn mochi -- --headless --",
-    "mochici":
-      "mochii --mc ./firefox --ci --default-test-path devtools/client/debugger/new --headless --",
+    "mochici": "mochii --mc ./firefox --ci --default-test-path devtools/client/debugger/new --headless --",
     "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "yarn test --coverage",
     "test:all": "yarn test; yarn lint; yarn flow",
-    "firefox":
-      "start-firefox --start --location https://devtools-html.github.io/debugger-examples/",
-    "chrome":
-      "start-chrome --location https://devtools-html.github.io/debugger-examples/",
+    "firefox": "start-firefox --start --location https://devtools-html.github.io/debugger-examples/",
+    "chrome": "start-chrome --location https://devtools-html.github.io/debugger-examples/",
     "watch": "node bin/copy --watch --symlink",
     "copy": "node bin/copy --assets",
-    "build-docs":
-      "documentation build --format html --sort-order alpha --shallow  --document-exported --output docs/reference/ src/types.js src/utils/ src/reducers/ src/actions/ src/test/mochitest/head.js",
-    "flow-coverage":
-      "flow-coverage-report --threshold 50 -i 'src/actions/*.js' -i 'src/reducers/*.js' -i 'src/utils/*.js' -i 'src/components/*.js' -i 'src/components/**/*.js' -t html -t text",
-    "flow-utils":
-      "flow-coverage-report -i 'src/utils/*.js' -i 'src/utils/**/*.js' -t text",
-    "flow-redux":
-      "flow-coverage-report  -i 'src/reducers/*.js' -i 'src/actions/*.js'  -t text",
+    "build-docs": "documentation build --format html --sort-order alpha --shallow  --document-exported --output docs/reference/ src/types.js src/utils/ src/reducers/ src/actions/ src/test/mochitest/head.js",
+    "flow-coverage": "flow-coverage-report --threshold 50 -i 'src/actions/*.js' -i 'src/reducers/*.js' -i 'src/utils/*.js' -i 'src/components/*.js' -i 'src/components/**/*.js' -t html -t text",
+    "flow-utils": "flow-coverage-report -i 'src/utils/*.js' -i 'src/utils/**/*.js' -t text",
+    "flow-redux": "flow-coverage-report  -i 'src/reducers/*.js' -i 'src/actions/*.js'  -t text",
     "flow-react": "flow-coverage-report -i 'src/components/**/*.js' -t text",
     "postcheckout": "node bin/post-checkout.js",
     "postmerge": "node bin/post-merge.js",
@@ -102,10 +92,21 @@
     "wasmparser": "^0.6.1"
   },
   "private": true,
-  "workspaces": ["packages/*"],
-  "files": ["src", "assets"],
+  "workspaces": [
+    "packages/*"
+  ],
+  "files": [
+    "src",
+    "assets"
+  ],
   "greenkeeper": {
-    "ignore": ["react", "react-dom", "react-redux", "redux", "codemirror"]
+    "ignore": [
+      "react",
+      "react-dom",
+      "react-redux",
+      "redux",
+      "codemirror"
+    ]
   },
   "main": "src/main.js",
   "author": "Jason Laster <jlaster@mozilla.com>",
@@ -171,11 +172,29 @@
     "workerjs": "github:jasonLaster/workerjs"
   },
   "lint-staged": {
-    "bin/*.js": ["prettier", "git add"],
-    "src/*.js": ["prettier", "git add"],
-    "src/*/*.js": ["prettier", "git add"],
-    "src/*/!(mochitest)**/*.js": ["prettier", "git add"],
-    "src/*/!(mochitest)*/**/*.js": ["prettier", "git add"],
-    "packages/**/src/*.js": ["prettier", "git add"]
+    "bin/*.js": [
+      "prettier",
+      "git add"
+    ],
+    "src/*.js": [
+      "prettier",
+      "git add"
+    ],
+    "src/*/*.js": [
+      "prettier",
+      "git add"
+    ],
+    "src/*/!(mochitest)**/*.js": [
+      "prettier",
+      "git add"
+    ],
+    "src/*/!(mochitest)*/**/*.js": [
+      "prettier",
+      "git add"
+    ],
+    "packages/**/src/*.js": [
+      "prettier",
+      "git add"
+    ]
   }
 }


### PR DESCRIPTION
When running `yarn install` the package.json gets auto-formatted for me, and this is the result.

I'm on yarn 1.9.4. Tried with Node 8.11.3 and 10.6.0.

Not sure if we actually want these changes or not, and if we don't that's cool.