### PR TITLE
Add a displayFullUrl prop to the Frame component.

### DIFF
--- a/src/components/SecondaryPanes/Frames/Frame.js
+++ b/src/components/SecondaryPanes/Frames/Frame.js
@@ -8,7 +8,7 @@ import classNames from "classnames";
 import Svg from "../../shared/Svg";
 
 import { formatDisplayName } from "../../../utils/pause/frames";
-import { getFilename } from "../../../utils/source";
+import { getFilename, getFileURL } from "../../../utils/source";
 import FrameMenu from "./FrameMenu";
 
 import type { Frame } from "../../../types";
@@ -24,9 +24,9 @@ function FrameTitle({ frame, options }: FrameTitleProps) {
   return <div className="title">{displayName}</div>;
 }
 
-type FrameLocationProps = { frame: LocalFrame };
+type FrameLocationProps = { frame: LocalFrame, displayFullUrl: boolean };
 
-function FrameLocation({ frame }: FrameLocationProps) {
+function FrameLocation({ frame, displayFullUrl = false }: FrameLocationProps) {
   if (!frame.source) {
     return null;
   }
@@ -40,9 +40,16 @@ function FrameLocation({ frame }: FrameLocationProps) {
     );
   }
 
-  const filename = getFilename(frame.source);
+  const { location, source } = frame;
+  const filename = displayFullUrl
+    ? getFileURL(source, false)
+    : getFilename(source);
+  const title = `${getFileURL(source, false)}:${location.line}`;
+
   return (
-    <div className="location">{`${filename}: ${frame.location.line}`}</div>
+    <div className="location" title={title}>{`${filename}:${
+      location.line
+    }`}</div>
   );
 }
 
@@ -57,7 +64,8 @@ type FrameComponentProps = {
   frameworkGroupingOn: boolean,
   hideLocation: boolean,
   shouldMapDisplayName: boolean,
-  toggleBlackBox: Function
+  toggleBlackBox: Function,
+  displayFullUrl: boolean
 };
 
 export default class FrameComponent extends Component<FrameComponentProps> {
@@ -109,7 +117,8 @@ export default class FrameComponent extends Component<FrameComponentProps> {
       frame,
       selectedFrame,
       hideLocation,
-      shouldMapDisplayName
+      shouldMapDisplayName,
+      displayFullUrl
     } = this.props;
 
     const className = classNames("frame", {
@@ -125,7 +134,9 @@ export default class FrameComponent extends Component<FrameComponentProps> {
         tabIndex={0}
       >
         <FrameTitle frame={frame} options={{ shouldMapDisplayName }} />
-        {!hideLocation && <FrameLocation frame={frame} />}
+        {!hideLocation && (
+          <FrameLocation frame={frame} displayFullUrl={displayFullUrl} />
+        )}
       </li>
     );
   }

--- a/src/components/SecondaryPanes/Frames/Group.js
+++ b/src/components/SecondaryPanes/Frames/Group.js
@@ -43,7 +43,8 @@ type Props = {
   toggleFrameworkGrouping: Function,
   copyStackTrace: Function,
   toggleBlackBox: Function,
-  frameworkGroupingOn: boolean
+  frameworkGroupingOn: boolean,
+  displayFullUrl: boolean
 };
 
 type State = {
@@ -87,7 +88,8 @@ export default class Group extends Component<Props, State> {
       toggleFrameworkGrouping,
       frameworkGroupingOn,
       toggleBlackBox,
-      copyStackTrace
+      copyStackTrace,
+      displayFullUrl
     } = this.props;
 
     const { expanded } = this.state;
@@ -109,6 +111,7 @@ export default class Group extends Component<Props, State> {
             shouldMapDisplayName={false}
             toggleBlackBox={toggleBlackBox}
             toggleFrameworkGrouping={toggleFrameworkGrouping}
+            displayFullUrl={displayFullUrl}
           />
         ))}
       </div>

--- a/src/components/SecondaryPanes/Frames/index.js
+++ b/src/components/SecondaryPanes/Frames/index.js
@@ -40,7 +40,8 @@ type Props = {
   selectFrame: Function,
   toggleBlackBox: Function,
   toggleFrameworkGrouping: Function,
-  disableFrameTruncate: Function
+  disableFrameTruncate: boolean,
+  displayFullUrl: boolean
 };
 
 type State = {
@@ -113,7 +114,8 @@ class Frames extends Component<Props, State> {
       selectFrame,
       selectedFrame,
       toggleBlackBox,
-      frameworkGroupingOn
+      frameworkGroupingOn,
+      displayFullUrl
     } = this.props;
 
     const framesOrGroups = this.truncateFrames(this.collapseFrames(frames));
@@ -133,6 +135,7 @@ class Frames extends Component<Props, State> {
                 selectedFrame={selectedFrame}
                 toggleBlackBox={toggleBlackBox}
                 key={String(frameOrGroup.id)}
+                displayFullUrl={displayFullUrl}
               />
             ) : (
               <Group
@@ -144,6 +147,7 @@ class Frames extends Component<Props, State> {
                 selectedFrame={selectedFrame}
                 toggleBlackBox={toggleBlackBox}
                 key={frameOrGroup[0].id}
+                displayFullUrl={displayFullUrl}
               />
             )
         )}
@@ -207,6 +211,7 @@ export default connect(
     selectFrame: actions.selectFrame,
     toggleBlackBox: actions.toggleBlackBox,
     toggleFrameworkGrouping: actions.toggleFrameworkGrouping,
-    disableFrameTruncate: actions.disableFrameTruncate
+    disableFrameTruncate: false,
+    displayFullUrl: false
   }
 )(Frames);

--- a/src/components/SecondaryPanes/Frames/tests/Frame.spec.js
+++ b/src/components/SecondaryPanes/Frames/tests/Frame.spec.js
@@ -3,7 +3,7 @@
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
 import React from "react";
-import { shallow } from "enzyme";
+import { shallow, mount } from "enzyme";
 import Frame from "../Frame.js";
 
 import FrameMenu from "../FrameMenu";
@@ -65,6 +65,39 @@ describe("Frame", () => {
 
     const { component } = render({ id: 3 }, backboneFrame);
     expect(component).toMatchSnapshot();
+  });
+
+  it("filename only", () => {
+    const frame = {
+      id: 1,
+      source: {
+        url: "https://firefox.com/assets/src/js/foo-view.js"
+      },
+      displayName: "renderFoo|",
+      location: {
+        line: 10
+      }
+    };
+
+    const component = mount(<Frame frame={frame} />);
+    expect(component.text()).toBe("renderFoo|foo-view.js:10");
+  });
+
+  it("full URL", () => {
+    const url = `https://${"a".repeat(100)}.com/assets/src/js/foo-view.js`;
+    const frame = {
+      id: 1,
+      source: {
+        url
+      },
+      displayName: "renderFoo",
+      location: {
+        line: 10
+      }
+    };
+
+    const component = mount(<Frame frame={frame} displayFullUrl={true} />);
+    expect(component.text()).toBe(`renderFoo${url}:10`);
   });
 
   describe("mouse events", () => {

--- a/src/components/SecondaryPanes/Frames/tests/Frames.spec.js
+++ b/src/components/SecondaryPanes/Frames/tests/Frames.spec.js
@@ -3,7 +3,7 @@
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
 import React from "react";
-import { shallow } from "enzyme";
+import { mount, shallow } from "enzyme";
 import Frames from "../index.js";
 // eslint-disable-next-line
 import { formatCallStackFrames } from "../../../../selectors/getCallStackFrames";
@@ -89,6 +89,32 @@ describe("Frames", () => {
       expect(getFrames()).toHaveLength(framesNumber);
 
       expect(component).toMatchSnapshot();
+    });
+
+    it("shows the full URL", () => {
+      const frames = [
+        {
+          id: 1,
+          displayName: "renderFoo|",
+          location: {
+            line: 55
+          },
+          source: {
+            url: "http://myfile.com/mahscripts.js"
+          }
+        }
+      ];
+
+      const component = mount(
+        <Frames.WrappedComponent
+          frames={frames}
+          disableFrameTruncate={true}
+          displayFullUrl={true}
+        />
+      );
+      expect(component.text()).toBe(
+        "renderFoo|http://myfile.com/mahscripts.js:55"
+      );
     });
   });
 

--- a/src/utils/source.js
+++ b/src/utils/source.js
@@ -130,10 +130,14 @@ export function getRawSourceURL(url: string): string {
 
 function resolveFileURL(
   url: string,
-  transformUrl: transformUrlCallback = initialUrl => initialUrl
+  transformUrl: transformUrlCallback = initialUrl => initialUrl,
+  truncate: boolean = true
 ) {
   url = getRawSourceURL(url || "");
   const name = transformUrl(url);
+  if (!truncate) {
+    return name;
+  }
   return endTruncateStr(name, 50);
 }
 
@@ -220,13 +224,13 @@ export function getDisplayPath(mySource: Source, sources: Source[]) {
  * @memberof utils/source
  * @static
  */
-export function getFileURL(source: Source) {
+export function getFileURL(source: Source, truncate: boolean = true) {
   const { url, id } = source;
   if (!url) {
     return getFormattedSourceId(id);
   }
 
-  return resolveFileURL(url, getUnicodeUrl);
+  return resolveFileURL(url, getUnicodeUrl, truncate);
 }
 
 const contentTypeModeMap = {


### PR DESCRIPTION
This props will allow the component to be rendered with the full URL of the frame, instead of just the filename as its currently the case.
This is needed by the webconsole where we do have a lot more space to display information.

### Screenshot

![image](https://user-images.githubusercontent.com/578107/47297881-ab845080-d616-11e8-8993-d9ead8d02410.png)
