### PR TITLE
Update mask-size for the new photon style help icon, fixes #6978.

### DIFF
--- a/src/components/SecondaryPanes/CommandBar.css
+++ b/src/components/SecondaryPanes/CommandBar.css
@@ -94,6 +94,7 @@ img.skipPausing {
 
 .command-bar img.shortcuts {
   mask: url(/mc/help.svg) no-repeat;
+  mask-size: contain;
 }
 
 .command-bar .replay-inactive {


### PR DESCRIPTION
Fixes #6978

### Summary of Changes

* Updated mask-size for the help (shortcuts) icon used in bottom toolbar. The icon was updated to Photon styling in mc and the size needs to be set to ```contain```

