### PR TITLE
Add consistent vertical padding to panes

### DIFF
--- a/src/components/PrimaryPanes/Outline.css
+++ b/src/components/PrimaryPanes/Outline.css
@@ -23,7 +23,7 @@
 
 .outline-list {
   list-style-type: none;
-  padding: 10px 0;
+  padding: 4px 0;
   margin: 0;
   font-family: var(--monospace-font-family);
   overflow: auto;

--- a/src/components/PrimaryPanes/Sources.css
+++ b/src/components/PrimaryPanes/Sources.css
@@ -64,6 +64,7 @@
   overflow-x: auto;
   overflow-y: auto;
   height: 100%;
+  padding: 4px 0;
 }
 
 .sources-list {


### PR DESCRIPTION
Corrects visual alignment issue when switching from `Sources` to `Outline` panes.

Fixes Issue: #6804

### Summary of Changes

* Adds `4px` vertical padding to the `Sources` pane content container
* Updates the `10px` vertical padding on `Outlines` pane to be consistent with the `Sources` pane 

### Test Plan

Tested visually by switching between `Sources` and `Outline` panes (see animated screenshots).

### Screenshots/Videos
|Before|After|
|----------|------|
|![before](https://user-images.githubusercontent.com/7773718/44064479-ff47e738-9f19-11e8-83c1-cfb5d67dfbf9.gif)|![after](https://user-images.githubusercontent.com/7773718/44064483-07c53c76-9f1a-11e8-8321-dab1cb0a550b.gif)|