### PR TITLE
Always show function name over filename in call stack

### DIFF
--- a/src/components/SecondaryPanes/Frames/Frames.css
+++ b/src/components/SecondaryPanes/Frames/Frames.css
@@ -30,12 +30,8 @@
 
 .frames .location {
   font-weight: lighter;
-  display: flex;
-  justify-content: space-between;
-  flex-direction: row;
-  align-items: center;
-  margin: 0;
-  flex-shrink: 0;
+  text-overflow: ellipsis;
+  overflow: hidden;
 }
 
 .theme-light .frames .location {
@@ -48,9 +44,8 @@
 }
 
 .frames .title {
-  text-overflow: ellipsis;
-  overflow: hidden;
   margin: 7px 0.5em 7px 0;
+  flex-shrink: 0;
 }
 
 .frames ul li:hover,


### PR DESCRIPTION
Fix issue where in the call stack, a long filename causes the function name to be hidden. This PR makes the function name always appear and the filename to show ellipsis when it is wider than available space.

Fixes #6889 

### Summary of Changes

* In the call stack, function name will now have precedence over filename. In narrow view, the filename will display an ellipsis while the function name will remain visible.
* Remove unnecessary CSS styles from `.title` and `.location` in the call stack. Currently, the `.title` div has ellipsis while the `.location` div does not. These styles are now swapped over. Further, on the `.location` div, `display: flex` along with its related styles were set. I am not sure if this makes sense given the content of the `.location` div is simply a string. Lastly, also on the `.location` div there exists `margin: 0;`. Given that the default value for margin is 0 and that no other styles set the margin on this element, there is no need to declare `margin: 0;`. This PR removes such styles.

### Test Plan

Referring to the original issue, I visited [https://www.cnbc.com/2017/07/20/tesla-adding-this-ceo-to-its-board-is-a-big-deal-for-silicon-valley.html](https://www.cnbc.com/2017/07/20/tesla-adding-this-ceo-to-its-board-is-a-big-deal-for-silicon-valley.html) and placed a breakpoint at the beginning of the specified file. After I refreshed the page, the breakpoint was hit and I was able to reproduce the issue and verify my fix.

### Screenshots/Videos (OPTIONAL)

Before:
![image](https://user-images.githubusercontent.com/1629317/45925251-8345ec80-bec6-11e8-81c4-686ea28298da.png)

After:
![image](https://user-images.githubusercontent.com/1629317/45925248-7d500b80-bec6-11e8-87ea-51867d5aca6f.png)

