### PR TITLE
Fix Find in Files border/spacing

### DIFF
--- a/src/components/Editor/SearchBar.css
+++ b/src/components/Editor/SearchBar.css
@@ -20,6 +20,7 @@
 
 .search-bar .search-shadow {
   flex-grow: 1;
+  border-bottom: none;
 }
 
 .search-bar .search-shadow.focused {

--- a/src/components/ProjectSearch.css
+++ b/src/components/ProjectSearch.css
@@ -96,6 +96,8 @@
   display: flex;
   align-self: stretch;
   flex-grow: 1;
+  width: 100%;
+  border-bottom: none;
 }
 
 .project-text-search .search-field .close-btn.big {

--- a/src/components/shared/SearchInput.css
+++ b/src/components/shared/SearchInput.css
@@ -3,7 +3,8 @@
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
 .search-shadow {
-  border: 1px solid transparent;
+  border: 1px solid var(--theme-toolbar-background);
+  border-bottom: 1px solid var(--theme-splitter-color);
 }
 
 .search-shadow.focused {


### PR DESCRIPTION
Fixes #7017

### Summary of Changes

* Fixed extra pixel of space on right of Find in Files search bar
* Made transparent border the same color as the rest of the bar

### Test Plan

- [x] Ctrl-Shift-f to bring up Find in Files and deselect bar to examine unhighlighted bar
- [x] Ctrl-f to bring up Find in File and deselect bar to examine unhighlighted bar

### Screenshots/Videos
![findinfiles](https://user-images.githubusercontent.com/14957948/46925101-30a8ad80-cff8-11e8-84fd-f4ef50df29eb.PNG)

