### PR TITLE
Roll back Tree component onFocus change.

### DIFF
--- a/packages/devtools-components/src/tree.js
+++ b/packages/devtools-components/src/tree.js
@@ -817,7 +817,17 @@ class Tree extends Component {
           if (focused || !nativeEvent || !this.treeRef) {
             return;
           }
-          this._focus(traversal[0].item);
+
+          const { explicitOriginalTarget } = nativeEvent;
+          // Only set default focus to the first tree node if the focus came
+          // from outside the tree (e.g. by tabbing to the tree from other
+          // external elements).
+          if (
+            explicitOriginalTarget !== this.treeRef &&
+            !this.treeRef.contains(explicitOriginalTarget)
+          ) {
+            this._focus(traversal[0].item);
+          }
         },
         onBlur: this._onBlur,
         "aria-label": this.props.label,


### PR DESCRIPTION
The check that was made there prevented the first
item of the Tree to be selected if the click happened
inside it. Without this check, the first item is automatically
selected and scrolled to, which is causing some weirdness in
the console (probably in the debugger as well).
The fix was made in mozilla-central directly in the reps bundle
as well.
