### PR TITLE
Improve regex pattern for determining React library files

### DIFF
--- a/src/selectors/test/getCallStackFrames.spec.js
+++ b/src/selectors/test/getCallStackFrames.spec.js
@@ -18,7 +18,7 @@ describe("getCallStackFrames selector", () => {
           source1: { id: "source1", url: "webpack:///src/App.js" },
           source2: {
             id: "source2",
-            url: "webpack:///~/react-dom/lib/ReactCompositeComponent.js"
+            url: "webpack:///foo/node_modules/react-dom/lib/ReactCompositeComponent.js"
           }
         },
         selectedSource: {

--- a/src/utils/pause/frames/getLibraryFromUrl.js
+++ b/src/utils/pause/frames/getLibraryFromUrl.js
@@ -22,7 +22,7 @@ const libraryMap = [
   },
   {
     label: "React",
-    pattern: /react[^\/]*\.js/i
+    pattern: /(node_modules\/react)|(react(\.[a-z]+)*\.js$)/i
   },
   {
     label: "Immutable",

--- a/src/utils/pause/frames/getLibraryFromUrl.js
+++ b/src/utils/pause/frames/getLibraryFromUrl.js
@@ -22,7 +22,7 @@ const libraryMap = [
   },
   {
     label: "React",
-    pattern: /react/i
+    pattern: /react[^\/]*\.js/i
   },
   {
     label: "Immutable",

--- a/src/utils/pause/frames/tests/getLibraryFromUrl.spec.js
+++ b/src/utils/pause/frames/tests/getLibraryFromUrl.spec.js
@@ -77,7 +77,9 @@ describe("getLibraryFromUrl", () => {
         "https://debugger-example.com/react.development.js",
         "https://debugger-example.com/react.production.min.js",
         "https://debugger-react-example.com/react.js",
-        "https://debugger-react-example.com/react/react.js"
+        "https://debugger-react-example.com/react/react.js",
+        "/node_modules/react/test.js",
+        "/node_modules/react-dom/test.js"
       ];
       reactUrlList.forEach(reactUrl => {
         const frame = {

--- a/src/utils/pause/frames/tests/getLibraryFromUrl.spec.js
+++ b/src/utils/pause/frames/tests/getLibraryFromUrl.spec.js
@@ -49,4 +49,47 @@ describe("getLibraryFromUrl", () => {
       });
     });
   });
+
+  describe("When React is in the URL", () => {
+    it("should not return React if it is not part of the filename", () => {
+      const notReactUrlList = [
+        "https://debugger-example.com/test.js",
+        "https://debugger-react-example.com/test.js",
+        "https://debugger-react-example.com/react/test.js"
+      ];
+      notReactUrlList.forEach(notReactUrl => {
+        const frame = {
+          displayName: "name",
+          location: {
+            line: 12
+          },
+          source: {
+            url: notReactUrl
+          }
+        };
+        expect(getLibraryFromUrl(frame)).toBeNull();
+      });
+    });
+    it("should return React if it is part of the filename", () => {
+      const reactUrlList = [
+        "https://debugger-example.com/react.js",
+        "https://debugger-example.com/react.development.js",
+        "https://debugger-example.com/react.production.min.js",
+        "https://debugger-react-example.com/react.js",
+        "https://debugger-react-example.com/react/react.js"
+      ];
+      reactUrlList.forEach(reactUrl => {
+        const frame = {
+          displayName: "name",
+          location: {
+            line: 12
+          },
+          source: {
+            url: reactUrl
+          }
+        };
+        expect(getLibraryFromUrl(frame)).toEqual("React");
+      });
+    });
+  });
 });

--- a/src/utils/pause/frames/tests/getLibraryFromUrl.spec.js
+++ b/src/utils/pause/frames/tests/getLibraryFromUrl.spec.js
@@ -53,6 +53,7 @@ describe("getLibraryFromUrl", () => {
   describe("When React is in the URL", () => {
     it("should not return React if it is not part of the filename", () => {
       const notReactUrlList = [
+        "https://react.js.com/test.js",
         "https://debugger-example.com/test.js",
         "https://debugger-react-example.com/test.js",
         "https://debugger-react-example.com/react/test.js"


### PR DESCRIPTION
Improve regex pattern for determining whether a particular frame belongs to the React library or not.

Fixes #6792 

### Summary of Changes

* Improve React regex pattern to detect React files correctly. Previously, if the word `react` appeared anywhere in the URL, the debugger will classify it as React library file. Now, the debugger will look for the word `react` in the filename rather than just the path.

### Test Plan

- [x] Test using the provided URL in the issue, ensure the functions in `Game.js` and `Board.js` are showing separate from the React group.

### Screenshots/Videos

Before:
![image](https://user-images.githubusercontent.com/1629317/45925964-d756ce00-bed2-11e8-957d-a50528bbcfb9.png)
![image](https://user-images.githubusercontent.com/1629317/45925971-df167280-bed2-11e8-8f78-e7db49727409.png)

After:
![image](https://user-images.githubusercontent.com/1629317/45925986-e5a4ea00-bed2-11e8-8e25-e6b29836380f.png)
![image](https://user-images.githubusercontent.com/1629317/45925992-f5bcc980-bed2-11e8-9c78-5dc65014446f.png)

