### PR TITLE
[SourceTree] Keyboard arrow behaviour integration tests

### DIFF
--- a/src/test/mochitest/browser.ini
+++ b/src/test/mochitest/browser.ini
@@ -727,6 +727,7 @@ skip-if = os == "win" || (verify) # Bug 1434792
 [browser_dbg-sourcemaps-bogus.js]
 skip-if = os == 'linux' && !asan # bug 1447118
 [browser_dbg-sources.js]
+[browser_dbg-sources-arrow-keys.js]
 [browser_dbg-sources-named-eval.js]
 [browser_dbg-stepping.js]
 skip-if = debug || (verify && (os == 'win')) || (os == "win" && os_version == "6.1")

--- a/src/test/mochitest/browser_dbg-sources-arrow-keys.js
+++ b/src/test/mochitest/browser_dbg-sources-arrow-keys.js
@@ -1,0 +1,79 @@
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
+
+ // Test keyboard arrow behaviour
+
+async function waitForNodeToGainFocus(dbg, index) {
+  await waitUntil(() => {
+    const element = findElement(dbg, "sourceNode", index);
+
+    if (element) {
+      return element.classList.contains("focused");
+    }
+
+    return false;
+  }, `waiting for source node ${index} to be focused`);
+}
+
+async function assertNodeIsFocused(dbg, index) {
+  await waitForNodeToGainFocus(dbg, index);
+  const node = findElement(dbg, "sourceNode", index);
+  ok(node.classList.contains("focused"), `${index} node is focused`);
+}
+
+add_task(async function() {
+  const dbg = await initDebugger("doc-sources.html");
+  await waitForSources(dbg, "simple1", "simple2", "nested-source", "long.js");
+
+  await clickElement(dbg, "sourceDirectoryLabel", 2);
+  await assertSourceCount(dbg, 7);
+
+  // Right key on open dir
+  await pressKey(dbg, "Right");
+  await assertNodeIsFocused(dbg, 3);
+
+  // Right key on closed dir
+  await pressKey(dbg, "Right");
+  await assertSourceCount(dbg, 8);
+  await assertNodeIsFocused(dbg, 3);
+
+  // Left key on a open dir
+  await pressKey(dbg, "Left");
+  await assertSourceCount(dbg, 7);
+  await assertNodeIsFocused(dbg, 3);
+
+  // Down key on a closed dir
+  await pressKey(dbg, "Down");
+  await assertNodeIsFocused(dbg, 4);
+
+  // Right key on a source
+  await pressKey(dbg, "Right");
+  await assertNodeIsFocused(dbg, 5);
+
+  // Down key on a source
+  await pressKey(dbg, "Down");
+  await assertNodeIsFocused(dbg, 6);
+
+  // Go to bottom of tree and press down key
+  await clickElement(dbg, "sourceDirectoryLabel", 7);
+  await pressKey(dbg, "Down");
+  await assertNodeIsFocused(dbg, 7);
+
+  // Up key on a source
+  await pressKey(dbg, "Up");
+  await assertNodeIsFocused(dbg, 6);
+
+  // Left key on a source
+  await pressKey(dbg, "Left");
+  await assertNodeIsFocused(dbg, 2);
+
+  // Left key on a closed dir
+  await pressKey(dbg, "Left");
+  await assertSourceCount(dbg, 2);
+  await pressKey(dbg, "Left");
+  await assertNodeIsFocused(dbg, 1);
+
+  // Up Key at the top of the source tree
+  await pressKey(dbg, "Up");
+  await assertNodeIsFocused(dbg, 1);
+});

--- a/src/test/mochitest/browser_dbg-sources-arrow-keys.js
+++ b/src/test/mochitest/browser_dbg-sources-arrow-keys.js
@@ -1,7 +1,7 @@
 /* Any copyright is dedicated to the Public Domain.
  * http://creativecommons.org/publicdomain/zero/1.0/ */
 
- // Test keyboard arrow behaviour
+// Test keyboard arrow behaviour
 
 async function waitForNodeToGainFocus(dbg, index) {
   await waitUntil(() => {
@@ -18,7 +18,7 @@ async function waitForNodeToGainFocus(dbg, index) {
 async function assertNodeIsFocused(dbg, index) {
   await waitForNodeToGainFocus(dbg, index);
   const node = findElement(dbg, "sourceNode", index);
-  ok(node.classList.contains("focused"), `${index} node is focused`);
+  ok(node.classList.contains("focused"), `node ${index} is focused`);
 }
 
 add_task(async function() {
@@ -55,7 +55,7 @@ add_task(async function() {
   await assertNodeIsFocused(dbg, 6);
 
   // Go to bottom of tree and press down key
-  await clickElement(dbg, "sourceDirectoryLabel", 7);
+  await pressKey(dbg, "Down");
   await pressKey(dbg, "Down");
   await assertNodeIsFocused(dbg, 7);
 

--- a/src/test/mochitest/browser_dbg-sources.js
+++ b/src/test/mochitest/browser_dbg-sources.js
@@ -3,35 +3,10 @@
 
 // Tests that the source tree works.
 
-async function waitForSourceCount(dbg, i) {
-  // We are forced to wait until the DOM nodes appear because the
-  // source tree batches its rendering.
-  await waitUntil(() => {
-    return findAllElements(dbg, "sourceNodes").length === i;
-  }, `waiting for ${i} sources`);
-}
-
-async function assertSourceCount(dbg, count) {
-  await waitForSourceCount(dbg, count);
-  is(findAllElements(dbg, "sourceNodes").length, count, `${count} sources`);
-}
-
 function getLabel(dbg, index) {
   return findElement(dbg, "sourceNode", index)
     .textContent.trim()
     .replace(/^[\s\u200b]*/g, "");
-}
-
-async function waitForNodeToGainFocus(dbg, index) {
-  await waitUntil(() => {
-    return findElement(dbg, "sourceNode", index).classList.contains("focused");
-  }, `waiting for source node ${index} to be focused`);
-}
-
-async function assertNodeIsFocused(dbg, index) {
-  await waitForNodeToGainFocus(dbg, index);
-  const node = findElement(dbg, "sourceNode", index);
-  ok(node.classList.contains("focused"), `${index} node is focused`);
 }
 
 add_task(async function() {
@@ -81,62 +56,4 @@ add_task(async function() {
     "math.min.js",
     "math.min.js - The dynamic script exists"
   );
-});
-
-// Test keyboard arrow behaviour
-add_task(async function() {
-  const dbg = await initDebugger("doc-sources.html");
-  await waitForSources(dbg, "simple1", "simple2", "nested-source", "long.js");
-
-  await clickElement(dbg, "sourceDirectoryLabel", 2);
-  await assertSourceCount(dbg, 7);
-
-  // Right key on open dir
-  await pressKey(dbg, "Right");
-  await assertNodeIsFocused(dbg, 3);
-
-  // Right key on closed dir
-  await pressKey(dbg, "Right");
-  await assertSourceCount(dbg, 8);
-  await assertNodeIsFocused(dbg, 3);
-
-  // Left key on a open dir
-  await pressKey(dbg, "Left");
-  await assertSourceCount(dbg, 7);
-  await assertNodeIsFocused(dbg, 3);
-
-  // Down key on a closed dir
-  await pressKey(dbg, "Down");
-  await assertNodeIsFocused(dbg, 4);
-
-  // Right key on a source
-  await pressKey(dbg, "Right");
-  await assertNodeIsFocused(dbg, 5);
-
-  // Down key on a source
-  await pressKey(dbg, "Down");
-  await assertNodeIsFocused(dbg, 6);
-
-  // Go to bottom of tree and press down key
-  await clickElement(dbg, "sourceDirectoryLabel", 7);
-  await pressKey(dbg, "Down");
-  await assertNodeIsFocused(dbg, 7);
-
-  // Up key on a source
-  await pressKey(dbg, "Up");
-  await assertNodeIsFocused(dbg, 6);
-
-  // Left key on a source
-  await pressKey(dbg, "Left");
-  await assertNodeIsFocused(dbg, 2);
-
-  // Left key on a closed dir
-  await pressKey(dbg, "Left");
-  await assertSourceCount(dbg, 2);
-  await pressKey(dbg, "Left");
-  await assertNodeIsFocused(dbg, 1);
-
-  // Up Key at the top of the source tree
-  await pressKey(dbg, "Up");
-  await assertNodeIsFocused(dbg, 1);
 });

--- a/src/test/mochitest/browser_dbg-sources.js
+++ b/src/test/mochitest/browser_dbg-sources.js
@@ -22,6 +22,18 @@ function getLabel(dbg, index) {
     .replace(/^[\s\u200b]*/g, "");
 }
 
+async function waitForNodeToGainFocus(dbg, index) {
+  await waitUntil(() => {
+    return findElement(dbg, "sourceNode", index).classList.contains("focused");
+  }, `waiting for source node ${index} to be focused`);
+}
+
+async function assertNodeIsFocused(dbg, index) {
+  await waitForNodeToGainFocus(dbg, index);
+  const node = findElement(dbg, "sourceNode", index);
+  ok(node.classList.contains("focused"), `${index} node is focused`);
+}
+
 add_task(async function() {
   const dbg = await initDebugger("doc-sources.html");
   const {
@@ -69,4 +81,62 @@ add_task(async function() {
     "math.min.js",
     "math.min.js - The dynamic script exists"
   );
+});
+
+// Test keyboard arrow behaviour
+add_task(async function() {
+  const dbg = await initDebugger("doc-sources.html");
+  await waitForSources(dbg, "simple1", "simple2", "nested-source", "long.js");
+
+  await clickElement(dbg, "sourceDirectoryLabel", 2);
+  await assertSourceCount(dbg, 7);
+
+  // Right key on open dir
+  await pressKey(dbg, "Right");
+  await assertNodeIsFocused(dbg, 3);
+
+  // Right key on closed dir
+  await pressKey(dbg, "Right");
+  await assertSourceCount(dbg, 8);
+  await assertNodeIsFocused(dbg, 3);
+
+  // Left key on a open dir
+  await pressKey(dbg, "Left");
+  await assertSourceCount(dbg, 7);
+  await assertNodeIsFocused(dbg, 3);
+
+  // Down key on a closed dir
+  await pressKey(dbg, "Down");
+  await assertNodeIsFocused(dbg, 4);
+
+  // Right key on a source
+  await pressKey(dbg, "Right");
+  await assertNodeIsFocused(dbg, 5);
+
+  // Down key on a source
+  await pressKey(dbg, "Down");
+  await assertNodeIsFocused(dbg, 6);
+
+  // Go to bottom of tree and press down key
+  await clickElement(dbg, "sourceDirectoryLabel", 7);
+  await pressKey(dbg, "Down");
+  await assertNodeIsFocused(dbg, 7);
+
+  // Up key on a source
+  await pressKey(dbg, "Up");
+  await assertNodeIsFocused(dbg, 6);
+
+  // Left key on a source
+  await pressKey(dbg, "Left");
+  await assertNodeIsFocused(dbg, 2);
+
+  // Left key on a closed dir
+  await pressKey(dbg, "Left");
+  await assertSourceCount(dbg, 2);
+  await pressKey(dbg, "Left");
+  await assertNodeIsFocused(dbg, 1);
+
+  // Up Key at the top of the source tree
+  await pressKey(dbg, "Up");
+  await assertNodeIsFocused(dbg, 1);
 });

--- a/src/test/mochitest/helpers.js
+++ b/src/test/mochitest/helpers.js
@@ -1339,3 +1339,16 @@ async function assertPreviews(dbg, previews) {
     dbg.actions.clearPreview();
   }
 }
+
+async function waitForSourceCount(dbg, i) {
+  // We are forced to wait until the DOM nodes appear because the
+  // source tree batches its rendering.
+  await waitUntil(() => {
+    return findAllElements(dbg, "sourceNodes").length === i;
+  }, `waiting for ${i} sources`);
+}
+
+async function assertSourceCount(dbg, count) {
+  await waitForSourceCount(dbg, count);
+  is(findAllElements(dbg, "sourceNodes").length, count, `${count} sources`);
+}


### PR DESCRIPTION
Fixes Issue: #6700 

### Summary of Changes
* Adds keyboard integrations tests for source-tree

### Test Plan
- [x] left arrow on a closed directory
- [x] left arrow on an open directory
- [x] left arrow on a source
- [x] right arrow on a closed directory
- [x] right arrow on an open directory
- [x] right arrow on a source
- [x] up arrow on a directory
- [x] up arrow on a source
- [x] down arrow on a directory
- [x] down arrow on a source
- [x] down arrow at the bottom of the tree
- [x] up arrow at the top of the tree

### A few questions
- I wasn't sure if it was okay to add a second `add_task` inside one mochitest file. It looks like it has been done before, but I am not sure if it's not recommended.
- I had some issues knowing _what to wait for_ after triggering a `pressKey`. I made a function that waits for a specific node to gain focus. This does work, but if that test is going to fail and the node won't gain focus, the test will just timeout not giving the best error message. Any idea what I should be waiting for instead?