### PR TITLE
Bug 1482401 - Fix preference name devtools.debugger.features.map-await-expression in test

### DIFF
--- a/src/test/mochitest/browser_dbg-console-async.js
+++ b/src/test/mochitest/browser_dbg-console-async.js
@@ -38,7 +38,7 @@ async function hasMessage(dbg, msg) {
 
 add_task(async function() {
   Services.prefs.setBoolPref("devtools.toolbox.splitconsoleEnabled", true);
-  Services.prefs.setBoolPref("devtools.map-await-expression", true);
+  Services.prefs.setBoolPref("devtools.debugger.features.map-await-expression", true);
 
   const dbg = await initDebugger("doc-script-switching.html");
 


### PR DESCRIPTION
### Summary of Changes

* change preference name in call to match the real preference's name which fixes test in beta simulations