### PR TITLE
[sources] add support for only adding one bp per source

### DIFF
--- a/src/actions/sources/newSources.js
+++ b/src/actions/sources/newSources.js
@@ -131,7 +131,7 @@ function checkPendingBreakpoints(sourceId: string) {
     const source = getSourceFromId(getState(), sourceId);
     const pendingBreakpoints = getPendingBreakpointsForSource(
       getState(),
-      source.url
+      source
     );
 
     if (pendingBreakpoints.length === 0) {
@@ -182,12 +182,12 @@ export function newSources(sources: Source[]) {
 
     dispatch(({ type: "ADD_SOURCES", sources: sources }: Action));
 
+    await dispatch(loadSourceMaps(sources));
+
     for (const source of sources) {
       dispatch(checkSelectedSource(source.id));
       dispatch(checkPendingBreakpoints(source.id));
     }
-
-    await dispatch(loadSourceMaps(sources));
 
     // We would like to restore the blackboxed state
     // after loading all states to make sure the correctness.


### PR DESCRIPTION
Fixes Issue: #5663

### Summary of Changes

- Adds support for only adding one bp.
- tested it here https://q7mmol9xy9.codesandbox.io/
- blocked on the `[sm]` pr because we need `getSourcesByUrl`

### Test Plan

- one jest test
- added a breakpoint in `index.js [sm]` on line 12 and refreshed. when it worked there was one bp, when it failed there were 2, the second was on line 11