### PR TITLE
Fix broken link in CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -158,7 +158,7 @@ Go to [local Development](../docs/local-development.md) to learn about:
 
 At some point, you'll want to debug firefox to see your changes in the devtools panel or inspect the debugger server.
 
-Here's a guide to help you get started [guide](./docs/debugging-firefox.md)
+Here's a guide to help you get started [guide](../docs/debugging-firefox.md)
 
 ### Issues
 


### PR DESCRIPTION
The link previously lead to a 404 page

Fixes Issue: #6807

### Summary of Changes

* Change URL of broken link

### Test Plan

Manually tested the fix by checking the destination of the link