### PR TITLE
7009/warn on yarn copy missing files

### DIFF
--- a/bin/copy.js
+++ b/bin/copy.js
@@ -44,7 +44,7 @@ function missingFilesErrorMessage() {
     'https://github.com/devtools-html/debugger.html/blob/master/docs/mochitests.md'
   ].join('');
 
-  console.warn(chalk.red(errorMessage));
+  console.warn(chalk.yellow(errorMessage));
 }
 
 start();

--- a/bin/copy.js
+++ b/bin/copy.js
@@ -18,15 +18,18 @@ const assets = args.assets
 console.log(`Copying Files to ${mc} with params: `, {watch, assets, symlink})
 
 async function start() {
-  // if (fs.existsSync(mc)) {
-  try {
-    await copyAssets({ assets, mc, watch, symlink})
-    await copyModules.run({ mc, watch })
-  } catch (e) {
-    console.error(e);
-    if (e.code === "ENOENT") {
-      missingFilesErrorMessage();
+  if (fs.existsSync(mc)) {
+    try {
+      await copyAssets({ assets, mc, watch, symlink})
+      await copyModules.run({ mc, watch })
+    } catch (e) {
+      console.error(e);
+      if (e.code === "ENOENT") {
+        missingFilesErrorMessage();
+      }
     }
+  } else {
+    missingFilesErrorMessage();
   }
 }
 
@@ -41,7 +44,7 @@ function missingFilesErrorMessage() {
     'https://github.com/devtools-html/debugger.html/blob/master/docs/mochitests.md'
   ].join('');
 
-  console.error(chalk.red(errorMessage));
+  console.warn(chalk.red(errorMessage));
 }
 
 start();

--- a/bin/copy.js
+++ b/bin/copy.js
@@ -2,6 +2,8 @@
 const copyAssets = require("./copy-assets")
 const copyModules = require("./copy-modules")
 const minimist = require("minimist");
+const fs = require("fs");
+const chalk = require("chalk");
 
 const args = minimist(process.argv.slice(1), {
   string: ["mc"],
@@ -16,8 +18,30 @@ const assets = args.assets
 console.log(`Copying Files to ${mc} with params: `, {watch, assets, symlink})
 
 async function start() {
-  await copyAssets({ assets, mc, watch, symlink})
-  await copyModules.run({ mc, watch })
+  // if (fs.existsSync(mc)) {
+  try {
+    await copyAssets({ assets, mc, watch, symlink})
+    await copyModules.run({ mc, watch })
+  } catch (e) {
+    console.error(e);
+    if (e.code === "ENOENT") {
+      missingFilesErrorMessage();
+    }
+  }
+}
+
+function missingFilesErrorMessage() {
+  let errorMessage = [
+    'It looks like you are missing some files. The mozilla-central ',
+    'codebase may be missing at ${mc}. You can clone mozilla-central by ',
+    'running \`./bin/prepare-mochitests-dev\` from the root of the ',
+    'debugger.html repository. You can find more information on bundling ',
+    'or mochitests at ',
+    'https://github.com/devtools-html/debugger.html/blob/master/docs/bundling.md or ',
+    'https://github.com/devtools-html/debugger.html/blob/master/docs/mochitests.md'
+  ].join('');
+
+  console.error(chalk.red(errorMessage));
 }
 
 start();

--- a/docs/mochitests.md
+++ b/docs/mochitests.md
@@ -212,21 +212,21 @@ Now you can make code changes the bundle will be automatically built for you ins
 If you see an `ENOENT` error when running either of these commands, like below:
 
 ```
-{ Error: ENOENT: no such file or directory, open '/Users/twendlan/Development/Projects/debugger.html/firefox/devtools/client/jar.mn'
+{ Error: ENOENT: no such file or directory, open '/path/to/debugger.html/firefox/devtools/client/jar.mn'
     at Object.fs.openSync (fs.js:646:18)
     at Object.fs.readFileSync (fs.js:551:33)
-    at updateFile (/Users/twendlan/Development/Projects/debugger.html/bin/copy-assets.js:29:17)
-    at copySVGs (/Users/twendlan/Development/Projects/debugger.html/bin/copy-assets.js:102:3)
-    at start (/Users/twendlan/Development/Projects/debugger.html/bin/copy-assets.js:225:3)
-    at module.exports (/Users/twendlan/Development/Projects/debugger.html/bin/copy-assets.js:319:12)
-    at start (/Users/twendlan/Development/Projects/debugger.html/bin/copy.js:23:13)
-    at Object.<anonymous> (/Users/twendlan/Development/Projects/debugger.html/bin/copy.js:50:1)
+    at updateFile (/path/to/debugger.html/bin/copy-assets.js:29:17)
+    at copySVGs (/path/to/debugger.html/bin/copy-assets.js:102:3)
+    at start (/path/to/debugger.html/bin/copy-assets.js:225:3)
+    at module.exports (/path/to/debugger.html/bin/copy-assets.js:319:12)
+    at start (/path/to/debugger.html/bin/copy.js:23:13)
+    at Object.<anonymous> (/path/to/debugger.html/bin/copy.js:50:1)
     at Module._compile (module.js:652:30)
     at Object.Module._extensions..js (module.js:663:10)
   errno: -2,
   code: 'ENOENT',
   syscall: 'open',
-  path: '/Users/twendlan/Development/Projects/debugger.html/firefox/devtools/client/jar.mn' }
+  path: '/path/to/debugger.html/firefox/devtools/client/jar.mn' }
 ```
 
 It may be that you have not cloned the latest `mozilla-central` repository, or it does not exist at the path you've provided. You can clone the latest `mozilla-central` by running the following command:

--- a/docs/mochitests.md
+++ b/docs/mochitests.md
@@ -209,6 +209,32 @@ yarn watch
 
 Now you can make code changes the bundle will be automatically built for you inside `firefox`, and you can simply run mochitests and edit code as much as you like.
 
+If you see an `ENOENT` error when running either of these commands, like below:
+
+```
+{ Error: ENOENT: no such file or directory, open '/Users/twendlan/Development/Projects/debugger.html/firefox/devtools/client/jar.mn'
+    at Object.fs.openSync (fs.js:646:18)
+    at Object.fs.readFileSync (fs.js:551:33)
+    at updateFile (/Users/twendlan/Development/Projects/debugger.html/bin/copy-assets.js:29:17)
+    at copySVGs (/Users/twendlan/Development/Projects/debugger.html/bin/copy-assets.js:102:3)
+    at start (/Users/twendlan/Development/Projects/debugger.html/bin/copy-assets.js:225:3)
+    at module.exports (/Users/twendlan/Development/Projects/debugger.html/bin/copy-assets.js:319:12)
+    at start (/Users/twendlan/Development/Projects/debugger.html/bin/copy.js:23:13)
+    at Object.<anonymous> (/Users/twendlan/Development/Projects/debugger.html/bin/copy.js:50:1)
+    at Module._compile (module.js:652:30)
+    at Object.Module._extensions..js (module.js:663:10)
+  errno: -2,
+  code: 'ENOENT',
+  syscall: 'open',
+  path: '/Users/twendlan/Development/Projects/debugger.html/firefox/devtools/client/jar.mn' }
+```
+
+It may be that you have not cloned the latest `mozilla-central` repository, or it does not exist at the path you've provided. You can clone the latest `mozilla-central` by running the following command:
+
+```
+./bin/prepare-mochitests-dev
+```
+
 ## Adding New Tests
 
 If you add new tests, make sure to list them in the `browser.ini` file. You will see the other tests there. Add a new entry with the same format as the others. You can also add new JS or HTML files by listing in under `support-files`.


### PR DESCRIPTION
Fixes #7009 

### Summary of Changes
- [x] Check if `mc` directory exists before trying to copy assets
- [x] If `yarn copy` returns an `ENOENT` error log the missing files message

### Test Plan
- Try running `yarn run copy --mc [non-existent directory]` and see the error message before any assets are copied
- Try running `yarn run copy --mc [existing directory]` and see it succeed
- Try running `yarn run copy` with no `./firefox` directory and see the error message
- Try running `yarn run copy` with a `./firefox` directory and see it succeed
