### PR TITLE
Handle anonymous functions more consistently.

### DIFF
--- a/assets/panel/debugger.properties
+++ b/assets/panel/debugger.properties
@@ -919,9 +919,10 @@ whyPaused.other=Debugger paused
 # keyboard shortcuts that use the control key
 ctrl=Ctrl
 
-# LOCALIZATION NOTE (anonymous): The text that is displayed when the
-# display name is null.
-anonymous=(anonymous)
+# LOCALIZATION NOTE (anonymous): this string is used to display JavaScript
+# functions that have no given name - they are said to be
+# anonymous.
+anonymousFunction=<anonymous>
 
 # LOCALIZATION NOTE (shortcuts.toggleBreakpoint): text describing
 # keyboard shortcut action for toggling breakpoint

--- a/assets/panel/debugger.properties
+++ b/assets/panel/debugger.properties
@@ -919,8 +919,8 @@ whyPaused.other=Debugger paused
 # keyboard shortcuts that use the control key
 ctrl=Ctrl
 
-# LOCALIZATION NOTE (anonymous): this string is used to display JavaScript
-# functions that have no given name - they are said to be
+# LOCALIZATION NOTE (anonymousFunction): this string is used to display
+# JavaScript functions that have no given name - they are said to be
 # anonymous.
 anonymousFunction=<anonymous>
 

--- a/src/client/firefox/create.js
+++ b/src/client/firefox/create.js
@@ -21,7 +21,10 @@ export function createFrame(frame: FramePacket): ?Frame {
   if (frame.type == "call") {
     const c = frame.callee;
     title =
-      c.name || c.userDisplayName || c.displayName || L10N.getStr("anonymous");
+      c.name ||
+      c.userDisplayName ||
+      c.displayName ||
+      L10N.getStr("anonymousFunction");
   } else {
     title = `(${frame.type})`;
   }

--- a/src/client/firefox/create.js
+++ b/src/client/firefox/create.js
@@ -20,11 +20,7 @@ export function createFrame(frame: FramePacket): ?Frame {
   let title;
   if (frame.type == "call") {
     const c = frame.callee;
-    title =
-      c.name ||
-      c.userDisplayName ||
-      c.displayName ||
-      L10N.getStr("anonymousFunction");
+    title = c.name || c.userDisplayName || c.displayName;
   } else {
     title = `(${frame.type})`;
   }

--- a/src/components/shared/PreviewFunction.js
+++ b/src/components/shared/PreviewFunction.js
@@ -8,7 +8,7 @@ import React, { Component } from "react";
 
 import { times, zip, flatten } from "lodash";
 
-import { simplifyDisplayName } from "../../utils/pause/frames";
+import { formatDisplayName } from "../../utils/pause/frames";
 
 import "./PreviewFunction.css";
 
@@ -21,14 +21,9 @@ type FunctionType = {
 
 type Props = { func: FunctionType };
 
-function getFunctionName(func: FunctionType) {
-  const name = func.userDisplayName || func.displayName || func.name;
-  return simplifyDisplayName(name);
-}
-
 export default class PreviewFunction extends Component<Props> {
   renderFunctionName(func: FunctionType) {
-    const name = getFunctionName(func);
+    const name = formatDisplayName(func, { maxLength: null });
     return <span className="function-name">{name}</span>;
   }
 

--- a/src/components/shared/tests/__snapshots__/PreviewFunction.spec.js.snap
+++ b/src/components/shared/tests/__snapshots__/PreviewFunction.spec.js.snap
@@ -7,7 +7,7 @@ exports[`PreviewFunction should return a span 1`] = `
   <span
     className="function-name"
   >
-    undefined
+    &lt;anonymous&gt;
   </span>
   <span
     className="paren"

--- a/src/utils/pause/frames/displayName.js
+++ b/src/utils/pause/frames/displayName.js
@@ -74,6 +74,11 @@ function mapDisplayNames(frame, library) {
   );
 }
 
+function getFrameDisplayName(frame: LocalFrame): string {
+  const { displayName, originalDisplayName, userDisplayName, name } = frame;
+  return originalDisplayName || userDisplayName || displayName || name;
+}
+
 type formatDisplayNameParams = {
   shouldMapDisplayName: boolean,
   maxLength: number
@@ -82,14 +87,8 @@ export function formatDisplayName(
   frame: LocalFrame,
   { shouldMapDisplayName = true, maxLength = 25 }: formatDisplayNameParams = {}
 ) {
-  let {
-    displayName,
-    originalDisplayName,
-    userDisplayName,
-    name,
-    library
-  } = frame;
-  displayName = originalDisplayName || userDisplayName || displayName || name;
+  const { library } = frame;
+  let displayName = getFrameDisplayName(frame);
   if (library && shouldMapDisplayName) {
     displayName = mapDisplayNames(frame, library);
   }

--- a/src/utils/pause/frames/displayName.js
+++ b/src/utils/pause/frames/displayName.js
@@ -17,7 +17,7 @@ const arrayProperty = /\[(.*?)\]$/;
 const functionProperty = /([\w\d]+)[\/\.<]*?$/;
 const annonymousProperty = /([\w\d]+)\(\^\)$/;
 
-export function simplifyDisplayName(displayName: string) {
+export function simplifyDisplayName(displayName: string | void): string | void {
   // if the display name has a space it has already been mapped
   if (!displayName || /\s/.exec(displayName)) {
     return displayName;
@@ -86,23 +86,22 @@ type formatDisplayNameParams = {
 export function formatDisplayName(
   frame: LocalFrame,
   { shouldMapDisplayName = true, maxLength = 25 }: formatDisplayNameParams = {}
-) {
+): string {
   const { library } = frame;
   let displayName = getFrameDisplayName(frame);
   if (library && shouldMapDisplayName) {
     displayName = mapDisplayNames(frame, library);
   }
 
-  displayName = displayName
-    ? simplifyDisplayName(displayName)
-    : L10N.getStr("anonymousFunction");
+  displayName =
+    simplifyDisplayName(displayName) || L10N.getStr("anonymousFunction");
 
   return Number.isInteger(maxLength)
     ? endTruncateStr(displayName, maxLength)
     : displayName;
 }
 
-export function formatCopyName(frame: LocalFrame) {
+export function formatCopyName(frame: LocalFrame): string {
   const displayName = formatDisplayName(frame);
   const fileName = getFilename(frame.source);
   const frameLocation = frame.location.line;

--- a/src/utils/pause/frames/displayName.js
+++ b/src/utils/pause/frames/displayName.js
@@ -19,7 +19,7 @@ const annonymousProperty = /([\w\d]+)\(\^\)$/;
 
 export function simplifyDisplayName(displayName: string) {
   // if the display name has a space it has already been mapped
-  if (/\s/.exec(displayName)) {
+  if (!displayName || /\s/.exec(displayName)) {
     return displayName;
   }
 
@@ -82,13 +82,22 @@ export function formatDisplayName(
   frame: LocalFrame,
   { shouldMapDisplayName = true, maxLength = 25 }: formatDisplayNameParams = {}
 ) {
-  let { displayName, originalDisplayName, library } = frame;
-  displayName = originalDisplayName || displayName;
+  let {
+    displayName,
+    originalDisplayName,
+    userDisplayName,
+    name,
+    library
+  } = frame;
+  displayName = originalDisplayName || userDisplayName || displayName || name;
   if (library && shouldMapDisplayName) {
     displayName = mapDisplayNames(frame, library);
   }
 
-  displayName = simplifyDisplayName(displayName);
+  displayName = displayName
+    ? simplifyDisplayName(displayName)
+    : L10N.getStr("anonymousFunction");
+
   return Number.isInteger(maxLength)
     ? endTruncateStr(displayName, maxLength)
     : displayName;

--- a/src/utils/pause/frames/tests/displayName.spec.js
+++ b/src/utils/pause/frames/tests/displayName.spec.js
@@ -94,6 +94,25 @@ describe("formatting display names", () => {
 
     expect(formatDisplayName(frame)).toEqual("originalFn");
   });
+
+  it("returns anonymous when displayName is undefined", () => {
+    const frame = {};
+    expect(formatDisplayName(frame)).toEqual("<anonymous>");
+  });
+
+  it("returns anonymous when displayName is null", () => {
+    const frame = {
+      displayName: null
+    };
+    expect(formatDisplayName(frame)).toEqual("<anonymous>");
+  });
+
+  it("returns anonymous when displayName is an empty string", () => {
+    const frame = {
+      displayName: ""
+    };
+    expect(formatDisplayName(frame)).toEqual("<anonymous>");
+  });
 });
 
 describe("simplifying display names", () => {

--- a/src/utils/pause/scopes/getScope.js
+++ b/src/utils/pause/scopes/getScope.js
@@ -40,7 +40,7 @@ function getScopeTitle(type, scope: RenderableScope) {
   if (type === "function" && scope.function) {
     return scope.function.displayName
       ? simplifyDisplayName(scope.function.displayName)
-      : L10N.getStr("anonymous");
+      : L10N.getStr("anonymousFunction");
   }
   return L10N.getStr("scopes.block");
 }


### PR DESCRIPTION
Anonymous function name was not displayed
at all in the callstack panel, neither it was
in PreviewFunction. In the scopes panel, it was
displayed in another way (`(anonymous)`) than
in the toolbox, where we use `<anonymous>`.
With this patch, we make sure to have anonymous
functions displayed in a consistent way in the debugger,
and matching other panels in the toolbox.

In order to do that, the anonymous item in the properties
file is updated to match the existing ones in mozilla-central.
