### PR TITLE
Add a maxLength option to formatDisplayName.

### DIFF
--- a/src/utils/pause/frames/displayName.js
+++ b/src/utils/pause/frames/displayName.js
@@ -74,10 +74,13 @@ function mapDisplayNames(frame, library) {
   );
 }
 
-type formatDisplayNameParams = { shouldMapDisplayName: boolean };
+type formatDisplayNameParams = {
+  shouldMapDisplayName: boolean,
+  maxLength: number
+};
 export function formatDisplayName(
   frame: LocalFrame,
-  { shouldMapDisplayName = true }: formatDisplayNameParams = {}
+  { shouldMapDisplayName = true, maxLength = 25 }: formatDisplayNameParams = {}
 ) {
   let { displayName, originalDisplayName, library } = frame;
   displayName = originalDisplayName || displayName;
@@ -86,7 +89,9 @@ export function formatDisplayName(
   }
 
   displayName = simplifyDisplayName(displayName);
-  return endTruncateStr(displayName, 25);
+  return Number.isInteger(maxLength)
+    ? endTruncateStr(displayName, maxLength)
+    : displayName;
 }
 
 export function formatCopyName(frame: LocalFrame) {

--- a/src/utils/pause/frames/tests/displayName.spec.js
+++ b/src/utils/pause/frames/tests/displayName.spec.js
@@ -59,6 +59,30 @@ describe("formatting display names", () => {
     expect(formatDisplayName(frame)).toEqual("...zbazbazbazbazbazbazbazbaz");
   });
 
+  it("truncates function names according to maxLength", () => {
+    const frame = {
+      displayName: "bazbazbazbazbazbazbazbazbazbazbazbazbaz",
+      source: {
+        url: "assets/bar.js"
+      }
+    };
+
+    expect(formatDisplayName(frame, { maxLength: 3 })).toEqual("...baz");
+  });
+
+  it("does not truncate when explicit null maxLength", () => {
+    const frame = {
+      displayName: "bazbazbazbazbazbazbazbazbazbazbazbazbaz",
+      source: {
+        url: "assets/bar.js"
+      }
+    };
+
+    expect(formatDisplayName(frame, { maxLength: null })).toEqual(
+      "bazbazbazbazbazbazbazbazbazbazbazbazbaz"
+    );
+  });
+
   it("returns the original function name when present", () => {
     const frame = {
       originalDisplayName: "originalFn",


### PR DESCRIPTION
The maxLength will default to the current length
we use (25), but could be overrided to whatever
the consumer wants. Setting it to null will not
truncate the string at all.
