### PR TITLE
Introduce utils/result-list spec

### DIFF
--- a/src/utils/tests/result-list.spec.js
+++ b/src/utils/tests/result-list.spec.js
@@ -1,0 +1,40 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
+jest.mock("devtools-environment", () => ({
+  isFirefox: jest.fn()
+}));
+
+import { isFirefox } from "devtools-environment";
+import { scrollList } from "../result-list.js";
+
+describe("scrollList", () => {
+  it("just returns if element not found", () => {
+    const li = document.createElement("li");
+    scrollList([li]);
+  });
+
+  it("calls scrollIntoView if Firefox", () => {
+    const ul = document.createElement("ul");
+    const li = document.createElement("li");
+
+    li.scrollIntoView = jest.fn();
+    ul.appendChild(li);
+    isFirefox.mockImplementation(() => true);
+
+    scrollList([li], 0);
+    expect(li.scrollIntoView).toHaveBeenCalled();
+  });
+
+  it("sets element scrollTop if not Firefox", () => {
+    const ul = document.createElement("ul");
+    const li = document.createElement("li");
+
+    ul.appendChild(li);
+    isFirefox.mockImplementation(() => false);
+
+    scrollList([li], 0);
+    expect(li.scrollTop).toEqual(0);
+  });
+});


### PR DESCRIPTION
Related https://github.com/devtools-html/debugger.html/issues/5100 

Trying to get familiar with the code base here. Let me know if I missed something and this is already tested somewhere pls.

Two of the tests below don't make much sense because I'm not sure how to set `clientHeight` so we can assert properly on `scrollTop` for the chrome scenario. Should it provide a complete mock object to the test instead?

Also for the [delayed branch](https://github.com/devtools-html/debugger.html/blob/3a530479dd10ed05a0394e714153dcb30a8bce03/src/utils/result-list.js#L23) would assert on `setTimeout`being called enough?

cheers