### PR TITLE
Fix misnamed property in accessible rep (#6932)

### DIFF
--- a/packages/devtools-reps/src/reps/accessible.js
+++ b/packages/devtools-reps/src/reps/accessible.js
@@ -21,7 +21,7 @@ Accessible.propTypes = {
   onAccessibleMouseOver: PropTypes.func,
   onAccessibleMouseOut: PropTypes.func,
   onInspectIconClick: PropTypes.func,
-  separator: PropTypes.string
+  separatorText: PropTypes.string
 };
 
 function Accessible(props) {


### PR DESCRIPTION
Fixes #6932

### Summary of Changes

* Fixed misnamed separator property and renamed to separatorText.
