### PR TITLE
prevent a regex infinite loop in the search worker

### DIFF
--- a/src/workers/search/get-matches.js
+++ b/src/workers/search/get-matches.js
@@ -20,8 +20,17 @@ export default function getMatches(
   for (let i = 0; i < lines.length; i++) {
     let singleMatch;
     const line = lines[i];
+    let previousLastIndex = regexQuery.lastIndex;
     while ((singleMatch = regexQuery.exec(line)) !== null) {
       matchedLocations.push({ line: i, ch: singleMatch.index });
+
+      // exec() is supposed to update the lastIndex property but sometimes
+      // doesn't and can cause this to be an infinite loop by matching on the
+      // same index.  A work around is to update the lastIndex manually
+      if (regexQuery.lastIndex === previousLastIndex) {
+        regexQuery.lastIndex++;
+      }
+      previousLastIndex = regexQuery.lastIndex;
     }
   }
   return matchedLocations;

--- a/src/workers/search/get-matches.js
+++ b/src/workers/search/get-matches.js
@@ -20,7 +20,7 @@ export default function getMatches(
   for (let i = 0; i < lines.length; i++) {
     let singleMatch;
     const line = lines[i];
-    let previousLastIndex = regexQuery.lastIndex;
+    let previousLastIndex = 0;
     while ((singleMatch = regexQuery.exec(line)) !== null) {
       matchedLocations.push({ line: i, ch: singleMatch.index });
 

--- a/src/workers/search/get-matches.js
+++ b/src/workers/search/get-matches.js
@@ -29,7 +29,7 @@ export default function getMatches(
       // increment it manually in that case.  See issue #7023
       if (singleMatch[0] === "") {
         assert(
-          regexQuery.unicode,
+          !regexQuery.unicode,
           "lastIndex++ can cause issues in unicode mode"
         );
         regexQuery.lastIndex++;

--- a/src/workers/search/get-matches.js
+++ b/src/workers/search/get-matches.js
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
+import assert from "../../utils/assert";
 import buildQuery from "../../utils/build-query";
 
 export default function getMatches(
@@ -20,17 +21,19 @@ export default function getMatches(
   for (let i = 0; i < lines.length; i++) {
     let singleMatch;
     const line = lines[i];
-    let previousLastIndex = 0;
     while ((singleMatch = regexQuery.exec(line)) !== null) {
       matchedLocations.push({ line: i, ch: singleMatch.index });
 
-      // exec() is supposed to update the lastIndex property but sometimes
-      // doesn't and can cause this to be an infinite loop by matching on the
-      // same index.  A work around is to update the lastIndex manually
-      if (regexQuery.lastIndex === previousLastIndex) {
+      // When the match is an empty string the regexQuery.lastIndex will not
+      // change resulting in an infinite loop so we need to check for this and
+      // increment it manually in that case.  See issue #7023
+      if (singleMatch[0] === "") {
+        assert(
+          regexQuery.unicode,
+          "lastIndex++ can cause issues in unicode mode"
+        );
         regexQuery.lastIndex++;
       }
-      previousLastIndex = regexQuery.lastIndex;
     }
   }
   return matchedLocations;

--- a/src/workers/search/tests/get-matches.spec.js
+++ b/src/workers/search/tests/get-matches.spec.js
@@ -71,5 +71,17 @@ describe("search", () => {
       });
       expect(matchLocations).toHaveLength(0);
     });
+
+    // regression test for #6896
+    it("doesn't crash on the regex 'a*'", () => {
+      const text = "abc";
+      const query = "a*";
+      const matchLocations = getMatches(query, text, {
+        caseSensitive: true,
+        wholeWord: false,
+        regexMatch: true
+      });
+      expect(matchLocations).toHaveLength(4);
+    });
   });
 });

--- a/src/workers/search/tests/get-matches.spec.js
+++ b/src/workers/search/tests/get-matches.spec.js
@@ -83,5 +83,17 @@ describe("search", () => {
       });
       expect(matchLocations).toHaveLength(4);
     });
+
+    // regression test for #6896
+    it("doesn't crash on the regex '^'", () => {
+      const text = "012";
+      const query = "^";
+      const matchLocations = getMatches(query, text, {
+        caseSensitive: true,
+        wholeWord: false,
+        regexMatch: true
+      });
+      expect(matchLocations).toHaveLength(1);
+    });
   });
 });


### PR DESCRIPTION
Fixes #6896

### Summary of Changes

* Add check in the search worker regex search loop to catch if the regex index is not being updated

### Test Plan

Example test plan:

- [x] Add a jest test
- [x] Ran the debugger and verified searching with regex 'a*' did not cause memory to increase wildly
- [x] Ran the debugger and verified searching with regex '' did not cause memory to increase wildly