### PR TITLE
Add style for suffix label source

### DIFF
--- a/src/components/PrimaryPanes/Sources.css
+++ b/src/components/PrimaryPanes/Sources.css
@@ -95,7 +95,8 @@
 
 .sources-list .tree .label .suffix {
   font-style: italic;
-  font-size: 0.7em;
+  font-size: 0.9em;
+  color: var(--theme-comment);
 }
 
 .sources-list .tree img.arrow.expanded {


### PR DESCRIPTION
Fixes Issue: #6821 @darkwing for review?

### Summary of Changes

* add some styles for font in the suffix label source (i think is a nice try :) ).

### Test Plan

- [x] Command-P opens the panel
- [x] Search in "Sources" a map file

### Screenshots/Videos (OPTIONAL)
![captura de pantalla de 2018-08-14 23-01-48](https://user-images.githubusercontent.com/25184000/44128270-76565f2c-a018-11e8-86dc-6fedd71a1e61.png)
