### PR TITLE
Add eslint-flow-type rule to eslint config

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -88,6 +88,10 @@
 
     "flowtype/define-flow-type": 1,
     "flowtype/use-flow-type": 1,
+    "flowtype/require-valid-file-annotation": [
+      2,
+      "always"
+    ],
 
     // Disallow flow control that escapes from "finally".
     "no-unsafe-finally": "error",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,7 @@
 {
+  "files.associations": {
+    "*.js": "javascriptreact"
+  },
   "flow.pathToFlow": "${workspaceRoot}/node_modules/.bin/flow",
   "eslint.autoFixOnSave": true,
   "prettier.eslintIntegration": true,

--- a/configs/development.json
+++ b/configs/development.json
@@ -19,7 +19,7 @@
     "port": 9229
   },
   "firefox": {
-    "webSocketConnection": false,
+    "webSocketConnection": true,
     "host": "localhost",
     "webSocketPort": 8116,
     "tcpPort": 6080,

--- a/src/actions/ast/setInScopeLines.js
+++ b/src/actions/ast/setInScopeLines.js
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
+// @flow
+
 import { getOutOfScopeLocations, getSelectedSource } from "../../selectors";
 import { getSourceLineCount } from "../../utils/source";
 

--- a/src/actions/breakpoints/addBreakpoint.js
+++ b/src/actions/breakpoints/addBreakpoint.js
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
+ // @flow
+
 import { isOriginalId } from "devtools-source-map";
 import {
   locationMoved,

--- a/src/actions/breakpoints/remapLocations.js
+++ b/src/actions/breakpoints/remapLocations.js
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
+ // @flow
+
 export default function remapLocations(breakpoints, sourceId, sourceMaps) {
   const sourceBreakpoints = breakpoints.map(async breakpoint => {
     if (breakpoint.location.sourceId !== sourceId) {

--- a/src/actions/event-listeners.js
+++ b/src/actions/event-listeners.js
@@ -10,6 +10,8 @@
  * @module actions/event-listeners
  */
 
+// @flow
+
 import { reportException } from "../utils/DevToolsUtils";
 import { isPaused, getSourceByURL } from "../selectors";
 import { NAME as WAIT_UNTIL } from "./utils/middleware/wait-service";

--- a/src/actions/source-tree.js
+++ b/src/actions/source-tree.js
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
+// @flow
+
 import type { Action, ThunkArgs } from "./types";
 
 export function setExpandedState(expanded) {

--- a/src/actions/utils/middleware/log.js
+++ b/src/actions/utils/middleware/log.js
@@ -3,6 +3,8 @@
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 /* global window */
 
+// @flow
+
 import { isTesting } from "devtools-environment";
 
 const blacklist = [

--- a/src/actions/utils/middleware/timing.js
+++ b/src/actions/utils/middleware/timing.js
@@ -9,6 +9,8 @@
  * will appear in performance tooling under the User Timing API
  */
 
+// @flow
+
 const mark =
   window.performance && window.performance.mark
     ? window.performance.mark.bind(window.performance)

--- a/src/components/SecondaryPanes/Breakpoints/BreakpointsContextMenu.js
+++ b/src/components/SecondaryPanes/Breakpoints/BreakpointsContextMenu.js
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
+// @flow
+
 import { buildMenu, showMenu } from "devtools-contextmenu";
 
 export default function showContextMenu(props) {

--- a/src/components/SecondaryPanes/Frames/types.js
+++ b/src/components/SecondaryPanes/Frames/types.js
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
+// @flow
+
 import type { Frame } from "../../../types";
 
 export type LocalFrame = Frame & {

--- a/src/reducers/async-requests.js
+++ b/src/reducers/async-requests.js
@@ -7,6 +7,8 @@
  * @module reducers/async-request
  */
 
+// @flow
+
 const initialAsyncRequestState = [];
 
 function update(state = initialAsyncRequestState, action) {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,3 +1,4 @@
+// @flow
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */


### PR DESCRIPTION
### Summary of Changes

* Add `eslint-flow-type` rule: 
```
"flowtype/require-valid-file-annotation": [
      2,
      "always"
    ],
```
to `.eslintrc`

* Add `//@flow` headers to several files in `ast`, `breakpoints`, and `SecondaryPanes`. Will check them off in the issue.

### Test Plan

Tell us a little a bit about how you tested your patch.

Example test plan:

- [x] Since this was a small fix, I ran `yarn test` to make sure there were no conflicts.

