### PR TITLE
Revert call stack formatting change

### DIFF
--- a/src/components/SecondaryPanes/Frames/Frames.css
+++ b/src/components/SecondaryPanes/Frames/Frames.css
@@ -30,8 +30,12 @@
 
 .frames .location {
   font-weight: normal;
-  text-overflow: ellipsis;
-  overflow: hidden;
+  display: flex;
+  justify-content: space-between;
+  flex-direction: row;
+  align-items: center;
+  margin: 0;
+  flex-shrink: 0;
 }
 
 .theme-light .frames .location {
@@ -44,8 +48,9 @@
 }
 
 .frames .title {
+  text-overflow: ellipsis;
+  overflow: hidden;
   margin: 7px 0.5em 7px 0;
-  flex-shrink: 0;
 }
 
 .frames ul li:hover,


### PR DESCRIPTION
Unfortunately we need to revert https://github.com/devtools-html/debugger.html/pull/7014 for now.

There's an side effect of the first PR that cause a formatting issue:

<img width="306" alt="screen shot 2018-09-27 at 3 54 24 pm" src="https://user-images.githubusercontent.com/46655/46173598-4c782980-c26c-11e8-88be-67aa573df249.png">

To reproduce:

1.  Open the following site in the debugger:  https://firefox-dev.tools/debugger-examples/examples/todomvc/

2.  Open backbone.js, add breakpoint to lines 1590, 1593

3.  Refresh todomvc

You'll see the top stack item looking huge.  @danny6514 Care to have another try?