### PR TITLE
Initialize a breakpoint as loading true

### DIFF
--- a/src/utils/breakpoint/index.js
+++ b/src/utils/breakpoint/index.js
@@ -133,7 +133,7 @@ export function createBreakpoint(
     condition: condition || null,
     disabled: disabled || false,
     hidden: hidden || false,
-    loading: false,
+    loading: true,
     astLocation: astLocation || defaultASTLocation,
     generatedLocation: generatedLocation || location,
     location,


### PR DESCRIPTION
Fixes Issue: #6771

Supercedes https://github.com/devtools-html/debugger.html/pull/6799

Initializes a breakpoint as loading.