### PR TITLE
extend callExpressions to include a.b().c()

### DIFF
--- a/src/utils/prefs.js
+++ b/src/utils/prefs.js
@@ -45,14 +45,13 @@ if (isDevelopment()) {
   pref("devtools.debugger.features.wasm", true);
   pref("devtools.debugger.features.shortcuts", true);
   pref("devtools.debugger.features.root", true);
-  pref("devtools.debugger.features.column-breakpoints", false);
   pref("devtools.debugger.features.map-scopes", true);
   pref("devtools.debugger.features.remove-command-bar-options", true);
   pref("devtools.debugger.features.code-coverage", false);
   pref("devtools.debugger.features.event-listeners", false);
   pref("devtools.debugger.features.code-folding", false);
   pref("devtools.debugger.features.outline", true);
-  pref("devtools.debugger.features.column-breakpoints", true);
+  pref("devtools.debugger.features.column-breakpoints", false);
   pref("devtools.debugger.features.pause-points", true);
   pref("devtools.debugger.features.skip-pausing", true);
   pref("devtools.debugger.features.component-pane", false);

--- a/src/workers/parser/getSymbols.js
+++ b/src/workers/parser/getSymbols.js
@@ -206,7 +206,16 @@ function extractSymbol(path: SimplePath, symbols) {
   if (t.isCallExpression(path)) {
     const callee = path.node.callee;
     const args = path.node.arguments;
-    if (!t.isMemberExpression(callee)) {
+    if (t.isMemberExpression(callee)) {
+      const {
+        property: { name, loc }
+      } = callee;
+      symbols.callExpressions.push({
+        name: name,
+        values: args.filter(arg => arg.value).map(arg => arg.value),
+        location: loc
+      });
+    } else {
       const { start, end, identifierName } = callee.loc;
       symbols.callExpressions.push({
         name: identifierName,

--- a/src/workers/parser/tests/__snapshots__/getSymbols.spec.js.snap
+++ b/src/workers/parser/tests/__snapshots__/getSymbols.spec.js.snap
@@ -22,7 +22,9 @@ variables:
 [(28, 12), (28, 18)]  person
 
 callExpressions:
-
+[(13, 12), (13, 15)]  log   hey
+[(29, 12), (29, 15)]  log
+[(33, 19), (33, 23)]  push
 
 memberExpressions:
 [(13, 12), (13, 15)] console.log log
@@ -119,9 +121,19 @@ variables:
 
 callExpressions:
 [(1, 0), (1, 8)]  dispatch
+[(4, 0), (4, 1)]  a
+[(4, 2), (4, 3)]  b
+[(4, 4), (4, 5)]  c
+[(6, 6), (6, 7)]  c
+[(6, 2), (6, 3)]  b
+[(7, 6), (7, 7)]  d
 
 memberExpressions:
-
+[(6, 6), (6, 7)]  c
+[(6, 2), (6, 3)] a.b b
+[(7, 6), (7, 7)] a.b.c.d d
+[(7, 4), (7, 5)] a.b.c c
+[(7, 2), (7, 3)] a.b b
 
 objectProperties:
 [(1, 11), (1, 12)]  d
@@ -145,6 +157,16 @@ identifiers:
 [(2, 55), (2, 56)] c c
 [(2, 55), (2, 56)] c c
 [(2, 61), (2, 62)] 2 c
+[(4, 0), (4, 1)] a a
+[(4, 2), (4, 3)] b b
+[(4, 4), (4, 5)] c c
+[(6, 0), (6, 1)] a a
+[(6, 2), (6, 3)] b b
+[(6, 6), (6, 7)] c c
+[(7, 0), (7, 1)] a a
+[(7, 2), (7, 3)] b b
+[(7, 4), (7, 5)] c c
+[(7, 6), (7, 7)] d d
 
 classes:
 
@@ -173,6 +195,8 @@ callExpressions:
 [(1, 0), (1, 3)]  aaa
 [(1, 4), (1, 7)]  bbb
 [(1, 11), (1, 14)]  ccc
+[(4, 3), (4, 7)]  ffff
+[(3, 3), (3, 6)]  eee
 [(2, 0), (2, 4)]  dddd
 
 memberExpressions:
@@ -221,7 +245,7 @@ variables:
 [(17, 4), (17, 30)]  expressiveClass
 
 callExpressions:
-
+[(7, 12), (7, 15)]  log   bar
 
 memberExpressions:
 [(3, 9), (3, 12)] this.foo foo
@@ -297,9 +321,17 @@ variables:
 
 callExpressions:
 [(7, 4), (7, 9)]
+[(8, 32), (8, 36)]  bind
+[(26, 31), (26, 37)]  extend
+[(30, 12), (30, 15)]  log   yo
 [(34, 18), (34, 29)]  createClass
+[(38, 12), (38, 15)]  log   yo
 [(42, 12), (42, 23)]  createClass
+[(46, 12), (46, 15)]  log   yo
 [(50, 16), (50, 27)]  createClass
+[(54, 12), (54, 15)]  log   yo
+[(65, 16), (65, 20)]  call
+[(68, 26), (68, 32)]  create
 
 memberExpressions:
 [(8, 9), (8, 16)] this.onClick onClick
@@ -470,6 +502,8 @@ variables:
 callExpressions:
 [(1, 21), (1, 28)]  compute
 [(4, 21), (4, 28)]  compute
+[(7, 35), (7, 42)]  entries
+[(8, 10), (8, 13)]  log
 
 memberExpressions:
 [(7, 35), (7, 42)] arr.entries entries
@@ -649,7 +683,8 @@ variables:
 [(25, 6), (25, 43)]  evil
 
 callExpressions:
-
+[(9, 24), (9, 30)]  extend
+[(25, 18), (25, 24)]  doEvil
 
 memberExpressions:
 [(2, 19), (2, 33)] obj2.c.secondProperty secondProperty
@@ -854,8 +889,14 @@ variables:
 [(37, 9), (37, 36)]  greeting
 
 callExpressions:
+[(23, 18), (23, 29)]  toUpperCase
+[(23, 39), (23, 48)]  substring   1
+[(28, 4), (28, 8)]  join
+[(27, 4), (27, 7)]  map
+[(26, 4), (26, 7)]  map
 [(36, 3), (39, 3)]
 [(37, 20), (37, 28)]  sayHello   Ryan
+[(38, 11), (38, 14)]  log
 
 memberExpressions:
 [(23, 18), (23, 29)] name[0].toUpperCase toUpperCase
@@ -1002,6 +1043,7 @@ variables:
 callExpressions:
 [(18, 9), (18, 12)]  foo
 [(23, 1), (25, 1)]
+[(41, 10), (41, 13)]  log   pause next here
 [(48, 4), (48, 7)]  foo
 
 memberExpressions:
@@ -1461,7 +1503,8 @@ variables:
 [(8, 10), (8, 11)]  b
 
 callExpressions:
-
+[(5, 31), (5, 37)]  extend
+[(9, 12), (9, 15)]  log   hi
 
 memberExpressions:
 [(5, 31), (5, 37)] Backbone.View.extend extend

--- a/src/workers/parser/tests/fixtures/callExpressions.js
+++ b/src/workers/parser/tests/fixtures/callExpressions.js
@@ -1,2 +1,7 @@
 dispatch({ d });
 function evaluate(script, { frameId } = {frameId: 3}, {c} = {c: 2}) {}
+
+a(b(c()));
+
+a.b().c();
+a.b.c.d();


### PR DESCRIPTION
Fixes part of #7028

### Screenshots/Videos (OPTIONAL)

![call](https://user-images.githubusercontent.com/7821757/46206495-ce865200-c341-11e8-94c9-6be46d9b6db3.gif)
