### PR TITLE
[Call Stack] Text visibility fix

### DIFF
--- a/src/components/SecondaryPanes/Frames/Frames.css
+++ b/src/components/SecondaryPanes/Frames/Frames.css
@@ -29,7 +29,7 @@
 }
 
 .frames .location {
-  font-weight: lighter;
+  font-weight: normal;
   text-overflow: ellipsis;
   overflow: hidden;
 }


### PR DESCRIPTION
Fixes [#17 from the UX repository](https://github.com/devtools-html/ux/issues/17)

This is a small fix to make the reading easier at the Call Stack on the right of the Debugger window.

### Summary of Changes

* CSS: change font-weight from lighter to normal. Selector is .frames .location (important to know, in case it affects other panels)
Location: _src/components/SecondaryPanes/Frames/Frames.css_

### Test Plan / How to see it

If you want to check the visibility, please open a page with a working Javascript file.

- [x] Select the .js file at the Sources tab 
- [x] Set a Breakpoint
- [x] Rerun your app/website to activate the Breakpoint
- [x] The Call Stack tab will appear on the right side


### Screenshots/Videos (OPTIONAL)

The change is very subtle, so there are a couple of screenshots below.


Before fix:
![01](https://user-images.githubusercontent.com/3901809/46123265-d1732c80-c1f3-11e8-821d-0846dbb2268c.PNG)


After fix:
![00](https://user-images.githubusercontent.com/3901809/46123273-d932d100-c1f3-11e8-96e3-161547902892.PNG)