### PR TITLE
Change tab interface to have blue borders WIP

### DIFF
--- a/src/components/Editor/Tab.js
+++ b/src/components/Editor/Tab.js
@@ -192,6 +192,7 @@ class Tab extends PureComponent<Props> {
         onContextMenu={e => this.onTabContextMenu(e, sourceId)}
         title={getFileURL(source)}
       >
+        <span className="devtools-tab-line"></span>
         <SourceIcon
           source={source}
           shouldHide={icon => ["file", "javascript"].includes(icon)}

--- a/src/components/Editor/Tab.js
+++ b/src/components/Editor/Tab.js
@@ -192,7 +192,7 @@ class Tab extends PureComponent<Props> {
         onContextMenu={e => this.onTabContextMenu(e, sourceId)}
         title={getFileURL(source)}
       >
-        <span className="devtools-tab-line"></span>
+        <span className="source-tab-line"></span>
         <SourceIcon
           source={source}
           shouldHide={icon => ["file", "javascript"].includes(icon)}

--- a/src/components/Editor/Tabs.css
+++ b/src/components/Editor/Tabs.css
@@ -58,13 +58,13 @@
 }
 
 .source-tab:hover {
-  border-top: 2px solid rgba(0,0,0,.2);
+  border-top: 2px solid rgba(0, 0, 0, 0.2);
   background-color: var(--theme-toolbar-hover);
 }
 
 .source-tab.active {
-  color: rgb(0, 96, 223);;
-  border-top: 2px solid rgb(0, 96, 223);;
+  color: rgb(0, 96, 223);
+  border-top: 2px solid rgb(0, 96, 223);
   border-bottom-color: transparent;
 }
 

--- a/src/components/Editor/Tabs.css
+++ b/src/components/Editor/Tabs.css
@@ -1,6 +1,10 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+ :root {
+  --animation-easing-function: cubic-bezier(.07, .95, 0, 1);
+  --theme-toolbar-selected: rgb(10, 132, 255);
+}
 
 .source-header {
   border-bottom: 1px solid var(--theme-splitter-color);
@@ -38,7 +42,8 @@
 }
 
 .source-tab {
-  border-top: 2px solid transparent;
+  border-left: 1px solid transparent;
+  border-right: 1px solid transparent;
   display: inline-flex;
   align-items: center;
   position: relative;
@@ -57,17 +62,11 @@
 }
 
 .source-tab:not(.active):hover {
-  border-top: 2px solid rgba(0, 0, 0, 0.2);
   background-color: var(--theme-toolbar-hover);
-}
-
-.theme-dark .source-tab:hover {
-  border-top: 2px solid var(--tab-line-hover-color);
 }
 
 .source-tab.active {
   color: rgb(0, 96, 223);
-  border-top: 2px solid rgb(10, 132, 255);
   border-bottom-color: transparent;
   border-left: 1px solid var(--theme-splitter-color);
   border-right: 1px solid var(--theme-splitter-color);
@@ -84,10 +83,6 @@
 
 .theme-dark .source-tab.active {
   color: var(--theme-toolbar-selected-color);
-}
-
-.theme-dark .source-tab.active:hover {
-  border-top: 2px solid rgb(10, 132, 255);
 }
 
 .source-tab.active path,
@@ -167,4 +162,16 @@ html[dir="rtl"] img.moreTabs {
 
 .source-tab:hover .close-btn {
   visibility: visible;
+}
+
+.source-tab:not(.active):hover .devtools-tab-line {
+  background: var(--tab-line-hover-color);
+  opacity: 1;
+  transform: scaleX(1);
+}
+
+.source-tab.active .devtools-tab-line {
+  background: var(--theme-toolbar-selected);
+  opacity: 1;
+  transform: scaleX(1);
 }

--- a/src/components/Editor/Tabs.css
+++ b/src/components/Editor/Tabs.css
@@ -62,8 +62,8 @@
   background-color: var(--theme-toolbar-hover);
 }
 
-.theme-dark .source-tab:hover { 
-  border-top: 2px solid rgb(177, 177, 179);;
+.theme-dark .source-tab:hover {
+  border-top: 2px solid rgb(177, 177, 179);
 }
 
 .source-tab.active {
@@ -76,7 +76,7 @@
   color: var(--theme-toolbar-selected-color);
 }
 
-.theme-dark .source-tab.active:hover { 
+.theme-dark .source-tab.active:hover {
   border-top: 2px solid rgb(0, 96, 223);
 }
 

--- a/src/components/Editor/Tabs.css
+++ b/src/components/Editor/Tabs.css
@@ -38,9 +38,7 @@
 }
 
 .source-tab {
-  border: 1px solid transparent;
-  border-top-left-radius: 2px;
-  border-top-right-radius: 2px;
+  border: 2px solid transparent;
   display: inline-flex;
   align-items: center;
   position: relative;
@@ -50,9 +48,9 @@
   overflow: hidden;
   padding: 5px;
   margin-inline-start: 3px;
-  margin-top: 3px;
   cursor: default;
   height: 27px;
+  font-size: 12px;
 }
 
 .source-tab:first-child {
@@ -60,14 +58,13 @@
 }
 
 .source-tab:hover {
-  background-color: var(--theme-toolbar-background-alt);
-  border-color: var(--theme-splitter-color);
+  border-top: 2px solid rgba(0,0,0,.2);
+  background-color: var(--theme-toolbar-hover);
 }
 
 .source-tab.active {
-  color: var(--theme-body-color);
-  background-color: var(--theme-body-background);
-  border-color: var(--theme-splitter-color);
+  color: rgb(0, 96, 223);;
+  border-top: 2px solid rgb(0, 96, 223);;
   border-bottom-color: transparent;
 }
 
@@ -129,7 +126,6 @@ html[dir="rtl"] img.moreTabs {
   overflow: hidden;
   padding: 0 4px;
   align-self: center;
-  margin-bottom: 2px;
 }
 
 .source-tab .filename span {

--- a/src/components/Editor/Tabs.css
+++ b/src/components/Editor/Tabs.css
@@ -47,7 +47,6 @@
   max-width: 100%;
   overflow: hidden;
   padding: 5px;
-  margin-inline-start: 3px;
   cursor: default;
   height: 28px;
   font-size: 12px;
@@ -57,19 +56,30 @@
   margin-inline-start: 0;
 }
 
-.source-tab:hover {
+.source-tab:not(.active):hover {
   border-top: 2px solid rgba(0, 0, 0, 0.2);
   background-color: var(--theme-toolbar-hover);
 }
 
 .theme-dark .source-tab:hover {
-  border-top: 2px solid rgb(177, 177, 179);
+  border-top: 2px solid var(--tab-line-hover-color);
 }
 
 .source-tab.active {
   color: rgb(0, 96, 223);
-  border-top: 2px solid rgb(0, 96, 223);
+  border-top: 2px solid rgb(10, 132, 255);
   border-bottom-color: transparent;
+  border-left: 1px solid var(--theme-splitter-color);
+  border-right: 1px solid var(--theme-splitter-color);
+
+  /* added this part to connect active file tab to editor */
+  background-color: var(--theme-body-background);
+  height: 30px;
+}
+
+/* added this part to balance out height of the not active file tabs */
+.source-tab:not(.active) {
+  bottom: 2px;
 }
 
 .theme-dark .source-tab.active {
@@ -77,7 +87,7 @@
 }
 
 .theme-dark .source-tab.active:hover {
-  border-top: 2px solid rgb(0, 96, 223);
+  border-top: 2px solid rgb(10, 132, 255);
 }
 
 .source-tab.active path,

--- a/src/components/Editor/Tabs.css
+++ b/src/components/Editor/Tabs.css
@@ -1,12 +1,8 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
- :root {
-  --animation-easing-function: cubic-bezier(0.07, 0.95, 0, 1);
-  --theme-toolbar-selected: rgb(10, 132, 255);
-}
 
-.source-header {
+ .source-header {
   border-bottom: 1px solid var(--theme-splitter-color);
   width: 100%;
   height: 29px;
@@ -53,7 +49,7 @@
   overflow: hidden;
   padding: 5px;
   cursor: default;
-  height: 28px;
+  height: 30px;
   font-size: 12px;
 }
 
@@ -62,23 +58,15 @@
 }
 
 .source-tab:not(.active):hover {
-  background-color: var(--theme-toolbar-hover);
+  background: linear-gradient(var(--theme-toolbar-hover) 28px, transparent 1px);
 }
 
 .source-tab.active {
-  color: rgb(0, 96, 223);
+  color: var(--theme-toolbar-selected-color);
   border-bottom-color: transparent;
   border-left: 1px solid var(--theme-splitter-color);
   border-right: 1px solid var(--theme-splitter-color);
-
-  /* added this part to connect active file tab to editor */
   background-color: var(--theme-body-background);
-  height: 30px;
-}
-
-/* added this part to balance out height of the not active file tabs */
-.source-tab:not(.active) {
-  bottom: 2px;
 }
 
 .theme-dark .source-tab.active {
@@ -164,14 +152,26 @@ html[dir="rtl"] img.moreTabs {
   visibility: visible;
 }
 
-.source-tab:not(.active):hover .devtools-tab-line {
+.source-tab-line {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 2px;
+  background: transparent;
+  transition: transform 250ms var(--animation-curve), opacity 250ms var(--animation-curve);
+  opacity: 0;
+  transform: scaleX(0);
+}
+
+.source-tab:not(.active):hover .source-tab-line {
   background: var(--tab-line-hover-color);
   opacity: 1;
   transform: scaleX(1);
 }
 
-.source-tab.active .devtools-tab-line {
-  background: var(--theme-toolbar-selected);
+.source-tab.active .source-tab-line {
+  background: var(--tab-line-selected-color);
   opacity: 1;
   transform: scaleX(1);
 }

--- a/src/components/Editor/Tabs.css
+++ b/src/components/Editor/Tabs.css
@@ -38,7 +38,7 @@
 }
 
 .source-tab {
-  border: 2px solid transparent;
+  border-top: 2px solid transparent;
   display: inline-flex;
   align-items: center;
   position: relative;
@@ -49,7 +49,7 @@
   padding: 5px;
   margin-inline-start: 3px;
   cursor: default;
-  height: 27px;
+  height: 28px;
   font-size: 12px;
 }
 
@@ -62,10 +62,22 @@
   background-color: var(--theme-toolbar-hover);
 }
 
+.theme-dark .source-tab:hover { 
+  border-top: 2px solid rgb(177, 177, 179);;
+}
+
 .source-tab.active {
   color: rgb(0, 96, 223);
   border-top: 2px solid rgb(0, 96, 223);
   border-bottom-color: transparent;
+}
+
+.theme-dark .source-tab.active {
+  color: var(--theme-toolbar-selected-color);
+}
+
+.theme-dark .source-tab.active:hover { 
+  border-top: 2px solid rgb(0, 96, 223);
 }
 
 .source-tab.active path,
@@ -126,6 +138,7 @@ html[dir="rtl"] img.moreTabs {
   overflow: hidden;
   padding: 0 4px;
   align-self: center;
+  margin-bottom: 1px;
 }
 
 .source-tab .filename span {

--- a/src/components/Editor/Tabs.css
+++ b/src/components/Editor/Tabs.css
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
  :root {
-  --animation-easing-function: cubic-bezier(.07, .95, 0, 1);
+  --animation-easing-function: cubic-bezier(0.07, 0.95, 0, 1);
   --theme-toolbar-selected: rgb(10, 132, 255);
 }
 

--- a/src/components/PrimaryPanes/Sources.css
+++ b/src/components/PrimaryPanes/Sources.css
@@ -161,7 +161,7 @@
 
 .source-outline-tabs .tab {
   background-color: var(--theme-toolbar-background);
-  border-top: 2px solid transparent; 
+  border-top: 2px solid transparent;
   border-bottom: 1px solid var(--theme-splitter-color);
   color: var(--theme-toolbar-color);
   cursor: default;
@@ -191,7 +191,7 @@
 
 .source-outline-tabs .tab.active {
   border-top: 2px solid rgb(0, 96, 223);
-  color: rgb(0, 96, 223)
+  color: rgb(0, 96, 223);
 }
 
 .theme-dark .source-outline-tabs .tab.active {

--- a/src/components/PrimaryPanes/Sources.css
+++ b/src/components/PrimaryPanes/Sources.css
@@ -146,6 +146,7 @@
 }
 
 .source-outline-tabs {
+  font-size: 12px;
   width: 100%;
   background: var(--theme-body-background);
   border-top: 1px solid var(--theme-splitter-color);
@@ -160,9 +161,9 @@
 
 .source-outline-tabs .tab {
   background-color: var(--theme-toolbar-background);
-  border-bottom: 1px solid transparent;
-  border-color: var(--theme-splitter-color);
-  color: var(--theme-body-color);
+  border-top: 2px solid transparent; 
+  border-bottom: 1px solid var(--theme-splitter-color);
+  color: var(--theme-toolbar-color);
   cursor: default;
   display: inline-flex;
   flex: 1;
@@ -170,7 +171,7 @@
   margin-bottom: 0px;
   margin-top: -1px;
   overflow: hidden;
-  padding: 8px 8px 7px 8px;
+  padding: 5px 8px 7px 8px;
   position: relative;
   transition: all 0.25s ease;
 }
@@ -180,13 +181,25 @@
 }
 
 .source-outline-tabs .tab:hover {
-  background-color: var(--theme-toolbar-background-alt);
-  border-color: var(--theme-splitter-color);
+  background-color: var(--theme-toolbar-hover);
+  border-top: 2px solid rgba(0, 0, 0, 0.2);
+}
+
+.theme-dark .source-outline-tabs .tab:hover {
+  border-top: 2px solid rgb(177, 177, 179);
 }
 
 .source-outline-tabs .tab.active {
-  background-color: var(--theme-body-background);
-  border-bottom-color: transparent;
+  border-top: 2px solid rgb(0, 96, 223);
+  color: rgb(0, 96, 223)
+}
+
+.theme-dark .source-outline-tabs .tab.active {
+  color: var(--theme-toolbar-selected-color);
+}
+
+.theme-dark .source-outline-tabs .tab.active:hover {
+  border-top: 2px solid rgb(0, 96, 223);
 }
 
 .source-outline-tabs .tab.active path,

--- a/src/components/PrimaryPanes/Sources.css
+++ b/src/components/PrimaryPanes/Sources.css
@@ -186,8 +186,8 @@
 }
 
 .source-outline-tabs .tab.active {
-  border-top: 2px solid rgb(10, 132, 255);
-  color: rgb(0, 96, 223);
+  border-top: 2px solid var(--tab-line-selected-color);
+  color: var(--theme-toolbar-selected-color);
 }
 
 .theme-dark .source-outline-tabs .tab.active {
@@ -195,7 +195,7 @@
 }
 
 .theme-dark .source-outline-tabs .tab.active:hover {
-  border-top: 2px solid rgb(10, 132, 255);
+  border-top: 2px solid var(--tab-line-selected-color);
 }
 
 .source-outline-tabs .tab.active path,

--- a/src/components/PrimaryPanes/Sources.css
+++ b/src/components/PrimaryPanes/Sources.css
@@ -176,21 +176,17 @@
   transition: all 0.25s ease;
 }
 
-.source-outline-tabs .tab:first-child {
-  border-inline-end: 1px solid var(--theme-splitter-color);
-}
-
-.source-outline-tabs .tab:hover {
+.source-outline-tabs .tab:not(.active):hover {
   background-color: var(--theme-toolbar-hover);
   border-top: 2px solid rgba(0, 0, 0, 0.2);
 }
 
 .theme-dark .source-outline-tabs .tab:hover {
-  border-top: 2px solid rgb(177, 177, 179);
+  border-top: 2px solid var(--tab-line-hover-color);
 }
 
 .source-outline-tabs .tab.active {
-  border-top: 2px solid rgb(0, 96, 223);
+  border-top: 2px solid rgb(10, 132, 255);
   color: rgb(0, 96, 223);
 }
 
@@ -199,7 +195,7 @@
 }
 
 .theme-dark .source-outline-tabs .tab.active:hover {
-  border-top: 2px solid rgb(0, 96, 223);
+  border-top: 2px solid rgb(10, 132, 255);
 }
 
 .source-outline-tabs .tab.active path,


### PR DESCRIPTION
Fixes #7034 

### Summary of Changes

* Added blue border style to the Source/Outline and file tabs

### To-do

- [x]  Add blue border style to the Sources / Outline tabs
- [x]  Get rid of line between Sources and Outline (image 1 below)
- [x] Get rid of space between file tabs (image 2 below)
- [x] Fix colouring for dark theme
- [x] No hover effect for currently selected tab
- [x] Create separator lines between tabs
    - [x] Remove bottom line for selected tabs
    - [x] Fix jittering when selecting a file tab
- [x] Copy over animation in hovered tabs from top-level DevTools tabs

### Screenshots
Light theme
<img width="1113" alt="screen shot 2018-10-18 at 8 48 58 pm" src="https://user-images.githubusercontent.com/16697942/47196986-55629500-d318-11e8-8230-145d4d520aaa.png">


Dark theme
<img width="1133" alt="screen shot 2018-10-18 at 8 48 14 pm" src="https://user-images.githubusercontent.com/16697942/47196989-5bf10c80-d318-11e8-9f75-9264ed5fac93.png">
