### PR TITLE
Properly set permissions for testing, label nit

### DIFF
--- a/assets/panel/debugger.properties
+++ b/assets/panel/debugger.properties
@@ -519,8 +519,8 @@ xhrBreakpoints.header=XHR Breakpoints
 xhrBreakpoints.placeholder=Break when URL contains
 xhrBreakpoints.label=Add XHR breakpoint
 
-# LOCALIZATION NOTE (pauseOnAnyXHR): The pause on any xhr checkbox description
-# when the debugger will pause on any xhr requests.
+# LOCALIZATION NOTE (pauseOnAnyXHR): The pause on any XHR checkbox description
+# when the debugger will pause on any XHR requests.
 pauseOnAnyXHR=Pause on any URL
 
 # LOCALIZATION NOTE (sourceTabs.closeTab): Editor source tab context menu item

--- a/src/test/mochitest/browser.ini
+++ b/src/test/mochitest/browser.ini
@@ -655,8 +655,8 @@ support-files =
 [browser_dbg-asm.js]
 [browser_dbg-async-stepping.js]
 [browser_dbg-sourcemapped-breakpoint-console.js]
-[browser_dbg-xhr-breakpoints.js]
 skip-if = (os == "win" && ccov) # Bug 1453549
+[browser_dbg-xhr-breakpoints.js]
 [browser_dbg-sourcemapped-scopes.js]
 skip-if = ccov || (verify && debug && (os == 'linux')) # Bug 1441545
 [browser_dbg-sourcemapped-stepping.js]


### PR DESCRIPTION
- Label nit was something @flodolo had pointed out but we missed.
- The condition for a test goes underneath it, so we accidentally added a condition to the xhr breakpoint test and removed it from its desired test.