### PR TITLE
Update community call

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Our [Weekly updates][weekly-updates] are also posted!
 
 Say hello in [Slack][slack] or in the [#devtools-html][irc-devtools-html] channel on irc.mozilla.org.
 
-* **Community Call**: Every Tuesday at 2 pm EST and Thursday at 12 pm EST. [Join the Hangout][community-call]
+* **Community Call**: Every Tuesday at 2 pm EST. [Join the Hangout][community-call]
 * **DevTools Call**: Every Tuesday at 12 pm EST. [Join the DevTools Vidyo][vidyo] Meeting Notes [Google Docs][google-docs]
 * **Pairing**: Ask in [Slack][slack] and you'll either find someone or be able to schedule a time for later.
 


### PR DESCRIPTION

### Summary of Changes

We haven't promoted the thursday call in awhile. Lets drop it and instead do more impromptu calls when folks are free.