### PR TITLE
[Docs] update contributing.md available issues link

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -116,7 +116,7 @@ We are lucky to have lots of [nice people][getting-help] here.
 #### Your First Code Contribution
 
 If you're looking for a good issue, you can look through
-the [help wanted](https://github.com/devtools-html/debugger.html/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22+-label%3A%22in+progress%22) issues.
+the [help wanted][labels-help-wanted-available] issues.
 
 These issues should be well documented.
 
@@ -269,6 +269,7 @@ Mozilla has and continues to hire many people from within the Open Source Softwa
 
 [getting-setup]:../docs/getting-setup.md
 [labels-available]:https://github.com/devtools-html/debugger.html/labels/available
+[labels-help-wanted-available]:https://github.com/devtools-html/debugger.html/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22+-label%3A%22in+progress%22
 [labels-first-timers-only]:https://github.com/devtools-html/debugger.html/labels/first-timers-only
 [labels-difficulty-easy]:https://github.com/devtools-html/debugger.html/labels/difficulty%3A%20easy
 [labels-difficulty-medium]:https://github.com/devtools-html/debugger.html/labels/difficulty%3A%medium

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -272,7 +272,7 @@ Mozilla has and continues to hire many people from within the Open Source Softwa
 [labels-help-wanted-available]:https://github.com/devtools-html/debugger.html/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22+-label%3A%22in+progress%22
 [labels-difficulty-medium]:https://github.com/devtools-html/debugger.html/labels/difficulty%3A%medium
 [labels-difficulty-hard]:https://github.com/devtools-html/debugger.html/labels/difficulty%3A%hard
-[labels-enhancement]:https://devtools-html.github.io/debugger.html/CONTRIBUTING.html#suggesting-enhancements-new
+[labels-enhancement]:https://github.com/devtools-html/debugger.html/labels/enhancement
 
 [@jasonlaster]:https://github.com/jasonlaster
 [@bomsy]:https://github.com/bomsy

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -270,8 +270,6 @@ Mozilla has and continues to hire many people from within the Open Source Softwa
 [getting-setup]:../docs/getting-setup.md
 [labels-available]:https://github.com/devtools-html/debugger.html/labels/available
 [labels-help-wanted-available]:https://github.com/devtools-html/debugger.html/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22+-label%3A%22in+progress%22
-[labels-first-timers-only]:https://github.com/devtools-html/debugger.html/labels/first-timers-only
-[labels-difficulty-easy]:https://github.com/devtools-html/debugger.html/labels/difficulty%3A%20easy
 [labels-difficulty-medium]:https://github.com/devtools-html/debugger.html/labels/difficulty%3A%medium
 [labels-difficulty-hard]:https://github.com/devtools-html/debugger.html/labels/difficulty%3A%hard
 [labels-enhancement]:https://devtools-html.github.io/debugger.html/CONTRIBUTING.html#suggesting-enhancements-new

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -116,7 +116,7 @@ We are lucky to have lots of [nice people][getting-help] here.
 #### Your First Code Contribution
 
 If you're looking for a good issue, you can look through
-the [available][labels-available] issues.
+the [help wanted](https://github.com/devtools-html/debugger.html/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22+-label%3A%22in+progress%22) issues.
 
 These issues should be well documented.
 


### PR DESCRIPTION
Updates the Contributing.md doc where there is a link to view availabe issues.  The current link shows issues with the [available label](https://github.com/devtools-html/debugger.html/labels/available).  It doesn't seem like this label is used anymore so I think querying for the label ['help wanted' that doesn't have the 'in progress' label](https://github.com/devtools-html/debugger.html/issues?q=is:issue+is:open+label:%22help+wanted%22+-label:%22in+progress%22) gives a better result.
