### PR TITLE
Fix 5815 - Show addon icon for addon path

### DIFF
--- a/assets/panel/debugger.properties
+++ b/assets/panel/debugger.properties
@@ -671,6 +671,10 @@ addWatchExpressionText=Add watch expression
 # variables view popup.
 addWatchExpressionButton=Watch
 
+# LOCALIZATION NOTE (extensionsText): The text that is displayed to represent
+# "moz-extension" directories in the source tree
+extensionsText=Extensions
+
 # LOCALIZATION NOTE (emptyVariablesText): The text that is displayed in the
 # variables pane when there are no variables to display.
 emptyVariablesText=No variables to display

--- a/assets/panel/debugger.properties
+++ b/assets/panel/debugger.properties
@@ -671,10 +671,6 @@ addWatchExpressionText=Add watch expression
 # variables view popup.
 addWatchExpressionButton=Watch
 
-# LOCALIZATION NOTE (extensionsText): The text that is displayed to represent
-# "moz-extension" directories in the source tree
-extensionsText=Extensions
-
 # LOCALIZATION NOTE (emptyVariablesText): The text that is displayed in the
 # variables pane when there are no variables to display.
 emptyVariablesText=No variables to display

--- a/src/components/PrimaryPanes/SourcesTree.js
+++ b/src/components/PrimaryPanes/SourcesTree.js
@@ -100,7 +100,6 @@ class SourcesTree extends Component<Props, State> {
 
     const { uncollapsedTree, sourceTree } = this.state;
 
-    
     if (
       projectRoot != nextProps.projectRoot ||
       debuggeeUrl != nextProps.debuggeeUrl ||
@@ -376,9 +375,12 @@ const mapStateToProps = state => {
   };
 };
 
-export default connect(mapStateToProps, {
-  selectSource: actions.selectSource,
-  setExpandedState: actions.setExpandedState,
-  setProjectDirectoryRoot: actions.setProjectDirectoryRoot,
-  clearProjectDirectoryRoot: actions.clearProjectDirectoryRoot
-})(SourcesTree);
+export default connect(
+  mapStateToProps,
+  {
+    selectSource: actions.selectSource,
+    setExpandedState: actions.setExpandedState,
+    setProjectDirectoryRoot: actions.setProjectDirectoryRoot,
+    clearProjectDirectoryRoot: actions.clearProjectDirectoryRoot
+  }
+)(SourcesTree);

--- a/src/components/PrimaryPanes/SourcesTreeItem.js
+++ b/src/components/PrimaryPanes/SourcesTreeItem.js
@@ -44,7 +44,7 @@ export default class SourceTreeItem extends Component<Props, State> {
       return <Svg name="webpack" />;
     } else if (item.path === "ng://") {
       return <Svg name="angular" />;
-    } else if (item.path === "moz-extension://") {
+    } else if (item.path.startsWith("moz-extension://") && depth === 0) {
       return <img className="extension" />;
     }
 
@@ -150,8 +150,6 @@ export default class SourceTreeItem extends Component<Props, State> {
         return "Angular";
       case "webpack://":
         return "Webpack";
-      case "moz-extension://":
-        return L10N.getStr("extensionsText");
       default:
         return name;
     }
@@ -160,7 +158,6 @@ export default class SourceTreeItem extends Component<Props, State> {
   render() {
     const { item, depth, focused } = this.props;
 
-    
     return (
       <div
         className={classnames("node", { focused })}

--- a/src/components/PrimaryPanes/tests/SourcesTreeItem.spec.js
+++ b/src/components/PrimaryPanes/tests/SourcesTreeItem.spec.js
@@ -142,8 +142,11 @@ describe("SourceTreeItem", () => {
     });
 
     it("should show icon for moz-extension item", async () => {
-      const item = createMockDirectory("moz-extension://", "moz-extension://");
-      const node = render({ item });
+      const item = createMockDirectory(
+        "moz-extension://e37c3c08-beac-a04b-8032-c4f699a1a856",
+        "moz-extension://e37c3c08-beac-a04b-8032-c4f699a1a856"
+      );
+      const node = render({ item, depth: 0 });
       expect(node).toMatchSnapshot();
     });
 

--- a/src/components/PrimaryPanes/tests/__snapshots__/SourcesTreeItem.spec.js.snap
+++ b/src/components/PrimaryPanes/tests/__snapshots__/SourcesTreeItem.spec.js.snap
@@ -988,7 +988,7 @@ exports[`SourceTreeItem renderItem should show icon for moz-extension item 1`] =
 Object {
   "component": <div
     className="node"
-    key="moz-extension://"
+    key="moz-extension://e37c3c08-beac-a04b-8032-c4f699a1a856"
     onClick={[Function]}
     onContextMenu={[Function]}
   >
@@ -1002,7 +1002,7 @@ Object {
       className="label"
     >
        
-      Extensions
+      moz-extension://e37c3c08-beac-a04b-8032-c4f699a1a856
        
     </span>
   </div>,
@@ -1014,12 +1014,13 @@ Object {
     "props": Object {
       "clearProjectDirectoryRoot": [MockFunction],
       "debuggeeUrl": "http://mdn.com",
+      "depth": 0,
       "expanded": false,
       "focusItem": [MockFunction],
       "item": Object {
         "contents": Array [],
-        "name": "moz-extension://",
-        "path": "moz-extension://",
+        "name": "moz-extension://e37c3c08-beac-a04b-8032-c4f699a1a856",
+        "path": "moz-extension://e37c3c08-beac-a04b-8032-c4f699a1a856",
         "type": "directory",
       },
       "projectRoot": "",
@@ -1048,13 +1049,14 @@ Object {
         "_element": <SourceTreeItem
           clearProjectDirectoryRoot={[MockFunction]}
           debuggeeUrl="http://mdn.com"
+          depth={0}
           expanded={false}
           focusItem={[MockFunction]}
           item={
             Object {
               "contents": Array [],
-              "name": "moz-extension://",
-              "path": "moz-extension://",
+              "name": "moz-extension://e37c3c08-beac-a04b-8032-c4f699a1a856",
+              "path": "moz-extension://e37c3c08-beac-a04b-8032-c4f699a1a856",
               "type": "directory",
             }
           }
@@ -1095,7 +1097,7 @@ Object {
             className="label"
           >
              
-            Extensions
+            moz-extension://e37c3c08-beac-a04b-8032-c4f699a1a856
              
           </span>
         </div>,
@@ -1107,12 +1109,13 @@ Object {
   "props": Object {
     "clearProjectDirectoryRoot": [MockFunction],
     "debuggeeUrl": "http://mdn.com",
+    "depth": 0,
     "expanded": false,
     "focusItem": [MockFunction],
     "item": Object {
       "contents": Array [],
-      "name": "moz-extension://",
-      "path": "moz-extension://",
+      "name": "moz-extension://e37c3c08-beac-a04b-8032-c4f699a1a856",
+      "path": "moz-extension://e37c3c08-beac-a04b-8032-c4f699a1a856",
       "type": "directory",
     },
     "projectRoot": "",


### PR DESCRIPTION
Fixes Issue: #5815

In some refactoring, I think we lost the addon icon in the sources tree.

<img width="370" alt="addonicon" src="https://user-images.githubusercontent.com/46655/43810250-427d7a06-9a7c-11e8-93c7-c93a2109a8c2.png">

I left the following in `debugger.properties`:

```

# LOCALIZATION NOTE (extensionsText): The text that is displayed to represent
# "moz-extension" directories in the source tree
extensionsText=Extensions
```

... in the case that we use this text again.  Seems reasonable