### PR TITLE
Getting changed/swapped code breakpoints to be skipped

### DIFF
--- a/src/actions/pause/paused.js
+++ b/src/actions/pause/paused.js
@@ -7,7 +7,8 @@ import {
   getHiddenBreakpointLocation,
   isEvaluatingExpression,
   getSelectedFrame,
-  getSources
+  getSources,
+  getBreakpointsAtLine
 } from "../../selectors";
 
 import { mapFrames } from ".";
@@ -22,6 +23,7 @@ import { shouldStep } from "../../utils/pause";
 import { updateFrameLocation } from "./mapFrames";
 
 import { fetchScopes } from "./fetchScopes";
+import { resume } from "./commands";
 
 import type { Pause, Frame } from "../../types";
 import type { ThunkArgs } from "../types";
@@ -53,6 +55,11 @@ export function paused(pauseInfo: Pause) {
         dispatch(command("stepOver"));
         return;
       }
+    }
+
+    const bps = getBreakpointsAtLine(getState(), topFrame.location.line);
+    if (why.type == "breakpoint" && bps.size === 0) {
+      return resume();
     }
 
     dispatch({


### PR DESCRIPTION
Fixes #4104

Here's the Pull Request Doc
https://firefox-dev.tools/debugger.html/docs/pull-requests.html

### Summary of Changes

* Using @jasonLaster's proposed solution to skip breakpoints that have been swapped out

### Test Plan

- [x] Open a page in the debugger, add a breakpoint to a part of the page's scripts that will run
- [x] Load/execute the page, and observe the correct breakpoint being hit
- [x] Swap out the order of some functions
- [x] Reload/re-execute the page, and observe that the new breakpoint has been moved over, but the line where the old breakpoint was is skipped

Here's the Debugger's Testing doc
https://docs.google.com/document/d/1oBMRxV8A2ag2t22YsQOxTdEv0mXKzIg0tggJjRkU1S0/edit#.
Feel free to improve it!

### Screenshots/Videos (OPTIONAL)
