### PR TITLE
Replace/expand stack frames with original source details

### DIFF
--- a/packages/devtools-source-map/src/index.js
+++ b/packages/devtools-source-map/src/index.js
@@ -34,6 +34,7 @@ const getOriginalSourceText = dispatcher.task("getOriginalSourceText");
 const applySourceMap = dispatcher.task("applySourceMap");
 const clearSourceMaps = dispatcher.task("clearSourceMaps");
 const hasMappedSource = dispatcher.task("hasMappedSource");
+const getOriginalStackFrames = dispatcher.task("getOriginalStackFrames");
 
 module.exports = {
   originalToGeneratedId,
@@ -51,6 +52,7 @@ module.exports = {
   getOriginalSourceText,
   applySourceMap,
   clearSourceMaps,
+  getOriginalStackFrames,
   startSourceMapWorker: dispatcher.start.bind(dispatcher),
   stopSourceMapWorker: dispatcher.stop.bind(dispatcher)
 };

--- a/packages/devtools-source-map/src/utils/getOriginalStackFrames.js
+++ b/packages/devtools-source-map/src/utils/getOriginalStackFrames.js
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
+// @flow
+
+import type { Location } from "debugger-html";
+
+// Returns expanded stack frames details based on the generated location.
+// The function return null if not information was found.
+async function getOriginalStackFrames(
+  generatedLocation: Location
+): Promise<?Array<{
+  displayName: string,
+  location?: Location
+}>> {
+  // Reserved for experemental source maps formats.
+  return null;
+}
+
+module.exports = {
+  getOriginalStackFrames
+};

--- a/packages/devtools-source-map/src/worker.js
+++ b/packages/devtools-source-map/src/worker.js
@@ -17,6 +17,8 @@ const {
 
 const { clearSourceMaps } = require("./utils/sourceMapRequests");
 
+const { getOriginalStackFrames } = require("./utils/getOriginalStackFrames");
+
 const {
   workerUtils: { workerHandler }
 } = require("devtools-utils");
@@ -32,6 +34,7 @@ self.onmessage = workerHandler({
   getOriginalLocation,
   getLocationScopes,
   getOriginalSourceText,
+  getOriginalStackFrames,
   hasMappedSource,
   applySourceMap,
   clearSourceMaps

--- a/src/actions/ast.js
+++ b/src/actions/ast.js
@@ -85,7 +85,7 @@ export function setOutOfScopeLocations() {
     const source = getSourceFromId(getState(), location.sourceId);
 
     let locations = null;
-    if (location.line && source && isPaused(getState())) {
+    if (location.line && source && !source.isWasm && isPaused(getState())) {
       locations = await findOutOfScopeLocations(source.id, location);
     }
 

--- a/src/actions/sources/tests/select.spec.js
+++ b/src/actions/sources/tests/select.spec.js
@@ -35,7 +35,7 @@ describe("sources", () => {
     await dispatch(
       actions.paused({
         why: { type: "debuggerStatement" },
-        frames: [makeFrame({ id: 1, sourceId: "foo1" })]
+        frames: [makeFrame({ id: "1", sourceId: "foo1" })]
       })
     );
 

--- a/src/actions/tests/ast.spec.js
+++ b/src/actions/tests/ast.spec.js
@@ -167,7 +167,7 @@ describe("ast", () => {
       await dispatch(
         actions.paused({
           why: { type: "debuggerStatement" },
-          frames: [makeFrame({ id: 1, sourceId: "scopes.js" })]
+          frames: [makeFrame({ id: "1", sourceId: "scopes.js" })]
         })
       );
 

--- a/src/actions/tests/expressions.spec.js
+++ b/src/actions/tests/expressions.spec.js
@@ -143,7 +143,7 @@ describe("expressions", () => {
 async function createFrames(dispatch) {
   const sourceId = "example.js";
   const frame = {
-    id: 2,
+    id: "2",
     location: { sourceId, line: 3 }
   };
 

--- a/src/reducers/pause.js
+++ b/src/reducers/pause.js
@@ -365,12 +365,20 @@ export function getFrames(state: OuterState) {
   return state.pause.frames;
 }
 
+function getGeneratedFrameId(frameId: string): string {
+  if (frameId.includes("-originalFrame")) {
+    // The mapFrames can add original stack frames -- get generated frameId.
+    return frameId.substr(0, frameId.lastIndexOf("-originalFrame"));
+  }
+  return frameId;
+}
+
 export function getGeneratedFrameScope(state: OuterState, frameId: ?string) {
   if (!frameId) {
     return null;
   }
 
-  return getFrameScopes(state).generated[frameId];
+  return getFrameScopes(state).generated[getGeneratedFrameId(frameId)];
 }
 
 export function getOriginalFrameScope(
@@ -386,7 +394,7 @@ export function getOriginalFrameScope(
   }
 
   const isGenerated = isGeneratedId(sourceId);
-  const original = getFrameScopes(state).original[frameId];
+  const original = getFrameScopes(state).original[getGeneratedFrameId(frameId)];
 
   if (!isGenerated && original && (original.pending || original.scope)) {
     return original;

--- a/src/types.js
+++ b/src/types.js
@@ -156,6 +156,7 @@ export type Frame = {
   // FIXME Define this type more clearly
   this: Object,
   framework?: string,
+  isOriginal?: boolean,
   originalDisplayName?: string
 };
 


### PR DESCRIPTION
Fixes Issue: generated frames can correspond to multiple original stack frames

### Summary of Changes

* modify mapFrames() to replace single frame with multiple
* add stub for getOriginalStackFrames

### Test Plan

- See unit test in src/actions/pause/tests/pause.spec.js

