### PR TITLE
Revert "[editor] add check in HighlightLine to fix unwanted highlight…

### DIFF
--- a/src/components/Editor/HighlightLine.js
+++ b/src/components/Editor/HighlightLine.js
@@ -95,18 +95,11 @@ export class HighlightLine extends Component<Props> {
     selectedSource: Source
   ) {
     const { sourceId, line } = selectedLocation;
-    const editorLine = toEditorLine(sourceId, line);
-
     if (!this.shouldSetHighlightLine(selectedLocation, selectedSource)) {
       return;
     }
-
-    if (!this.previousEditorLine) {
-      this.previousEditorLine = editorLine;
-      return;
-    }
-
     this.isStepping = false;
+    const editorLine = toEditorLine(sourceId, line);
     this.previousEditorLine = editorLine;
 
     if (!line || isDebugLine(selectedFrame, selectedLocation)) {

--- a/src/test/mochitest/browser_dbg-editor-highlight.js
+++ b/src/test/mochitest/browser_dbg-editor-highlight.js
@@ -46,17 +46,3 @@ add_task(async function() {
   ok(getSource(getState(), simple1.id).text);
   assertHighlightLocation(dbg, "simple1.js", 6);
 });
-
-add_task(async function() {
-  const dbg = await initDebugger("doc-scripts.html");
-  await selectSource(dbg, "simple1");
-  await addBreakpoint(dbg, "simple1", 4);
-  invokeInTab("main");
-  await waitForPaused(dbg);
-  assertPausedLocation(dbg);
-
-  await reload(dbg);
-  await waitForLoadedSource(dbg, "simple1");
-  const highlightedLine = findElementWithSelector(dbg, ".highlight-line");
-  ok(!highlightedLine, "should be no highlighted lines after reloading");
-});


### PR DESCRIPTION
This was merged with a false positive from Travis.  Two tests were broken:

- browser_dbg-outline.js
- browser_dbg-console-link.js

@kenjiO I think it best we revert this for now and resubmit when the test issues are fixed.  The console-link failure looks legit (i.e. no highlight)