### PR TITLE
Making sure that accessible rep only supports grips of accessible ob…

### DIFF
--- a/packages/devtools-reps/src/reps/accessible.js
+++ b/packages/devtools-reps/src/reps/accessible.js
@@ -106,7 +106,7 @@ function supportsObject(object, noGrip = false) {
     return false;
   }
 
-  return object.typeName && object.typeName === "accessible";
+  return object.preview && object.typeName && object.typeName === "accessible";
 }
 
 // Exports from this module

--- a/packages/devtools-reps/src/reps/stubs/accessible.js
+++ b/packages/devtools-reps/src/reps/stubs/accessible.js
@@ -33,6 +33,11 @@ stubs.set("NoName", {
   }
 });
 
+stubs.set("NoPreview", {
+  actor: "server1.conn1.child1/accessible93",
+  typeName: "accessible"
+});
+
 stubs.set("DisconnectedAccessible", {
   actor: null,
   typeName: "accessible",

--- a/packages/devtools-reps/src/reps/tests/accessible.js
+++ b/packages/devtools-reps/src/reps/tests/accessible.js
@@ -147,6 +147,14 @@ describe("Accessible - Disconnected accessible", () => {
   );
 });
 
+describe("Accessible - No Preview (not a valid grip)", () => {
+  const stub = stubs.get("NoPreview");
+
+  it("does not select Accessible Rep", () => {
+    expect(getRep(stub)).not.toBe(Accessible.rep);
+  });
+});
+
 describe("Accessible - Accessible with long name", () => {
   const stub = stubs.get("AccessibleWithLongName");
 


### PR DESCRIPTION
…jects and not plain accessible fronts (#6932).

Fixes #6932

Currently a match for accessible rep checks for typeName this is too general since typeName property also exists is front accessible objects. We need to make it more specific and also check if preview property is available which indicates it is a grip.

### Summary of Changes

Added a check for existence of the ```preview``` property when matching accessible rep.
