### PR TITLE
[Tabs] change Tab click handler event from onMouseUp to onClick

### DIFF
--- a/src/components/Editor/Tab.js
+++ b/src/components/Editor/Tab.js
@@ -188,7 +188,7 @@ class Tab extends PureComponent<Props> {
       <div
         className={className}
         key={sourceId}
-        onMouseUp={handleTabClick}
+        onClick={handleTabClick}
         onContextMenu={e => this.onTabContextMenu(e, sourceId)}
         title={getFileURL(source)}
       >


### PR DESCRIPTION
Fixes Issue: #6781

The Tab component outer div has an onMouseUp handler that seems to fire before the close button onClick handler and sets this tab active before the CloseButton onClick handler closes the tab.  By setting the Tab div handler to onClick as well, the CloseButton handler fires first and prevents the Tab `handleTabClick` handler from firing as well.  Is this something that a mochi test will work to test for?  If so, I'll try to write one for it.



