### PR TITLE
[search] collapse search input box to make room for buttons

### DIFF
--- a/src/components/shared/SearchInput.css
+++ b/src/components/shared/SearchInput.css
@@ -114,9 +114,10 @@
   height: 100%;
   background: transparent;
   transition: all 0.25s ease-in-out;
-  border: 1px solid transparent;
   justify-content: center;
   padding-top: 4px;
+  padding-left: 5px;
+  padding-right: 5px;
 }
 
 .search-field .search-nav-buttons .nav-btn:hover {

--- a/src/components/shared/SearchInput.css
+++ b/src/components/shared/SearchInput.css
@@ -97,7 +97,8 @@
 .search-field .summary {
   line-height: 27px;
   text-align: center;
-  padding-inline-end: 10px;
+  padding-inline-start: 5px;
+  padding-inline-end: 5px;
   color: var(--theme-body-color-inactive);
   align-self: center;
   padding-top: 1px;

--- a/src/components/shared/SearchInput.css
+++ b/src/components/shared/SearchInput.css
@@ -46,8 +46,8 @@
   line-height: 30px;
   background-color: var(--theme-toolbar-background);
   color: var(--theme-body-color-active);
-  width: calc(100% - 38px);
-  flex: 1;
+  flex-grow: 1;
+  min-width: 40px;
 }
 
 .search-field.big input {


### PR DESCRIPTION
Fixes Issue: #6858

### Summary of Changes

* style search-field input so in shrinks more giving more space for nav buttons in a narrow window
* style search nav buttons to have same width as breakpoint buttons
* for search summary, add 5px left padding and change right padding from 10px to 5px

With this change the main panel width can be made a good deal smaller before the buttons get clipped.  Then I think we might be OK not having to move them to the modifiers bar.  

**Before**
![](http://g.recordit.co/0M97Jngd8Y.gif)

**After**
![](http://g.recordit.co/Jg7r7L9lTF.gif)
