### PR TITLE
Bump launchpad to 0.0.132

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "babel-plugin-transform-imports": "^1.5.0",
     "codemirror": "^5.28.0",
     "devtools-environment": "^0.0.5",
-    "devtools-launchpad": "0.0.131",
+    "devtools-launchpad": "0.0.132",
     "devtools-linters": "^0.0.4",
     "devtools-modules": "0.0.38",
     "devtools-reps": "0.23.0",


### PR DESCRIPTION
Update to latest launchpad that simply removes an unused css variable. Will need to update the browser_parsable_css test when releasing to mozilla-central.