### PR TITLE
Alternative UX changes for issue 6803

### DIFF
--- a/src/components/Editor/Tabs.css
+++ b/src/components/Editor/Tabs.css
@@ -52,7 +52,7 @@
   margin-inline-start: 3px;
   margin-top: 3px;
   cursor: default;
-  height: 26px;
+  height: 27px;
 }
 
 .source-tab:first-child {

--- a/src/components/Editor/Tabs.css
+++ b/src/components/Editor/Tabs.css
@@ -5,7 +5,7 @@
 .source-header {
   border-bottom: 1px solid var(--theme-splitter-color);
   width: 100%;
-  height: 30px;
+  height: 29px;
   display: flex;
 }
 
@@ -52,7 +52,7 @@
   margin-inline-start: 3px;
   margin-top: 3px;
   cursor: default;
-  height: 27px;
+  height: 26px;
 }
 
 .source-tab:first-child {
@@ -129,6 +129,7 @@ html[dir="rtl"] img.moreTabs {
   overflow: hidden;
   padding: 0 4px;
   align-self: center;
+  margin-bottom: 2px;
 }
 
 .source-tab .filename span {

--- a/src/components/PrimaryPanes/Sources.css
+++ b/src/components/PrimaryPanes/Sources.css
@@ -153,7 +153,7 @@
   -moz-user-select: none;
   user-select: none;
   box-sizing: border-box;
-  height: 30px;
+  height: 29px;
   margin: 0;
   padding: 0;
 }

--- a/src/components/SecondaryPanes/CommandBar.css
+++ b/src/components/SecondaryPanes/CommandBar.css
@@ -3,7 +3,7 @@
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
 .command-bar {
-  flex: 0 0 30px;
+  flex: 0 0 29px;
   border-bottom: 1px solid var(--theme-splitter-color);
   display: flex;
   overflow: hidden;


### PR DESCRIPTION
Fixes #6803

The alternative approach suggested in the issue where the file tab design does not change. Original approach: https://github.com/devtools-html/debugger.html/pull/7006

### Summary of Changes

* Changed height of Debugger's tab bar to 28px excluding borders
* Adjusted file tab labels to align

### Test Plan

-Tested hovering action
-Tested multiple tabs open

### Screenshots
<img width="1437" alt="screen shot 2018-09-22 at 11 02 15 am" src="https://user-images.githubusercontent.com/16697942/45918831-8b684280-be5a-11e8-97dd-edc159c0ad7b.png">
