### PR TITLE
In getMappedExpression, return the result of parser.mapExpression.

### DIFF
--- a/src/actions/expressions.js
+++ b/src/actions/expressions.js
@@ -173,21 +173,15 @@ export function getMappedExpression(expression: string) {
     // 2. does not contain `await` - we do not need to map top level awaits
     // 3. does not contain `=` - we do not need to map assignments
     if (!mappings && !expression.match(/(await|=)/)) {
-      // TODO: return null when
-      // https://bugzilla.mozilla.org/show_bug.cgi?id=1491354 lands.
-      return expression;
+      return null;
     }
 
-    const mapResult = await parser.mapExpression(
+    return parser.mapExpression(
       expression,
       mappings,
       bindings || [],
       features.mapExpressionBindings,
       features.mapAwaitExpression
     );
-
-    // TODO: Directly return mapResult when
-    // https://bugzilla.mozilla.org/show_bug.cgi?id=1491354 lands.
-    return mapResult.expression;
   };
 }

--- a/src/actions/expressions.js
+++ b/src/actions/expressions.js
@@ -141,7 +141,7 @@ function evaluateExpression(expression: Expression) {
       if (selectedSource && isOriginal(source) && isOriginal(selectedSource)) {
         const mapResult = await dispatch(getMappedExpression(input));
         if (mapResult) {
-          input = mapResult.expression || mapResult;
+          input = mapResult.expression;
         }
       }
     }

--- a/src/actions/preview.js
+++ b/src/actions/preview.js
@@ -92,7 +92,7 @@ export function setPreview(
         if (location && isOriginal(source)) {
           const mapResult = await dispatch(getMappedExpression(expression));
           if (mapResult) {
-            expression = mapResult.expression || mapResult;
+            expression = mapResult.expression;
           }
         }
 


### PR DESCRIPTION
Now that Bug 1491354 landed, the console will expect
`getMappedExpression` function to return the same object
than parser's `mapExpression` function, or null if the
expression doesn't need any mapping.