### PR TITLE
enable github autoclose issues on PR merging

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,4 +1,4 @@
-Fixes Issue: #<issue number>
+Fixes #<issue number>
 
 Here's the Pull Request Doc
 https://firefox-dev.tools/debugger.html/docs/pull-requests.html


### PR DESCRIPTION
If you want github to [automatically close](https://help.github.com/articles/closing-issues-using-keywords/) the associated issue when you merge a PR this change should do it.  If you prefer to keep it the way it is now please just go ahead and close this PR.
