### PR TITLE
Changing the order of accessible rep properties from role:name to nam…

### DIFF
--- a/packages/devtools-reps/src/reps/accessible.js
+++ b/packages/devtools-reps/src/reps/accessible.js
@@ -21,6 +21,7 @@ Accessible.propTypes = {
   onAccessibleMouseOver: PropTypes.func,
   onAccessibleMouseOut: PropTypes.func,
   onInspectIconClick: PropTypes.func,
+  roleFirst: PropTypes.bool,
   separatorText: PropTypes.string
 };
 
@@ -33,9 +34,10 @@ function Accessible(props) {
     onAccessibleMouseOver,
     onAccessibleMouseOut,
     onInspectIconClick,
+    roleFirst,
     separatorText
   } = props;
-  const elements = getElements(object, nameMaxLength, separatorText);
+  const elements = getElements(object, nameMaxLength, roleFirst, separatorText);
   const isInTree = object.preview && object.preview.isConnected === true;
   const baseConfig = {
     "data-link-actor-id": object.actor,
@@ -81,23 +83,27 @@ function Accessible(props) {
   return span(baseConfig, ...elements, inspectIcon);
 }
 
-function getElements(grip, nameMaxLength, separatorText = ": ") {
+function getElements(
+  grip,
+  nameMaxLength,
+  roleFirst = false,
+  separatorText = ": "
+) {
   const { name, role } = grip.preview;
   const elements = [];
-
-  elements.push(span({ className: "accessible-role" }, role));
   if (name) {
     elements.push(
-      span({ className: "separator" }, separatorText),
       StringRep({
         className: "accessible-name",
         object: name,
         cropLimit: nameMaxLength
-      })
+      }),
+      span({ className: "separator" }, separatorText)
     );
   }
 
-  return elements;
+  elements.push(span({ className: "accessible-role" }, role));
+  return roleFirst ? elements.reverse() : elements;
 }
 
 // Registration

--- a/packages/devtools-reps/src/reps/tests/accessible.js
+++ b/packages/devtools-reps/src/reps/tests/accessible.js
@@ -24,7 +24,7 @@ describe("Accessible - Document", () => {
       })
     );
 
-    expect(renderedComponent.text()).toEqual('document: "New Tab"');
+    expect(renderedComponent.text()).toEqual('"New Tab": document');
   });
 });
 
@@ -43,7 +43,7 @@ describe("Accessible - ButtonMenu", () => {
     );
 
     expect(renderedComponent.text()).toEqual(
-      'buttonmenu: "New to Nightly? Let’s get started."'
+      '"New to Nightly? Let’s get started.": buttonmenu'
     );
   });
 
@@ -170,7 +170,7 @@ describe("Accessible - Accessible with long name", () => {
     );
 
     expect(renderedComponent.text()).toEqual(
-      `text leaf: "${"a".repeat(1000)}"`
+      `"${"a".repeat(1000)}": text leaf`
     );
   });
 
@@ -183,7 +183,7 @@ describe("Accessible - Accessible with long name", () => {
     );
 
     expect(renderedComponent.text()).toEqual(
-      `text leaf: "${"a".repeat(9)}${ELLIPSIS}${"a".repeat(8)}"`
+      `"${"a".repeat(9)}${ELLIPSIS}${"a".repeat(8)}": text leaf`
     );
   });
 });
@@ -220,7 +220,22 @@ describe("Accessible - Separator text", () => {
       })
     );
 
-    expect(renderedComponent.text()).toEqual('pushbutton - "Search"');
+    expect(renderedComponent.text()).toEqual('"Search" - pushbutton');
+  });
+});
+
+describe("Accessible - Role first", () => {
+  const stub = stubs.get("PushButton");
+
+  it("renders with expected title", () => {
+    const renderedComponent = shallow(
+      Accessible.rep({
+        roleFirst: true,
+        object: stub
+      })
+    );
+
+    expect(renderedComponent.text()).toEqual('pushbutton: "Search"');
   });
 });
 


### PR DESCRIPTION
…e:role based on UX feedback (#6932).

Fixes #6932

### Summary of Changes

After talking to Victoria, it became apparent that changing the order of properties rendered as part of the accessible rep makes more sense, especially with the picker functionality present.