### PR TITLE
[Tabs] Move actions and reducer for the editor tabs into their own files

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -18,6 +18,7 @@ import * as replay from "./replay";
 import * as quickOpen from "./quick-open";
 import * as sourceTree from "./source-tree";
 import * as sources from "./sources";
+import * as tabs from "./tabs";
 import * as debuggee from "./debuggee";
 import * as toolbox from "./toolbox";
 import * as preview from "./preview";
@@ -28,6 +29,7 @@ export default {
   ...expressions,
   ...eventListeners,
   ...sources,
+  ...tabs,
   ...pause,
   ...ui,
   ...fileSearch,

--- a/src/actions/sources/index.js
+++ b/src/actions/sources/index.js
@@ -8,4 +8,3 @@ export * from "./loadSourceText";
 export * from "./newSources";
 export * from "./prettyPrint";
 export * from "./select";
-export * from "./tabs";

--- a/src/actions/sources/select.js
+++ b/src/actions/sources/select.js
@@ -15,7 +15,7 @@ import { setOutOfScopeLocations, setSymbols } from "../ast";
 import { closeActiveSearch, updateActiveFileSearch } from "../ui";
 
 import { togglePrettyPrint } from "./prettyPrint";
-import { addTab, closeTab } from "./tabs";
+import { addTab, closeTab } from "../tabs";
 import { loadSourceText } from "./loadSourceText";
 
 import { prefs } from "../../utils/prefs";

--- a/src/actions/tabs.js
+++ b/src/actions/tabs.js
@@ -5,12 +5,12 @@
 // @flow
 
 /**
- * Redux actions for the sources state
- * @module actions/sources
+ * Redux actions for the editor tabs
+ * @module actions/tabs
  */
 
-import { removeDocument } from "../../utils/editor";
-import { selectSource } from "../sources";
+import { removeDocument } from "../utils/editor";
+import { selectSource } from "./sources";
 
 import {
   getSourceByURL,
@@ -18,9 +18,9 @@ import {
   getNewSelectedSourceId,
   removeSourcesFromTabList,
   removeSourceFromTabList
-} from "../../selectors";
+} from "../selectors";
 
-import type { Action, ThunkArgs } from "../types";
+import type { Action, ThunkArgs } from "./types";
 
 export function addTab(url: string, tabIndex: number): Action {
   return {
@@ -39,7 +39,7 @@ export function moveTab(url: string, tabIndex: number): Action {
 }
 
 /**
- * @memberof actions/sources
+ * @memberof actions/tabs
  * @static
  */
 export function closeTab(url: string) {
@@ -54,7 +54,7 @@ export function closeTab(url: string) {
 }
 
 /**
- * @memberof actions/sources
+ * @memberof actions/tabs
  * @static
  */
 export function closeTabs(urls: string[]) {

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -10,6 +10,7 @@
 import expressions from "./expressions";
 import eventListeners from "./event-listeners";
 import sources from "./sources";
+import tabs from "./tabs";
 import breakpoints from "./breakpoints";
 import pendingBreakpoints from "./pending-breakpoints";
 import asyncRequests from "./async-requests";
@@ -28,6 +29,7 @@ export default {
   expressions,
   eventListeners,
   sources,
+  tabs,
   breakpoints,
   pendingBreakpoints,
   asyncRequests,

--- a/src/reducers/tabs.js
+++ b/src/reducers/tabs.js
@@ -1,0 +1,172 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
+// @flow
+
+/**
+ * Tabs reducer
+ * @module reducers/tabs
+ */
+
+import { createSelector } from "reselect";
+import move from "lodash-move";
+
+import { prefs } from "../utils/prefs";
+import {
+  getSource,
+  getSources,
+  getSourceByURL,
+  getSourceByUrlInSources
+} from "./sources";
+
+import type { Action } from "../actions/types";
+import type { SourcesMap, SourcesState } from "./sources";
+
+type Tab = string;
+export type TabList = Tab[];
+export type TabsState = Tab[];
+
+export function initialTabsState(): TabsState {
+  return restoreTabs();
+}
+
+function update(
+  state: TabsState = initialTabsState(),
+  action: Action
+): TabsState {
+  switch (action.type) {
+    case "ADD_TAB":
+      return updateTabList(state, action.url);
+
+    case "MOVE_TAB":
+      return updateTabList(state, action.url, action.tabIndex);
+
+    case "CLOSE_TAB":
+      prefs.tabs = action.tabs;
+      return action.tabs;
+
+    case "CLOSE_TABS":
+      prefs.tabs = action.tabs;
+      return action.tabs;
+
+    default:
+      return state;
+  }
+}
+
+export function removeSourceFromTabList(tabs: TabList, url: string): TabList {
+  return tabs.filter(tab => tab !== url);
+}
+
+export function removeSourcesFromTabList(tabs: TabList, urls: TabList) {
+  return urls.reduce((t, url) => removeSourceFromTabList(t, url), tabs);
+}
+
+function restoreTabs() {
+  const prefsTabs = prefs.tabs || [];
+  return prefsTabs;
+}
+
+/**
+ * Adds the new source to the tab list if it is not already there
+ * @memberof reducers/tabs
+ * @static
+ */
+function updateTabList(tabs: TabList, url: string, newIndex: ?number) {
+  const currentIndex = tabs.indexOf(url);
+  if (currentIndex === -1) {
+    tabs = [url, ...tabs];
+  } else if (newIndex !== undefined) {
+    tabs = move(tabs, currentIndex, newIndex);
+  }
+
+  prefs.tabs = tabs;
+  return tabs;
+}
+
+/**
+ * Gets the next tab to select when a tab closes. Heuristics:
+ * 1. if the selected tab is available, it remains selected
+ * 2. if it is gone, the next available tab to the left should be active
+ * 3. if the first tab is active and closed, select the second tab
+ *
+ * @memberof reducers/tabs
+ * @static
+ */
+export function getNewSelectedSourceId(
+  state: OuterState,
+  availableTabs: TabList
+): string {
+  const selectedLocation = state.sources.selectedLocation;
+  if (!selectedLocation) {
+    return "";
+  }
+
+  const selectedTab = getSource(state, selectedLocation.sourceId);
+  if (!selectedTab) {
+    return "";
+  }
+
+  if (availableTabs.includes(selectedTab.url)) {
+    const sources = state.sources.sources;
+    if (!sources) {
+      return "";
+    }
+
+    const selectedSource = getSourceByURL(state, selectedTab.url);
+
+    if (selectedSource) {
+      return selectedSource.id;
+    }
+
+    return "";
+  }
+
+  const tabUrls = state.tabs;
+  const leftNeighborIndex = Math.max(tabUrls.indexOf(selectedTab.url) - 1, 0);
+  const lastAvailbleTabIndex = availableTabs.length - 1;
+  const newSelectedTabIndex = Math.min(leftNeighborIndex, lastAvailbleTabIndex);
+  const availableTab = availableTabs[newSelectedTabIndex];
+  const tabSource = getSourceByUrlInSources(
+    state.sources.sources,
+    availableTab
+  );
+
+  if (tabSource) {
+    return tabSource.id;
+  }
+
+  return "";
+}
+
+// Selectors
+
+// Unfortunately, it's really hard to make these functions accept just
+// the state that we care about and still type it with Flow. The
+// problem is that we want to re-export all selectors from a single
+// module for the UI, and all of those selectors should take the
+// top-level app state, so we'd have to "wrap" them to automatically
+// pick off the piece of state we're interested in. It's impossible
+// (right now) to type those wrapped functions.
+type OuterState = { tabs: TabsState, sources: SourcesState };
+
+export const getTabs = (state: OuterState): TabsState => state.tabs;
+
+export const getSourceTabs = createSelector(
+  getTabs,
+  getSources,
+  (tabs, sources) => tabs.filter(tab => getSourceByUrlInSources(sources, tab))
+);
+
+export const getSourcesForTabs = createSelector(
+  getSourceTabs,
+  getSources,
+  (tabs: TabList, sources: SourcesMap) => {
+    return tabs
+      .map(tab => getSourceByUrlInSources(sources, tab))
+      .filter(source => source);
+  }
+);
+
+export default update;

--- a/src/reducers/tabs.js
+++ b/src/reducers/tabs.js
@@ -25,12 +25,8 @@ import type { SourcesMap, SourcesState } from "./sources";
 
 type Tab = string;
 export type TabList = Tab[];
-export type TabsState = Tab[];
 
-function update(
-  state: TabsState = prefs.tabs || [],
-  action: Action
-): TabsState {
+function update(state: TabList = prefs.tabs || [], action: Action): TabList {
   switch (action.type) {
     case "ADD_TAB":
       return updateTabList(state, action.url);
@@ -137,9 +133,9 @@ export function getNewSelectedSourceId(
 // top-level app state, so we'd have to "wrap" them to automatically
 // pick off the piece of state we're interested in. It's impossible
 // (right now) to type those wrapped functions.
-type OuterState = { tabs: TabsState, sources: SourcesState };
+type OuterState = { tabs: TabList, sources: SourcesState };
 
-export const getTabs = (state: OuterState): TabsState => state.tabs;
+export const getTabs = (state: OuterState): TabList => state.tabs;
 
 export const getSourceTabs = createSelector(
   getTabs,

--- a/src/reducers/tabs.js
+++ b/src/reducers/tabs.js
@@ -27,12 +27,8 @@ type Tab = string;
 export type TabList = Tab[];
 export type TabsState = Tab[];
 
-export function initialTabsState(): TabsState {
-  return restoreTabs();
-}
-
 function update(
-  state: TabsState = initialTabsState(),
+  state: TabsState = prefs.tabs || [],
   action: Action
 ): TabsState {
   switch (action.type) {
@@ -43,9 +39,6 @@ function update(
       return updateTabList(state, action.url, action.tabIndex);
 
     case "CLOSE_TAB":
-      prefs.tabs = action.tabs;
-      return action.tabs;
-
     case "CLOSE_TABS":
       prefs.tabs = action.tabs;
       return action.tabs;
@@ -61,11 +54,6 @@ export function removeSourceFromTabList(tabs: TabList, url: string): TabList {
 
 export function removeSourcesFromTabList(tabs: TabList, urls: TabList) {
   return urls.reduce((t, url) => removeSourceFromTabList(t, url), tabs);
-}
-
-function restoreTabs() {
-  const prefsTabs = prefs.tabs || [];
-  return prefsTabs;
 }
 
 /**

--- a/src/reducers/types.js
+++ b/src/reducers/types.js
@@ -18,7 +18,7 @@ import type { PendingBreakpointsState } from "../selectors";
 import type { ProjectTextSearchState } from "./project-text-search";
 import type { Record } from "../utils/makeRecord";
 import type { SourcesState } from "./sources";
-import type { TabsState } from "./tabs";
+import type { TabList } from "./tabs";
 import type { UIState } from "./ui";
 
 export type State = {
@@ -30,7 +30,7 @@ export type State = {
   pendingBreakpoints: PendingBreakpointsState,
   projectTextSearch: Record<ProjectTextSearchState>,
   sources: SourcesState,
-  tabs: TabsState,
+  tabs: TabList,
   ui: Record<UIState>
 };
 

--- a/src/reducers/types.js
+++ b/src/reducers/types.js
@@ -18,6 +18,7 @@ import type { PendingBreakpointsState } from "../selectors";
 import type { ProjectTextSearchState } from "./project-text-search";
 import type { Record } from "../utils/makeRecord";
 import type { SourcesState } from "./sources";
+import type { TabsState } from "./tabs";
 import type { UIState } from "./ui";
 
 export type State = {
@@ -29,6 +30,7 @@ export type State = {
   pendingBreakpoints: PendingBreakpointsState,
   projectTextSearch: Record<ProjectTextSearchState>,
   sources: SourcesState,
+  tabs: TabsState,
   ui: Record<UIState>
 };
 

--- a/src/selectors/index.js
+++ b/src/selectors/index.js
@@ -6,6 +6,7 @@
 
 export * from "../reducers/expressions";
 export * from "../reducers/sources";
+export * from "../reducers/tabs";
 export * from "../reducers/pause";
 export * from "../reducers/debuggee";
 export * from "../reducers/breakpoints";

--- a/src/utils/quick-open.js
+++ b/src/utils/quick-open.js
@@ -10,7 +10,7 @@ import { isPretty, getFilename, getSourceClassnames } from "./source";
 import type { Location as BabelLocation } from "@babel/types";
 import type { Symbols } from "../reducers/ast";
 import type { QuickOpenType } from "../reducers/quick-open";
-import type { TabList } from "../reducers/sources";
+import type { TabList } from "../reducers/tabs";
 import type { Source } from "../types";
 import type { SymbolDeclaration } from "../workers/parser";
 


### PR DESCRIPTION
Fixes #3279.  This is to finish the work started in PR #5672 as discussed in #6711.

Tasks:
- [x] create a reducers/tabs.js file
- [x]  separate tabs actions
- [x]  wire it all up

