### PR TITLE
Use F8 for both pause and breakOnNext commands

### DIFF
--- a/src/components/SecondaryPanes/CommandBar.js
+++ b/src/components/SecondaryPanes/CommandBar.js
@@ -177,10 +177,7 @@ class CommandBar extends Component<Props> {
         () => this.resume(),
         "resume",
         "active",
-        L10N.getFormatStr(
-          "resumeButtonTooltip",
-          formatKey("resume")
-        )
+        L10N.getFormatStr("resumeButtonTooltip", formatKey("resume"))
       );
     }
 

--- a/src/components/SecondaryPanes/CommandBar.js
+++ b/src/components/SecondaryPanes/CommandBar.js
@@ -26,24 +26,26 @@ import { appinfo } from "devtools-services";
 
 const isMacOS = appinfo.OS === "Darwin";
 
-const COMMANDS = ["resumeOrBreakOnNext", "stepOver", "stepIn", "stepOut"];
+// NOTE: the "resume" command will call either the resume or breakOnNext action
+// depending on whether or not the debugger is paused or running
+const COMMANDS = ["resume", "stepOver", "stepIn", "stepOut"];
 
 const KEYS = {
   WINNT: {
-    resumeOrBreakOnNext: "F8",
+    resume: "F8",
     stepOver: "F10",
     stepIn: "F11",
     stepOut: "Shift+F11"
   },
   Darwin: {
-    resumeOrBreakOnNext: "Cmd+\\",
+    resume: "Cmd+\\",
     stepOver: "Cmd+'",
     stepIn: "Cmd+;",
     stepOut: "Cmd+Shift+:",
     stepOutDisplay: "Cmd+Shift+;"
   },
   Linux: {
-    resumeOrBreakOnNext: "F8",
+    resume: "F8",
     stepOver: "F10",
     stepIn: "Ctrl+F11",
     stepOut: "Ctrl+Shift+F11"
@@ -119,7 +121,7 @@ class CommandBar extends Component<Props> {
   handleEvent(e, action) {
     e.preventDefault();
     e.stopPropagation();
-    if (action === "resumeOrBreakOnNext") {
+    if (action === "resume") {
       this.props.isPaused ? this.props.resume() : this.props.breakOnNext();
     } else {
       this.props[action]();
@@ -177,7 +179,7 @@ class CommandBar extends Component<Props> {
         "active",
         L10N.getFormatStr(
           "resumeButtonTooltip",
-          formatKey("resumeOrBreakOnNext")
+          formatKey("resume")
         )
       );
     }
@@ -200,7 +202,7 @@ class CommandBar extends Component<Props> {
       breakOnNext,
       "pause",
       "active",
-      L10N.getFormatStr("pauseButtonTooltip", formatKey("resumeOrBreakOnNext"))
+      L10N.getFormatStr("pauseButtonTooltip", formatKey("resume"))
     );
   }
 

--- a/src/components/SecondaryPanes/CommandBar.js
+++ b/src/components/SecondaryPanes/CommandBar.js
@@ -22,32 +22,28 @@ import actions from "../../actions";
 import { debugBtn } from "../shared/Button/CommandBarButton";
 import "./CommandBar.css";
 
-import Services from "devtools-services";
-const { appinfo } = Services;
+import { appinfo } from "devtools-services";
 
 const isMacOS = appinfo.OS === "Darwin";
 
-const COMMANDS = ["resume", "stepOver", "stepIn", "stepOut"];
+const COMMANDS = ["resumeOrBreakOnNext", "stepOver", "stepIn", "stepOut"];
 
 const KEYS = {
   WINNT: {
-    resume: "F8",
-    pause: "F8",
+    resumeOrBreakOnNext: "F8",
     stepOver: "F10",
     stepIn: "F11",
     stepOut: "Shift+F11"
   },
   Darwin: {
-    resume: "Cmd+\\",
-    pause: "Cmd+\\",
+    resumeOrBreakOnNext: "Cmd+\\",
     stepOver: "Cmd+'",
     stepIn: "Cmd+;",
     stepOut: "Cmd+Shift+:",
     stepOutDisplay: "Cmd+Shift+;"
   },
   Linux: {
-    resume: "F8",
-    pause: "F8",
+    resumeOrBreakOnNext: "F8",
     stepOver: "F10",
     stepIn: "Ctrl+F11",
     stepOut: "Ctrl+Shift+F11"
@@ -123,8 +119,11 @@ class CommandBar extends Component<Props> {
   handleEvent(e, action) {
     e.preventDefault();
     e.stopPropagation();
-
-    this.props[action]();
+    if (action === "resumeOrBreakOnNext") {
+      this.props.isPaused ? this.props.resume() : this.props.breakOnNext();
+    } else {
+      this.props[action]();
+    }
   }
 
   renderStepButtons() {
@@ -176,7 +175,10 @@ class CommandBar extends Component<Props> {
         () => this.resume(),
         "resume",
         "active",
-        L10N.getFormatStr("resumeButtonTooltip", formatKey("resume"))
+        L10N.getFormatStr(
+          "resumeButtonTooltip",
+          formatKey("resumeOrBreakOnNext")
+        )
       );
     }
 
@@ -198,7 +200,7 @@ class CommandBar extends Component<Props> {
       breakOnNext,
       "pause",
       "active",
-      L10N.getFormatStr("pauseButtonTooltip", formatKey("pause"))
+      L10N.getFormatStr("pauseButtonTooltip", formatKey("resumeOrBreakOnNext"))
     );
   }
 

--- a/src/components/SecondaryPanes/tests/CommandBar.spec.js
+++ b/src/components/SecondaryPanes/tests/CommandBar.spec.js
@@ -1,0 +1,70 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
+import React from "react";
+import { shallow } from "enzyme";
+import CommandBar from "../CommandBar";
+
+describe("CommandBar", () => {
+  it("f8 key command calls props.breakOnNext when not in paused state", () => {
+    const props = {
+      breakOnNext: jest.fn(),
+      resume: jest.fn(),
+      isPaused: false
+    };
+    const mockEvent = {
+      preventDefault: jest.fn(),
+      stopPropagation: jest.fn()
+    };
+
+    // The "on" spy will see all the keyboard listeners being registered by
+    // the shortcuts.on function
+    const context = { shortcuts: { on: jest.fn() } };
+
+    shallow(<CommandBar.WrappedComponent {...props} />, { context });
+
+    // get the keyboard event listeners recorded from the "on" spy.
+    // this will be an array where each item is itself a two item array
+    // containing the key code and the corresponding handler for that key code
+    const keyEventHandlers = context.shortcuts.on.mock.calls;
+
+    // simulate pressing the F8 key by calling the F8 handlers
+    keyEventHandlers.filter(i => i[0] === "F8").forEach(([_, handler]) => {
+      handler(null, mockEvent);
+    });
+
+    expect(props.breakOnNext).toBeCalled();
+    expect(props.resume).not.toBeCalled();
+  });
+
+  it("f8 key command calls props.resume when in paused state", () => {
+    const props = {
+      breakOnNext: jest.fn(),
+      resume: jest.fn(),
+      isPaused: true
+    };
+    const mockEvent = {
+      preventDefault: jest.fn(),
+      stopPropagation: jest.fn()
+    };
+
+    // The "on" spy will see all the keyboard listeners being registered by
+    // the shortcuts.on function
+    const context = { shortcuts: { on: jest.fn() } };
+
+    shallow(<CommandBar.WrappedComponent {...props} />, { context });
+
+    // get the keyboard event listeners recorded from the "on" spy.
+    // this will be an array where each item is itself a two item array
+    // containing the key code and the corresponding handler for that key code
+    const keyEventHandlers = context.shortcuts.on.mock.calls;
+
+    // simulate pressing the F8 key by calling the F8 handlers
+    keyEventHandlers.filter(i => i[0] === "F8").forEach(([_, handler]) => {
+      handler(null, mockEvent);
+    });
+    expect(props.resume).toBeCalled();
+    expect(props.breakOnNext).not.toBeCalled();
+  });
+});


### PR DESCRIPTION
Fixes #6963

### Summary of Changes
Update the `CommandBar.js` component so the handler for the F8 key press will call either `props.breakOnNext` or `props.resume` depending on the state of `props.isPaused`.  Previously two F8 event handlers were created.  One called `props.resume` always regardless of paused state.  The other one called a non-existant `props.pause` function.


### Test Plan

- [x] jest tests
- [x] test `command \` shortcut key breaks on next and pauses on a mac
- [x] test `F8` shortcut key breaks on next and pauses on a mac
- [ ] test `F8` shortcut key breaks on next and pauses on windows
- [ ] test `F8` shortcut key breaks on next and pauses on linux
