### PR TITLE
Better format duplicate filename text

### DIFF
--- a/src/utils/source.js
+++ b/src/utils/source.js
@@ -181,7 +181,9 @@ export function getDisplayPath(mySource: Source, sources: Source[]) {
   // Find sources that have the same filename, but different paths
   // as the original source
   const similarSources = sources.filter(
-    source => mySource.url != source.url && filename == getFilename(source)
+    source =>
+      getRawSourceURL(mySource.url) != getRawSourceURL(source.url) &&
+      filename == getFilename(source)
   );
 
   if (similarSources.length == 0) {

--- a/src/utils/tests/source.spec.js
+++ b/src/utils/tests/source.spec.js
@@ -184,20 +184,24 @@ describe("sources", () => {
         )
       ).toBe(undefined);
     });
-    it(`should give us the path for files with same name when one is pretty`, () => {
+    it(`should give us the path for files with same name when both 
+      are pretty and different path`, () => {
       expect(
         getDisplayPath(
           {
-            url: "http://localhost.com:7999/increment/abc/web/hello.html:formatted",
+            url:
+              "http://localhost.com:7999/increment/abc/web/hello.html:formatted",
             id: ""
           },
           [
             {
-              url: "http://localhost.com:7999/increment/xyz/web/hello.html:formatted",
+              url:
+                "http://localhost.com:7999/increment/xyz/web/hello.html:formatted",
               id: ""
             },
             {
-              url: "http://localhost.com:7999/increment/abc/web/hello.html:formatted",
+              url:
+                "http://localhost.com:7999/increment/abc/web/hello.html:formatted",
               id: ""
             },
             {
@@ -208,7 +212,6 @@ describe("sources", () => {
         )
       ).toBe("abc/web");
     });
-
   });
 
   describe("getFileURL", () => {

--- a/src/utils/tests/source.spec.js
+++ b/src/utils/tests/source.spec.js
@@ -135,7 +135,7 @@ describe("sources", () => {
       ).toBe("abc/web");
     });
 
-    it("should give np path for files with unique name", () => {
+    it("should give no path for files with unique name", () => {
       expect(
         getDisplayPath(
           {
@@ -153,6 +153,31 @@ describe("sources", () => {
             },
             {
               url: "http://localhost.com:7999/increment/hello.html",
+              id: ""
+            }
+          ]
+        )
+      ).toBe(undefined);
+    });
+    it("should not show display path for pretty file", () => {
+      expect(
+        getDisplayPath(
+          {
+            url:
+              "http://localhost.com:7999/increment/abc/web/hello.html:formatted",
+            id: ""
+          },
+          [
+            {
+              url: "http://localhost.com:7999/increment/abc/web/hell.html",
+              id: ""
+            },
+            {
+              url: "http://localhost.com:7999/increment/abc/web/hello.html",
+              id: ""
+            },
+            {
+              url: "http://localhost.com:7999/increment/xyz.html:formatted",
               id: ""
             }
           ]

--- a/src/utils/tests/source.spec.js
+++ b/src/utils/tests/source.spec.js
@@ -184,6 +184,31 @@ describe("sources", () => {
         )
       ).toBe(undefined);
     });
+    it(`should give us the path for files with same name when one is pretty`, () => {
+      expect(
+        getDisplayPath(
+          {
+            url: "http://localhost.com:7999/increment/abc/web/hello.html:formatted",
+            id: ""
+          },
+          [
+            {
+              url: "http://localhost.com:7999/increment/xyz/web/hello.html:formatted",
+              id: ""
+            },
+            {
+              url: "http://localhost.com:7999/increment/abc/web/hello.html:formatted",
+              id: ""
+            },
+            {
+              url: "http://localhost.com:7999/increment/hello.html:formatted",
+              id: ""
+            }
+          ]
+        )
+      ).toBe("abc/web");
+    });
+
   });
 
   describe("getFileURL", () => {


### PR DESCRIPTION
Fixes Issue: #6733

### Summary of Changes

* Add logic that hides the extended file information when both files are same just pretty-printed

### Test Plan

Add the test cases for the following:
* duplicate file path,  different name
* duplicate file path, same name (pretty print)


### Screenshots
<img width="383" alt="screen shot 2018-08-07 at 2 02 49 am" src="https://user-images.githubusercontent.com/13422807/43740485-f82047c4-99e8-11e8-9213-8de854bb6888.png">

