### PR TITLE
Tweak memoize to use n keys

### DIFF
--- a/src/selectors/visibleBreakpoints.js
+++ b/src/selectors/visibleBreakpoints.js
@@ -19,7 +19,7 @@ function getLocation(breakpoint, isGeneratedSource) {
     : breakpoint.location;
 }
 
-const formatBreakpoint = memoize(2, function(breakpoint, selectedSource) {
+const formatBreakpoint = memoize(function(breakpoint, selectedSource) {
   const { condition, loading, disabled, hidden } = breakpoint;
   const sourceId = selectedSource.id;
   const isGeneratedSource = isGeneratedId(sourceId);

--- a/src/selectors/visibleBreakpoints.js
+++ b/src/selectors/visibleBreakpoints.js
@@ -8,6 +8,7 @@ import { getBreakpoints } from "../reducers/breakpoints";
 import { getSelectedSource } from "../reducers/sources";
 import { isGeneratedId } from "devtools-source-map";
 import { createSelector } from "reselect";
+import memoize from "../utils/memoize";
 
 import type { BreakpointsMap } from "../reducers/types";
 import type { Source } from "../types";
@@ -18,21 +19,7 @@ function getLocation(breakpoint, isGeneratedSource) {
     : breakpoint.location;
 }
 
-function memoize(func) {
-  const store = new WeakMap();
-
-  return function(key, ...rest) {
-    if (store.has(key)) {
-      return store.get(key);
-    }
-
-    const value = func.apply(null, arguments);
-    store.set(key, value);
-    return value;
-  };
-}
-
-const formatBreakpoint = memoize(function(breakpoint, selectedSource) {
+const formatBreakpoint = memoize(2, function(breakpoint, selectedSource) {
   const { condition, loading, disabled, hidden } = breakpoint;
   const sourceId = selectedSource.id;
   const isGeneratedSource = isGeneratedId(sourceId);

--- a/src/utils/memoize.js
+++ b/src/utils/memoize.js
@@ -2,30 +2,69 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
+ function hasValue(keys, store) {
+   let currentStore = store;
+   for (const key in keys) {
+     if (!currentStore || currentStore.has(key)) {
+       return false;
+     }
+
+     currentStore = currentStore.get(key)
+   }
+ }
+
+ function getValue(keys, store) {
+   let currentStore = store;
+   for (const key in keys) {
+     currentStore = currentStore.get(key)
+   }
+
+   return currentStore;
+ }
+
+ function setValue(keys, store, value) {
+   let currentStore = getValue(keys.slice(0,-1), store)
+   if (!currentStore) {
+     currentStore = new WeakMap()
+   }
+   currentStore.set(keys[keys.length - 1], value)
+ }
+
+
 // memoize with n arguments
-export default function memoize(n, func) {
+export default function memoize(func) {
   const store = new WeakMap();
 
   return function(...keys) {
-    let currentStore = store;
 
-    for (let i = 0; i < n - 1; i++) {
-      const key = keys[i];
-      if (!currentStore.has(key)) {
-        currentStore.set(key, new WeakMap());
-      }
-
-      currentStore = currentStore.get(key);
+    if (hasValue(keys, store)) {
+      return getValue(keys, store)
     }
 
-    const lastKey = keys[n - 1];
-
-    if (currentStore.has(lastKey)) {
-      return currentStore.get(lastKey);
-    }
-
-    const value = func.apply(null, arguments);
-    currentStore.set(lastKey, value);
-    return value;
+    const newValue = func.apply(null, keys)
+    setValue(keys, store, newValue)
+    return newValue;
   };
 }
+
+
+
+
+// let currentStore = store;
+// let index = 0
+// const key = keys[index]
+//
+// if (store.has(key)) {
+//   let value = currentStore.get(key)
+//   while (value instanceof WeakMap && value.has(keys[index])) {
+//     value = value.get(keys[index])
+//     index++
+//   }
+//
+//   console.log(typeof value,  value instanceof WeakMap)
+//   return value;
+// }
+//
+// const value = func.apply(null, arguments);
+// currentStore.set(key, value);
+// return value;

--- a/src/utils/memoize.js
+++ b/src/utils/memoize.js
@@ -2,53 +2,56 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
- function hasValue(keys, store) {
-   let currentStore = store;
-   for (const key in keys) {
-     if (!currentStore || currentStore.has(key)) {
-       return false;
-     }
+function hasValue(keys, store) {
+  let currentStore = store;
+  for (const key of keys) {
+    if (!currentStore || !currentStore.has(key)) {
+      return false;
+    }
 
-     currentStore = currentStore.get(key)
-   }
- }
+    currentStore = currentStore.get(key);
+  }
+  return true;
+}
 
- function getValue(keys, store) {
-   let currentStore = store;
-   for (const key in keys) {
-     currentStore = currentStore.get(key)
-   }
+function getValue(keys, store) {
+  let currentStore = store;
+  for (const key of keys) {
+    currentStore = currentStore.get(key);
+  }
 
-   return currentStore;
- }
+  return currentStore;
+}
 
- function setValue(keys, store, value) {
-   let currentStore = getValue(keys.slice(0,-1), store)
-   if (!currentStore) {
-     currentStore = new WeakMap()
-   }
-   currentStore.set(keys[keys.length - 1], value)
- }
+function setValue(keys, store, value) {
+  const keysExceptLast = keys.slice(0, -1);
+  const lastKey = keys[keys.length - 1];
 
+  let currentStore = store;
+  for (const key of keysExceptLast) {
+    if (!currentStore.has(key)) {
+      currentStore.set(key, new WeakMap());
+    }
+    currentStore = currentStore.get(key);
+  }
+
+  currentStore.set(lastKey, value);
+}
 
 // memoize with n arguments
 export default function memoize(func) {
   const store = new WeakMap();
 
   return function(...keys) {
-
     if (hasValue(keys, store)) {
-      return getValue(keys, store)
+      return getValue(keys, store);
     }
 
-    const newValue = func.apply(null, keys)
-    setValue(keys, store, newValue)
+    const newValue = func.apply(null, keys);
+    setValue(keys, store, newValue);
     return newValue;
   };
 }
-
-
-
 
 // let currentStore = store;
 // let index = 0

--- a/src/utils/memoize.js
+++ b/src/utils/memoize.js
@@ -1,0 +1,31 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
+// memoize with n arguments
+export default function memoize(n, func) {
+  const store = new WeakMap();
+
+  return function(...keys) {
+    let currentStore = store;
+
+    for (let i = 0; i < n - 1; i++) {
+      const key = keys[i];
+      if (!currentStore.has(key)) {
+        currentStore.set(key, new WeakMap());
+      }
+
+      currentStore = currentStore.get(key);
+    }
+
+    const lastKey = keys[n - 1];
+
+    if (currentStore.has(lastKey)) {
+      return currentStore.get(lastKey);
+    }
+
+    const value = func.apply(null, arguments);
+    currentStore.set(lastKey, value);
+    return value;
+  };
+}

--- a/src/utils/tests/memoize.spec.js
+++ b/src/utils/tests/memoize.spec.js
@@ -1,0 +1,47 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
+import memoize from "../memoize";
+
+const a = {
+  number: 3
+};
+const b = {
+  number: 4
+};
+const c = {
+  number: 5
+};
+const d = {
+  number: 6
+};
+
+function add(...numberObjects) {
+  return numberObjects.reduce((prev, cur) => prev + cur.number, 0);
+}
+
+describe("memozie", () => {
+  it("should work for one arg as key", () => {
+    const memoizedAdd = memoize(1, add);
+    expect(memoizedAdd(a, b)).toEqual(7);
+    expect(memoizedAdd(a, c)).toEqual(7);
+  });
+
+  it("should work for two args as key", () => {
+    const memoizedAdd = memoize(2, add);
+    expect(memoizedAdd(a, b, d)).toEqual(13);
+    expect(memoizedAdd(a, b, c)).toEqual(13);
+    expect(memoizedAdd(b, c)).toEqual(9);
+    expect(memoizedAdd(b, a)).toEqual(7);
+  });
+
+  it("should work for three args as key", () => {
+    const memoizeAdd = memoize(3, add);
+    expect(memoizeAdd(a, b, c, d)).toEqual(18);
+    expect(memoizeAdd(a, b, c, b)).toEqual(18);
+    expect(memoizeAdd(a, b, c, a)).toEqual(18);
+    expect(memoizeAdd(a, a, b, d)).toEqual(16);
+    expect(memoizeAdd(a, a, b, c)).toEqual(16);
+  });
+});

--- a/src/utils/tests/memoize.spec.js
+++ b/src/utils/tests/memoize.spec.js
@@ -15,30 +15,34 @@ function add(...numberObjects) {
 
 describe("memozie", () => {
   it("should work for one arg as key", () => {
-    const mAdd = memoize(add)
-    mAdd(a)
-    expect(mAdd(a)).toEqual(3)
-    expect(spy.calls).toHavelength(1)
+    const mAdd = memoize(add);
+    mAdd(a);
+    expect(mAdd(a)).toEqual(3);
+    mAdd(b);
+    expect(mAdd(b)).toEqual(4);
   });
 
   it("should only be called once", () => {
-    const spy = jest.fn(add)
-    const mAdd = memoize(spy)
+    const spy = jest.fn(() => 2);
+    const mAdd = memoize(spy);
 
-    mAdd(a)
-    expect(mAdd(a)).toEqual(3)
-    expect(spy.calls).toHavelength(1)
+    mAdd(a);
+    mAdd(a);
+    mAdd(a);
+    expect(spy).toHaveBeenCalledTimes(1);
   });
 
-
-  it("should work for multiple args as key", () => {
-
+  it("should work for two args as key", () => {
     const mAdd = memoize(add);
-    expect(mAdd(a,b)).toEqual(7)
-
-    expect(mAdd(a,c)).toEqual(8)
-    expect(mAdd(a,b,c)).toEqual(12)
-    expect(mAdd(a,b,d)).toEqual(13)
+    expect(mAdd(a, b)).toEqual(7);
+    expect(mAdd(a, b)).toEqual(7);
+    expect(mAdd(a, c)).toEqual(8);
   });
 
+  it("should work with many args as key", () => {
+    const mAdd = memoize(add);
+    expect(mAdd(a, b, c)).toEqual(12);
+    expect(mAdd(a, b, d)).toEqual(13);
+    expect(mAdd(a, b, c)).toEqual(12);
+  });
 });

--- a/src/utils/tests/memoize.spec.js
+++ b/src/utils/tests/memoize.spec.js
@@ -4,18 +4,10 @@
 
 import memoize from "../memoize";
 
-const a = {
-  number: 3
-};
-const b = {
-  number: 4
-};
-const c = {
-  number: 5
-};
-const d = {
-  number: 6
-};
+const a = { number: 3 };
+const b = { number: 4 };
+const c = { number: 5 };
+const d = { number: 6 };
 
 function add(...numberObjects) {
   return numberObjects.reduce((prev, cur) => prev + cur.number, 0);
@@ -23,25 +15,30 @@ function add(...numberObjects) {
 
 describe("memozie", () => {
   it("should work for one arg as key", () => {
-    const memoizedAdd = memoize(1, add);
-    expect(memoizedAdd(a, b)).toEqual(7);
-    expect(memoizedAdd(a, c)).toEqual(7);
+    const mAdd = memoize(add)
+    mAdd(a)
+    expect(mAdd(a)).toEqual(3)
+    expect(spy.calls).toHavelength(1)
   });
 
-  it("should work for two args as key", () => {
-    const memoizedAdd = memoize(2, add);
-    expect(memoizedAdd(a, b, d)).toEqual(13);
-    expect(memoizedAdd(a, b, c)).toEqual(13);
-    expect(memoizedAdd(b, c)).toEqual(9);
-    expect(memoizedAdd(b, a)).toEqual(7);
+  it("should only be called once", () => {
+    const spy = jest.fn(add)
+    const mAdd = memoize(spy)
+
+    mAdd(a)
+    expect(mAdd(a)).toEqual(3)
+    expect(spy.calls).toHavelength(1)
   });
 
-  it("should work for three args as key", () => {
-    const memoizeAdd = memoize(3, add);
-    expect(memoizeAdd(a, b, c, d)).toEqual(18);
-    expect(memoizeAdd(a, b, c, b)).toEqual(18);
-    expect(memoizeAdd(a, b, c, a)).toEqual(18);
-    expect(memoizeAdd(a, a, b, d)).toEqual(16);
-    expect(memoizeAdd(a, a, b, c)).toEqual(16);
+
+  it("should work for multiple args as key", () => {
+
+    const mAdd = memoize(add);
+    expect(mAdd(a,b)).toEqual(7)
+
+    expect(mAdd(a,c)).toEqual(8)
+    expect(mAdd(a,b,c)).toEqual(12)
+    expect(mAdd(a,b,d)).toEqual(13)
   });
+
 });


### PR DESCRIPTION
Fixes #6938

### Summary of Changes

* We can now use Memoize to cache upto n arguments serially

### Screenshots/Videos (OPTIONAL)
![memoize](https://user-images.githubusercontent.com/7821757/46041716-1c783b80-c131-11e8-8419-fd28d9accaf6.gif)
