### PR TITLE
[sources] update tree-node path so it is always unique

### DIFF
--- a/src/components/PrimaryPanes/SourcesTree.js
+++ b/src/components/PrimaryPanes/SourcesTree.js
@@ -169,19 +169,14 @@ class SourcesTree extends Component<Props, State> {
 
   getPath = (item: TreeNode): string => {
     const path = `${item.path}/${item.name}`;
+    const source = this.getSource(item);
 
-    if (isDirectory(item)) {
+    if (!source || isDirectory(item)) {
       return path;
     }
 
-    const source = this.getSource(item);
-    const blackBoxedPart = source && source.isBlackBoxed ? ":blackboxed" : "";
-
-    // Original and generated sources can point to the same path
-    // therefore necessary to distinguish as path is used as keys.
-    const generatedPart = source && source.sourceMapURL ? ":generated" : "";
-
-    return `${path}${blackBoxedPart}${generatedPart}`;
+    const blackBoxedPart = source.isBlackBoxed ? ":blackboxed" : "";
+    return `${path}/${source.id}/${blackBoxedPart}`;
   };
 
   onExpand = (item: Item, expandedState: Set<string>) => {

--- a/src/components/PrimaryPanes/tests/SourcesTree.spec.js
+++ b/src/components/PrimaryPanes/tests/SourcesTree.spec.js
@@ -318,7 +318,9 @@ describe("SourcesTree", () => {
     it("should return path for item", async () => {
       const { instance } = render();
       const path = instance.getPath(createMockItem());
-      expect(path).toEqual("http://mdn.com/one.js/one.js");
+      expect(path).toEqual(
+        "http://mdn.com/one.js/one.js/server1.conn13.child1/39/"
+      );
     });
 
     it("should return path for blackboxedboxed item", async () => {
@@ -341,7 +343,7 @@ describe("SourcesTree", () => {
       });
       const path = instance.getPath(item);
       expect(path).toEqual(
-        "http://mdn.com/blackboxed.js/blackboxed.js:blackboxed"
+        "http://mdn.com/blackboxed.js/blackboxed.js/server1.conn13.child1/59/:blackboxed"
       );
     });
 
@@ -352,14 +354,18 @@ describe("SourcesTree", () => {
           id: "server1.conn13.child1/42/originalSource-sha"
         })
       );
-      expect(pathOriginal).toEqual("http://mdn.com/four.js/four.js");
+      expect(pathOriginal).toEqual(
+        "http://mdn.com/four.js/four.js/server1.conn13.child1/42/originalSource-sha/"
+      );
 
       const pathGenerated = instance.getPath(
         createMockItem("http://mdn.com/four.js", "four.js", {
           id: "server1.conn13.child1/42"
         })
       );
-      expect(pathGenerated).toEqual("http://mdn.com/four.js/four.js:generated");
+      expect(pathGenerated).toEqual(
+        "http://mdn.com/four.js/four.js/server1.conn13.child1/42/"
+      );
     });
   });
 });


### PR DESCRIPTION
Fixes #6829 

### Summary of Changes

- it is possible for two sources with the same URL to be added to the tree 
- this updates the tree path so that it is always unique

### Testing

- we should have a unit test for this case