### PR TITLE
Fix detection of different VueJS builds

### DIFF
--- a/src/utils/pause/frames/getLibraryFromUrl.js
+++ b/src/utils/pause/frames/getLibraryFromUrl.js
@@ -70,7 +70,7 @@ const libraryMap = [
   },
   {
     label: "VueJS",
-    pattern: /vue\.js/i
+    pattern: /vue(?:\.[a-z]+)*\.js/i
   },
   {
     label: "RxJS",

--- a/src/utils/pause/frames/tests/getLibraryFromUrl.spec.js
+++ b/src/utils/pause/frames/tests/getLibraryFromUrl.spec.js
@@ -22,7 +22,7 @@ describe("getLibraryFromUrl", () => {
   });
 
   describe("When Vue is on the frame", () => {
-    it("should return VueJS for differnt builds", () => {
+    it("should return VueJS for different builds", () => {
       const buildTypeList = [
         "vue.js",
         "vue.common.js",

--- a/src/utils/pause/frames/tests/getLibraryFromUrl.spec.js
+++ b/src/utils/pause/frames/tests/getLibraryFromUrl.spec.js
@@ -20,4 +20,33 @@ describe("getLibraryFromUrl", () => {
       expect(getLibraryFromUrl(frame)).toEqual("Preact");
     });
   });
+
+  describe("When Vue is on the frame", () => {
+    it("should return VueJS for differnt builds", () => {
+      const buildTypeList = [
+        "vue.js",
+        "vue.common.js",
+        "vue.esm.js",
+        "vue.runtime.js",
+        "vue.runtime.common.js",
+        "vue.runtime.esm.js",
+        "vue.min.js",
+        "vue.runtime.min.js"
+      ];
+
+      buildTypeList.forEach(buildType => {
+        const frame = {
+          displayName: "name",
+          location: {
+            line: 42
+          },
+          source: {
+            url: `https://cdnjs.cloudflare.com/ajax/libs/vue/2.5.17/${buildType}`
+          }
+        };
+
+        expect(getLibraryFromUrl(frame)).toEqual("VueJS");
+      });
+    });
+  });
 });

--- a/src/utils/source.js
+++ b/src/utils/source.js
@@ -29,7 +29,8 @@ export const sourceTypes = {
   coffee: "coffeescript",
   js: "javascript",
   jsx: "react",
-  ts: "typescript"
+  ts: "typescript",
+  vue: "vue"
 };
 
 /**
@@ -166,6 +167,17 @@ export function getFilename(source: Source) {
  */
 export function getTruncatedFileName(source: Source, length: number = 30) {
   return truncateMiddleText(getFilename(source), length);
+}
+
+/**
+ * Returns the file extension of a source.
+ * Trims any query part or reference identifier.
+ *
+ * @memberof utils/source
+ * @static
+ */
+export function getTrimmedFileExtension(source: Source) {
+  return trimUrlQuery(getFileExtension(source));
 }
 
 /* Gets path for files with same filename for editor tabs, breakpoints, etc.
@@ -414,5 +426,6 @@ export function getSourceClassnames(
   if (source.isBlackBoxed) {
     return "blackBox";
   }
-  return sourceTypes[getFileExtension(source)] || defaultClassName;
+
+  return sourceTypes[getTrimmedFileExtension(source)] || defaultClassName;
 }

--- a/src/utils/source.js
+++ b/src/utils/source.js
@@ -169,17 +169,6 @@ export function getTruncatedFileName(source: Source, length: number = 30) {
   return truncateMiddleText(getFilename(source), length);
 }
 
-/**
- * Returns the file extension of a source.
- * Trims any query part or reference identifier.
- *
- * @memberof utils/source
- * @static
- */
-export function getTrimmedFileExtension(source: Source) {
-  return trimUrlQuery(getFileExtension(source));
-}
-
 /* Gets path for files with same filename for editor tabs, breakpoints, etc.
  * Pass the source, and list of other sources
  *
@@ -427,5 +416,5 @@ export function getSourceClassnames(
     return "blackBox";
   }
 
-  return sourceTypes[getTrimmedFileExtension(source)] || defaultClassName;
+  return sourceTypes[getFileExtension(source)] || defaultClassName;
 }

--- a/src/utils/sources-tree/getURL.js
+++ b/src/utils/sources-tree/getURL.js
@@ -37,7 +37,7 @@ function _getURL(source: Source, defaultDomain: string): ParsedURL {
     return def;
   }
 
-  const { pathname, protocol, host, path } = parse(url);
+  const { pathname, protocol, host } = parse(url);
   const filename = getUnicodeUrlPath(getFilenameFromPath(pathname));
 
   switch (protocol) {
@@ -49,7 +49,7 @@ function _getURL(source: Source, defaultDomain: string): ParsedURL {
     case "resource:":
       return {
         ...def,
-        path,
+        path: pathname,
         filename,
         group: `${protocol}//${host || ""}`
       };
@@ -58,7 +58,7 @@ function _getURL(source: Source, defaultDomain: string): ParsedURL {
     case "ng:":
       return {
         ...def,
-        path: path,
+        path: pathname,
         filename,
         group: `${protocol}//`
       };
@@ -85,7 +85,7 @@ function _getURL(source: Source, defaultDomain: string): ParsedURL {
         // use file protocol for a URL like "/foo/bar.js"
         return {
           ...def,
-          path: path,
+          path: pathname,
           filename,
           group: "file://"
         };
@@ -111,7 +111,7 @@ function _getURL(source: Source, defaultDomain: string): ParsedURL {
 
   return {
     ...def,
-    path: path,
+    path: pathname,
     group: protocol ? `${protocol}//` : "",
     filename
   };

--- a/src/utils/tests/source.spec.js
+++ b/src/utils/tests/source.spec.js
@@ -435,7 +435,7 @@ describe("sources", () => {
       const source = {
         contentType: "text/vue",
         text: "<h1></h1>",
-        url: "App.vue?bc27"
+        url: "App.vue"
       };
       expect(getTrimmedFileExtension(source)).toEqual("vue");
     });

--- a/src/utils/tests/source.spec.js
+++ b/src/utils/tests/source.spec.js
@@ -4,7 +4,6 @@
 
 import {
   getFilename,
-  getTrimmedFileExtension,
   getTruncatedFileName,
   getFileURL,
   getDisplayPath,
@@ -427,44 +426,6 @@ describe("sources", () => {
         text: "function foo(){\n}"
       };
       expect(getSourceLineCount(source)).toEqual(2);
-    });
-  });
-
-  describe("getTrimmedFileExtension", () => {
-    it("should return vue if the file extension is .vue", () => {
-      const source = {
-        contentType: "text/vue",
-        text: "<h1></h1>",
-        url: "App.vue"
-      };
-      expect(getTrimmedFileExtension(source)).toEqual("vue");
-    });
-
-    it("should return jsx if the file extension is .jsx", () => {
-      const source = {
-        contentType: "text/jsx",
-        text: "<span></span>",
-        url: "myComponent.jsx"
-      };
-      expect(getTrimmedFileExtension(source)).toEqual("jsx");
-    });
-
-    it("should return vue if the file extension is .vue with hash", () => {
-      const source = {
-        contentType: "text/vue",
-        text: "<h1></h1>",
-        url: "App.vue?bc27"
-      };
-      expect(getTrimmedFileExtension(source)).toEqual("vue");
-    });
-
-    it("should return empty string if no file extension is given", () => {
-      const source = {
-        contentType: "text/vue",
-        text: "<h1></h1>",
-        url: ""
-      };
-      expect(getTrimmedFileExtension(source)).toEqual("");
     });
   });
 });

--- a/src/utils/tests/source.spec.js
+++ b/src/utils/tests/source.spec.js
@@ -4,6 +4,7 @@
 
 import {
   getFilename,
+  getTrimmedFileExtension,
   getTruncatedFileName,
   getFileURL,
   getDisplayPath,
@@ -426,6 +427,44 @@ describe("sources", () => {
         text: "function foo(){\n}"
       };
       expect(getSourceLineCount(source)).toEqual(2);
+    });
+  });
+
+  describe("getTrimmedFileExtension", () => {
+    it("should return vue if the file extension is .vue", () => {
+      const source = {
+        contentType: "text/vue",
+        text: "<h1></h1>",
+        url: "App.vue?bc27"
+      };
+      expect(getTrimmedFileExtension(source)).toEqual("vue");
+    });
+
+    it("should return jsx if the file extension is .jsx", () => {
+      const source = {
+        contentType: "text/jsx",
+        text: "<span></span>",
+        url: "myComponent.jsx"
+      };
+      expect(getTrimmedFileExtension(source)).toEqual("jsx");
+    });
+
+    it("should return vue if the file extension is .vue with hash", () => {
+      const source = {
+        contentType: "text/vue",
+        text: "<h1></h1>",
+        url: "App.vue?bc27"
+      };
+      expect(getTrimmedFileExtension(source)).toEqual("vue");
+    });
+
+    it("should return empty string if no file extension is given", () => {
+      const source = {
+        contentType: "text/vue",
+        text: "<h1></h1>",
+        url: ""
+      };
+      expect(getTrimmedFileExtension(source)).toEqual("");
     });
   });
 });


### PR DESCRIPTION
Fixes Issue: #6793

### Summary of Changes
This PR fixes the detection problem of different Vue build types.
It also trims any query parts of file extensions in order to show the correct file logo. [Vue adds a hash value to the filename](https://forum.vuejs.org/t/cant-get-sourcemaps-to-work-properly-please-help/22246/2) and because of that the file logo couldn't be found.


### Screenshots/Videos 
<img width="1679" alt="screen shot 2018-08-11 at 20 21 01" src="https://user-images.githubusercontent.com/2528506/43994857-30d3f458-9da4-11e8-8584-4092640b0e50.png">
