### PR TITLE
Ignore mochi test and firefox build directories on jest test runs

### DIFF
--- a/jest-test.config.js
+++ b/jest-test.config.js
@@ -17,6 +17,7 @@ module.exports = {
     "package.json",
     "<rootDir>/packages"
   ],
+  modulePathIgnorePatterns: ["src/test/mochitest", "firefox"],
   collectCoverageFrom: [
     "src/**/*.js",
     "!src/**/fixtures/*.js",


### PR DESCRIPTION
### Summary of Changes

Add ` modulePathIgnorePatterns: ["src/test/mochitest", "firefox"]` to jest config.  

This fixes the following errors I am getting when running jest.

```
jest-haste-map: @providesModule naming collision:
  Duplicate module name: sorted-es6
  Paths: debugger.html/firefox/devtools/client/debugger/new/test/mochitest/examples/sourcemaps3/package.json collides with debugger.html/src/test/mochitest/examples/sourcemaps3/package.json

This warning is caused by a @providesModule declaration with the same name across two different files.

jest-haste-map: @providesModule naming collision:
  Duplicate module name: sourcemaps-reload
  Paths: debugger.html/firefox/devtools/client/debugger/new/test/mochitest/examples/sourcemaps-reload/package.json collides with debugger.html/src/test/mochitest/examples/sourcemaps-reload/package.json

This warning is caused by a @providesModule declaration with the same name across two different files.

jest-haste-map: @providesModule naming collision:
  Duplicate module name: babel-sourcemaps
  Paths: debugger.html/firefox/devtools/client/debugger/new/test/mochitest/examples/sourcemapped/package.json collides with debugger.html/src/test/mochitest/examples/sourcemapped/package.json

This warning is caused by a @providesModule declaration with the same name across two different files.
```
