### PR TITLE
Don't repeat filename in subtitle for result list

### DIFF
--- a/src/components/shared/ResultList.js
+++ b/src/components/shared/ResultList.js
@@ -61,9 +61,11 @@ export default class ResultList extends Component<Props> {
         <div id={`${item.id}-title`} className="title">
           {item.title}
         </div>
-        <div id={`${item.id}-subtitle`} className="subtitle">
-          {item.subtitle}
-        </div>
+        {item.subtitle != item.title ? (
+          <div id={`${item.id}-subtitle`} className="subtitle">
+            {item.subtitle}
+          </div>
+        ) : null}
       </li>
     );
   };

--- a/src/components/test/__snapshots__/QuickOpenModal.spec.js.snap
+++ b/src/components/test/__snapshots__/QuickOpenModal.spec.js.snap
@@ -694,10 +694,6 @@ exports[`QuickOpenModal showErrorEmoji false when count + query 1`] = `
                     className="title"
                     id="undefined-title"
                   />
-                  <div
-                    className="subtitle"
-                    id="undefined-subtitle"
-                  />
                 </li>
                 <li
                   aria-describedby="undefined-subtitle"
@@ -710,10 +706,6 @@ exports[`QuickOpenModal showErrorEmoji false when count + query 1`] = `
                   <div
                     className="title"
                     id="undefined-title"
-                  />
-                  <div
-                    className="subtitle"
-                    id="undefined-subtitle"
                   />
                 </li>
               </ul>


### PR DESCRIPTION
I spotted this issue and it bugged me.  If the subtitle and title match, there's no point in showing a subtitle:

<img width="1016" alt="wuuuut" src="https://user-images.githubusercontent.com/46655/44161700-bacda780-a083-11e8-8701-ccf70d3b9ddd.png">
