### PR TITLE
Use --error-color for --string-color (#7149)

### DIFF
--- a/packages/devtools-reps/src/reps/reps.css
+++ b/packages/devtools-reps/src/reps/reps.css
@@ -6,7 +6,7 @@
 .theme-dark,
 .theme-light {
   --number-color: var(--theme-highlight-green);
-  --string-color: var(--theme-highlight-red);
+  --string-color: var(--error-color);
   --null-color: var(--theme-comment);
   --object-color: var(--theme-highlight-blue);
   --caption-color: var(--theme-highlight-blue);


### PR DESCRIPTION
Fixes #7149

We need to land this so when the next devtools update lands in mozilla central, we don't overwrite the following change (landed in 1494789): https://hg.mozilla.org/mozilla-central/rev/5566199eda70

r? @nchevobbe 
