### PR TITLE
Change onClick to onMouse/KeyDown for search bar modifiers

### DIFF
--- a/src/components/Editor/SearchBar.js
+++ b/src/components/Editor/SearchBar.js
@@ -276,6 +276,12 @@ class SearchBar extends Component<Props, State> {
             toggleFileSearchModifier(modVal);
             doSearch(query);
           }}
+          onKeyDown={(e: any) => {
+            if (e.key === "Enter") {
+              toggleFileSearchModifier(modVal);
+              doSearch(query);
+            }
+          }}
           title={tooltip}
         >
           <Svg name={svgName} />

--- a/src/components/Editor/SearchBar.js
+++ b/src/components/Editor/SearchBar.js
@@ -272,7 +272,7 @@ class SearchBar extends Component<Props, State> {
       return (
         <button
           className={preppedClass}
-          onClick={() => {
+          onMouseDown={() => {
             toggleFileSearchModifier(modVal);
             doSearch(query);
           }}


### PR DESCRIPTION
Fixes #7013

### Summary of Changes

* Modifiers on the Find in File search bar no longer need to be clicked twice when the search bar is in focus.

### Test Plan

- [x] Ctrl-F opens the search bar
- [x] Search for something
- [x] Clicking a modifier makes the search results change immediately.
