### PR TITLE
Allow to pass a window in WorkerDispatcher.start.

### DIFF
--- a/packages/devtools-utils/src/worker-utils.js
+++ b/packages/devtools-utils/src/worker-utils.js
@@ -18,8 +18,8 @@ function WorkerDispatcher() {
 }
 
 WorkerDispatcher.prototype = {
-  start(url) {
-    this.worker = new Worker(url);
+  start(url, win = window) {
+    this.worker = new win.Worker(url);
     this.worker.onerror = () => {
       console.error(`Error in worker ${url}`);
     };


### PR DESCRIPTION
We might start the worker from places where we don't
have a `window` reference, which we would make the
function fail when creating the worker.
In this patch we allow to pass a window object to the
function which is then used to create the worker.
