### PR TITLE
Create Breakpoints with loading set

### DIFF
--- a/src/utils/breakpoint/index.js
+++ b/src/utils/breakpoint/index.js
@@ -133,7 +133,7 @@ export function createBreakpoint(
     condition: condition || null,
     disabled: disabled || false,
     hidden: hidden || false,
-    loading: false,
+    loading: true,
     astLocation: astLocation || defaultASTLocation,
     generatedLocation: generatedLocation || location,
     location,


### PR DESCRIPTION
Fixes Issue: #6771 

### Summary of Changes

* This will make sure that when a Breakpoint is created it's `loading` property is set 
* When the `addBreakpointPromise` promise completes it will set the value of `loading` to `false`

### Test Plan

For now, I used Redux DevTools to test this, but moving forward I think I can write a test for this as well. 

### Screenshots

Screenshot for Redux DevTools depicting the change in `loading` property
<img width="508" alt="screen shot 2018-08-11 at 12 29 56 am" src="https://user-images.githubusercontent.com/13422807/43976719-3b95ddca-9cff-11e8-8aca-41d1c787202b.png">
