### PR TITLE
[sources] add a webconsole sourcemap test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,4 +64,5 @@ script:
     browser_webconsole_eval_in_debugger_stackframe2.js
     browser_webconsole_location_debugger_link.js
     browser_webconsole_stacktrace_location_debugger_link.js
+    browser_webconsole_sourcemap_nosource
   - ./node_modules/.bin/mochii --ci --mc ./firefox --headless devtools/client/debugger/new

--- a/assets/panel/prefs.js
+++ b/assets/panel/prefs.js
@@ -65,4 +65,3 @@ pref("devtools.debugger.features.async-stepping", true);
 pref("devtools.debugger.features.skip-pausing", true);
 pref("devtools.debugger.features.autocomplete-expressions", false);
 pref("devtools.debugger.features.map-expression-bindings", true);
-pref("devtools.debugger.features.map-await-expression", true);

--- a/src/components/PrimaryPanes/SourcesTree.js
+++ b/src/components/PrimaryPanes/SourcesTree.js
@@ -20,7 +20,7 @@ import {
   getSourceCount
 } from "../../selectors";
 
-import { getSourceByURL } from "../../reducers/sources";
+import { getGeneratedSourceByURL } from "../../reducers/sources";
 
 // Actions
 import actions from "../../actions";
@@ -358,7 +358,7 @@ function getSourceForTree(state: AppState, source: ?Source): ?Source | null {
     return source;
   }
 
-  return getSourceByURL(state, getRawSourceURL(source.url), false);
+  return getGeneratedSourceByURL(state, getRawSourceURL(source.url));
 }
 
 const mapStateToProps = state => {

--- a/src/components/PrimaryPanes/SourcesTreeItem.js
+++ b/src/components/PrimaryPanes/SourcesTreeItem.js
@@ -12,7 +12,7 @@ import { showMenu } from "devtools-contextmenu";
 import SourceIcon from "../shared/SourceIcon";
 import Svg from "../shared/Svg";
 
-import { getSourceByURL } from "../../selectors";
+import { getGeneratedSourceByURL } from "../../selectors";
 import actions from "../../actions";
 
 import { isOriginal as isOriginalSource } from "../../utils/source";
@@ -191,7 +191,7 @@ function getHasMatchingGeneratedSource(state, source: ?Source) {
     return false;
   }
 
-  return !!getSourceByURL(state, source.url, false);
+  return !!getGeneratedSourceByURL(state, source.url);
 }
 
 const mapStateToProps = (state, props) => {

--- a/src/reducers/tabs.js
+++ b/src/reducers/tabs.js
@@ -18,8 +18,8 @@ import {
   getSource,
   getSources,
   getUrls,
-  getSourceByURL,
-  getSourceByUrlInSources
+  getSpecificSourceByURL,
+  getSpecificSourceByUrlInSources
 } from "./sources";
 
 import type { Action } from "../actions/types";
@@ -131,7 +131,7 @@ export function getNewSelectedSourceId(
       return "";
     }
 
-    const selectedSource = getSourceByURL(
+    const selectedSource = getSpecificSourceByURL(
       state,
       selectedTab.url,
       isOriginalId(selectedTab.id)
@@ -151,7 +151,7 @@ export function getNewSelectedSourceId(
   const availableTab = availableTabs[newSelectedTabIndex];
 
   if (availableTab) {
-    const tabSource = getSourceByUrlInSources(
+    const tabSource = getSpecificSourceByUrlInSources(
       getSources(state),
       getUrls(state),
       availableTab.url,
@@ -185,7 +185,7 @@ export const getSourceTabs = createSelector(
   getUrls,
   (tabs, sources, urls) =>
     tabs.filter(tab =>
-      getSourceByUrlInSources(sources, urls, tab.url, tab.isOriginal)
+      getSpecificSourceByUrlInSources(sources, urls, tab.url, tab.isOriginal)
     )
 );
 
@@ -196,7 +196,7 @@ export const getSourcesForTabs = createSelector(
   (tabs, sources, urls) => {
     return tabs
       .map(tab =>
-        getSourceByUrlInSources(sources, urls, tab.url, tab.isOriginal)
+        getSpecificSourceByUrlInSources(sources, urls, tab.url, tab.isOriginal)
       )
       .filter(Boolean);
   }

--- a/src/test/mochitest/helpers.js
+++ b/src/test/mochitest/helpers.js
@@ -15,11 +15,6 @@ var { Toolbox } = require("devtools/client/framework/toolbox");
 var { Task } = require("devtools/shared/task");
 var asyncStorage = require("devtools/shared/async-storage");
 
-// Import helpers for the new debugger
-Services.scriptloader.loadSubScript(
-  "chrome://mochitests/content/browser/devtools/client/debugger/new/test/mochitest/helpers/context.js",
-  this);
-
 const sourceUtils = {
   isLoaded: source => source.loadedState === "loaded"
 };


### PR DESCRIPTION
### Summary of Changes

- adds a failing webconsole test
- it fails because #6867 changed the definition of getSourceByURL to either look for original or generated sources


we might need to reintroduce an agnostic search. This could look like three separate selectors: `getSourceByUR`, `getOriginalSourceByURL`, `getGeneratedSourceByURL`