### PR TITLE
[WASM] Provides information about inlined functions and their original function names

### DIFF
--- a/packages/devtools-source-map/src/source-map.js
+++ b/packages/devtools-source-map/src/source-map.js
@@ -17,7 +17,7 @@ const { fetchSourceMap } = require("./utils/fetchSourceMap");
 const {
   getSourceMap,
   setSourceMap,
-  clearSourceMaps
+  clearSourceMaps: clearSourceMapsRequests
 } = require("./utils/sourceMapRequests");
 const {
   originalToGeneratedId,
@@ -26,6 +26,7 @@ const {
   isOriginalId,
   getContentType
 } = require("./utils");
+const { clearWasmXScopes } = require("./utils/wasmXScopes");
 
 import type { Location, Source, SourceId } from "debugger-html";
 
@@ -306,6 +307,11 @@ function applySourceMap(
 
   const map = SourceMapConsumer(generator.toJSON());
   setSourceMap(generatedId, Promise.resolve(map));
+}
+
+function clearSourceMaps() {
+  clearSourceMapsRequests();
+  clearWasmXScopes();
 }
 
 module.exports = {

--- a/packages/devtools-source-map/src/utils/convertToJSON.js
+++ b/packages/devtools-source-map/src/utils/convertToJSON.js
@@ -14,7 +14,7 @@ function convertDwarf(wasm, instance) {
     new Uint8Array(wasm)
   );
   const resultPtr = alloc_mem(12);
-  const enableXScopes = false;
+  const enableXScopes = true;
   convert_dwarf(
     wasmPtr,
     wasm.byteLength,

--- a/packages/devtools-source-map/src/utils/fetchSourceMap.js
+++ b/packages/devtools-source-map/src/utils/fetchSourceMap.js
@@ -47,6 +47,11 @@ async function _resolveAndFetch(generatedSource: Source): SourceMapConsumer {
   let map = new SourceMapConsumer(fetched.content, baseURL);
   if (generatedSource.isWasm) {
     map = new WasmRemap(map);
+    // Check if experimental scope info exists.
+    if (fetched.content.includes("x-scopes")) {
+      const parsedJSON = JSON.parse(fetched.content);
+      map.xScopes = parsedJSON["x-scopes"];
+    }
   }
 
   return map;

--- a/packages/devtools-source-map/src/utils/getOriginalStackFrames.js
+++ b/packages/devtools-source-map/src/utils/getOriginalStackFrames.js
@@ -6,6 +6,8 @@
 
 import type { Location } from "debugger-html";
 
+const { getWasmXScopes } = require("./wasmXScopes");
+
 // Returns expanded stack frames details based on the generated location.
 // The function return null if not information was found.
 async function getOriginalStackFrames(
@@ -14,8 +16,17 @@ async function getOriginalStackFrames(
   displayName: string,
   location?: Location
 }>> {
-  // Reserved for experemental source maps formats.
-  return null;
+  const wasmXScopes = await getWasmXScopes(generatedLocation.sourceId);
+  if (!wasmXScopes) {
+    return null;
+  }
+
+  const scopes = wasmXScopes.search(generatedLocation);
+  if (scopes.length === 0) {
+    console.warn("Something wrong with debug data: none original frames found");
+    return null;
+  }
+  return scopes;
 }
 
 module.exports = {

--- a/packages/devtools-source-map/src/utils/wasmXScopes.js
+++ b/packages/devtools-source-map/src/utils/wasmXScopes.js
@@ -1,0 +1,186 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
+// @flow
+/* eslint camelcase: 0*/
+
+import type { Location, SourceId } from "debugger-html";
+
+const { getSourceMap } = require("./sourceMapRequests");
+const { generatedToOriginalId } = require("./index");
+
+const xScopes = new Map();
+
+type XScopeItem = any;
+type XScopeItemsIndex = Map<string, XScopeItem>;
+
+function indexLinkingNames(items: XScopeItem[]): XScopeItemsIndex {
+  const result = new Map();
+  let queue = [...items];
+  while (queue.length > 0) {
+    const item = queue.shift();
+    if ("linkage_name" in item) {
+      result.set(item.linkage_name, item);
+    }
+    if ("children" in item) {
+      queue = [...queue, ...item.children];
+    }
+  }
+  return result;
+}
+
+type XScopeData = {
+  code_section_offset: number,
+  debug_info: Array<XScopeItem>,
+  idIndex: XScopeItemsIndex,
+  sources: Array<string>
+};
+
+async function getXScopes(sourceId: SourceId): Promise<?XScopeData> {
+  if (xScopes.has(sourceId)) {
+    return xScopes.get(sourceId);
+  }
+  const map = await getSourceMap(sourceId);
+  if (!map || !map.xScopes) {
+    xScopes.set(sourceId, null);
+    return null;
+  }
+  const { code_section_offset, debug_info } = map.xScopes;
+  const xScope = {
+    code_section_offset,
+    debug_info,
+    idIndex: indexLinkingNames(debug_info),
+    sources: map.sources
+  };
+  xScopes.set(sourceId, xScope);
+  return xScope;
+}
+
+function isInRange(item: XScopeItem, pc: number): boolean {
+  if ("ranges" in item) {
+    return item.ranges.some(r => r[0] <= pc && pc < r[1]);
+  }
+  if ("high_pc" in item) {
+    return item.low_pc <= pc && pc < item.high_pc;
+  }
+  return false;
+}
+
+type FoundScope = {
+  id: string,
+  name?: string,
+  file?: number,
+  line?: number
+};
+
+function filterScopes(
+  items: XScopeItem[],
+  pc: number,
+  lastItem: ?FoundScope,
+  index: XScopeItemsIndex
+): FoundScope[] {
+  if (!items) {
+    return [];
+  }
+  return items.reduce((result, item) => {
+    switch (item.tag) {
+      case "compile_unit":
+        if (isInRange(item, pc)) {
+          result = [
+            ...result,
+            ...filterScopes(item.children, pc, lastItem, index)
+          ];
+        }
+        break;
+      case "namespace":
+      case "structure_type":
+      case "union_type":
+        result = [
+          ...result,
+          ...filterScopes(item.children, pc, lastItem, index)
+        ];
+        break;
+      case "subprogram":
+        if (isInRange(item, pc)) {
+          const s: FoundScope = {
+            id: item.linkage_name,
+            name: item.name
+          };
+          result = [...result, s, ...filterScopes(item.children, pc, s, index)];
+        }
+        break;
+      case "inlined_subroutine":
+        if (isInRange(item, pc)) {
+          const linkedItem = index.get(item.abstract_origin);
+          const s: FoundScope = {
+            id: item.abstract_origin,
+            name: linkedItem ? linkedItem.name : void 0
+          };
+          if (lastItem) {
+            lastItem.file = item.call_file;
+            lastItem.line = item.call_line;
+          }
+          result = [...result, s, ...filterScopes(item.children, pc, s, index)];
+        }
+        break;
+    }
+    return result;
+  }, []);
+}
+
+class XScope {
+  xScope: XScopeData;
+
+  constructor(xScopeData: XScopeData) {
+    this.xScope = xScopeData;
+  }
+
+  search(
+    generatedLocation: Location
+  ): Array<{
+    displayName: string,
+    location?: Location
+  }> {
+    const { code_section_offset, debug_info, sources, idIndex } = this.xScope;
+    const pc = generatedLocation.line - (code_section_offset || 0);
+    const scopes = filterScopes(debug_info, pc, null, idIndex);
+    scopes.reverse();
+
+    return scopes.map(i => {
+      if (!("file" in i)) {
+        return {
+          displayName: i.name || ""
+        };
+      }
+      const sourceId = generatedToOriginalId(
+        generatedLocation.sourceId,
+        sources[i.file || 0]
+      );
+      return {
+        displayName: i.name || "",
+        location: {
+          line: i.line || 0,
+          sourceId
+        }
+      };
+    });
+  }
+}
+
+async function getWasmXScopes(sourceId: SourceId): Promise<?XScope> {
+  const xScopeData = await getXScopes(sourceId);
+  if (!xScopeData) {
+    return null;
+  }
+  return new XScope(xScopeData);
+}
+
+function clearWasmXScopes() {
+  xScopes.clear();
+}
+
+module.exports = {
+  getWasmXScopes,
+  clearWasmXScopes
+};

--- a/packages/devtools-source-map/src/worker.js
+++ b/packages/devtools-source-map/src/worker.js
@@ -12,10 +12,9 @@ const {
   getOriginalSourceText,
   getLocationScopes,
   hasMappedSource,
+  clearSourceMaps,
   applySourceMap
 } = require("./source-map");
-
-const { clearSourceMaps } = require("./utils/sourceMapRequests");
 
 const { getOriginalStackFrames } = require("./utils/getOriginalStackFrames");
 


### PR DESCRIPTION
(Continuation of #6870 and #6795)

Using [dwarf-to-json](https://github.com/yurydelendik/dwarf-to-json), it materializes additional [x-scopes](https://gist.github.com/yurydelendik/802f36983d50cedb05f984d784dc5159) field in the source maps JSON.

Sample debuggee demo at https://yurydelendik.github.io/old-man-sandbox/rust-wasm-hey/hey.dbg.html (set breakpoint at .../libcore/fmt/mod.rs:381)

/cc @fitzgen @jimblandy 