### PR TITLE
Return what was mapped in mapExpression.

### DIFF
--- a/src/actions/expressions.js
+++ b/src/actions/expressions.js
@@ -178,10 +178,12 @@ export function getMappedExpression(expression: string) {
     // 2. does not contain `await` - we do not need to map top level awaits
     // 3. does not contain `=` - we do not need to map assignments
     if (!mappings && !expression.match(/(await|=)/)) {
-      return null;
+      // TODO: return null when
+      // https://bugzilla.mozilla.org/show_bug.cgi?id=1491354 lands.
+      return expression;
     }
 
-    const mapResult = parser.mapExpression(
+    const mapResult = await parser.mapExpression(
       expression,
       mappings,
       bindings || [],

--- a/src/actions/expressions.js
+++ b/src/actions/expressions.js
@@ -144,7 +144,8 @@ function evaluateExpression(expression: Expression) {
         !isGeneratedId(sourceId) &&
         !isGeneratedId(selectedSource.id)
       ) {
-        input = await dispatch(getMappedExpression(input));
+        const mapResult = await dispatch(getMappedExpression(input));
+        input = mapResult.expression;
       }
     }
 

--- a/src/actions/expressions.js
+++ b/src/actions/expressions.js
@@ -145,7 +145,9 @@ function evaluateExpression(expression: Expression) {
         !isGeneratedId(selectedSource.id)
       ) {
         const mapResult = await dispatch(getMappedExpression(input));
-        input = mapResult.expression;
+        if (mapResult) {
+          input = mapResult.expression || mapResult;
+        }
       }
     }
 
@@ -176,15 +178,19 @@ export function getMappedExpression(expression: string) {
     // 2. does not contain `await` - we do not need to map top level awaits
     // 3. does not contain `=` - we do not need to map assignments
     if (!mappings && !expression.match(/(await|=)/)) {
-      return expression;
+      return null;
     }
 
-    return parser.mapExpression(
+    const mapResult = parser.mapExpression(
       expression,
       mappings,
       bindings || [],
       features.mapExpressionBindings,
       features.mapAwaitExpression
     );
+
+    // TODO: Directly return mapResult when
+    // https://bugzilla.mozilla.org/show_bug.cgi?id=1491354 lands.
+    return mapResult.expression;
   };
 }

--- a/src/actions/preview.js
+++ b/src/actions/preview.js
@@ -92,7 +92,9 @@ export function setPreview(
 
         if (location && !isGeneratedId(sourceId)) {
           const mapResult = await dispatch(getMappedExpression(expression));
-          expression = mapResult.expression;
+          if (mapResult) {
+            expression = mapResult.expression || mapResult;
+          }
         }
 
         if (!selectedFrame) {

--- a/src/actions/preview.js
+++ b/src/actions/preview.js
@@ -91,7 +91,8 @@ export function setPreview(
         const selectedFrame = getSelectedFrame(getState());
 
         if (location && !isGeneratedId(sourceId)) {
-          expression = await dispatch(getMappedExpression(expression));
+          const mapResult = await dispatch(getMappedExpression(expression));
+          expression = mapResult.expression;
         }
 
         if (!selectedFrame) {

--- a/src/test/mochitest/browser_dbg-sourcemapped-preview.js
+++ b/src/test/mochitest/browser_dbg-sourcemapped-preview.js
@@ -28,19 +28,19 @@ function testForOf(dbg) {
     {
       line: 5,
       column: 7,
-      expression: "doThing;",
+      expression: "doThing",
       result: "doThing(arg)"
     },
     {
       line: 5,
       column: 13,
-      expression: "x;",
+      expression: "x",
       result: "1"
     },
     {
       line: 8,
       column: 16,
-      expression: "doThing;",
+      expression: "doThing",
       result: "doThing(arg)"
     }
   ]);
@@ -60,7 +60,7 @@ function testShadowing(dbg) {
       {
         line: 2,
         column: 9,
-        expression: "aVar;",
+        expression: "aVar",
         result: '"var3"'
       },
       {
@@ -78,7 +78,7 @@ function testShadowing(dbg) {
       {
         line: 10,
         column: 11,
-        expression: "aVar;",
+        expression: "aVar",
         result: '"var3"'
       },
       {
@@ -98,7 +98,7 @@ function testShadowing(dbg) {
       {
         line: 14,
         column: 13,
-        expression: "aVar;",
+        expression: "aVar",
         result: '"var3"'
       },
       {
@@ -146,7 +146,7 @@ function testImportedBindings(dbg) {
     {
       line: 24,
       column: 16,
-      expression: "aNamespace;",
+      expression: "aNamespace",
       fields: [["aNamed", "a-named"], ["default", "a-default"]]
     },
     {

--- a/src/workers/parser/mapAwaitExpression.js
+++ b/src/workers/parser/mapAwaitExpression.js
@@ -32,12 +32,13 @@ function wrapExpression(ast) {
   return generate(newAst).code;
 }
 
-export default function handleTopLevelAwait(expression: string) {
+export default function mapTopLevelAwait(expression: string) {
   const ast = hasTopLevelAwait(expression);
   if (ast) {
     const func = wrapExpression(ast);
-    return generate(template.ast(`(${func})().then(r => console.log(r));`))
-      .code;
+    return generate(
+      template.ast(`(${func})().then(console.log).catch(console.error);`)
+    ).code;
   }
 
   return expression;

--- a/src/workers/parser/mapBindings.js
+++ b/src/workers/parser/mapBindings.js
@@ -58,7 +58,9 @@ export default function mapExpressionBindings(
   bindings: string[] = []
 ): string {
   const ast = parseScript(expression, { allowAwaitOutsideFunction: true });
+  let isMapped = false;
   let shouldUpdate = true;
+
   t.traverse(ast, (node, ancestors) => {
     const parent = ancestors[ancestors.length - 1];
 
@@ -74,6 +76,7 @@ export default function mapExpressionBindings(
     if (t.isAssignmentExpression(node)) {
       if (t.isIdentifier(node.left)) {
         const newNode = globalizeAssignment(node, bindings);
+        isMapped = true;
         return replaceNode(ancestors, newNode);
       }
 
@@ -94,11 +97,12 @@ export default function mapExpressionBindings(
 
     if (!t.isForStatement(parent.node)) {
       const newNodes = globalizeDeclaration(node, bindings);
+      isMapped = true;
       replaceNode(ancestors, newNodes);
     }
   });
 
-  if (!shouldUpdate) {
+  if (!shouldUpdate || !isMapped) {
     return expression;
   }
 

--- a/src/workers/parser/mapExpression.js
+++ b/src/workers/parser/mapExpression.js
@@ -6,7 +6,7 @@
 
 import mapOriginalExpression from "./mapOriginalExpression";
 import mapExpressionBindings from "./mapBindings";
-import handleTopLevelAwait from "./mapAwaitExpression";
+import mapTopLevelAwait from "./mapAwaitExpression";
 
 export default function mapExpression(
   expression: string,
@@ -16,22 +16,44 @@ export default function mapExpression(
   bindings: string[],
   shouldMapBindings: boolean = true,
   shouldMapAwait: boolean = true
-): string {
+): {
+  expression: string,
+  mapped: {
+    await: boolean,
+    bindings: boolean,
+    originalExpression: boolean
+  }
+} {
+  const mapped = {
+    await: false,
+    bindings: false,
+    originalExpression: false
+  };
+
   try {
     if (mappings) {
+      const beforeOriginalExpression = expression;
       expression = mapOriginalExpression(expression, mappings);
+      mapped.originalExpression = beforeOriginalExpression !== expression;
     }
 
     if (shouldMapBindings) {
+      const beforeBindings = expression;
       expression = mapExpressionBindings(expression, bindings);
+      mapped.bindings = beforeBindings !== expression;
     }
 
     if (shouldMapAwait) {
-      expression = handleTopLevelAwait(expression);
+      const beforeAwait = expression;
+      expression = mapTopLevelAwait(expression);
+      mapped.await = beforeAwait !== expression;
     }
   } catch (e) {
-    console.log(e);
+    console.warn(`Error when mapping ${expression} expression:`, e);
   }
 
-  return expression;
+  return {
+    expression,
+    mapped
+  };
 }

--- a/src/workers/parser/mapOriginalExpression.js
+++ b/src/workers/parser/mapOriginalExpression.js
@@ -42,9 +42,9 @@ export default function mapOriginalExpression(
 ): string {
   const ast = parseScript(expression, { allowAwaitOutsideFunction: true });
   const scopes = buildScopeList(ast, "");
+  let shouldUpdate = false;
 
   const nodes = new Map();
-
   const replacements = new Map();
 
   // The ref-only global bindings are the ones that are accessed, but not
@@ -55,6 +55,7 @@ export default function mapOriginalExpression(
   for (const name of Object.keys(scopes[0].bindings)) {
     const { refs } = scopes[0].bindings[name];
     const mapping = mappings[name];
+
     if (
       !refs.every(ref => ref.type === "ref") ||
       !mapping ||
@@ -95,8 +96,13 @@ export default function mapOriginalExpression(
     const replacement = replacements.get(locationKey(node.loc.start));
     if (replacement) {
       replaceNode(ancestors, t.cloneNode(replacement));
+      shouldUpdate = true;
     }
   });
 
-  return generate(ast).code;
+  if (shouldUpdate) {
+    return generate(ast).code;
+  }
+
+  return expression;
 }

--- a/src/workers/parser/tests/mapExpression.spec.js
+++ b/src/workers/parser/tests/mapExpression.spec.js
@@ -45,8 +45,7 @@ describe("mapExpression", () => {
       shouldMapExpression: true,
       expectedMapped: {
         await: true,
-        // XXX: Only a semi-colon is added, should be false.
-        bindings: true,
+        bindings: false,
         originalExpression: false
       }
     },
@@ -111,8 +110,7 @@ describe("mapExpression", () => {
       shouldMapExpression: true,
       expectedMapped: {
         await: false,
-        // XXX: Only a semi-colon is added, should be false.
-        bindings: true,
+        bindings: false,
         originalExpression: false
       }
     },


### PR DESCRIPTION
In `mapExpression`, we now return an object instead of the mapped expression directly.
The object contains the mapped expression, as well as a `mapped` object containing
all the mapping the happened on the expression or not (await, originalExpression, bindings).

We take this as an opprtunity to clean-up `mapAwaitExpression`:
 - the default exported function is renamed to `mapTopLevelAwait` to match other mapping functions
 - we add a `.catch` in which we `console.error` to catch any promise rejection or Exception.
