### PR TITLE
Fix position of watch expression "delete" button

### DIFF
--- a/src/components/SecondaryPanes/Breakpoints/Breakpoints.css
+++ b/src/components/SecondaryPanes/Breakpoints/Breakpoints.css
@@ -188,7 +188,9 @@ html[dir="rtl"] .breakpoints-list .breakpoint .breakpoint-line {
 
 .breakpoint .close-btn {
   offset-inline-end: 15px;
+  inset-inline-end: 15px;
   offset-inline-start: auto;
+  inset-inline-start: auto;
   position: absolute;
   top: 8px;
   display: none;

--- a/src/components/SecondaryPanes/Expressions.css
+++ b/src/components/SecondaryPanes/Expressions.css
@@ -94,6 +94,7 @@
 .expression-container__close-btn {
   position: absolute;
   offset-inline-end: 0px;
+  inset-inline-end: 0px;
   top: 1px;
 }
 

--- a/src/components/WelcomeBox.css
+++ b/src/components/WelcomeBox.css
@@ -27,7 +27,9 @@
   position: absolute;
   top: auto;
   offset-inline-end: 0;
+  inset-inline-end: 0;
   offset-inline-start: auto;
+  inset-inline-start: auto;
   bottom: 0;
 }
 


### PR DESCRIPTION
Fixes Issue: #6670

### Summary of Changes

* Add renamed css properties `offset-*` to `inset-*` following https://bugzilla.mozilla.org/show_bug.cgi?id=1464782

### Test Plan

1.  Test at your localhost:8000 that the close button still displays properly
2.  Open Firefox, open Tools -> Web Developer -> Browser Toolbox, and use the inspector to manually set the same CSS change and confirm the [x] shows up in the right spot! :)

### Screenshots/Videos
![delete-expression-button-placement](https://user-images.githubusercontent.com/4756833/44290953-a81dc300-a27b-11e8-83a2-b1be6e2d51c6.gif)
