### PR TITLE
Change jump to line shortcut from Cmd+; to Ctrl+G

### DIFF
--- a/assets/panel/debugger.properties
+++ b/assets/panel/debugger.properties
@@ -796,11 +796,11 @@ gotoLineModal.placeholder=Go to line…
 # to open the go to line modal
 gotoLineModal.title=Go to a line number in a file
 
-# LOCALIZATION NOTE(gotoLineModal.key2): The shortcut for opening the
+# LOCALIZATION NOTE(gotoLineModal.key3): The shortcut for opening the
 # go to line modal
-# Do not localize "CmdOrCtrl+;", or change the format of the string. These are
+# Do not localize "Ctrl+G", or change the format of the string. These are
 # key identifiers, not messages displayed to the user.
-gotoLineModal.key2=CmdOrCtrl+;
+gotoLineModal.key3=Ctrl+G
 
 # LOCALIZATION NOTE(symbolSearch.search.functionsPlaceholder): The placeholder
 # text displayed when the user searches for functions in a file

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -111,7 +111,7 @@ class App extends Component<Props, State> {
     ];
     searchKeys.forEach(key => shortcuts.on(key, this.toggleQuickOpenModal));
 
-    shortcuts.on(L10N.getStr("gotoLineModal.key2"), (_, e) =>
+    shortcuts.on(L10N.getStr("gotoLineModal.key3"), (_, e) =>
       this.toggleQuickOpenModal(_, e, ":")
     );
 
@@ -133,7 +133,7 @@ class App extends Component<Props, State> {
     ];
     searchKeys.forEach(key => shortcuts.off(key, this.toggleQuickOpenModal));
 
-    shortcuts.off(L10N.getStr("gotoLineModal.key2"), this.toggleQuickOpenModal);
+    shortcuts.off(L10N.getStr("gotoLineModal.key3"), this.toggleQuickOpenModal);
 
     shortcuts.off("Escape", this.onEscape);
   }

--- a/src/components/ShortcutsModal.js
+++ b/src/components/ShortcutsModal.js
@@ -88,7 +88,7 @@ export class ShortcutsModal extends Component<Props> {
         )}
         {this.renderShorcutItem(
           L10N.getStr("shortcuts.gotoLine"),
-          formatKeyShortcut(L10N.getStr("gotoLineModal.key2"))
+          formatKeyShortcut(L10N.getStr("gotoLineModal.key3"))
         )}
       </ul>
     );

--- a/src/components/test/__snapshots__/ShortcutsModal.spec.js.snap
+++ b/src/components/test/__snapshots__/ShortcutsModal.spec.js.snap
@@ -247,16 +247,9 @@ exports[`ShortcutsModal renders when enabled 1`] = `
           <span>
             <span
               className="keystroke"
-              key="Ctrl"
+              key="Ctrl+G"
             >
-              Ctrl
-            </span>
-             + 
-            <span
-              className="keystroke"
-              key=";"
-            >
-              ;
+              Ctrl+G
             </span>
           </span>
         </li>


### PR DESCRIPTION
Fixes #6946

### Summary of Changes

The Cmd+; shortcut conflicts with the step-in shortcut, which is
especially needed on newer Macbooks, as the function keys are off by
default with the new touchbar.

The shortcut was replaced to use the same as Atom Editor, and other
editors, with Ctrl+G.

### Test Plan

This shortcut was covered by a snapshot test, and I performed manual testing.