### PR TITLE
Export non-connected Frames component.

### DIFF
--- a/src/components/SecondaryPanes/Frames/index.js
+++ b/src/components/SecondaryPanes/Frames/index.js
@@ -55,7 +55,7 @@ class Frames extends Component<Props, State> {
   toggleFrameworkGrouping: Function;
   renderToggleButton: Function;
 
-  constructor(props) {
+  constructor(props: Props) {
     super(props);
 
     this.state = {
@@ -63,7 +63,7 @@ class Frames extends Component<Props, State> {
     };
   }
 
-  shouldComponentUpdate(nextProps, nextState): boolean {
+  shouldComponentUpdate(nextProps: Props, nextState: State): boolean {
     const { frames, selectedFrame, frameworkGroupingOn } = this.props;
     const { showAllFrames } = this.state;
     return (
@@ -80,7 +80,7 @@ class Frames extends Component<Props, State> {
     }));
   };
 
-  collapseFrames(frames) {
+  collapseFrames(frames: Array<Frame>) {
     const { frameworkGroupingOn } = this.props;
     if (!frameworkGroupingOn) {
       return frames;
@@ -89,7 +89,7 @@ class Frames extends Component<Props, State> {
     return collapseFrames(frames);
   }
 
-  truncateFrames(frames) {
+  truncateFrames(frames: Array<Frame>): Array<Frame> {
     const numFramesToShow = this.state.showAllFrames
       ? frames.length
       : NUM_FRAMES_SHOWN;
@@ -210,3 +210,7 @@ export default connect(
     disableFrameTruncate: actions.disableFrameTruncate
   }
 )(Frames);
+
+// Export the non-connected component in order to use it outside of the debugger
+// panel (e.g. console, netmonitor, …).
+export { Frames };


### PR DESCRIPTION
This will allow other panels (e.g. Console, Netmonitor, …) to import it and passing the appropriate props.

For some reasons, this triggered Flow errors (which I fixed)
