### PR TITLE
Preview - speed up the previews

### DIFF
--- a/src/actions/expressions.js
+++ b/src/actions/expressions.js
@@ -167,7 +167,14 @@ export function getMappedExpression(expression: string) {
     const mappings = getSelectedScopeMappings(getState());
     const bindings = getSelectedFrameBindings(getState());
 
-    if (!mappings && !bindings && !expression.includes("await")) {
+    // We bail early if we do not need to map the expression. This is important
+    // because mapping an expression can be slow if the parser worker is
+    // busy doing other work.
+    //
+    // 1. there are no mappings - we do not need to map original expressions
+    // 2. does not contain `await` - we do not need to map top level awaits
+    // 3. does not contain `=` - we do not need to map assignments
+    if (!mappings && !expression.match(/(await|=)/)) {
       return expression;
     }
 

--- a/src/reducers/pause.js
+++ b/src/reducers/pause.js
@@ -453,11 +453,19 @@ export function getFrameScope(
 }
 
 export function getSelectedScope(state: OuterState) {
-  const sourceRecord = getSelectedSource(state);
+  const source = getSelectedSource(state);
   const frameId = getSelectedFrameId(state);
-  const { scope } =
-    getFrameScope(state, sourceRecord && sourceRecord.id, frameId) || {};
-  return scope || null;
+
+  if (!source) {
+    return null;
+  }
+
+  const frameScope = getFrameScope(state, source.id, frameId);
+  if (!frameScope) {
+    return null;
+  }
+
+  return frameScope.scope || null;
 }
 
 export function getSelectedScopeMappings(

--- a/src/test/mochitest/browser_dbg-preview-source-maps.js
+++ b/src/test/mochitest/browser_dbg-preview-source-maps.js
@@ -49,7 +49,7 @@ add_task(async function() {
 
   info(`Test previewing in the original location`);
   await assertPreviews(dbg, [
-    { line: 2, column: 10, result: 4, expression: "x;" }
+    { line: 2, column: 10, result: 4, expression: "x" }
   ]);
 
   info(`Test previewing in the generated location`);


### PR DESCRIPTION
Fixes Issue: #6868

### Summary of Changes

- prevents mapping expressions when there arent mappings
- this fixes a slow case in the debugger when the debugger tries to map an expression while the parser worker is buy calculating original and generated scopes
- next steps - in the future it would be better to show a "loading" indicator when hovering and wait until we have the mappings to calculate the mapped expression. This is a significant amount of work that I think we can prioritize later.

### Testing

1. debug the debugger or another [app] w/ sourcemaps 
2. add a breakpoint in an original file
3. pause and quickly hover or use the console

[app]: https://firefox-debugger-example-react-js.glitch.me/

### GIFS

#### Old

![](http://g.recordit.co/UBLfLfJV7i.gif)

#### New

![](http://g.recordit.co/yU3HqcV9nM.gif)