### PR TITLE
Handle Frame overflow (function and location) in CSS.

### DIFF
--- a/src/components/SecondaryPanes/Frames/Frame.js
+++ b/src/components/SecondaryPanes/Frames/Frame.js
@@ -19,8 +19,8 @@ type FrameTitleProps = {
   options: Object
 };
 
-function FrameTitle({ frame, options }: FrameTitleProps) {
-  const displayName = formatDisplayName(frame, options);
+function FrameTitle({ frame, options = {} }: FrameTitleProps) {
+  const displayName = formatDisplayName(frame, { ...options, maxLength: null });
   return <div className="title">{displayName}</div>;
 }
 

--- a/src/components/SecondaryPanes/Frames/Frames.css
+++ b/src/components/SecondaryPanes/Frames/Frames.css
@@ -9,13 +9,16 @@
 }
 
 .frames ul li {
-  padding: 0 10px 0 21px;
+  padding: 7px 10px 7px 21px;
   overflow: hidden;
   display: flex;
   justify-content: space-between;
+  column-gap: 0.5em;
   flex-direction: row;
   align-items: center;
   margin: 0;
+  max-width: 100%;
+  flex-wrap: wrap;
 }
 
 .frames ul li * {
@@ -30,12 +33,15 @@
 
 .frames .location {
   font-weight: normal;
-  display: flex;
-  justify-content: space-between;
-  flex-direction: row;
-  align-items: center;
   margin: 0;
-  flex-shrink: 0;
+  flex-grow: 1;
+  max-width: 100%;
+  overflow: hidden;
+  white-space: nowrap;
+  /* Trick to get the ellipsis at the start of the string */
+  text-overflow: ellipsis;
+  direction: rtl;
+  text-align: right;
 }
 
 .theme-light .frames .location {
@@ -50,7 +56,6 @@
 .frames .title {
   text-overflow: ellipsis;
   overflow: hidden;
-  margin: 7px 0.5em 7px 0;
 }
 
 .frames ul li:hover,
@@ -96,9 +101,9 @@
 }
 
 .annotation-logo {
+  display: inline-block;
   width: 12px;
-  margin-left: 3px;
-  line-height: 8px;
+  margin-inline-start: 4px;
 }
 
 :root.theme-dark .annotation-logo svg path {

--- a/src/components/SecondaryPanes/Frames/Group.css
+++ b/src/components/SecondaryPanes/Frames/Group.css
@@ -6,6 +6,12 @@
 .frames ul .frames-group .group .location {
   font-weight: 500;
   cursor: default;
+  /*
+   * direction:rtl is set in Frames.css to overflow the location text from the
+   * start. Here we need to reset it in order to display the framework icon
+   * after the framework name.
+   */
+  direction: ltr;
 }
 
 .frames ul .frames-group.expanded .group,

--- a/src/components/SecondaryPanes/Frames/Group.js
+++ b/src/components/SecondaryPanes/Frames/Group.js
@@ -123,7 +123,7 @@ export default class Group extends Component<Props, State> {
 
   renderDescription() {
     const frame = this.props.group[0];
-    const displayName = formatDisplayName(frame);
+    const displayName = formatDisplayName(frame, { maxLength: null });
     return (
       <li
         key={frame.id}


### PR DESCRIPTION
Fixes #7131 

The Frames component has limited space available,
and it might happen that we need to truncate some
information.
Previouysly, this was done by manually setting a
length limit on the string we were displaying.
This is a bit unfortunate since CSS has some useful
properties we can use to show whatever fits on the
screen.
So now, in Frames, we don't truncate strings anymore,
and, in CSS, we set the text-overflow we want.
Furthermore, we make the Frame element wrap, so when
the panel gets smaller, the location is put on a
new line instead of shrinking (and then shrinks if
it needs to).
In order to have such feature, we needed to have the
location element to not have display: flex. This was
not hard to fix since flex was only used to place an
optional icon after the framework name, which can be
do with inline display.

### Video
(full URL was enabled only to have long location, we'll still only display the filename in the debugger)

![oct-25-2018 10-39-31](https://user-images.githubusercontent.com/578107/47488247-49109780-d844-11e8-8f14-d2d2d6ade8ba.gif)

