### PR TITLE
Use results with single file in browser_dbg-quick-open.js

### DIFF
--- a/src/test/mochitest/browser_dbg-quick-open.js
+++ b/src/test/mochitest/browser_dbg-quick-open.js
@@ -62,24 +62,26 @@ add_task(async function() {
   pressKey(dbg, "Escape");
   assertDisabled(dbg);
 
-  await waitForSource(dbg, "switching-01");
-  quickOpen(dbg, "sw");
-  pressKey(dbg, "Enter");
-  await waitForSelectedSource(dbg, "switching-01");
-
-  info("Arrow keys and check to see if source is selected");
+  info("Testing the number of results for source search");
   quickOpen(dbg, "sw");
   is(resultCount(dbg), 2, "two file results");
   pressKey(dbg, "Escape");
 
+  info("Testing source search and check to see if source is selected");
+  await waitForSource(dbg, "switching-01");
+  quickOpen(dbg, "sw1");
+  is(resultCount(dbg), 1, "one file results");
+  pressKey(dbg, "Enter");
+  await waitForSelectedSource(dbg, "switching-01");
 
+  info("Testing arrow keys in source search and check to see if source is selected");
   quickOpen(dbg, "sw2");
+  is(resultCount(dbg), 1, "one file results");
   pressKey(dbg, "Down");
   pressKey(dbg, "Enter");
-
   await waitForSelectedSource(dbg, "switching-02");
 
-
+  info("Testing tab closes the search");
   quickOpen(dbg, "sw");
   pressKey(dbg, "Tab");
   assertDisabled(dbg);


### PR DESCRIPTION
Corresponds to https://bugzilla.mozilla.org/show_bug.cgi?id=1438778

### Summary of Changes

* in browser_dbg-quick-open.js, stop using search results with 2 files before selecting file, to avoid failure from non-deterministic items order
* reorder tests for clarity

### Test Plan

This is a fix for testcase
