### PR TITLE
[sources] Cache sources by url

### DIFF
--- a/src/reducers/tabs.js
+++ b/src/reducers/tabs.js
@@ -16,12 +16,13 @@ import { prefs } from "../utils/prefs";
 import {
   getSource,
   getSources,
+  getUrls,
   getSourceByURL,
   getSourceByUrlInSources
 } from "./sources";
 
 import type { Action } from "../actions/types";
-import type { SourcesMap, SourcesState } from "./sources";
+import type { SourcesState } from "./sources";
 
 type Tab = string;
 export type TabList = Tab[];
@@ -113,7 +114,8 @@ export function getNewSelectedSourceId(
   const newSelectedTabIndex = Math.min(leftNeighborIndex, lastAvailbleTabIndex);
   const availableTab = availableTabs[newSelectedTabIndex];
   const tabSource = getSourceByUrlInSources(
-    state.sources.sources,
+    getSources(state),
+    getUrls(state),
     availableTab
   );
 
@@ -140,15 +142,18 @@ export const getTabs = (state: OuterState): TabList => state.tabs;
 export const getSourceTabs = createSelector(
   getTabs,
   getSources,
-  (tabs, sources) => tabs.filter(tab => getSourceByUrlInSources(sources, tab))
+  getUrls,
+  (tabs, sources, urls) =>
+    tabs.filter(tab => getSourceByUrlInSources(sources, urls, tab))
 );
 
 export const getSourcesForTabs = createSelector(
   getSourceTabs,
   getSources,
-  (tabs: TabList, sources: SourcesMap) => {
+  getUrls,
+  (tabs, sources, urls) => {
     return tabs
-      .map(tab => getSourceByUrlInSources(sources, tab))
+      .map(tab => getSourceByUrlInSources(sources, urls, tab))
       .filter(source => source);
   }
 );


### PR DESCRIPTION
Helps Issue: #6774 

### Summary of Changes

* memoizes sourceByUrl queries so that they're cheaper to do
* this will help us show ` [sm]` in the source tree, which requires doing this check quickly
* it helps us clean up this [profile][p] quite a bit


[p]: https://perf-html.io/public/6bd671a68bd75516a407a408eeffd982cd38984b/flame-graph/?hiddenThreads=1-2-3-4-5-6-7-8&implementation=js&range=0.9551_1.0781&thread=0&threadOrder=0-2-3-4-5-6-7-8-1&v=3

![screen shot 2018-08-08 at 11 55 12 am](https://user-images.githubusercontent.com/254562/43848881-f752d72a-9b01-11e8-8614-703290cf62cc.png)
