### PR TITLE
[Tabs/Framework] Cache tabs icon 

### DIFF
--- a/src/actions/ast.js
+++ b/src/actions/ast.js
@@ -13,7 +13,7 @@ import {
 } from "../selectors";
 
 import { mapFrames, fetchExtra } from "./pause";
-import { updateTab } from "./sources/tabs";
+import { updateTab } from "./tabs";
 
 import { setInScopeLines } from "./ast/setInScopeLines";
 import {

--- a/src/actions/ast.js
+++ b/src/actions/ast.js
@@ -41,7 +41,7 @@ export function setSourceMetaData(sourceId: SourceId) {
     const framework = await getFramework(source.id);
 
     // undefined is to keep the tap where it is
-    dispatch(updateTab(source.url, undefined, framework));
+    dispatch(updateTab(source.url, framework));
 
     dispatch(
       ({

--- a/src/actions/ast.js
+++ b/src/actions/ast.js
@@ -13,6 +13,7 @@ import {
 } from "../selectors";
 
 import { mapFrames, fetchExtra } from "./pause";
+import { updateTab } from "./sources/tabs";
 
 import { setInScopeLines } from "./ast/setInScopeLines";
 import {
@@ -38,6 +39,9 @@ export function setSourceMetaData(sourceId: SourceId) {
     }
 
     const framework = await getFramework(source.id);
+
+    // undefined is to keep the tap where it is
+    dispatch(updateTab(source.url, undefined, framework));
 
     dispatch(
       ({

--- a/src/actions/ast.js
+++ b/src/actions/ast.js
@@ -39,8 +39,6 @@ export function setSourceMetaData(sourceId: SourceId) {
     }
 
     const framework = await getFramework(source.id);
-
-    // undefined is to keep the tap where it is
     dispatch(updateTab(source.url, framework));
 
     dispatch(

--- a/src/actions/sources/select.js
+++ b/src/actions/sources/select.js
@@ -21,6 +21,7 @@ import { loadSourceText } from "./loadSourceText";
 
 import { prefs } from "../../utils/prefs";
 import { shouldPrettyPrint, isMinified } from "../../utils/source";
+import { getFramework } from "../../utils/tabs";
 import { createLocation } from "../../utils/location";
 import { getMappedLocation } from "../../utils/source-maps";
 
@@ -30,7 +31,8 @@ import {
   getPrettySource,
   getActiveSearch,
   getSelectedLocation,
-  getSelectedSource
+  getSelectedSource,
+  getTabs
 } from "../../selectors";
 
 import type { Location, Position, Source } from "../../types";
@@ -129,6 +131,10 @@ export function selectLocation(
     }
 
     dispatch(addTab(source.url, 0));
+
+    const framework = getFramework(getTabs(getState()), source.url);
+    dispatch(addTab(source.url, framework));
+
     dispatch(setSelectedLocation(source, location));
 
     await dispatch(loadSourceText(source));

--- a/src/actions/sources/select.js
+++ b/src/actions/sources/select.js
@@ -130,7 +130,7 @@ export function selectLocation(
       source = getSourceFromId(getState(), location.sourceId);
     }
 
-    dispatch(addTab(source.url, 0));
+    await dispatch(addTab(source.url, 0));
 
     const framework = getFramework(getTabs(getState()), source.url);
     dispatch(addTab(source.url, framework));

--- a/src/actions/sources/select.js
+++ b/src/actions/sources/select.js
@@ -130,9 +130,11 @@ export function selectLocation(
       source = getSourceFromId(getState(), location.sourceId);
     }
 
-    await dispatch(addTab(source.url));
+    dispatch(addTab(source.url));
     const framework = getFramework(getTabs(getState()), source.url);
-    dispatch(updateTab(source.url, framework));
+    if (framework) {
+      dispatch(updateTab(source.url, framework));
+    }
 
     dispatch(setSelectedLocation(source, location));
 

--- a/src/actions/sources/select.js
+++ b/src/actions/sources/select.js
@@ -16,12 +16,11 @@ import { setOutOfScopeLocations, setSymbols } from "../ast";
 import { closeActiveSearch, updateActiveFileSearch } from "../ui";
 
 import { togglePrettyPrint } from "./prettyPrint";
-import { addTab, updateTab, closeTab } from "../tabs";
+import { addTab, closeTab } from "../tabs";
 import { loadSourceText } from "./loadSourceText";
 
 import { prefs } from "../../utils/prefs";
 import { shouldPrettyPrint, isMinified } from "../../utils/source";
-import { getFramework } from "../../utils/tabs";
 import { createLocation } from "../../utils/location";
 import { getMappedLocation } from "../../utils/source-maps";
 
@@ -31,8 +30,7 @@ import {
   getPrettySource,
   getActiveSearch,
   getSelectedLocation,
-  getSelectedSource,
-  getTabs
+  getSelectedSource
 } from "../../selectors";
 
 import type { Location, Position, Source } from "../../types";
@@ -131,10 +129,6 @@ export function selectLocation(
     }
 
     dispatch(addTab(source.url));
-    const framework = getFramework(getTabs(getState()), source.url);
-    if (framework) {
-      dispatch(updateTab(source.url, framework));
-    }
 
     dispatch(setSelectedLocation(source, location));
 

--- a/src/actions/sources/select.js
+++ b/src/actions/sources/select.js
@@ -16,7 +16,7 @@ import { setOutOfScopeLocations, setSymbols } from "../ast";
 import { closeActiveSearch, updateActiveFileSearch } from "../ui";
 
 import { togglePrettyPrint } from "./prettyPrint";
-import { addTab, closeTab } from "../tabs";
+import { addTab, updateTab, closeTab } from "../tabs";
 import { loadSourceText } from "./loadSourceText";
 
 import { prefs } from "../../utils/prefs";
@@ -130,10 +130,9 @@ export function selectLocation(
       source = getSourceFromId(getState(), location.sourceId);
     }
 
-    await dispatch(addTab(source.url, 0));
-
+    await dispatch(addTab(source.url));
     const framework = getFramework(getTabs(getState()), source.url);
-    dispatch(addTab(source.url, framework));
+    dispatch(updateTab(source.url, framework));
 
     dispatch(setSelectedLocation(source, location));
 

--- a/src/actions/sources/tests/select.spec.js
+++ b/src/actions/sources/tests/select.spec.js
@@ -67,7 +67,7 @@ describe("sources", () => {
 
     const tabs = getSourceTabs(getState());
     expect(tabs).toHaveLength(1);
-    expect(tabs[0]).toEqual("http://localhost:8000/examples/foo.js");
+    expect(tabs[0].url).toEqual("http://localhost:8000/examples/foo.js");
   });
 
   it("should select previous tab on tab closed", async () => {

--- a/src/actions/sources/tests/select.spec.js
+++ b/src/actions/sources/tests/select.spec.js
@@ -75,10 +75,10 @@ describe("sources", () => {
     await dispatch(actions.newSource(makeSource("foo.js")));
     await dispatch(actions.newSource(makeSource("bar.js")));
     await dispatch(actions.newSource(makeSource("baz.js")));
-    dispatch(actions.selectLocation({ sourceId: "foo.js" }));
-    dispatch(actions.selectLocation({ sourceId: "bar.js" }));
-    dispatch(actions.selectLocation({ sourceId: "baz.js" }));
-    dispatch(actions.closeTab("http://localhost:8000/examples/baz.js"));
+    await dispatch(actions.selectLocation({ sourceId: "foo.js" }));
+    await dispatch(actions.selectLocation({ sourceId: "bar.js" }));
+    await dispatch(actions.selectLocation({ sourceId: "baz.js" }));
+    await dispatch(actions.closeTab("http://localhost:8000/examples/baz.js"));
     expect(getSelectedSource(getState()).id).toBe("bar.js");
     expect(getSourceTabs(getState())).toHaveLength(2);
   });
@@ -89,11 +89,11 @@ describe("sources", () => {
     await dispatch(actions.newSource(makeSource("bar.js")));
     await dispatch(actions.newSource(makeSource("baz.js")));
 
-    dispatch(actions.selectLocation({ sourceId: "foo.js" }));
-    dispatch(actions.selectLocation({ sourceId: "bar.js" }));
-    dispatch(actions.selectLocation({ sourceId: "baz.js" }));
-    dispatch(actions.selectLocation({ sourceId: "foo.js" }));
-    dispatch(actions.closeTab("http://localhost:8000/examples/foo.js"));
+    await dispatch(actions.selectLocation({ sourceId: "foo.js" }));
+    await dispatch(actions.selectLocation({ sourceId: "bar.js" }));
+    await dispatch(actions.selectLocation({ sourceId: "baz.js" }));
+    await dispatch(actions.selectLocation({ sourceId: "foo.js" }));
+    await dispatch(actions.closeTab("http://localhost:8000/examples/foo.js"));
     expect(getSelectedSource(getState()).id).toBe("bar.js");
     expect(getSourceTabs(getState())).toHaveLength(2);
   });

--- a/src/actions/tabs.js
+++ b/src/actions/tabs.js
@@ -22,28 +22,18 @@ import {
 
 import type { Action, ThunkArgs } from "./types";
 
-export function updateTab(
-  url: string,
-  tabIndex: number,
-  framework: string
-): Action {
+export function updateTab(url: string, framework: string): Action {
   return {
     type: "UPDATE_TAB",
     url,
-    tabIndex,
     framework
   };
 }
 
-export function addTab(
-  url: string,
-  tabIndex: ?number,
-  framework?: string
-): Action {
+export function addTab(url: string, framework?: string): Action {
   return {
     type: "ADD_TAB",
     url,
-    tabIndex,
     framework
   };
 }
@@ -65,7 +55,7 @@ export function closeTab(url: string) {
     removeDocument(url);
 
     const tabs = removeSourceFromTabList(getSourceTabs(getState()), url);
-    const sourceId = getNewSelectedSourceId(getState(), tabs.map(t => t.url));
+    const sourceId = getNewSelectedSourceId(getState(), tabs);
     dispatch(({ type: "CLOSE_TAB", url, tabs }: Action));
     dispatch(selectSource(sourceId));
   };
@@ -87,7 +77,7 @@ export function closeTabs(urls: string[]) {
     const tabs = removeSourcesFromTabList(getSourceTabs(getState()), urls);
     dispatch(({ type: "CLOSE_TABS", urls, tabs }: Action));
 
-    const sourceId = getNewSelectedSourceId(getState(), tabs.map(t => t.url));
+    const sourceId = getNewSelectedSourceId(getState(), tabs);
     dispatch(selectSource(sourceId));
   };
 }

--- a/src/actions/tabs.js
+++ b/src/actions/tabs.js
@@ -22,11 +22,24 @@ import {
 
 import type { Action, ThunkArgs } from "./types";
 
-export function addTab(url: string, tabIndex: number): Action {
+export function updateTab(
+  url: string,
+  tabIndex: number,
+  framework: string
+): Action {
+  return {
+    type: "UPDATE_TAB",
+    url,
+    tabIndex,
+    framework
+  };
+}
+
+export function addTab(url: string, framework: string): Action {
   return {
     type: "ADD_TAB",
     url,
-    tabIndex
+    framework
   };
 }
 
@@ -47,7 +60,7 @@ export function closeTab(url: string) {
     removeDocument(url);
 
     const tabs = removeSourceFromTabList(getSourceTabs(getState()), url);
-    const sourceId = getNewSelectedSourceId(getState(), tabs);
+    const sourceId = getNewSelectedSourceId(getState(), tabs.map(t => t.url));
     dispatch(({ type: "CLOSE_TAB", url, tabs }: Action));
     dispatch(selectSource(sourceId));
   };
@@ -69,7 +82,7 @@ export function closeTabs(urls: string[]) {
     const tabs = removeSourcesFromTabList(getSourceTabs(getState()), urls);
     dispatch(({ type: "CLOSE_TABS", urls, tabs }: Action));
 
-    const sourceId = getNewSelectedSourceId(getState(), tabs);
+    const sourceId = getNewSelectedSourceId(getState(), tabs.map(t => t.url));
     dispatch(selectSource(sourceId));
   };
 }

--- a/src/actions/tabs.js
+++ b/src/actions/tabs.js
@@ -16,8 +16,8 @@ import {
   getSourceByURL,
   getSourceTabs,
   getNewSelectedSourceId,
-  removeSourcesFromTabList,
-  removeSourceFromTabList
+  removeSourceFromTabList,
+  removeSourcesFromTabList
 } from "../selectors";
 
 import type { Action, ThunkArgs } from "./types";

--- a/src/actions/tabs.js
+++ b/src/actions/tabs.js
@@ -35,10 +35,15 @@ export function updateTab(
   };
 }
 
-export function addTab(url: string, framework: string): Action {
+export function addTab(
+  url: string,
+  tabIndex: ?number,
+  framework?: string
+): Action {
   return {
     type: "ADD_TAB",
     url,
+    tabIndex,
     framework
   };
 }

--- a/src/actions/tests/tabs.spec.js
+++ b/src/actions/tests/tabs.spec.js
@@ -51,7 +51,7 @@ describe("closing tabs", () => {
     await dispatch(actions.newSource(makeSource("bar.js")));
     await dispatch(actions.selectLocation({ sourceId: "foo.js" }));
     await dispatch(actions.selectLocation({ sourceId: "bar.js" }));
-    dispatch(actions.closeTab("http://localhost:8000/examples/bar.js"));
+    await dispatch(actions.closeTab("http://localhost:8000/examples/bar.js"));
 
     expect(getSelectedSource(getState()).id).toBe("foo.js");
     expect(getSourceTabs(getState())).toHaveLength(1);
@@ -84,12 +84,11 @@ describe("closing tabs", () => {
     await dispatch(actions.selectLocation({ sourceId: "foo.js" }));
     await dispatch(actions.selectLocation({ sourceId: "bar.js" }));
     await dispatch(actions.selectLocation({ sourceId: "bazz.js" }));
-    dispatch(
-      actions.closeTabs([
-        "http://localhost:8000/examples/bar.js",
-        "http://localhost:8000/examples/bazz.js"
-      ])
-    );
+    const tabs = [
+      "http://localhost:8000/examples/bar.js",
+      "http://localhost:8000/examples/bazz.js"
+    ];
+    await dispatch(actions.closeTabs(tabs));
 
     expect(getSelectedSource(getState()).id).toBe("foo.js");
     expect(getSourceTabs(getState())).toHaveLength(1);

--- a/src/actions/types/SourceAction.js
+++ b/src/actions/types/SourceAction.js
@@ -51,8 +51,7 @@ export type SourceAction =
     >
   | {|
       +type: "ADD_TAB",
-      +url: string,
-      +tabIndex: number
+      +url: string
     |}
   | {|
       +type: "MOVE_TAB",

--- a/src/actions/types/SourceAction.js
+++ b/src/actions/types/SourceAction.js
@@ -50,10 +50,6 @@ export type SourceAction =
       |}
     >
   | {|
-      +type: "ADD_TAB",
-      +url: string
-    |}
-  | {|
       +type: "MOVE_TAB",
       +url: string,
       +tabIndex: number

--- a/src/actions/types/index.js
+++ b/src/actions/types/index.js
@@ -48,7 +48,12 @@ type ProjectTextSearchResult = {
 type AddTabAction = {|
   +type: "ADD_TAB",
   +url: string,
-  +tabIndex: ?number,
+  +framework?: string
+|};
+
+type UpdateTabAction = {|
+  +type: "UPDATE_TAB",
+  +url: string,
   +framework?: string
 |};
 
@@ -150,6 +155,7 @@ export type { ASTAction } from "./ASTAction";
  */
 export type Action =
   | AddTabAction
+  | UpdateTabAction
   | SourceAction
   | BreakpointAction
   | PauseAction

--- a/src/actions/types/index.js
+++ b/src/actions/types/index.js
@@ -48,7 +48,8 @@ type ProjectTextSearchResult = {
 type AddTabAction = {|
   +type: "ADD_TAB",
   +url: string,
-  +tabIndex: ?number
+  +tabIndex: ?number,
+  +framework?: string
 |};
 
 type ReplayAction =

--- a/src/components/shared/SourceIcon.js
+++ b/src/components/shared/SourceIcon.js
@@ -22,7 +22,8 @@ type Props = {
   // sourceMetaData will provide framework information
   sourceMetaData: SourceMetaDataType,
   // An additional validator for the icon returned
-  shouldHide?: Function
+  shouldHide?: Function,
+  framework?: string
 };
 
 class SourceIcon extends PureComponent<Props> {

--- a/src/components/shared/SourceIcon.js
+++ b/src/components/shared/SourceIcon.js
@@ -9,7 +9,8 @@ import React, { PureComponent } from "react";
 import { connect } from "react-redux";
 
 import { getSourceClassnames } from "../../utils/source";
-import { getSourceMetaData } from "../../selectors";
+import { getFramework } from "../../utils/tabs";
+import { getSourceMetaData, getTabs } from "../../selectors";
 
 import type { Source } from "../../types";
 import type { SourceMetaDataType } from "../../reducers/ast";
@@ -26,8 +27,10 @@ type Props = {
 
 class SourceIcon extends PureComponent<Props> {
   render() {
-    const { shouldHide, source, sourceMetaData } = this.props;
-    const iconClass = getSourceClassnames(source, sourceMetaData);
+    const { shouldHide, source, sourceMetaData, framework } = this.props;
+    const iconClass = framework
+      ? framework.toLowerCase()
+      : getSourceClassnames(source, sourceMetaData);
 
     if (shouldHide && shouldHide(iconClass)) {
       return null;
@@ -39,6 +42,7 @@ class SourceIcon extends PureComponent<Props> {
 
 export default connect((state, props) => {
   return {
-    sourceMetaData: getSourceMetaData(state, props.source.id)
+    sourceMetaData: getSourceMetaData(state, props.source.id),
+    framework: getFramework(getTabs(state), props.source.url)
   };
 })(SourceIcon);

--- a/src/reducers/tabs.js
+++ b/src/reducers/tabs.js
@@ -24,16 +24,16 @@ import {
 import type { Action } from "../actions/types";
 import type { SourcesState } from "./sources";
 
-type Tab = string;
+type Tab = { url: string, framework: string };
 export type TabList = Tab[];
 
 function update(state: TabList = prefs.tabs || [], action: Action): TabList {
   switch (action.type) {
     case "ADD_TAB":
-      return updateTabList(state, action.url);
+      return updateTabList(state, action);
 
     case "MOVE_TAB":
-      return updateTabList(state, action.url, action.tabIndex);
+      return updateTabList(state, action);
 
     case "CLOSE_TAB":
     case "CLOSE_TABS":
@@ -46,11 +46,11 @@ function update(state: TabList = prefs.tabs || [], action: Action): TabList {
 }
 
 export function removeSourceFromTabList(tabs: TabList, url: string): TabList {
-  return tabs.filter(tab => tab !== url);
+  return tabs.filter(tab => tab.url !== url);
 }
 
 export function removeSourcesFromTabList(tabs: TabList, urls: TabList) {
-  return urls.reduce((t, url) => removeSourceFromTabList(t, url), tabs);
+  return urls.reduce((t, url) => removeSourceFromTabList(t.url, url), tabs);
 }
 
 /**
@@ -58,12 +58,14 @@ export function removeSourcesFromTabList(tabs: TabList, urls: TabList) {
  * @memberof reducers/tabs
  * @static
  */
-function updateTabList(tabs: TabList, url: string, newIndex: ?number) {
-  const currentIndex = tabs.indexOf(url);
+function updateTabList(tabs: TabList, { url, tabIndex: newIndex, framework }) {
+  const currentIndex = tabs.indexOf(tab => tab.url === url);
   if (currentIndex === -1) {
-    tabs = [url, ...tabs];
+    tabs = [{ url, framework }, ...tabs];
   } else if (newIndex !== undefined) {
     tabs = move(tabs, currentIndex, newIndex);
+  } else if (framework) {
+    tabs[currentIndex].framework = framework;
   }
 
   prefs.tabs = tabs;

--- a/src/reducers/tabs.js
+++ b/src/reducers/tabs.js
@@ -57,7 +57,10 @@ export function removeSourcesFromTabList(tabs: TabList, urls: [string]) {
  * @memberof reducers/tabs
  * @static
  */
-function updateTabList(tabs: TabList, { url, framework, tabIndex: newIndex }) {
+function updateTabList(
+  tabs: TabList,
+  { url, framework = "", tabIndex: newIndex }
+) {
   const currentIndex = tabs.findIndex(tab => tab.url == url);
   if (currentIndex === -1) {
     tabs = [{ url, framework }, ...tabs];
@@ -82,7 +85,7 @@ function updateTabList(tabs: TabList, { url, framework, tabIndex: newIndex }) {
  */
 export function getNewSelectedSourceId(
   state: OuterState,
-  availableTabs: TabList
+  availableTabs: [TabList]
 ): string {
   const selectedLocation = state.sources.selectedLocation;
   if (!selectedLocation) {

--- a/src/reducers/tabs.js
+++ b/src/reducers/tabs.js
@@ -30,9 +30,8 @@ export type TabList = Tab[];
 function update(state: TabList = prefs.tabs || [], action: Action): TabList {
   switch (action.type) {
     case "ADD_TAB":
-      return updateTabList(state, action);
-
     case "MOVE_TAB":
+    case "UPDATE_TAB":
       return updateTabList(state, action);
 
     case "CLOSE_TAB":
@@ -58,8 +57,8 @@ export function removeSourcesFromTabList(tabs: TabList, urls: TabList) {
  * @memberof reducers/tabs
  * @static
  */
-function updateTabList(tabs: TabList, { url, tabIndex: newIndex, framework }) {
-  const currentIndex = tabs.indexOf(tab => tab.url === url);
+function updateTabList(tabs: TabList, { url, framework, tabIndex: newIndex }) {
+  const currentIndex = tabs.findIndex(tab => tab.url == url);
   if (currentIndex === -1) {
     tabs = [{ url, framework }, ...tabs];
   } else if (newIndex !== undefined) {
@@ -146,7 +145,7 @@ export const getSourceTabs = createSelector(
   getSources,
   getUrls,
   (tabs, sources, urls) =>
-    tabs.filter(tab => getSourceByUrlInSources(sources, urls, tab))
+    tabs.filter(tab => getSourceByUrlInSources(sources, urls, tab.url))
 );
 
 export const getSourcesForTabs = createSelector(
@@ -155,7 +154,7 @@ export const getSourcesForTabs = createSelector(
   getUrls,
   (tabs, sources, urls) => {
     return tabs
-      .map(tab => getSourceByUrlInSources(sources, urls, tab))
+      .map(tab => getSourceByUrlInSources(sources, urls, tab.url))
       .filter(source => source);
   }
 );

--- a/src/reducers/tabs.js
+++ b/src/reducers/tabs.js
@@ -48,7 +48,7 @@ export function removeSourceFromTabList(tabs: TabList, url: string): TabList {
   return tabs.filter(tab => tab.url !== url);
 }
 
-export function removeSourcesFromTabList(tabs: TabList, urls: [string]) {
+export function removeSourcesFromTabList(tabs: TabList, urls: string[]) {
   return urls.reduce((t, url) => removeSourceFromTabList(t, url), tabs);
 }
 

--- a/src/reducers/tabs.js
+++ b/src/reducers/tabs.js
@@ -48,8 +48,8 @@ export function removeSourceFromTabList(tabs: TabList, url: string): TabList {
   return tabs.filter(tab => tab.url !== url);
 }
 
-export function removeSourcesFromTabList(tabs: TabList, urls: TabList) {
-  return urls.reduce((t, url) => removeSourceFromTabList(t.url, url), tabs);
+export function removeSourcesFromTabList(tabs: TabList, urls: [string]) {
+  return urls.reduce((t, url) => removeSourceFromTabList(t, url), tabs);
 }
 
 /**
@@ -109,7 +109,7 @@ export function getNewSelectedSourceId(
     return "";
   }
 
-  const tabUrls = state.tabs;
+  const tabUrls = state.tabs.map(t => t.url);
   const leftNeighborIndex = Math.max(tabUrls.indexOf(selectedTab.url) - 1, 0);
   const lastAvailbleTabIndex = availableTabs.length - 1;
   const newSelectedTabIndex = Math.min(leftNeighborIndex, lastAvailbleTabIndex);

--- a/src/reducers/tabs.js
+++ b/src/reducers/tabs.js
@@ -24,7 +24,7 @@ import {
 import type { Action } from "../actions/types";
 import type { SourcesState } from "./sources";
 
-type Tab = { url: string, framework?: string };
+type Tab = { url: string, framework?: string | null };
 export type TabList = Tab[];
 
 function update(state: TabList = prefs.tabs || [], action: Action): TabList {
@@ -59,7 +59,7 @@ export function removeSourcesFromTabList(tabs: TabList, urls: string[]) {
  * @memberof reducers/tabs
  * @static
  */
-function updateTabList(tabs: TabList, { url, framework = "" }) {
+function updateTabList(tabs: TabList, { url, framework = null }) {
   const currentIndex = tabs.findIndex(tab => tab.url == url);
   if (currentIndex === -1) {
     tabs = [{ url, framework }, ...tabs];

--- a/src/test/mochitest/browser_dbg-tabs.js
+++ b/src/test/mochitest/browser_dbg-tabs.js
@@ -30,8 +30,8 @@ add_task(async function() {
 
   await selectSource(dbg, "simple1");
   await selectSource(dbg, "simple2");
-  closeTab(dbg, "simple1");
-  closeTab(dbg, "simple2");
+  await closeTab(dbg, "simple1");
+  await closeTab(dbg, "simple2");
 
   // Test reloading the debugger
   await reload(dbg, "simple1", "simple2");

--- a/src/test/mochitest/helpers.js
+++ b/src/test/mochitest/helpers.js
@@ -609,9 +609,9 @@ async function selectSpecificSource(dbg, url, line) {
 }
 
 
-function closeTab(dbg, url) {
+async function closeTab(dbg, url) {
   const source = findSource(dbg, url);
-  return dbg.actions.closeTab(source.url);
+  await dbg.actions.closeTab(source.url);
 }
 
 /**

--- a/src/test/mochitest/helpers.js
+++ b/src/test/mochitest/helpers.js
@@ -377,8 +377,7 @@ function assertHighlightLocation(dbg, source, line) {
   const cm = getCM(dbg);
   const lineInfo = cm.lineInfo(line - 1);
   ok(
-    lineInfo
-      .wrapClass.includes("highlight-line"),
+    lineInfo.wrapClass.includes("highlight-line"),
     "Line is highlighted"
   );
 }

--- a/src/test/mochitest/helpers.js
+++ b/src/test/mochitest/helpers.js
@@ -373,9 +373,11 @@ function assertHighlightLocation(dbg, source, line) {
   );
 
   ok(isVisibleInEditor(dbg, lineEl), "Highlighted line is visible");
+
+  const cm = getCM(dbg);
+  const lineInfo = cm.lineInfo(line - 1);
   ok(
-    getCM(dbg)
-      .lineInfo(line - 1)
+    lineInfo
       .wrapClass.includes("highlight-line"),
     "Line is highlighted"
   );

--- a/src/utils/tabs.js
+++ b/src/utils/tabs.js
@@ -5,6 +5,7 @@
 // @flow
 
 import type { Source } from "../types";
+import type { TabList } from "../reducers";
 
 type SourcesList = Source[];
 /*
@@ -40,7 +41,7 @@ export function getHiddenTabs(
   });
 }
 
-export function getFramework(tabs, url) {
+export function getFramework(tabs: TabList[], url: string) {
   const tab = tabs.find(t => t.url === url);
 
   if (tab) {

--- a/src/utils/tabs.js
+++ b/src/utils/tabs.js
@@ -40,6 +40,14 @@ export function getHiddenTabs(
   });
 }
 
+export function getFramework(tabs, url) {
+  const tab = tabs.find(t => t.url === url);
+
+  if (tab) {
+    return tab.framework;
+  }
+}
+
 export function getTabMenuItems() {
   return {
     closeTab: {

--- a/src/utils/tabs.js
+++ b/src/utils/tabs.js
@@ -47,6 +47,8 @@ export function getFramework(tabs: TabList[], url: string) {
   if (tab) {
     return tab.framework;
   }
+
+  return "";
 }
 
 export function getTabMenuItems() {


### PR DESCRIPTION
Fixes Issue: #6725 

### Summary of Changes

* Change tabs structure from [url] to [{url, framework}]
* Cache the framework 

### Test Plan
- [ ] need to do a little more testing  
- [ ] Initial load takes time, make it performant
- [ ] Upon selecting a tab, the tab becomes first tabIndex

Test it:
- Go to [ahfarmer.github.io](https://ahfarmer.github.io/calculator/)
- Open a few components

![tabs](https://user-images.githubusercontent.com/7821757/44071639-043f6ad4-9fa8-11e8-9a86-a07f286861af.gif)
