### PR TITLE
[Search] remove focus ring for search inputs

### DIFF
--- a/src/components/SecondaryPanes/Expressions.css
+++ b/src/components/SecondaryPanes/Expressions.css
@@ -14,6 +14,7 @@
   font-size: 12px;
   padding: 0.5em 1.6em;
   color: var(--theme-body-color);
+  outline: 0;
 }
 
 @keyframes shake {

--- a/src/components/shared/SearchInput.css
+++ b/src/components/shared/SearchInput.css
@@ -57,6 +57,10 @@
   line-height: 40px;
 }
 
+.search-field input:focus {
+  outline: none;
+}
+
 .theme-dark .search-field input {
   color: var(--theme-body-color-inactive);
 }


### PR DESCRIPTION
Fixes #6901

### Summary of Changes

Removes focus rings for input bars

![screen shot 2018-08-29 at 5 54 06 pm](https://user-images.githubusercontent.com/254562/44817813-9eb62400-abb4-11e8-9f24-75d710637c3e.png)
![screen shot 2018-08-29 at 5 53 01 pm](https://user-images.githubusercontent.com/254562/44817814-9eb62400-abb4-11e8-874d-30350f12536d.png)
![screen shot 2018-08-29 at 5 52 50 pm](https://user-images.githubusercontent.com/254562/44817816-a1b11480-abb4-11e8-939f-5c7dec7c7583.png)
![screen shot 2018-08-29 at 5 54 58 pm](https://user-images.githubusercontent.com/254562/44817826-abd31300-abb4-11e8-8f21-2b617fb6844f.png)
