### PR TITLE
rollback to a specific commit of workerjs that works

### DIFF
--- a/package.json
+++ b/package.json
@@ -165,7 +165,7 @@
     "stylelint": "^9.0.0",
     "webpack": "^3.5.5",
     "webpack-visualizer-plugin": "^0.1.11",
-    "workerjs": "github:jasonLaster/workerjs"
+    "workerjs": "github:jasonLaster/workerjs#a2425aaeebacae7a7640e496a54c2a41962f3890"
   },
   "lint-staged": {
     "bin/*.js": [


### PR DESCRIPTION
Fixes issue where the jest tests are breaking while trying to run babel 7

thanks for help @loganfsmyth 

### Summary of Changes

* use specific hash of workerjs

### Test Plan

- [x] pull latest updates from master
- [x] run `yarn nom`
- [x] run `yarn jest`


##### ER: 
Tests run fine

##### AR (before fix):
![image](https://user-images.githubusercontent.com/792924/46695062-6881b080-cc06-11e8-8144-2f6e41cafdff.png)
