### PR TITLE
[Editor] continue resizing breakpoints

### DIFF
--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -237,10 +237,8 @@ class Editor extends PureComponent<Props, State> {
         const editor = this.setupEditor();
         updateDocument(editor, selectedSource);
       } else {
-        startOperation();
         this.setText(this.props);
         this.setSize(this.props);
-        endOperation();
       }
     }
   }

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -130,11 +130,9 @@ class Editor extends PureComponent<Props, State> {
       return;
     }
 
-    startOperation();
     this.setText(nextProps);
     this.setSize(nextProps);
     this.scrollToLocation(nextProps);
-    endOperation();
   }
 
   setupEditor() {


### PR DESCRIPTION
### Summary of Changes

when we introduced some of the codemirror operations we began to see the breakpoint sizes update  late when we switched files. This fixes that by removing one of the operation groups.

### before

![](http://g.recordit.co/w5n0jrfkHq.gif)

### after

![](http://g.recordit.co/GirU4h7g3l.gif)