### PR TITLE
[reps] getLinkifiedElements doesn't properly linkify strings #6843

### DIFF
--- a/packages/devtools-reps/src/reps/string.js
+++ b/packages/devtools-reps/src/reps/string.js
@@ -224,8 +224,7 @@ function getLinkifiedElements(text, cropLimit, openLink) {
   if (currentIndex !== text.length) {
     let nonUrlText = text.slice(currentIndex, text.length);
     if (currentIndex < endCropIndex) {
-      const cutIndex = endCropIndex - currentIndex;
-      nonUrlText = nonUrlText.substring(cutIndex);
+      nonUrlText = getCroppedString(nonUrlText, currentIndex, startCropIndex, endCropIndex);
     }
     items.push(nonUrlText);
   }

--- a/packages/devtools-reps/src/reps/tests/string-with-url.js
+++ b/packages/devtools-reps/src/reps/tests/string-with-url.js
@@ -379,6 +379,21 @@ describe("test String with URL", () => {
     expect(element.find("a").exists()).toBeFalsy();
   });
 
+  it("does not render an invalid URL that requires cropping", () => {
+    const text =
+      "//www.youtubeinmp3.com/download/?video=https://www.youtube.com/watch?v=8vkfsCIfDFc";
+    const openLink = jest.fn();
+    const element = renderRep(text, {
+      openLink,
+      useQuotes: false,
+      cropLimit: 60
+    });
+    expect(element.text()).toEqual(
+      "//www.youtubeinmp3.com/downloa…outube.com/watch?v=8vkfsCIfDFc"
+    );
+    expect(element.find("a").exists()).toBeFalsy();
+  });
+
   it("does render a link in a plain array", () => {
     const url = "http://example.com/abcdefghijabcdefghij";
     const string = `${url} some other text`;


### PR DESCRIPTION
Fixes #6843

### Summary of Changes
- Removed logic that cuts non-URL text, providing inconsistent results.
- Used existing method `getCroppedString` to ensure that consistent results are displayed back as a header value.

### Test Plan

Steps to reproduce in this [link](https://bugzilla.mozilla.org/show_bug.cgi?id=1483891#c4).

### Screenshots:

Before click:
![image](https://user-images.githubusercontent.com/25320782/45530869-6d2d9180-b81f-11e8-97d3-f1b9ab74952e.png)

After click:
![image](https://user-images.githubusercontent.com/25320782/45530885-8cc4ba00-b81f-11e8-9c98-85554f15d4c7.png)
