### PR TITLE
Remove jdescottes from properties file codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
-# flod as main contact for string changes - jdescottes as backup
-assets/panel/debugger.properties @flodolo @juliandescottes
+# flod as main contact for string changes
+assets/panel/debugger.properties @flodolo


### PR DESCRIPTION
The main reason I added myself to the properties file codeowners was to keep an eye on localization change before accepting new releases to m-c. 

Since I no longer do much m-c release review, I don't need to notifications anymore, and I think it can be a little overwhelming for contributors to see 2 reviewers automatically popping up when they touch the localization file :) 