### PR TITLE
[Parser] getFramework false positive angularjs detection

### DIFF
--- a/src/workers/parser/frameworks.js
+++ b/src/workers/parser/frameworks.js
@@ -71,7 +71,9 @@ const identifiesAngular = identifiers => {
 
 const hasAngularExpressions = memberExpressions => {
   return memberExpressions.some(
-    item => item.name == "controller" || item.name == "module"
+    item =>
+      item.expression == "angular.controller" ||
+      item.expression == "angular.module"
   );
 };
 

--- a/src/workers/parser/tests/fixtures/frameworks/angular1FalsePositive.js
+++ b/src/workers/parser/tests/fixtures/frameworks/angular1FalsePositive.js
@@ -1,0 +1,11 @@
+const frameworkStars = {
+  angular: 40779,
+  react: 111576,
+  vue: 114358,
+};
+
+const container = new Container();
+container.module("sum", (...args) => args.reduce((s, c) => s + c, 0));
+
+container.get("sum",
+  (sum) => sum(Object.values(frameworkStars)));

--- a/src/workers/parser/tests/framework.spec.js
+++ b/src/workers/parser/tests/framework.spec.js
@@ -7,45 +7,53 @@ import { getSource, getOriginalSource } from "./helpers";
 import { setSource } from "../sources";
 
 describe("Parser.frameworks", () => {
-  it("is undefined when no framework", () => {
-    const source = getOriginalSource("frameworks/plainJavascript");
-    setSource(source);
-    expect(getFramework(source.id)).toBeUndefined();
+  describe("no framework", () => {
+    it("is undefined when no framework", () => {
+      const source = getOriginalSource("frameworks/plainJavascript");
+      setSource(source);
+      expect(getFramework(source.id)).toBeUndefined();
+    });
+
+    it("does not get confused with angular (#6833)", () => {
+      const source = getOriginalSource("frameworks/angular1FalsePositive");
+      setSource(source);
+      expect(getFramework(source.id)).toBeUndefined();
+    });
   });
 
-  // React
+  describe("react", () => {
+    it("recognizes ES6 React component", () => {
+      const source = getOriginalSource("frameworks/reactComponent");
+      setSource(source);
+      expect(getFramework(source.id)).toBe("React");
+    });
 
-  it("recognizes ES6 React component", () => {
-    const source = getOriginalSource("frameworks/reactComponent");
-    setSource(source);
-    expect(getFramework(source.id)).toBe("React");
+    it("recognizes ES5 React component", () => {
+      const source = getSource("frameworks/reactComponentEs5");
+      setSource(source);
+      expect(getFramework(source.id)).toBe("React");
+    });
   });
 
-  it("recognizes ES5 React component", () => {
-    const source = getSource("frameworks/reactComponentEs5");
-    setSource(source);
-    expect(getFramework(source.id)).toBe("React");
+  describe("angular 1.*", () => {
+    it("recognizes Angular 1 module", () => {
+      const source = getOriginalSource("frameworks/angular1Module");
+      setSource(source);
+      expect(getFramework(source.id)).toBe("Angular");
+    });
   });
 
-  // Angular
+  describe("vue", () => {
+    it("recognizes declarative Vue file", () => {
+      const source = getOriginalSource("frameworks/vueFileDeclarative");
+      setSource(source);
+      expect(getFramework(source.id)).toBe("Vue");
+    });
 
-  it("recognizes Angular 1 module", () => {
-    const source = getOriginalSource("frameworks/angular1Module");
-    setSource(source);
-    expect(getFramework(source.id)).toBe("Angular");
-  });
-
-  // Vue
-
-  it("recognizes declarative Vue file", () => {
-    const source = getOriginalSource("frameworks/vueFileDeclarative");
-    setSource(source);
-    expect(getFramework(source.id)).toBe("Vue");
-  });
-
-  it("recognizes component Vue file", () => {
-    const source = getOriginalSource("frameworks/vueFileComponent");
-    setSource(source);
-    expect(getFramework(source.id)).toBe("Vue");
+    it("recognizes component Vue file", () => {
+      const source = getOriginalSource("frameworks/vueFileComponent");
+      setSource(source);
+      expect(getFramework(source.id)).toBe("Vue");
+    });
   });
 });


### PR DESCRIPTION
Fixes #6833 

### Summary of Changes

* Fix `hasAngularExpressions` method, so that it checks not just the property name, but also the host object name (eg. occurrences of `angular.controller`, instead of simply `controller`). 
* Added test case for false positive detection.
* Organised unit test in framework specific

### Test Plan

![debugger](https://user-images.githubusercontent.com/3489757/45798005-6a5ff000-bca8-11e8-8e3d-49a7416007d9.png)

I wasn't able to reproduce the issue in a running instance of devtools; I've written a failing test that exposed the problem, and then made it turns green.