### PR TITLE
[Preview] let users hover on the tooltip

### DIFF
--- a/src/components/Editor/Preview/index.js
+++ b/src/components/Editor/Preview/index.js
@@ -41,6 +41,7 @@ function inPopup(e) {
   }
 
   const pop =
+    relatedTarget.closest(".tooltip") ||
     relatedTarget.closest(".popover") ||
     relatedTarget.classList.contains("debug-expression");
 


### PR DESCRIPTION
Improves Issue: #6028 

### Summary of Changes

Lets users mouse from the preview token to the tooltip. Oops!