### PR TITLE
[breakpoints] double clicking a conditional breakpoint opens edit mode for condition

### DIFF
--- a/src/components/SecondaryPanes/Breakpoints/Breakpoint.js
+++ b/src/components/SecondaryPanes/Breakpoints/Breakpoint.js
@@ -63,6 +63,13 @@ class Breakpoint extends PureComponent<Props> {
     showContextMenu({ ...this.props, contextMenuEvent: e });
   };
 
+  onDoubleClick = () => {
+    const { breakpoint, openConditionalPanel } = this.props;
+    if (breakpoint.condition) {
+      openConditionalPanel(breakpoint.location.line);
+    }
+  }
+
   selectBreakpoint = () => {
     const { breakpoint, selectSpecificLocation } = this.props;
     selectSpecificLocation(breakpoint.location);
@@ -158,6 +165,7 @@ class Breakpoint extends PureComponent<Props> {
           "is-conditional": !!breakpoint.condition
         })}
         onClick={this.selectBreakpoint}
+        onDoubleClick={this.onDoubleClick}
         onContextMenu={this.onContextMenu}
       >
         <input


### PR DESCRIPTION
Fixes Issue: # 6838

### Summary of Changes

* Add double click handler to breakpoint component that opens the edit mode if it is a conditional breakpoint

I found an easy fix to this was just to add a doubleClick handler to the breakpoint component.  But this [stack overflow answer](https://stackoverflow.com/a/25780754) indicates it is not advisable to use both a click and double click handler on the same element.  Should I come up with another way besides the double click handler?  One of the other answers to the stack overflow question had a method for detecting double clicks using a ref callback and another method using lodash debounce.  Would you prefer either of those?

### Test Plan

- [x] Add a conditonal breakpoint.  Double click the conditional breakpoint in the breakpoint list and verify it highlights the line and the edit mode opens.
- [x] Add a regular breakpoint.  Double click the regular breakpoint in the breakpoint list and verify it highlights the line and no edit mode opens.