### PR TITLE
Fix preview popup horizontal scrollbar

### DIFF
--- a/packages/devtools-components/src/tree.css
+++ b/packages/devtools-components/src/tree.css
@@ -2,10 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-.tree {
-  overflow: auto;
-}
-
 .tree.inline {
   display: inline-block;
 }


### PR DESCRIPTION
Fixes Issue: #6686 

### Summary of Changes

* removed unneeded css block for `.tree` with the declaration `overflow: auto`

### Test Plan

1. At your localhost:8000 debugging, for example:`https://30926wj5o5.codesandbox.io/`.
2. Open debugger tool > Sources > `index.js`
2. Add a breakpoint at line 34
3. Reload `https://30926wj5o5.codesandbox.io/`
4. When the execution is halted at line 34 hover over `myLongObject` variable
3. Notice how after the fix the horizontal scrollbar is visible at any time independently from  the vertical scroll position.

### Screenshots/Videos (OPTIONAL)

#### Before fix
![Before fix](https://user-images.githubusercontent.com/12601542/44299896-45214000-a2fe-11e8-85bc-a21a6a06a726.gif)

#### After fix
![After fix](https://user-images.githubusercontent.com/12601542/44299900-5702e300-a2fe-11e8-8db5-44c50fd0bff6.gif)




