### PR TITLE
[Quick Open] Fix tabs icon in modal

### DIFF
--- a/src/utils/quick-open.js
+++ b/src/utils/quick-open.js
@@ -58,7 +58,7 @@ export function formatSourcesForList(source: Source, tabs: TabList) {
     value: source.relativeUrl,
     title,
     subtitle,
-    icon: tabs.includes(source.url)
+    icon: tabs.some(tab => tab.url == source.url)
       ? "tab result-item-icon"
       : classnames(getSourceClassnames(source), "result-item-icon"),
     id: source.id,


### PR DESCRIPTION

### Summary of Changes

When we changed the tabs list from an array of URLS to an array of objects we stopped showing the tab icon in quick open.

### Test Plan

Write a new mochitest