### PR TITLE
Make search results files collapse / expand

### DIFF
--- a/src/components/ProjectSearch.js
+++ b/src/components/ProjectSearch.js
@@ -224,7 +224,6 @@ export class ProjectSearch extends Component<Props, State> {
       <div
         className={classnames("file-result", { focused })}
         key={file.sourceId}
-        onClick={e => setExpanded(file, !expanded)}
       >
         <Svg name="arrow" className={classnames({ expanded })} />
         <img className="file" />

--- a/src/components/test/__snapshots__/ProjectSearch.spec.js.snap
+++ b/src/components/test/__snapshots__/ProjectSearch.spec.js.snap
@@ -276,7 +276,6 @@ exports[`ProjectSearch found search results 1`] = `
                 >
                   <div
                     className="file-result"
-                    onClick={[Function]}
                   >
                     <Svg
                       className="expanded"
@@ -543,7 +542,6 @@ exports[`ProjectSearch found search results 1`] = `
                 >
                   <div
                     className="file-result"
-                    onClick={[Function]}
                   >
                     <Svg
                       className="expanded"


### PR DESCRIPTION
Fixes Issue: #6953 

### Summary of Changes
* Remove `setExpanded` from `ProjectSearch` `renderFile` method
* the `Tree` component handles expanding and collapsing on its own

### Test Plan
- [x] Search for a search term with at least 1 result
- [x] click the arrow to expand or collapse a result

### In action
![collapse-expand-fixed](https://user-images.githubusercontent.com/10165959/45256736-a5058680-b392-11e8-95d6-d1a8e0ed9df9.gif)
