### PR TITLE
Explore using isOriginal instead of isGeneratedId and isOriginalId

### DIFF
--- a/src/actions/ast.js
+++ b/src/actions/ast.js
@@ -39,7 +39,7 @@ export function setSourceMetaData(sourceId: SourceId) {
     }
 
     const framework = await getFramework(source.id);
-    dispatch(updateTab(source.url, framework));
+    dispatch(updateTab(source, framework));
 
     dispatch(
       ({

--- a/src/actions/ast.js
+++ b/src/actions/ast.js
@@ -24,9 +24,8 @@ import {
 } from "../workers/parser";
 
 import { PROMISE } from "./utils/middleware/promise";
-import { isGeneratedId } from "devtools-source-map";
 import { features } from "../utils/prefs";
-import { isLoaded } from "../utils/source";
+import { isLoaded, isOriginal } from "../utils/source";
 
 import type { SourceId } from "../types";
 import type { ThunkArgs, Action } from "./types";
@@ -128,7 +127,7 @@ export function setPausePoints(sourceId: SourceId) {
     const pausePoints = await getPausePoints(sourceId);
     const compressed = compressPausePoints(pausePoints);
 
-    if (isGeneratedId(sourceId)) {
+    if (!isOriginal(source)) {
       await client.setPausePoints(sourceId, compressed);
     }
 

--- a/src/actions/breakpoints/addBreakpoint.js
+++ b/src/actions/breakpoints/addBreakpoint.js
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
-import { isOriginalId } from "devtools-source-map";
 import {
   locationMoved,
   breakpointExists,
@@ -14,7 +13,7 @@ import {
 import { PROMISE } from "../utils/middleware/promise";
 import { getSource, getSymbols, getBreakpoint } from "../../selectors";
 import { getGeneratedLocation } from "../../utils/source-maps";
-import { getTextAtPosition } from "../../utils/source";
+import { getTextAtPosition, isOriginal } from "../../utils/source";
 import { recordEvent } from "../../utils/telemetry";
 
 async function addBreakpointPromise(getState, client, sourceMaps, breakpoint) {
@@ -48,7 +47,7 @@ async function addBreakpointPromise(getState, client, sourceMaps, breakpoint) {
   const { id, hitCount, actualLocation } = await client.setBreakpoint(
     generatedLocation,
     breakpoint.condition,
-    isOriginalId(location.sourceId)
+    isOriginal(source)
   );
 
   const newGeneratedLocation = actualLocation || generatedLocation;

--- a/src/actions/expressions.js
+++ b/src/actions/expressions.js
@@ -15,9 +15,9 @@ import {
   getSelectedFrameBindings
 } from "../selectors";
 import { PROMISE } from "./utils/middleware/promise";
-import { isGeneratedId } from "devtools-source-map";
 import { wrapExpression } from "../utils/expressions";
 import { features } from "../utils/prefs";
+import { isOriginal } from "../utils/source";
 
 import * as parser from "../workers/parser";
 import type { Expression } from "../types";
@@ -135,15 +135,10 @@ function evaluateExpression(expression: Expression) {
     if (frame) {
       const { location } = frame;
       const source = getSourceFromId(getState(), location.sourceId);
-      const sourceId = source.id;
 
       const selectedSource = getSelectedSource(getState());
 
-      if (
-        selectedSource &&
-        !isGeneratedId(sourceId) &&
-        !isGeneratedId(selectedSource.id)
-      ) {
+      if (selectedSource && isOriginal(source) && isOriginal(selectedSource)) {
         input = await dispatch(getMappedExpression(input));
       }
     }

--- a/src/actions/pause/mapScopes.js
+++ b/src/actions/pause/mapScopes.js
@@ -10,7 +10,7 @@ import { PROMISE } from "../utils/middleware/promise";
 
 import { features } from "../../utils/prefs";
 import { log } from "../../utils/log";
-import { isGeneratedId } from "devtools-source-map";
+import { isOriginal } from "../../utils/source";
 import type { Frame, Scope } from "../../types";
 
 import type { ThunkArgs } from "../types";
@@ -24,13 +24,14 @@ export function mapScopes(scopes: Promise<Scope>, frame: Frame) {
       frame.generatedLocation.sourceId
     );
 
+    // To Do:  Use "getSourceFromId" everywhere we have "frame.location.sourceId"
     const source = getSourceFromId(getState(), frame.location.sourceId);
 
     const shouldMapScopes =
       features.mapScopes &&
       !generatedSource.isWasm &&
       !source.isPrettyPrinted &&
-      !isGeneratedId(frame.location.sourceId);
+      isOriginal(source);
 
     await dispatch({
       type: "MAP_SCOPES",

--- a/src/actions/preview.js
+++ b/src/actions/preview.js
@@ -5,7 +5,7 @@
 // @flow
 import { isConsole } from "../utils/preview";
 import { findBestMatchExpression } from "../utils/ast";
-import { isGeneratedId } from "devtools-source-map";
+import { isOriginal } from "../utils/source";
 import { PROMISE } from "./utils/middleware/promise";
 import { getExpressionFromCoords } from "../utils/editor/get-expression";
 
@@ -87,10 +87,9 @@ export function setPreview(
           return;
         }
 
-        const sourceId = source.id;
         const selectedFrame = getSelectedFrame(getState());
 
-        if (location && !isGeneratedId(sourceId)) {
+        if (location && isOriginal(source)) {
           expression = await dispatch(getMappedExpression(expression));
         }
 

--- a/src/actions/sources/loadSourceText.js
+++ b/src/actions/sources/loadSourceText.js
@@ -4,11 +4,11 @@
 
 // @flow
 
-import { isOriginalId } from "devtools-source-map";
+
 import { PROMISE } from "../utils/middleware/promise";
 import { getGeneratedSource, getSourceFromId } from "../../selectors";
 import * as parser from "../../workers/parser";
-import { isLoaded } from "../../utils/source";
+import { isLoaded, isOriginal } from "../../utils/source";
 import { Telemetry } from "devtools-modules";
 
 import defer from "../../utils/defer";
@@ -24,7 +24,7 @@ const telemetry = new Telemetry();
 
 async function loadSource(source: Source, { sourceMaps, client }) {
   const id = source.id;
-  if (isOriginalId(id)) {
+  if (isOriginal(source)) {
     return sourceMaps.getOriginalSourceText(source);
   }
 
@@ -71,7 +71,7 @@ export function loadSourceText(source: Source) {
     }
 
     const newSource = getSourceFromId(getState(), source.id);
-    if (isOriginalId(newSource.id) && !newSource.isWasm) {
+    if (isOriginal(newSource) && !newSource.isWasm) {
       const generatedSource = getGeneratedSource(getState(), source);
       await dispatch(loadSourceText(generatedSource));
     }

--- a/src/actions/sources/loadSourceText.js
+++ b/src/actions/sources/loadSourceText.js
@@ -4,7 +4,6 @@
 
 // @flow
 
-
 import { PROMISE } from "../utils/middleware/promise";
 import { getGeneratedSource, getSourceFromId } from "../../selectors";
 import * as parser from "../../workers/parser";

--- a/src/actions/sources/newSources.js
+++ b/src/actions/sources/newSources.js
@@ -103,6 +103,8 @@ function checkSelectedSource(sourceId: string) {
   return async ({ dispatch, getState }: ThunkArgs) => {
     const source = getSourceFromId(getState(), sourceId);
 
+    // eval("debugger;");
+
     const pendingLocation = getPendingSelectedLocation(getState());
 
     if (!pendingLocation || !pendingLocation.url || !source.url) {

--- a/src/actions/sources/newSources.js
+++ b/src/actions/sources/newSources.js
@@ -9,7 +9,7 @@
  * @module actions/sources
  */
 
-import { isGeneratedId, generatedToOriginalId } from "devtools-source-map";
+import { generatedToOriginalId } from "devtools-source-map";
 import { flatten } from "lodash";
 
 import { toggleBlackBox } from "./blackbox";
@@ -17,7 +17,7 @@ import { syncBreakpoint } from "../breakpoints";
 import { loadSourceText } from "./loadSourceText";
 import { togglePrettyPrint } from "./prettyPrint";
 import { selectLocation } from "../sources";
-import { getRawSourceURL, isPrettyURL } from "../../utils/source";
+import { getRawSourceURL, isPrettyURL, isOriginal } from "../../utils/source";
 import {
   getBlackBoxList,
   getSource,
@@ -70,7 +70,7 @@ function loadSourceMap(sourceId: SourceId) {
   return async function({ dispatch, getState, sourceMaps }: ThunkArgs) {
     const source = getSource(getState(), sourceId);
 
-    if (!source || !isGeneratedId(sourceId) || !source.sourceMapURL) {
+    if (!source || isOriginal(source) || !source.sourceMapURL) {
       return;
     }
 

--- a/src/actions/sources/newSources.js
+++ b/src/actions/sources/newSources.js
@@ -102,9 +102,6 @@ function loadSourceMap(sourceId: SourceId) {
 function checkSelectedSource(sourceId: string) {
   return async ({ dispatch, getState }: ThunkArgs) => {
     const source = getSourceFromId(getState(), sourceId);
-
-    // eval("debugger;");
-
     const pendingLocation = getPendingSelectedLocation(getState());
 
     if (!pendingLocation || !pendingLocation.url || !source.url) {

--- a/src/actions/sources/select.js
+++ b/src/actions/sources/select.js
@@ -130,7 +130,7 @@ export function selectLocation(
 
     const tabSources = getSourcesForTabs(getState());
     if (!tabSources.includes(source)) {
-      dispatch(addTab(source.url));
+      dispatch(addTab(source));
     }
 
     dispatch(setSelectedLocation(source, location));
@@ -151,7 +151,7 @@ export function selectLocation(
       isMinified(loadedSource)
     ) {
       await dispatch(togglePrettyPrint(loadedSource.id));
-      dispatch(closeTab(loadedSource.url));
+      dispatch(closeTab(loadedSource));
     }
 
     dispatch(setSymbols(loadedSource.id));

--- a/src/actions/sources/tests/newSources.spec.js
+++ b/src/actions/sources/tests/newSources.spec.js
@@ -61,7 +61,7 @@ describe("sources - new sources", () => {
 
     const baseSource = makeSource("base.js", { sourceMapURL: "base.js.map" });
     await dispatch(actions.newSource(baseSource));
-    const magic = getSourceByURL(getState(), "magic.js");
+    const magic = getSourceByURL(getState(), "magic.js", true);
     expect(magic.url).toEqual("magic.js");
   });
 

--- a/src/actions/sources/tests/select.spec.js
+++ b/src/actions/sources/tests/select.spec.js
@@ -74,18 +74,23 @@ describe("sources", () => {
     const { dispatch, getState } = createStore(sourceThreadClient);
     await dispatch(actions.newSource(makeSource("foo.js")));
     await dispatch(actions.newSource(makeSource("bar.js")));
-    await dispatch(actions.newSource(makeSource("baz.js")));
+
+    const bazSource = makeSource("baz.js");
+    await dispatch(actions.newSource(bazSource));
+
     await dispatch(actions.selectLocation({ sourceId: "foo.js" }));
     await dispatch(actions.selectLocation({ sourceId: "bar.js" }));
     await dispatch(actions.selectLocation({ sourceId: "baz.js" }));
-    await dispatch(actions.closeTab("http://localhost:8000/examples/baz.js"));
+    await dispatch(actions.closeTab(bazSource));
     expect(getSelectedSource(getState()).id).toBe("bar.js");
     expect(getSourceTabs(getState())).toHaveLength(2);
   });
 
   it("should select next tab on tab closed if no previous tab", async () => {
     const { dispatch, getState } = createStore(sourceThreadClient);
-    await dispatch(actions.newSource(makeSource("foo.js")));
+
+    const fooSource = makeSource("foo.js");
+    await dispatch(actions.newSource(fooSource));
     await dispatch(actions.newSource(makeSource("bar.js")));
     await dispatch(actions.newSource(makeSource("baz.js")));
 
@@ -93,7 +98,7 @@ describe("sources", () => {
     await dispatch(actions.selectLocation({ sourceId: "bar.js" }));
     await dispatch(actions.selectLocation({ sourceId: "baz.js" }));
     await dispatch(actions.selectLocation({ sourceId: "foo.js" }));
-    await dispatch(actions.closeTab("http://localhost:8000/examples/foo.js"));
+    await dispatch(actions.closeTab(fooSource));
     expect(getSelectedSource(getState()).id).toBe("bar.js");
     expect(getSourceTabs(getState())).toHaveLength(2);
   });

--- a/src/actions/tabs.js
+++ b/src/actions/tabs.js
@@ -42,7 +42,7 @@ export function addTab(source: Source): Action {
   return {
     type: "ADD_TAB",
     url,
-    isOriginal:  isOriginal(source)
+    isOriginal: isOriginal(source)
   };
 }
 

--- a/src/actions/tabs.js
+++ b/src/actions/tabs.js
@@ -9,7 +9,7 @@
  * @module actions/tabs
  */
 
-import { isOriginalId } from "devtools-source-map";
+import { isOriginal } from "../utils/source";
 
 import { removeDocument } from "../utils/editor";
 import { selectSource } from "./sources";
@@ -27,24 +27,22 @@ import type { Source } from "../types";
 
 export function updateTab(source: Source, framework: string): Action {
   const { url } = source;
-  const isOriginal = isOriginalId(source.id);
 
   return {
     type: "UPDATE_TAB",
     url,
     framework,
-    isOriginal
+    isOriginal: isOriginal(source)
   };
 }
 
 export function addTab(source: Source): Action {
   const { url } = source;
-  const isOriginal = isOriginalId(source.id);
 
   return {
     type: "ADD_TAB",
     url,
-    isOriginal
+    isOriginal:  isOriginal(source)
   };
 }
 

--- a/src/actions/tabs.js
+++ b/src/actions/tabs.js
@@ -15,7 +15,7 @@ import { removeDocument } from "../utils/editor";
 import { selectSource } from "./sources";
 
 import {
-  getSourceByURL,
+  getSourcesByURLs,
   getSourceTabs,
   getNewSelectedSourceId,
   removeSourceFromTabList,
@@ -81,15 +81,8 @@ export function closeTab(source: Source) {
  */
 export function closeTabs(urls: string[]) {
   return ({ dispatch, getState, client }: ThunkArgs) => {
-    const sources = urls
-      .map(url => {
-        const source = getSourceByURL(getState(), url);
-        if (source) {
-          removeDocument(source.id);
-          return source;
-        }
-      })
-      .filter(source => source);
+    const sources = getSourcesByURLs(getState(), urls);
+    sources.map(source => removeDocument(source.id));
 
     const tabs = removeSourcesFromTabList(getSourceTabs(getState()), sources);
     dispatch(({ type: "CLOSE_TABS", sources, tabs }: Action));

--- a/src/actions/tabs.js
+++ b/src/actions/tabs.js
@@ -9,6 +9,8 @@
  * @module actions/tabs
  */
 
+import { isOriginalId } from "devtools-source-map";
+
 import { removeDocument } from "../utils/editor";
 import { selectSource } from "./sources";
 
@@ -21,20 +23,30 @@ import {
 } from "../selectors";
 
 import type { Action, ThunkArgs } from "./types";
+import type { Source } from "../types";
 
-export function updateTab(url: string, framework: string): Action {
+export function updateTab(source: Source, framework: string): Action {
+  const { url } = source;
+  const isOriginal = isOriginalId(source.id);
+
   return {
     type: "UPDATE_TAB",
     url,
-    framework
+    framework,
+    isOriginal
   };
 }
 
-export function addTab(url: string, framework?: string): Action {
+export function addTab(source: Source): Action {
+  const { url } = source;
+  const framework = "";
+  const isOriginal = isOriginalId(source.id);
+
   return {
     type: "ADD_TAB",
     url,
-    framework
+    framework,
+    isOriginal
   };
 }
 
@@ -50,11 +62,16 @@ export function moveTab(url: string, tabIndex: number): Action {
  * @memberof actions/tabs
  * @static
  */
-export function closeTab(url: string) {
+export function closeTab(source: Source) {
   return ({ dispatch, getState, client }: ThunkArgs) => {
-    removeDocument(url);
+    const { id, url } = source;
+    removeDocument(id);
 
-    const tabs = removeSourceFromTabList(getSourceTabs(getState()), url);
+    const tabs = removeSourceFromTabList(
+      getSourceTabs(getState()),
+      url,
+      isOriginalId(id)
+    );
     const sourceId = getNewSelectedSourceId(getState(), tabs);
     dispatch(({ type: "CLOSE_TAB", url, tabs }: Action));
     dispatch(selectSource(sourceId));

--- a/src/actions/tabs.js
+++ b/src/actions/tabs.js
@@ -39,13 +39,11 @@ export function updateTab(source: Source, framework: string): Action {
 
 export function addTab(source: Source): Action {
   const { url } = source;
-  const framework = "";
   const isOriginal = isOriginalId(source.id);
 
   return {
     type: "ADD_TAB",
     url,
-    framework,
     isOriginal
   };
 }

--- a/src/actions/tests/project-text-search.spec.js
+++ b/src/actions/tests/project-text-search.spec.js
@@ -90,10 +90,19 @@ describe("project text search", () => {
   });
 
   it("should ignore sources with minified versions", async () => {
-    const { dispatch, getState } = createStore(threadClient);
-    const mockQuery = "bla";
-    const source1 = makeSource("bar");
+    const source1 = makeSource("bar", { sourceMapURL: "bar:formatted" });
     const source2 = makeSource("bar:formatted");
+
+    const mockMaps = {
+      getOriginalSourceText: async () => ({
+        source: "function bla(x, y) {\n const bar = 4; return 2;\n}",
+        contentType: "text/javascript"
+      }),
+      getOriginalURLs: async () => [source2.url]
+    };
+
+    const { dispatch, getState } = createStore(threadClient, {}, mockMaps);
+    const mockQuery = "bla";
 
     await dispatch(actions.newSource(source1));
     await dispatch(actions.newSource(source2));

--- a/src/actions/tests/tabs.spec.js
+++ b/src/actions/tests/tabs.spec.js
@@ -15,9 +15,11 @@ import { sourceThreadClient as threadClient } from "./helpers/threadClient.js";
 describe("closing tabs", () => {
   it("closing a tab", async () => {
     const { dispatch, getState } = createStore(threadClient);
-    await dispatch(actions.newSource(makeSource("foo.js")));
+
+    const fooSource = makeSource("foo.js");
+    await dispatch(actions.newSource(fooSource));
     await dispatch(actions.selectLocation({ sourceId: "foo.js" }));
-    dispatch(actions.closeTab("http://localhost:8000/examples/foo.js"));
+    dispatch(actions.closeTab(fooSource));
 
     expect(getSelectedSource(getState())).toBe(undefined);
     expect(getSourceTabs(getState())).toHaveLength(0);
@@ -25,11 +27,13 @@ describe("closing tabs", () => {
 
   it("closing the inactive tab", async () => {
     const { dispatch, getState } = createStore(threadClient);
-    await dispatch(actions.newSource(makeSource("foo.js")));
+
+    const fooSource = makeSource("foo.js");
+    await dispatch(actions.newSource(fooSource));
     await dispatch(actions.newSource(makeSource("bar.js")));
     await dispatch(actions.selectLocation({ sourceId: "foo.js" }));
     await dispatch(actions.selectLocation({ sourceId: "bar.js" }));
-    dispatch(actions.closeTab("http://localhost:8000/examples/foo.js"));
+    dispatch(actions.closeTab(fooSource));
 
     expect(getSelectedSource(getState()).id).toBe("bar.js");
     expect(getSourceTabs(getState())).toHaveLength(1);
@@ -37,9 +41,11 @@ describe("closing tabs", () => {
 
   it("closing the only tab", async () => {
     const { dispatch, getState } = createStore(threadClient);
-    await dispatch(actions.newSource(makeSource("foo.js")));
+
+    const fooSource = makeSource("foo.js");
+    await dispatch(actions.newSource(fooSource));
     await dispatch(actions.selectLocation({ sourceId: "foo.js" }));
-    dispatch(actions.closeTab("http://localhost:8000/examples/foo.js"));
+    dispatch(actions.closeTab(fooSource));
 
     expect(getSelectedSource(getState())).toBe(undefined);
     expect(getSourceTabs(getState())).toHaveLength(0);
@@ -47,11 +53,13 @@ describe("closing tabs", () => {
 
   it("closing the active tab", async () => {
     const { dispatch, getState } = createStore(threadClient);
+
+    const barSource = makeSource("bar.js");
     await dispatch(actions.newSource(makeSource("foo.js")));
-    await dispatch(actions.newSource(makeSource("bar.js")));
+    await dispatch(actions.newSource(barSource));
     await dispatch(actions.selectLocation({ sourceId: "foo.js" }));
     await dispatch(actions.selectLocation({ sourceId: "bar.js" }));
-    await dispatch(actions.closeTab("http://localhost:8000/examples/bar.js"));
+    await dispatch(actions.closeTab(barSource));
 
     expect(getSelectedSource(getState()).id).toBe("foo.js");
     expect(getSourceTabs(getState())).toHaveLength(1);
@@ -59,18 +67,21 @@ describe("closing tabs", () => {
 
   it("closing many inactive tabs", async () => {
     const { dispatch, getState } = createStore(threadClient);
-    await dispatch(actions.newSource(makeSource("foo.js")));
-    await dispatch(actions.newSource(makeSource("bar.js")));
+
+    const fooSource = makeSource("foo.js");
+    const barSource = makeSource("bar.js");
+    await dispatch(actions.newSource(fooSource));
+    await dispatch(actions.newSource(barSource));
     await dispatch(actions.newSource(makeSource("bazz.js")));
     await dispatch(actions.selectLocation({ sourceId: "foo.js" }));
     await dispatch(actions.selectLocation({ sourceId: "bar.js" }));
     await dispatch(actions.selectLocation({ sourceId: "bazz.js" }));
-    dispatch(
-      actions.closeTabs([
-        "http://localhost:8000/examples/foo.js",
-        "http://localhost:8000/examples/bar.js"
-      ])
-    );
+
+    const tabs = [
+      "http://localhost:8000/examples/foo.js",
+      "http://localhost:8000/examples/bar.js"
+    ];
+    dispatch(actions.closeTabs(tabs));
 
     expect(getSelectedSource(getState()).id).toBe("bazz.js");
     expect(getSourceTabs(getState())).toHaveLength(1);
@@ -78,6 +89,7 @@ describe("closing tabs", () => {
 
   it("closing many tabs including the active tab", async () => {
     const { dispatch, getState } = createStore(threadClient);
+
     await dispatch(actions.newSource(makeSource("foo.js")));
     await dispatch(actions.newSource(makeSource("bar.js")));
     await dispatch(actions.newSource(makeSource("bazz.js")));
@@ -96,11 +108,12 @@ describe("closing tabs", () => {
 
   it("closing all the tabs", async () => {
     const { dispatch, getState } = createStore(threadClient);
+
     await dispatch(actions.newSource(makeSource("foo.js")));
     await dispatch(actions.newSource(makeSource("bar.js")));
     await dispatch(actions.selectLocation({ sourceId: "foo.js" }));
     await dispatch(actions.selectLocation({ sourceId: "bar.js" }));
-    dispatch(
+    await dispatch(
       actions.closeTabs([
         "http://localhost:8000/examples/foo.js",
         "http://localhost:8000/examples/bar.js"

--- a/src/actions/types/SourceAction.js
+++ b/src/actions/types/SourceAction.js
@@ -61,6 +61,6 @@ export type SourceAction =
     |}
   | {|
       +type: "CLOSE_TABS",
-      +urls: string[],
+      +sources: Array<Source>,
       +tabs: any
     |};

--- a/src/actions/types/index.js
+++ b/src/actions/types/index.js
@@ -48,13 +48,15 @@ type ProjectTextSearchResult = {
 type AddTabAction = {|
   +type: "ADD_TAB",
   +url: string,
-  +framework?: string
+  +framework?: string,
+  +isOriginal?: boolean
 |};
 
 type UpdateTabAction = {|
   +type: "UPDATE_TAB",
   +url: string,
-  +framework?: string
+  +framework?: string,
+  +isOriginal?: boolean // Is this needed?
 |};
 
 type ReplayAction =

--- a/src/actions/types/index.js
+++ b/src/actions/types/index.js
@@ -56,7 +56,7 @@ type UpdateTabAction = {|
   +type: "UPDATE_TAB",
   +url: string,
   +framework?: string,
-  +isOriginal?: boolean // Is this needed?
+  +isOriginal?: boolean
 |};
 
 type ReplayAction =

--- a/src/components/Editor/EditorMenu.js
+++ b/src/components/Editor/EditorMenu.js
@@ -14,7 +14,10 @@ import {
   getSourceLocationFromMouseEvent,
   toSourceLine
 } from "../../utils/editor";
-import { isOriginal, getRawSourceURL } from "../../utils/source";
+import {
+  isOriginal as isOriginalSource,
+  getRawSourceURL
+} from "../../utils/source";
 import {
   getContextMenu,
   getPrettySource,
@@ -50,7 +53,7 @@ function getMenuItems(
   // variables
   const hasSourceMap = !!selectedSource.sourceMapURL;
   const isOriginal = isOriginalId(selectedLocation.sourceId);
-  const isMapped = isOriginal(selectedSource) || hasSourceMap;
+  const isMapped = isOriginalSource(selectedSource) || hasSourceMap;
   const { line } = editor.codeMirror.coordsChar({
     left: event.clientX,
     top: event.clientY
@@ -159,7 +162,7 @@ function getMenuItems(
     id: "node-menu-blackbox",
     label: toggleBlackBoxLabel,
     accesskey: blackboxKey,
-    disabled: isOriginal || isPrettyPrinted || hasSourceMap,
+    disabled: isOriginal || hasSourceMap,
     click: () => toggleBlackBox(selectedSource)
   };
 

--- a/src/components/Editor/EditorMenu.js
+++ b/src/components/Editor/EditorMenu.js
@@ -14,7 +14,7 @@ import {
   getSourceLocationFromMouseEvent,
   toSourceLine
 } from "../../utils/editor";
-import { isPretty, getRawSourceURL } from "../../utils/source";
+import { isOriginal, getRawSourceURL } from "../../utils/source";
 import {
   getContextMenu,
   getPrettySource,
@@ -39,7 +39,6 @@ function getMenuItems(
     flashLineRange,
     getFunctionLocation,
     getFunctionText,
-    hasPrettyPrint,
     jumpToMappedLocation,
     onGutterContextMenu,
     selectedLocation,
@@ -51,9 +50,7 @@ function getMenuItems(
   // variables
   const hasSourceMap = !!selectedSource.sourceMapURL;
   const isOriginal = isOriginalId(selectedLocation.sourceId);
-  const isPrettyPrinted = isPretty(selectedSource);
-  const isPrettified = isPrettyPrinted || hasPrettyPrint;
-  const isMapped = isOriginal || hasSourceMap;
+  const isMapped = isOriginal(selectedSource) || hasSourceMap;
   const { line } = editor.codeMirror.coordsChar({
     left: event.clientX,
     top: event.clientY
@@ -146,7 +143,7 @@ function getMenuItems(
     id: "node-menu-jump",
     label: jumpToMappedLocLabel,
     accesskey: jumpToMappedLocKey,
-    disabled: !isMapped && !isPrettified,
+    disabled: !isMapped,
     click: () => jumpToMappedLocation(sourceLocation)
   };
 

--- a/src/components/Editor/Footer.js
+++ b/src/components/Editor/Footer.js
@@ -5,7 +5,6 @@
 // @flow
 import React, { PureComponent } from "react";
 import { connect } from "react-redux";
-import { isOriginalId } from "devtools-source-map";
 import classnames from "classnames";
 
 import actions from "../../actions";
@@ -16,7 +15,12 @@ import {
 } from "../../selectors";
 
 import { features } from "../../utils/prefs";
-import { isPretty, isLoaded, getFilename } from "../../utils/source";
+import {
+  isPretty,
+  isLoaded,
+  getFilename,
+  isOriginal
+} from "../../utils/source";
 import { getGeneratedSource } from "../../reducers/sources";
 import { shouldShowFooter, shouldShowPrettyPrint } from "../../utils/editor";
 
@@ -158,7 +162,7 @@ class SourceFooter extends PureComponent<Props> {
   renderSourceSummary() {
     const { mappedSource, jumpToMappedLocation, selectedSource } = this.props;
 
-    if (!mappedSource || !isOriginalId(selectedSource.id)) {
+    if (!mappedSource || !isOriginal(selectedSource)) {
       return null;
     }
 

--- a/src/components/Editor/Tab.js
+++ b/src/components/Editor/Tab.js
@@ -80,13 +80,13 @@ class Tab extends PureComponent<Props> {
       {
         item: {
           ...tabMenuItems.closeTab,
-          click: () => closeTab(sourceTab.url)
+          click: () => closeTab(sourceTab)
         }
       },
       {
         item: {
           ...tabMenuItems.closeOtherTabs,
-          click: () => closeTabs(otherTabURLs)
+          click: () => closeTabs(otherTabURLs) // TODO:  How to handle this?
         },
         hidden: () => tabSources.size === 1
       },
@@ -162,7 +162,7 @@ class Tab extends PureComponent<Props> {
 
     function onClickClose(e) {
       e.stopPropagation();
-      closeTab(source.url);
+      closeTab(source);
     }
 
     function handleTabClick(e) {

--- a/src/components/Editor/Tab.js
+++ b/src/components/Editor/Tab.js
@@ -86,7 +86,7 @@ class Tab extends PureComponent<Props> {
       {
         item: {
           ...tabMenuItems.closeOtherTabs,
-          click: () => closeTabs(otherTabURLs) // TODO:  How to handle this?
+          click: () => closeTabs(otherTabURLs)
         },
         hidden: () => tabSources.size === 1
       },

--- a/src/components/Editor/Tab.js
+++ b/src/components/Editor/Tab.js
@@ -43,7 +43,7 @@ type Props = {
   source: Source,
   activeSearch: string,
   selectSource: string => void,
-  closeTab: string => void,
+  closeTab: Source => void,
   closeTabs: (List<string>) => void,
   togglePrettyPrint: string => void,
   showSource: string => void
@@ -184,7 +184,7 @@ class Tab extends PureComponent<Props> {
         key={sourceId}
         onClick={handleTabClick}
         // Accommodate middle click to close tab
-        onMouseUp={e => e.button === 1 && closeTab(source.url)}
+        onMouseUp={e => e.button === 1 && closeTab(source)}
         onContextMenu={e => this.onTabContextMenu(e, sourceId)}
         title={getFileURL(source)}
       >

--- a/src/components/PrimaryPanes/SourcesTree.js
+++ b/src/components/PrimaryPanes/SourcesTree.js
@@ -8,7 +8,6 @@
 import React, { Component } from "react";
 import classnames from "classnames";
 import { connect } from "react-redux";
-import { isOriginalId } from "devtools-source-map";
 
 // Selectors
 import {
@@ -97,7 +96,6 @@ class SourcesTree extends Component<Props, State> {
       shownSource,
       selectedSource
     } = this.props;
-
     const { uncollapsedTree, sourceTree } = this.state;
 
     if (
@@ -350,11 +348,7 @@ function getSourceForTree(state: AppState, source: ?Source): ?Source | null {
     return source;
   }
 
-  return getSourceByURL(
-    state,
-    getRawSourceURL(source.url),
-    isOriginalId(source.id)
-  );
+  return getSourceByURL(state, getRawSourceURL(source.url), false);
 }
 
 const mapStateToProps = state => {

--- a/src/components/PrimaryPanes/SourcesTree.js
+++ b/src/components/PrimaryPanes/SourcesTree.js
@@ -8,6 +8,7 @@
 import React, { Component } from "react";
 import classnames from "classnames";
 import { connect } from "react-redux";
+import { isOriginalId } from "devtools-source-map";
 
 // Selectors
 import {
@@ -349,7 +350,11 @@ function getSourceForTree(state: AppState, source: ?Source): ?Source | null {
     return source;
   }
 
-  return getSourceByURL(state, getRawSourceURL(source.url));
+  return getSourceByURL(
+    state,
+    getRawSourceURL(source.url),
+    isOriginalId(source.id)
+  );
 }
 
 const mapStateToProps = state => {

--- a/src/components/PrimaryPanes/SourcesTreeItem.js
+++ b/src/components/PrimaryPanes/SourcesTreeItem.js
@@ -4,7 +4,6 @@
 
 // @flow
 
-import { isOriginalId } from "devtools-source-map";
 import React, { Component } from "react";
 import { connect } from "react-redux";
 import classnames from "classnames";
@@ -16,6 +15,7 @@ import Svg from "../shared/Svg";
 import { getSourcesByURL } from "../../selectors";
 import actions from "../../actions";
 
+import { isOriginal as isOriginalSource } from "../../utils/source";
 import { isDirectory } from "../../utils/sources-tree";
 import { copyToTheClipboard } from "../../utils/clipboard";
 import { features } from "../../utils/prefs";
@@ -191,7 +191,7 @@ function getHasMatchingGeneratedSource(state, source: ?Source) {
     return false;
   }
 
-  const isOriginal = isOriginalId(source.id);
+  const isOriginal = isOriginalSource(source);
   const sources = getSourcesByURL(state, source.url, isOriginal);
   return isOriginal && sources.length > 0;
 }

--- a/src/components/PrimaryPanes/SourcesTreeItem.js
+++ b/src/components/PrimaryPanes/SourcesTreeItem.js
@@ -191,8 +191,9 @@ function getHasMatchingGeneratedSource(state, source: ?Source) {
     return false;
   }
 
-  const sources = getSourcesByURL(state, source.url);
-  return isOriginalId(source.id) && sources.length > 1;
+  const isOriginal = isOriginalId(source.id);
+  const sources = getSourcesByURL(state, source.url, isOriginal);
+  return isOriginal && sources.length > 0;
 }
 
 const mapStateToProps = (state, props) => {

--- a/src/components/SecondaryPanes/Breakpoints/Breakpoint.js
+++ b/src/components/SecondaryPanes/Breakpoints/Breakpoint.js
@@ -6,7 +6,7 @@
 
 import React, { PureComponent } from "react";
 import { connect } from "react-redux";
-import { isGeneratedId } from "devtools-source-map";
+import { isOriginal } from "../../../utils/source";
 
 import classnames from "classnames";
 
@@ -53,7 +53,7 @@ type Props = {
 };
 
 function getMappedLocation(mappedLocation: MappedLocation, selectedSource) {
-  return selectedSource && isGeneratedId(selectedSource.id)
+  return selectedSource && !isOriginal(selectedSource)
     ? mappedLocation.generatedLocation
     : mappedLocation.location;
 }
@@ -132,7 +132,7 @@ class Breakpoint extends PureComponent<Props> {
       return condition;
     }
 
-    if (selectedSource && isGeneratedId(selectedSource.id)) {
+    if (selectedSource && !isOriginal(selectedSource)) {
       return breakpoint.text;
     }
 

--- a/src/reducers/pause.js
+++ b/src/reducers/pause.js
@@ -11,9 +11,9 @@
  */
 
 import { createSelector } from "reselect";
-import { isGeneratedId } from "devtools-source-map";
+import { isOriginal } from "../utils/source";
 import { prefs } from "../utils/prefs";
-import { getSelectedSource } from "./sources";
+import { getSelectedSource, getSourceFromId } from "./sources";
 
 import type { OriginalScope } from "../utils/pause/mapScopes";
 import type { Action } from "../actions/types";
@@ -377,7 +377,8 @@ export function getOriginalFrameScope(
     return null;
   }
 
-  const isGenerated = isGeneratedId(sourceId);
+  const source = getSourceFromId(state, sourceId);
+  const isGenerated = !isOriginal(source);
   const original = getFrameScopes(state).original[getGeneratedFrameId(frameId)];
 
   if (!isGenerated && original && (original.pending || original.scope)) {

--- a/src/reducers/pending-breakpoints.js
+++ b/src/reducers/pending-breakpoints.js
@@ -9,8 +9,8 @@
  * @module reducers/pending-breakpoints
  */
 
-import { isGeneratedId } from "devtools-source-map";
 import { getSourcesByURL } from "./sources";
+import { isOriginal } from "../utils/source";
 
 import {
   createPendingBreakpoint,
@@ -164,7 +164,7 @@ export function getPendingBreakpointsForSource(
   source: Source
 ): PendingBreakpoint[] {
   const sources = getSourcesByURL(state, source.url);
-  if (sources.length > 1 && isGeneratedId(source.id)) {
+  if (sources.length > 1 && !isOriginal(source)) {
     // Don't return pending breakpoints for duplicated generated sources
     return [];
   }

--- a/src/reducers/sources.js
+++ b/src/reducers/sources.js
@@ -344,11 +344,7 @@ export function getPrettySource(state: OuterState, id: string) {
     return;
   }
 
-  return getSourceByURL(
-    state,
-    getPrettySourceURL(source.url),
-    isOriginalId(source.id)
-  );
+  return getSourceByURL(state, getPrettySourceURL(source.url), true);
 }
 
 export function hasPrettySource(state: OuterState, id: string) {

--- a/src/reducers/sources.js
+++ b/src/reducers/sources.js
@@ -286,12 +286,30 @@ export function getSourceFromId(state: OuterState, id: string): Source {
   return getSourcesState(state).sources[id];
 }
 
-export function getSourceByURL(state: OuterState, url: string): ?Source {
-  return getSourceByUrlInSources(getSources(state), getUrls(state), url);
+export function getSourceByURL(
+  state: OuterState,
+  url: string,
+  isOriginal?: boolean
+): ?Source {
+  return getSourceByUrlInSources(
+    getSources(state),
+    getUrls(state),
+    url,
+    isOriginal
+  );
 }
 
-export function getSourcesByURL(state: OuterState, url: string): Source[] {
-  return getSourcesByUrlInSources(getSources(state), getUrls(state), url);
+export function getSourcesByURL(
+  state: OuterState,
+  url: string,
+  isOriginal?: boolean
+): Source[] {
+  return getSourcesByUrlInSources(
+    getSources(state),
+    getUrls(state),
+    url,
+    isOriginal
+  );
 }
 
 export function getGeneratedSource(state: OuterState, source: Source): Source {
@@ -312,7 +330,11 @@ export function getPrettySource(state: OuterState, id: string) {
     return;
   }
 
-  return getSourceByURL(state, getPrettySourceURL(source.url));
+  return getSourceByURL(
+    state,
+    getPrettySourceURL(source.url),
+    isOriginalId(source.id)
+  );
 }
 
 export function hasPrettySource(state: OuterState, id: string) {
@@ -322,20 +344,25 @@ export function hasPrettySource(state: OuterState, id: string) {
 export function getSourceByUrlInSources(
   sources: SourcesMap,
   urls: UrlsMap,
-  url: string
+  url: string,
+  isOriginal?: boolean
 ) {
   const foundSources = getSourcesByUrlInSources(sources, urls, url);
   if (!foundSources) {
     return null;
   }
 
+  if (isOriginal !== undefined) {
+    return foundSources.find(source => isOriginalId(source.id) === isOriginal);
+  }
   return foundSources[0];
 }
 
 function getSourcesByUrlInSources(
   sources: SourcesMap,
   urls: UrlsMap,
-  url: string
+  url: string,
+  isOriginal?: boolean
 ) {
   if (!url || !urls[url]) {
     return [];

--- a/src/reducers/sources.js
+++ b/src/reducers/sources.js
@@ -14,9 +14,10 @@ import {
   getPrettySourceURL,
   underRoot,
   getRelativeUrl,
-  isPrettyURL
+  isPrettyURL,
+  isOriginal as isOriginalSource
 } from "../utils/source";
-import { originalToGeneratedId, isOriginalId } from "devtools-source-map";
+import { originalToGeneratedId } from "devtools-source-map";
 import { prefs } from "../utils/prefs";
 
 import type { Source, SourceId, Location } from "../types";
@@ -327,7 +328,7 @@ export function getSourcesByURL(
 }
 
 export function getGeneratedSource(state: OuterState, source: Source): Source {
-  if (!isOriginalId(source.id)) {
+  if (!isOriginalSource(source)) {
     return source;
   }
 
@@ -362,7 +363,7 @@ export function getSourceByUrlInSources(
     return null;
   }
 
-  return foundSources.find(source => isOriginalId(source.id) == isOriginal);
+  return foundSources.find(source => isOriginalSource(source) == isOriginal);
 }
 
 function getSourcesByUrlInSources(

--- a/src/reducers/sources.js
+++ b/src/reducers/sources.js
@@ -10,7 +10,12 @@
  */
 
 import { createSelector } from "reselect";
-import { getPrettySourceURL, underRoot, getRelativeUrl } from "../utils/source";
+import {
+  getPrettySourceURL,
+  underRoot,
+  getRelativeUrl,
+  isPrettyURL
+} from "../utils/source";
 import { originalToGeneratedId, isOriginalId } from "devtools-source-map";
 import { prefs } from "../utils/prefs";
 
@@ -289,8 +294,13 @@ export function getSourceFromId(state: OuterState, id: string): Source {
 export function getSourceByURL(
   state: OuterState,
   url: string,
-  isOriginal?: boolean
+  isOriginal: boolean = false
 ): ?Source {
+  // Pretty sources should always be original
+  if (isPrettyURL(url)) {
+    isOriginal = true;
+  }
+
   return getSourceByUrlInSources(
     getSources(state),
     getUrls(state),
@@ -306,7 +316,7 @@ export function getSourcesByURLs(state: OuterState, urls: string[]) {
 export function getSourcesByURL(
   state: OuterState,
   url: string,
-  isOriginal?: boolean
+  isOriginal: boolean = false
 ): Source[] {
   return getSourcesByUrlInSources(
     getSources(state),
@@ -349,17 +359,14 @@ export function getSourceByUrlInSources(
   sources: SourcesMap,
   urls: UrlsMap,
   url: string,
-  isOriginal?: boolean
+  isOriginal: boolean
 ) {
   const foundSources = getSourcesByUrlInSources(sources, urls, url);
   if (!foundSources) {
     return null;
   }
 
-  if (isOriginal !== undefined) {
-    return foundSources.find(source => isOriginalId(source.id) === isOriginal);
-  }
-  return foundSources[0];
+  return foundSources.find(source => isOriginalId(source.id) == isOriginal);
 }
 
 function getSourcesByUrlInSources(

--- a/src/reducers/sources.js
+++ b/src/reducers/sources.js
@@ -299,6 +299,10 @@ export function getSourceByURL(
   );
 }
 
+export function getSourcesByURLs(state: OuterState, urls: string[]) {
+  return urls.map(url => getSourceByURL(state, url)).filter(Boolean);
+}
+
 export function getSourcesByURL(
   state: OuterState,
   url: string,

--- a/src/reducers/tabs.js
+++ b/src/reducers/tabs.js
@@ -198,7 +198,7 @@ export const getSourcesForTabs = createSelector(
       .map(tab =>
         getSourceByUrlInSources(sources, urls, tab.url, tab.isOriginal)
       )
-      .filter(source => source);
+      .filter(Boolean);
   }
 );
 

--- a/src/reducers/tabs.js
+++ b/src/reducers/tabs.js
@@ -14,6 +14,7 @@ import { isOriginalId } from "devtools-source-map";
 import move from "lodash-move";
 
 import { prefs } from "../utils/prefs";
+import { isOriginal as isOriginalSource } from "../utils/source";
 import {
   getSource,
   getSources,
@@ -57,7 +58,7 @@ export function removeSourceFromTabList(
   source: Source
 ): TabList {
   return tabs.filter(
-    tab => tab.url !== source.url || tab.isOriginal != isOriginalId(source.id)
+    tab => tab.url !== source.url || tab.isOriginal != isOriginalSource(source)
   );
 }
 

--- a/src/reducers/tabs.js
+++ b/src/reducers/tabs.js
@@ -29,6 +29,10 @@ import type { Source } from "../types";
 type Tab = { url: string, framework?: string | null, isOriginal: boolean };
 export type TabList = Tab[];
 
+function isSimilarTab(tab: Tab, url: string, isOriginal: boolean) {
+  return tab.url === url && tab.isOriginal === isOriginal;
+}
+
 function update(state: TabList = prefs.tabs || [], action: Action): TabList {
   switch (action.type) {
     case "ADD_TAB":
@@ -53,9 +57,7 @@ export function removeSourceFromTabList(
   source: Source
 ): TabList {
   return tabs.filter(
-    tab =>
-      tab.url !== source.url ||
-      (tab.url === source.url && tab.isOriginal != isOriginalId(source.id))
+    tab => tab.url !== source.url || tab.isOriginal != isOriginalId(source.id)
   );
 }
 
@@ -75,8 +77,8 @@ function updateTabList(
   tabs: TabList,
   { url, framework = null, isOriginal = false }
 ) {
-  const currentIndex = tabs.findIndex(
-    tab => tab.url === url && tab.isOriginal === isOriginal
+  const currentIndex = tabs.findIndex(tab =>
+    isSimilarTab(tab, url, isOriginal)
   );
 
   if (currentIndex === -1) {
@@ -119,10 +121,8 @@ export function getNewSelectedSourceId(
     return "";
   }
 
-  const matchingTab = availableTabs.find(
-    tab =>
-      tab.url === selectedTab.url &&
-      tab.isOriginal === isOriginalId(selectedLocation.sourceId)
+  const matchingTab = availableTabs.find(tab =>
+    isSimilarTab(tab, selectedTab.url, isOriginalId(selectedLocation.sourceId))
   );
 
   if (matchingTab) {

--- a/src/reducers/tabs.js
+++ b/src/reducers/tabs.js
@@ -26,7 +26,7 @@ import type { Action } from "../actions/types";
 import type { SourcesState } from "./sources";
 import type { Source } from "../types";
 
-type Tab = { url: string, framework?: string | null, isOriginal?: boolean };
+type Tab = { url: string, framework?: string | null, isOriginal: boolean };
 export type TabList = Tab[];
 
 function update(state: TabList = prefs.tabs || [], action: Action): TabList {

--- a/src/reducers/tabs.js
+++ b/src/reducers/tabs.js
@@ -24,6 +24,7 @@ import {
 
 import type { Action } from "../actions/types";
 import type { SourcesState } from "./sources";
+import type { Source } from "../types";
 
 type Tab = { url: string, framework?: string | null, isOriginal?: boolean };
 export type TabList = Tab[];
@@ -49,16 +50,20 @@ function update(state: TabList = prefs.tabs || [], action: Action): TabList {
 
 export function removeSourceFromTabList(
   tabs: TabList,
-  url: string,
-  isOriginal: boolean
+  source: Source
 ): TabList {
   return tabs.filter(
-    tab => tab.url !== url || (tab.url === url && tab.isOriginal != isOriginal)
+    tab =>
+      tab.url !== source.url ||
+      (tab.url === source.url && tab.isOriginal != isOriginalId(source.id))
   );
 }
 
-export function removeSourcesFromTabList(tabs: TabList, urls: string[]) {
-  return urls.reduce((t, url) => removeSourceFromTabList(t, url), tabs);
+export function removeSourcesFromTabList(tabs: TabList, sources: Source[]) {
+  return sources.reduce(
+    (t, source) => removeSourceFromTabList(t, source),
+    tabs
+  );
 }
 
 /**
@@ -126,7 +131,6 @@ export function getNewSelectedSourceId(
       return "";
     }
 
-    console.log("calling getSourceByURL; selectedTab: ", selectedTab);
     const selectedSource = getSourceByURL(
       state,
       selectedTab.url,

--- a/src/selectors/breakpointAtLocation.js
+++ b/src/selectors/breakpointAtLocation.js
@@ -4,24 +4,20 @@
 
 import { getSelectedSource } from "../reducers/sources";
 import { getBreakpoints } from "../reducers/breakpoints";
-import { isGeneratedId } from "devtools-source-map";
-
-function isGenerated(selectedSource) {
-  return isGeneratedId(selectedSource.id);
-}
+import { isOriginal } from "../utils/source";
 
 function getColumn(column, selectedSource) {
   if (column) {
     return column;
   }
 
-  return isGenerated(selectedSource) ? undefined : 0;
+  return isOriginal(selectedSource) ? 0 : undefined;
 }
 
 function getLocation(bp, selectedSource) {
-  return isGenerated(selectedSource)
-    ? bp.generatedLocation || bp.location
-    : bp.location;
+  return isOriginal(selectedSource)
+    ? bp.location
+    : bp.generatedLocation || bp.location;
 }
 
 function getBreakpointsForSource(state: OuterState, selectedSource: Source) {

--- a/src/selectors/getCallStackFrames.js
+++ b/src/selectors/getCallStackFrames.js
@@ -9,7 +9,7 @@ import {
 } from "../reducers/sources";
 import { getFrames } from "../reducers/pause";
 import { annotateFrames } from "../utils/pause/frames";
-import { isOriginalId } from "devtools-source-map";
+import { isOriginal } from "../utils/source";
 import { get } from "lodash";
 import type { Frame, Source } from "../types";
 import type { SourcesMap } from "../reducers/sources";
@@ -27,7 +27,7 @@ function getSourceForFrame(sources, frame, isGeneratedSource) {
 }
 
 function appendSource(sources, frame, selectedSource) {
-  const isGeneratedSource = selectedSource && !isOriginalId(selectedSource.id);
+  const isGeneratedSource = selectedSource && !isOriginal(selectedSource);
   return {
     ...frame,
     location: getLocation(frame, isGeneratedSource),

--- a/src/selectors/visibleBreakpoints.js
+++ b/src/selectors/visibleBreakpoints.js
@@ -6,8 +6,8 @@
 
 import { getBreakpoints } from "../reducers/breakpoints";
 import { getSelectedSource } from "../reducers/sources";
-import { isGeneratedId } from "devtools-source-map";
 import { createSelector } from "reselect";
+import { isOriginal } from "../utils/source";
 
 import type { BreakpointsMap } from "../reducers/types";
 import type { Source } from "../types";
@@ -34,8 +34,7 @@ function memoize(func) {
 
 const formatBreakpoint = memoize(function(breakpoint, selectedSource) {
   const { condition, loading, disabled, hidden } = breakpoint;
-  const sourceId = selectedSource.id;
-  const isGeneratedSource = isGeneratedId(sourceId);
+  const isGeneratedSource = !isOriginal(selectedSource);
 
   return {
     location: getLocation(breakpoint, isGeneratedSource),
@@ -48,7 +47,7 @@ const formatBreakpoint = memoize(function(breakpoint, selectedSource) {
 
 function isVisible(breakpoint, selectedSource) {
   const sourceId = selectedSource.id;
-  const isGeneratedSource = isGeneratedId(sourceId);
+  const isGeneratedSource = !isOriginal(selectedSource);
 
   const location = getLocation(breakpoint, isGeneratedSource);
   return location.sourceId === sourceId;

--- a/src/test/mochitest/browser_dbg-tabs-pretty-print.js
+++ b/src/test/mochitest/browser_dbg-tabs-pretty-print.js
@@ -19,6 +19,7 @@ add_task(async function() {
   await selectSource(dbg, "math.min.js:formatted");
   const source = findSource(dbg, "math.min.js:formatted");
   dbg.actions.showSource(source.id);
+  debugger;
   const focusedTreeElement = findElementWithSelector(dbg, ".sources-list .focused .label");
   is(focusedTreeElement.textContent.trim(), "math.min.js", "Pretty printed source is selected in tree");
 });

--- a/src/test/mochitest/browser_dbg-tabs-pretty-print.js
+++ b/src/test/mochitest/browser_dbg-tabs-pretty-print.js
@@ -19,7 +19,6 @@ add_task(async function() {
   await selectSource(dbg, "math.min.js:formatted");
   const source = findSource(dbg, "math.min.js:formatted");
   dbg.actions.showSource(source.id);
-  debugger;
   const focusedTreeElement = findElementWithSelector(dbg, ".sources-list .focused .label");
   is(focusedTreeElement.textContent.trim(), "math.min.js", "Pretty printed source is selected in tree");
 });

--- a/src/test/mochitest/helpers.js
+++ b/src/test/mochitest/helpers.js
@@ -605,8 +605,7 @@ async function selectSource(dbg, url, line) {
 
 
 async function closeTab(dbg, url) {
-  const source = findSource(dbg, url);
-  await dbg.actions.closeTab(source.url);
+  await dbg.actions.closeTab( findSource(dbg, url));
 }
 
 /**

--- a/src/test/mochitest/helpers.js
+++ b/src/test/mochitest/helpers.js
@@ -605,7 +605,7 @@ async function selectSource(dbg, url, line) {
 
 
 async function closeTab(dbg, url) {
-  await dbg.actions.closeTab( findSource(dbg, url));
+  await dbg.actions.closeTab(findSource(dbg, url));
 }
 
 /**

--- a/src/utils/editor/index.js
+++ b/src/utils/editor/index.js
@@ -11,11 +11,10 @@ export * from "../ui";
 export { onMouseOver } from "./token-events";
 
 import { createEditor } from "./create-editor";
-import { shouldPrettyPrint } from "../source";
+import { shouldPrettyPrint, isOriginal } from "../source";
 import { findNext, findPrev } from "./source-search";
 
 import { isWasm, lineToWasmOffset, wasmOffsetToLine } from "../wasm";
-import { isOriginalId } from "devtools-source-map";
 
 import type { AstLocation } from "../../workers/parser";
 import type { EditorPosition, EditorRange } from "../editor/types";
@@ -52,9 +51,7 @@ export function shouldShowFooter(selectedSource, horizontal) {
   if (!selectedSource) {
     return false;
   }
-  return (
-    shouldShowPrettyPrint(selectedSource) || isOriginalId(selectedSource.id)
-  );
+  return shouldShowPrettyPrint(selectedSource) || isOriginal(selectedSource);
 }
 
 export function traverseResults(e, ctx, query, dir, modifiers) {

--- a/src/utils/pause/stepping.js
+++ b/src/utils/pause/stepping.js
@@ -5,9 +5,10 @@
 // @flow
 
 import { isEqual } from "lodash";
-import { isGeneratedId, isOriginalId } from "devtools-source-map";
+import { getSourceFromId } from "../../reducers/sources";
 import type { Frame, MappedLocation } from "../../types";
 import type { State } from "../../reducers/types";
+import { isOriginal } from "../../utils/source";
 
 import {
   getSelectedSource,
@@ -20,7 +21,7 @@ function getFrameLocation(source, frame: ?MappedLocation) {
     return null;
   }
 
-  return isOriginalId(source.id) ? frame.location : frame.generatedLocation;
+  return isOriginal(source) ? frame.location : frame.generatedLocation;
 }
 
 export function shouldStep(rootFrame: ?Frame, state: State, sourceMaps: any) {
@@ -39,7 +40,7 @@ export function shouldStep(rootFrame: ?Frame, state: State, sourceMaps: any) {
   const invalidPauseLocation = pausePoint && !pausePoint.step;
 
   // We always want to pause in generated locations
-  if (!frameLoc || isGeneratedId(frameLoc.sourceId)) {
+  if (!frameLoc || !isOriginal(getSourceFromId(state, frameLoc.sourceId))) {
     return false;
   }
 

--- a/src/utils/source-maps.js
+++ b/src/utils/source-maps.js
@@ -2,8 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
-import { isOriginalId } from "devtools-source-map";
-import { getSource } from "../selectors";
+import { getSource, getSourceFromId } from "../selectors";
+import { isOriginal } from "./source";
 
 export async function getGeneratedLocation(
   state: Object,
@@ -11,7 +11,8 @@ export async function getGeneratedLocation(
   location: Location,
   sourceMaps: Object
 ) {
-  if (!isOriginalId(location.sourceId)) {
+  const locationSource = getSourceFromId(state, location.sourceId);
+  if (!isOriginal(locationSource)) {
     return location;
   }
 
@@ -40,7 +41,7 @@ export async function getMappedLocation(
 ) {
   const source = getSource(state, location.sourceId);
 
-  if (isOriginalId(location.sourceId)) {
+  if (isOriginal(source)) {
     return getGeneratedLocation(state, source, location, sourceMaps);
   }
 

--- a/src/utils/source.js
+++ b/src/utils/source.js
@@ -87,6 +87,10 @@ export function isJavaScript(source: Source): boolean {
   );
 }
 
+export function isOriginal(source: Source) {
+  return isOriginalId(source.id) || isPrettyURL(source.url)
+}
+
 /**
  * @memberof utils/source
  * @static

--- a/src/utils/source.js
+++ b/src/utils/source.js
@@ -58,7 +58,7 @@ export function shouldPrettyPrint(source: Source) {
     !source ||
     isPretty(source) ||
     !isJavaScript(source) ||
-    isOriginalId(source.id) ||
+    isOriginal(source) ||
     source.sourceMapURL ||
     !prefs.clientSourceMapsEnabled
   ) {

--- a/src/utils/source.js
+++ b/src/utils/source.js
@@ -88,7 +88,9 @@ export function isJavaScript(source: Source): boolean {
 }
 
 export function isOriginal(source: Source) {
-  return isOriginalId(source.id) || isPrettyURL(source.url)
+  // Pretty-printed sources are given original IDs, so need
+  // for any additional check
+  return isOriginalId(source.id);
 }
 
 /**


### PR DESCRIPTION
I looked through all of our `isOriginalId` and `isGeneratedId` usage and about 70% of it was easily swapping out `isOriginal|GeneratedId(source.id)`; 20% of it took some `getSourceFromId(id)` massaging before the `isOriginal` call, and the last 5% will take some reworking of some kind to get the source object before we can switch to isOriginal.

A few thoughts or concerns I have:

1.  I know it's not much overhead but if we already have the sourceID, which is technically all we need, getting the source and then passing it seems like extra code & work.  I guess we could let `isOriginal` accept a string (id) or source?

2.  I kind of like using `isGeneratedId` since it's a "positive" and we aren't doing `!isOriginal()` everywhere.  Maybe we could also have an `isGenerated()` function that returns the inverse of isOriginal?

3.  Pretty-printed sources are given an `originalSource`-style ID, so we don't need the pretty print check, so essentially all `isOriginal` does is wrap `isOriginalId`.  I do acknowledge that calling one boolean-returning function is nice, but we do, I guess, lose a bit of readability (point 2 above).

I'd like to here thoughts of others if interested.

Note:  I didn't realize @jasonLaster's original commit was based off of older work so I need to rebase this in the mean time.