### PR TITLE
Remove unecessary check when focusing Tree

### DIFF
--- a/packages/devtools-components/src/tree.css
+++ b/packages/devtools-components/src/tree.css
@@ -2,6 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+ /* We can remove the outline since we do add our own focus style on nodes */
+.tree:focus {
+  outline: none;
+}
+
 .tree.inline {
   display: inline-block;
 }

--- a/packages/devtools-components/src/tree.js
+++ b/packages/devtools-components/src/tree.js
@@ -817,18 +817,7 @@ class Tree extends Component {
           if (focused || !nativeEvent || !this.treeRef) {
             return;
           }
-
-          const { explicitOriginalTarget } = nativeEvent;
-
-          // Only set default focus to the first tree node if the focus came
-          // from outside the tree (e.g. by tabbing to the tree from other
-          // external elements).
-          if (
-            explicitOriginalTarget !== this.treeRef &&
-            !this.treeRef.contains(explicitOriginalTarget)
-          ) {
-            this._focus(traversal[0].item);
-          }
+          this._focus(traversal[0].item);
         },
         onBlur: this._onBlur,
         "aria-label": this.props.label,

--- a/packages/devtools-reps/src/launchpad/components/Result.js
+++ b/packages/devtools-reps/src/launchpad/components/Result.js
@@ -85,7 +85,6 @@ class Result extends Component {
         createLongStringClient,
         releaseActor,
         mode: MODE[modeKey],
-        disableFocus: false,
         // The following properties are optional function props called by the
         // objectInspector on some occasions. Here we pass dull functions that
         // only logs the parameters with which the callback was called.


### PR DESCRIPTION
According to James Teh in https://bugzilla.mozilla.org/show_bug.cgi?id=1424159#c8 , the check we were doing in the Tree was preventing interacting with them in a given mode of screenreaders.

The original check was made to make sure we only automatically select the first node of a Tree if the focus was not set in the Tree. We did that by relying on `explicitOriginalTarget`.
But we already bail out if there's already a `focused` prop. So it makes sense to simply remove the extra check. According to my manual testing in the Reps test app (and in the console with the reps bundle updated), it seems to work fine. 

I pushed to [TRY](https://treeherder.mozilla.org/#/jobs?repo=try&revision=69647b885a2dfa7eec3fa4ee0b7e04201457ad9b) to see if everything is okay