### PR TITLE
Update local-development.md

### DIFF
--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -167,7 +167,7 @@ index 429d56c..dadb36c 100644
    projectTextSearch: ["Bool", "project-text-search", true],
    wasm: ["Bool", "wasm", true],
    shortcuts: ["Bool", "shortcuts", false]
-+  awesome: ["Bool", "shortcuts", false]
++  awesome: ["Bool", "awesome", false]
  });
 
  if (prefs.debuggerPrefsSchemaVersion !== prefsSchemaVersion) {


### PR DESCRIPTION
use right property name

In creating a new feature flag, the feature was named "awesome", but in the example it was using the value "search" instead.
