### PR TITLE
feat: Set accelerator text for context menu items

### DIFF
--- a/assets/panel/debugger.properties
+++ b/assets/panel/debugger.properties
@@ -19,10 +19,11 @@ collapsePanes=Collapse panes
 copyToClipboard.label=Copy to clipboard
 copyToClipboard.accesskey=C
 
-# LOCALIZATION NOTE (copySource): This is the text that appears in the
+# LOCALIZATION NOTE (copySource2): This is the text that appears in the
 # context menu to copy the selected source of file open.
-copySource=Copy source text
-copySource.accesskey=y
+copySource=Copy
+copySource2=Copy source text
+copySource2.accesskey=y
 
 # LOCALIZATION NOTE (copySourceUri2): This is the text that appears in the
 # context menu to copy the source URI of file open.

--- a/assets/panel/debugger.properties
+++ b/assets/panel/debugger.properties
@@ -19,11 +19,11 @@ collapsePanes=Collapse panes
 copyToClipboard.label=Copy to clipboard
 copyToClipboard.accesskey=C
 
-# LOCALIZATION NOTE (copySource2): This is the text that appears in the
+# LOCALIZATION NOTE (copySource.label): This is the text that appears in the
 # context menu to copy the selected source of file open.
 copySource=Copy
-copySource2=Copy source text
-copySource2.accesskey=y
+copySource.label=Copy source text
+copySource.accesskey=y
 
 # LOCALIZATION NOTE (copySourceUri2): This is the text that appears in the
 # context menu to copy the source URI of file open.

--- a/assets/panel/debugger.properties
+++ b/assets/panel/debugger.properties
@@ -21,7 +21,7 @@ copyToClipboard.accesskey=C
 
 # LOCALIZATION NOTE (copySource): This is the text that appears in the
 # context menu to copy the selected source of file open.
-copySource=Copy
+copySource=Copy Source Text
 copySource.accesskey=y
 
 # LOCALIZATION NOTE (copySourceUri2): This is the text that appears in the
@@ -504,6 +504,7 @@ expressions.placeholder=Add watch expression
 expressions.errorMsg=Invalid expression…
 expressions.label=Add watch expression
 expressions.accesskey=e
+expressions.key=CmdOrCtrl+Shift+E
 
 # LOCALIZATION NOTE (sourceTabs.closeTab): Editor source tab context menu item
 # for closing the selected tab below the mouse.

--- a/assets/panel/debugger.properties
+++ b/assets/panel/debugger.properties
@@ -21,7 +21,7 @@ copyToClipboard.accesskey=C
 
 # LOCALIZATION NOTE (copySource): This is the text that appears in the
 # context menu to copy the selected source of file open.
-copySource=Copy Source Text
+copySource=Copy source text
 copySource.accesskey=y
 
 # LOCALIZATION NOTE (copySourceUri2): This is the text that appears in the

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "babel-plugin-transform-imports": "^1.5.0",
     "codemirror": "^5.28.0",
     "devtools-environment": "^0.0.5",
-    "devtools-launchpad": "0.0.135",
+    "devtools-launchpad": "^0.0.136",
     "devtools-linters": "^0.0.4",
     "devtools-reps": "0.23.0",
     "devtools-source-map": "0.16.0",

--- a/packages/devtools-reps/package.json
+++ b/packages/devtools-reps/package.json
@@ -38,7 +38,7 @@
     "babel-plugin-transform-es2015-modules-commonjs": "^6.26.0",
     "babel-preset-react": "^6.24.1",
     "devtools-config": "^0.0.15",
-    "devtools-launchpad": "^0.0.135",
+    "devtools-launchpad": "^0.0.136",
     "devtools-license-check": "^0.5.1",
     "devtools-modules": "^0.0.38",
     "devtools-services": "^0.0.1",

--- a/src/components/Editor/EditorMenu.js
+++ b/src/components/Editor/EditorMenu.js
@@ -23,6 +23,8 @@ import {
   getSymbols
 } from "../../selectors";
 
+import { formatKeyShortcut } from "../../utils/text";
+
 import actions from "../../actions";
 
 type Props = {
@@ -170,7 +172,8 @@ function getMenuItems(
     id: "node-menu-add-watch-expression",
     label: watchExpressionLabel,
     accesskey: watchExpressionKey,
-    click: () => addExpression(editor.codeMirror.getSelection())
+    click: () => addExpression(editor.codeMirror.getSelection()),
+    accelerator: formatKeyShortcut(L10N.getStr("expressions.key"))
   };
 
   const evaluateInConsoleItem = {
@@ -220,6 +223,7 @@ class EditorMenu extends Component {
   showMenu(nextProps) {
     const { contextMenu, ...options } = nextProps;
     const { event } = contextMenu;
+
     showMenu(event, getMenuItems(event, options));
   }
 

--- a/src/components/Editor/EditorMenu.js
+++ b/src/components/Editor/EditorMenu.js
@@ -23,8 +23,6 @@ import {
   getSymbols
 } from "../../selectors";
 
-import { formatKeyShortcut } from "../../utils/text";
-
 import actions from "../../actions";
 
 type Props = {
@@ -173,7 +171,7 @@ function getMenuItems(
     label: watchExpressionLabel,
     accesskey: watchExpressionKey,
     click: () => addExpression(editor.codeMirror.getSelection()),
-    accelerator: formatKeyShortcut(L10N.getStr("expressions.key"))
+    accelerator: L10N.getStr("expressions.key")
   };
 
   const evaluateInConsoleItem = {

--- a/src/components/Editor/EditorMenu.js
+++ b/src/components/Editor/EditorMenu.js
@@ -75,8 +75,8 @@ function getMenuItems(
     : blackboxLabel;
   const copyFunctionKey = L10N.getStr("copyFunction.accesskey");
   const copyFunctionLabel = L10N.getStr("copyFunction.label");
-  const copySourceKey = L10N.getStr("copySource2.accesskey");
-  const copySourceLabel = L10N.getStr("copySource2");
+  const copySourceKey = L10N.getStr("copySource.accesskey");
+  const copySourceLabel = L10N.getStr("copySource.label");
   const copyToClipboardKey = L10N.getStr("copyToClipboard.accesskey");
   const copyToClipboardLabel = L10N.getStr("copyToClipboard.label");
   const copySourceUri2Key = L10N.getStr("copySourceUri2.accesskey");
@@ -170,8 +170,7 @@ function getMenuItems(
     id: "node-menu-add-watch-expression",
     label: watchExpressionLabel,
     accesskey: watchExpressionKey,
-    click: () => addExpression(editor.codeMirror.getSelection()),
-    accelerator: L10N.getStr("expressions.key")
+    click: () => addExpression(editor.codeMirror.getSelection())
   };
 
   const evaluateInConsoleItem = {
@@ -221,7 +220,6 @@ class EditorMenu extends Component {
   showMenu(nextProps) {
     const { contextMenu, ...options } = nextProps;
     const { event } = contextMenu;
-
     showMenu(event, getMenuItems(event, options));
   }
 

--- a/src/components/Editor/EditorMenu.js
+++ b/src/components/Editor/EditorMenu.js
@@ -77,8 +77,8 @@ function getMenuItems(
     : blackboxLabel;
   const copyFunctionKey = L10N.getStr("copyFunction.accesskey");
   const copyFunctionLabel = L10N.getStr("copyFunction.label");
-  const copySourceKey = L10N.getStr("copySource.accesskey");
-  const copySourceLabel = L10N.getStr("copySource");
+  const copySourceKey = L10N.getStr("copySource2.accesskey");
+  const copySourceLabel = L10N.getStr("copySource2");
   const copyToClipboardKey = L10N.getStr("copyToClipboard.accesskey");
   const copyToClipboardLabel = L10N.getStr("copyToClipboard.label");
   const copySourceUri2Key = L10N.getStr("copySourceUri2.accesskey");

--- a/src/components/Editor/GutterMenu.js
+++ b/src/components/Editor/GutterMenu.js
@@ -15,8 +15,6 @@ import {
   isPaused as getIsPaused
 } from "../../selectors";
 
-import { formatKeyShortcut } from "../../utils/text";
-
 import actions from "../../actions";
 
 type Props = {
@@ -79,7 +77,7 @@ export function gutterMenu({
         closeConditionalPanel();
       }
     },
-    accelerator: formatKeyShortcut(L10N.getStr("toggleBreakpoint.key")),
+    accelerator: L10N.getStr("toggleBreakpoint.key"),
     ...(breakpoint ? gutterItems.removeBreakpoint : gutterItems.addBreakpoint)
   };
 
@@ -87,7 +85,7 @@ export function gutterMenu({
     accesskey: L10N.getStr("editor.addConditionalBreakpoint.accesskey"),
     disabled: false,
     click: () => openConditionalPanel(line),
-    accelerator: formatKeyShortcut(L10N.getStr("toggleCondPanel.key")),
+    accelerator: L10N.getStr("toggleCondPanel.key"),
     ...(breakpoint && breakpoint.condition
       ? gutterItems.editConditional
       : gutterItems.addConditional)

--- a/src/components/Editor/GutterMenu.js
+++ b/src/components/Editor/GutterMenu.js
@@ -15,6 +15,8 @@ import {
   isPaused as getIsPaused
 } from "../../selectors";
 
+import { formatKeyShortcut } from "../../utils/text";
+
 import actions from "../../actions";
 
 type Props = {
@@ -77,6 +79,7 @@ export function gutterMenu({
         closeConditionalPanel();
       }
     },
+    accelerator: formatKeyShortcut(L10N.getStr("toggleBreakpoint.key")),
     ...(breakpoint ? gutterItems.removeBreakpoint : gutterItems.addBreakpoint)
   };
 
@@ -84,6 +87,7 @@ export function gutterMenu({
     accesskey: L10N.getStr("editor.addConditionalBreakpoint.accesskey"),
     disabled: false,
     click: () => openConditionalPanel(line),
+    accelerator: formatKeyShortcut(L10N.getStr("toggleCondPanel.key")),
     ...(breakpoint && breakpoint.condition
       ? gutterItems.editConditional
       : gutterItems.addConditional)

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -97,7 +97,8 @@ export type Props = {
   toggleBreakpointsAtLine: (?number) => void,
   addOrToggleDisabledBreakpoint: (?number) => void,
   jumpToMappedLocation: any => void,
-  traverseResults: (boolean, Object) => void
+  traverseResults: (boolean, Object) => void,
+  addExpression: string => void
 };
 
 type State = {
@@ -211,6 +212,7 @@ class Editor extends PureComponent<Props, State> {
     shortcuts.on("Esc", this.onEscape);
     shortcuts.on(searchAgainPrevKey, this.onSearchAgain);
     shortcuts.on(searchAgainKey, this.onSearchAgain);
+    shortcuts.on(L10N.getStr("expressions.key"), this.onAddWatchExpression);
   }
 
   componentWillUnmount() {
@@ -228,6 +230,7 @@ class Editor extends PureComponent<Props, State> {
     shortcuts.off(L10N.getStr("toggleCondPanel.key"));
     shortcuts.off(searchAgainPrevKey);
     shortcuts.off(searchAgainKey);
+    shortcuts.off(L10N.getStr("expressions.key"));
   }
 
   componentDidUpdate(prevProps, prevState) {
@@ -278,6 +281,14 @@ class Editor extends PureComponent<Props, State> {
       this.toggleConditionalPanel(line);
       this.props.toggleBreakpoint(line);
     }
+  };
+
+  onAddWatchExpression = (_, e: KeyboardEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    const { codeMirror } = this.state.editor;
+    const selection = codeMirror.getSelection();
+    return this.props.addExpression(selection);
   };
 
   onToggleConditionalPanel = (key, e: KeyboardEvent) => {
@@ -641,6 +652,7 @@ const mapStateToProps = state => {
 export default connect(
   mapStateToProps,
   {
+    addExpression: actions.addExpression,
     openConditionalPanel: actions.openConditionalPanel,
     closeConditionalPanel: actions.closeConditionalPanel,
     setContextMenu: actions.setContextMenu,

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -97,12 +97,11 @@ export type Props = {
   toggleBreakpointsAtLine: (?number) => void,
   addOrToggleDisabledBreakpoint: (?number) => void,
   jumpToMappedLocation: any => void,
-  traverseResults: (boolean, Object) => void,
-  addExpression: string => void
+  traverseResults: (boolean, Object) => void
 };
 
 type State = {
-  editor: ?SourceEditor
+  editor: SourceEditor
 };
 
 class Editor extends PureComponent<Props, State> {
@@ -212,7 +211,6 @@ class Editor extends PureComponent<Props, State> {
     shortcuts.on("Esc", this.onEscape);
     shortcuts.on(searchAgainPrevKey, this.onSearchAgain);
     shortcuts.on(searchAgainKey, this.onSearchAgain);
-    shortcuts.on(L10N.getStr("expressions.key"), this.onAddWatchExpression);
   }
 
   componentWillUnmount() {
@@ -230,7 +228,6 @@ class Editor extends PureComponent<Props, State> {
     shortcuts.off(L10N.getStr("toggleCondPanel.key"));
     shortcuts.off(searchAgainPrevKey);
     shortcuts.off(searchAgainKey);
-    shortcuts.off(L10N.getStr("expressions.key"));
   }
 
   componentDidUpdate(prevProps, prevState) {
@@ -280,16 +277,6 @@ class Editor extends PureComponent<Props, State> {
     } else {
       this.toggleConditionalPanel(line);
       this.props.toggleBreakpoint(line);
-    }
-  };
-
-  onAddWatchExpression = (_, e: KeyboardEvent) => {
-    e.preventDefault();
-    e.stopPropagation();
-    if (this.state.editor) {
-      const { codeMirror } = this.state.editor;
-      const selection = codeMirror.getSelection();
-      return this.props.addExpression(selection);
     }
   };
 
@@ -654,7 +641,6 @@ const mapStateToProps = state => {
 export default connect(
   mapStateToProps,
   {
-    addExpression: actions.addExpression,
     openConditionalPanel: actions.openConditionalPanel,
     closeConditionalPanel: actions.closeConditionalPanel,
     setContextMenu: actions.setContextMenu,

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -102,7 +102,7 @@ export type Props = {
 };
 
 type State = {
-  editor: SourceEditor
+  editor: ?SourceEditor
 };
 
 class Editor extends PureComponent<Props, State> {
@@ -286,9 +286,11 @@ class Editor extends PureComponent<Props, State> {
   onAddWatchExpression = (_, e: KeyboardEvent) => {
     e.preventDefault();
     e.stopPropagation();
-    const { codeMirror } = this.state.editor;
-    const selection = codeMirror.getSelection();
-    return this.props.addExpression(selection);
+    if (this.state.editor) {
+      const { codeMirror } = this.state.editor;
+      const selection = codeMirror.getSelection();
+      return this.props.addExpression(selection);
+    }
   };
 
   onToggleConditionalPanel = (key, e: KeyboardEvent) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3368,19 +3368,19 @@ devtools-connection@0.0.12:
   version "0.0.12"
   resolved "https://registry.yarnpkg.com/devtools-connection/-/devtools-connection-0.0.12.tgz#a1bb6add55e4b317dd5122c25d3bb47bc896918c"
 
-devtools-contextmenu@^0.0.10:
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/devtools-contextmenu/-/devtools-contextmenu-0.0.10.tgz#c16a348256cde6dc2f7946543a54b525d18f0863"
+devtools-contextmenu@^0.0.11:
+  version "0.0.11"
+  resolved "https://registry.yarnpkg.com/devtools-contextmenu/-/devtools-contextmenu-0.0.11.tgz#a0520cf82e77d07d0f04c5c66d26de1090cba893"
   dependencies:
-    devtools-modules "^0.0.39"
+    devtools-modules "^0.0.40"
 
 devtools-environment@^0.0.5:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/devtools-environment/-/devtools-environment-0.0.5.tgz#0333bf35009fe09c21c315069e6b4d9177a4b8d1"
 
-devtools-launchpad@0.0.135, devtools-launchpad@^0.0.135:
-  version "0.0.135"
-  resolved "https://registry.yarnpkg.com/devtools-launchpad/-/devtools-launchpad-0.0.135.tgz#79eceec38047fef1766aa770599174570d464f86"
+devtools-launchpad@^0.0.136:
+  version "0.0.136"
+  resolved "https://registry.yarnpkg.com/devtools-launchpad/-/devtools-launchpad-0.0.136.tgz#774c330d6297122ed59a88a3d08fed7106c1014f"
   dependencies:
     amd-loader "0.0.8"
     autoprefixer "^7.1.2"
@@ -3406,11 +3406,11 @@ devtools-launchpad@0.0.135, devtools-launchpad@^0.0.135:
     debug "^3.1.0"
     devtools-config "^0.0.16"
     devtools-connection "0.0.12"
-    devtools-contextmenu "^0.0.10"
+    devtools-contextmenu "^0.0.11"
     devtools-environment "^0.0.5"
     devtools-license-check "^0.7.0"
     devtools-mc-assets "^0.0.6"
-    devtools-modules "^0.0.39"
+    devtools-modules "^0.0.40"
     devtools-sprintf-js "^1.0.3"
     express "^4.13.4"
     express-static "^1.2.5"
@@ -3505,9 +3505,9 @@ devtools-modules@^0.0.38:
     devtools-services "0.0.1"
     punycode "^2.1.0"
 
-devtools-modules@^0.0.39:
-  version "0.0.39"
-  resolved "https://registry.yarnpkg.com/devtools-modules/-/devtools-modules-0.0.39.tgz#742aa40cf723c43712c7e2a12c30be997b1979ba"
+devtools-modules@^0.0.40:
+  version "0.0.40"
+  resolved "https://registry.yarnpkg.com/devtools-modules/-/devtools-modules-0.0.40.tgz#72a5c19d82afbe539ec547b0418dfdbc5804177f"
   dependencies:
     devtools-services "0.0.1"
     punycode "^2.1.0"


### PR DESCRIPTION
Fixes #3673 

Associated PR: https://github.com/devtools-html/devtools-core/pull/1087

### Summary of Changes

* Add context menu accelerator for existing shortcuts
* Also add a shortcut for watch expressions
* Update string for copy source to be more accurate

### Test Plan
- Manual testing

### Screenshots/Videos (OPTIONAL)

#### Editor
<img width="249" alt="screen shot 2018-09-12 at 11 11 10 pm" src="https://user-images.githubusercontent.com/2481105/45465009-36e9f800-b6e1-11e8-8c9d-af7c11c3110e.png">

#### Gutter
<img width="283" alt="screen shot 2018-09-12 at 11 11 22 pm" src="https://user-images.githubusercontent.com/2481105/45465016-4406e700-b6e1-11e8-99bf-31204ae46af0.png">
