### PR TITLE
Fix 7026 - Only show (mapped) when duplicate file names

### DIFF
--- a/src/components/PrimaryPanes/SourcesTreeItem.js
+++ b/src/components/PrimaryPanes/SourcesTreeItem.js
@@ -187,13 +187,15 @@ class SourceTreeItem extends Component<Props, State> {
 }
 
 function getHasMatchingGeneratedSource(state, source: ?Source) {
-  if (!source) {
+  if (!source || !isOriginalSource(source)) {
     return false;
   }
 
-  const isOriginal = isOriginalSource(source);
-  const sources = getSourcesByURL(state, source.url, isOriginal);
-  return isOriginal && sources.length > 0;
+  const sources = getSourcesByURL(state, source.url).filter(
+    src => !isOriginalSource(src)
+  );
+
+  return sources.length > 0;
 }
 
 const mapStateToProps = (state, props) => {

--- a/src/reducers/sources.js
+++ b/src/reducers/sources.js
@@ -322,17 +322,8 @@ export function getSourcesByURLs(state: OuterState, urls: string[]) {
   return urls.map(url => getSourceByURL(state, url)).filter(Boolean);
 }
 
-export function getSourcesByURL(
-  state: OuterState,
-  url: string,
-  isOriginal: boolean = false
-): Source[] {
-  return getSourcesByUrlInSources(
-    getSources(state),
-    getUrls(state),
-    url,
-    isOriginal
-  );
+export function getSourcesByURL(state: OuterState, url: string): Source[] {
+  return getSourcesByUrlInSources(getSources(state), getUrls(state), url);
 }
 
 export function getGeneratedSource(state: OuterState, source: Source): Source {
@@ -377,8 +368,7 @@ export function getSourceByUrlInSources(
 function getSourcesByUrlInSources(
   sources: SourcesMap,
   urls: UrlsMap,
-  url: string,
-  isOriginal?: boolean
+  url: string
 ) {
   if (!url || !urls[url]) {
     return [];


### PR DESCRIPTION
Fixes #7026

I was going to give this issue to @ZhangYue-vhyt but, in reviewing the code, I realized I wasn't very concise with my original `isOriginal` pull request.

`getSourcesByURL` should return all sources with a given URL; `isOriginal` shouldn't be in play with that function.