### PR TITLE
6864/keep item focused on tree update

### DIFF
--- a/src/components/PrimaryPanes/SourcesTree.js
+++ b/src/components/PrimaryPanes/SourcesTree.js
@@ -142,7 +142,8 @@ class SourcesTree extends Component<Props, State> {
           debuggeeUrl,
           projectRoot,
           uncollapsedTree,
-          sourceTree
+          sourceTree,
+          focusedItem: this.state.focusedItem
         })
       );
     }

--- a/src/test/mochitest/browser_dbg-sources-arrow-keys.js
+++ b/src/test/mochitest/browser_dbg-sources-arrow-keys.js
@@ -2,25 +2,6 @@
  * http://creativecommons.org/publicdomain/zero/1.0/ */
 
 // Test keyboard arrow behaviour
-
-async function waitForNodeToGainFocus(dbg, index) {
-  await waitUntil(() => {
-    const element = findElement(dbg, "sourceNode", index);
-
-    if (element) {
-      return element.classList.contains("focused");
-    }
-
-    return false;
-  }, `waiting for source node ${index} to be focused`);
-}
-
-async function assertNodeIsFocused(dbg, index) {
-  await waitForNodeToGainFocus(dbg, index);
-  const node = findElement(dbg, "sourceNode", index);
-  ok(node.classList.contains("focused"), `node ${index} is focused`);
-}
-
 add_task(async function() {
   const dbg = await initDebugger("doc-sources.html");
   await waitForSources(dbg, "simple1", "simple2", "nested-source", "long.js");

--- a/src/test/mochitest/browser_dbg-sources.js
+++ b/src/test/mochitest/browser_dbg-sources.js
@@ -40,7 +40,7 @@ add_task(async function() {
 
   ok(fourthNode.classList.contains("focused"), "4th node is focused");
   ok(selectedSource.includes("nested-source.js"), "nested-source is selected");
-
+  await assertNodeIsFocused(dbg, 4);
   await waitForSelectedSource(dbg, "nested-source");
 
   // Make sure new sources appear in the list.
@@ -51,6 +51,7 @@ add_task(async function() {
   });
 
   await waitForSourceCount(dbg, 9);
+  await assertNodeIsFocused(dbg, 4);
   is(
     getLabel(dbg, 7),
     "math.min.js",

--- a/src/test/mochitest/helpers.js
+++ b/src/test/mochitest/helpers.js
@@ -1340,3 +1340,21 @@ async function assertSourceCount(dbg, count) {
   await waitForSourceCount(dbg, count);
   is(findAllElements(dbg, "sourceNodes").length, count, `${count} sources`);
 }
+
+async function waitForNodeToGainFocus(dbg, index) {
+  await waitUntil(() => {
+    const element = findElement(dbg, "sourceNode", index);
+
+    if (element) {
+      return element.classList.contains("focused");
+    }
+
+    return false;
+  }, `waiting for source node ${index} to be focused`);
+}
+
+async function assertNodeIsFocused(dbg, index) {
+  await waitForNodeToGainFocus(dbg, index);
+  const node = findElement(dbg, "sourceNode", index);
+  ok(node.classList.contains("focused"), `node ${index} is focused`);
+}

--- a/src/utils/sources-tree/updateTree.js
+++ b/src/utils/sources-tree/updateTree.js
@@ -34,7 +34,12 @@ function findFocusedItemInTree(
     const parts = focusedItem.path.split("/").filter(p => p !== "");
     let path = "";
 
+    console.log("------ START OF TREE SEARCH ------");
     focusedItem = parts.reduce((subTree, part, index) => {
+      console.log("SUB TREE:", subTree);
+      console.log("PART:", part);
+      console.log("PARTS:", parts);
+      console.log("IS DIRECTORY:", isPartDir(focusedItem, parts.length, index));
       path = path ? `${path}/${part}` : part;
       const { index: childIndex } = findNodeInContents(
         subTree,
@@ -44,8 +49,11 @@ function findFocusedItemInTree(
           debuggeeHost
         )
       );
+      console.log("------ END OF LOOP ------");
       return subTree.contents[childIndex];
     }, newSourceTree);
+    console.log("------ END OF TREE SEARCH ------");
+    console.log("FOCUSED ITEM:", focusedItem);
   }
 
   return focusedItem;

--- a/src/utils/sources-tree/updateTree.js
+++ b/src/utils/sources-tree/updateTree.js
@@ -6,11 +6,13 @@
 
 import { addToTree } from "./addToTree";
 import { collapseTree } from "./collapseTree";
-import { createParentMap, getSourceFromNode, partIsFile, isDirectory } from "./utils";
+import { createParentMap, isDirectory } from "./utils";
 import { difference } from "lodash";
-import { getDomain, findNodeInContents, createTreeNodeMatcher } from "./treeOrder";
-import { getURL } from "./getURL";
-
+import {
+  getDomain,
+  findNodeInContents,
+  createTreeNodeMatcher
+} from "./treeOrder";
 import type { SourcesMap } from "../../reducers/types";
 import type { TreeDirectory, TreeNode } from "./types";
 
@@ -31,18 +33,29 @@ function findFocusedItemInTree(
   if (focusedItem) {
     const parts = focusedItem.path.split("/").filter(p => p !== "");
     let path = "";
+
     focusedItem = parts.reduce((subTree, part, index) => {
-      path = path ? `${path}/${part}`: part;
-      // const isDir = index < parts.length - 1;
-      const { found, index: childIndex } = findNodeInContents(subTree, createTreeNodeMatcher(part, true, debuggeeHost));
-      console.log('found:', found);
+      path = path ? `${path}/${part}` : part;
+      const { index: childIndex } = findNodeInContents(
+        subTree,
+        createTreeNodeMatcher(
+          part,
+          isPartDir(focusedItem, parts.length, index),
+          debuggeeHost
+        )
+      );
       return subTree.contents[childIndex];
     }, newSourceTree);
-
-    console.log('focusedItem:', focusedItem);
   }
 
-  return focusedItem
+  return focusedItem;
+}
+
+function isPartDir(focusedItem: ?TreeNode, partsLength, index) {
+  if (focusedItem && isDirectory(focusedItem)) {
+    return true;
+  }
+  return partsLength - 1 != index;
 }
 
 type Params = {
@@ -77,6 +90,6 @@ export function updateTree({
     uncollapsedTree,
     sourceTree: newSourceTree,
     parentMap: createParentMap(newSourceTree),
-    focusedItem: findFocusedItemInTree(newSourceTree, debuggeeHost, focusedItem),
+    focusedItem: findFocusedItemInTree(newSourceTree, debuggeeHost, focusedItem)
   };
 }

--- a/src/utils/sources-tree/updateTree.js
+++ b/src/utils/sources-tree/updateTree.js
@@ -6,7 +6,7 @@
 
 import { addToTree } from "./addToTree";
 import { collapseTree } from "./collapseTree";
-import { createParentMap, isDirectory } from "./utils";
+import { createParentMap, isDirectory, isSource } from "./utils";
 import { difference } from "lodash";
 import {
   getDomain,
@@ -34,12 +34,13 @@ function findFocusedItemInTree(
     const parts = focusedItem.path.split("/").filter(p => p !== "");
     let path = "";
 
-    console.log("------ START OF TREE SEARCH ------");
     focusedItem = parts.reduce((subTree, part, index) => {
-      console.log("SUB TREE:", subTree);
-      console.log("PART:", part);
-      console.log("PARTS:", parts);
-      console.log("IS DIRECTORY:", isPartDir(focusedItem, parts.length, index));
+      if (subTree == undefined) {
+        return null;
+      } else if (isSource(subTree)) {
+        return subTree;
+      }
+
       path = path ? `${path}/${part}` : part;
       const { index: childIndex } = findNodeInContents(
         subTree,
@@ -49,11 +50,9 @@ function findFocusedItemInTree(
           debuggeeHost
         )
       );
-      console.log("------ END OF LOOP ------");
+
       return subTree.contents[childIndex];
     }, newSourceTree);
-    console.log("------ END OF TREE SEARCH ------");
-    console.log("FOCUSED ITEM:", focusedItem);
   }
 
   return focusedItem;


### PR DESCRIPTION
Fixes #6864 

**WIP**
The issue is that the source tree looses focus when new sources are added to it. One of the reasons that's happening is because we return a `null` `focusedItem` from the [updateTree](https://github.com/devtools-html/debugger.html/blob/master/src/utils/sources-tree/updateTree.js#L55) call. However, even if we were to return the current `focusedItem` in that call it would not stay focused because we build a _new tree_ each time we call `updateTree` so this [equality check](https://github.com/devtools-html/debugger.html/blob/master/packages/devtools-components/src/tree.js#L778) will fail as the old focused item is no longer referencing the same item in the tree.

### Summary of Changes
* Search `newSourceTree` for `focusedItem` and set it in the `SourcesTree` state.

### Current Issues
I left some debug logging in the function that searches for the `focusedItem`. It looks like the `focusedItem` is consistently found, but only passes the [equality check](https://github.com/devtools-html/debugger.html/blob/master/packages/devtools-components/src/tree.js#L778) if it is a `source` and not a directory. The result of that is that `sources` remain focused as the tree updates, but `directories` do not. I am a little stuck on that, as it seems like the `focusedItem` is always found in the tree.

Right now I'm focused on getting the code working, before I focus on making the code better. I'd love some help with the above issue 😄 

#### STR
* Open debugger
* Set network throttling (optional)
* Open cnn.com 
* click on a source (it remains focused)
* click on a directory (loses focus as the sources are added)

### Test Plan
**Test Plan has not been created yet**
