### PR TITLE
UX changes for issue #6803

### DIFF
--- a/src/components/Editor/Tabs.css
+++ b/src/components/Editor/Tabs.css
@@ -5,7 +5,7 @@
 .source-header {
   border-bottom: 1px solid var(--theme-splitter-color);
   width: 100%;
-  height: 30px;
+  height: 29px;
   display: flex;
 }
 
@@ -50,9 +50,8 @@
   overflow: hidden;
   padding: 5px;
   margin-inline-start: 3px;
-  margin-top: 3px;
   cursor: default;
-  height: 27px;
+  height: 29px;
 }
 
 .source-tab:first-child {
@@ -61,7 +60,7 @@
 
 .source-tab:hover {
   background-color: var(--theme-toolbar-background-alt);
-  border-color: var(--theme-splitter-color);
+  border-bottom-color: var(--theme-splitter-color);
 }
 
 .source-tab.active {
@@ -69,6 +68,7 @@
   background-color: var(--theme-body-background);
   border-color: var(--theme-splitter-color);
   border-bottom-color: transparent;
+  border-top-color: transparent;
 }
 
 .source-tab.active path,

--- a/src/components/PrimaryPanes/Sources.css
+++ b/src/components/PrimaryPanes/Sources.css
@@ -153,7 +153,7 @@
   -moz-user-select: none;
   user-select: none;
   box-sizing: border-box;
-  height: 30px;
+  height: 29px;
   margin: 0;
   padding: 0;
 }

--- a/src/components/SecondaryPanes/CommandBar.css
+++ b/src/components/SecondaryPanes/CommandBar.css
@@ -3,7 +3,7 @@
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
 .command-bar {
-  flex: 0 0 30px;
+  flex: 0 0 29px;
   border-bottom: 1px solid var(--theme-splitter-color);
   display: flex;
   overflow: hidden;


### PR DESCRIPTION
Fixes #6803 

### Summary of Changes

* Changed height of Debugger's tab bar to 28px excluding borders
* Aligned the file tab labels and changed to look like the Source | Outline tabs

### Test Plan

-Tested hovering action
-Tested multiple file tabs open

### Screenshots
<img width="1427" alt="screen shot 2018-09-21 at 4 48 06 pm" src="https://user-images.githubusercontent.com/16697942/45905773-8d30f800-bdbf-11e8-8d37-5826b160fd97.png">
