### PR TITLE
show wasm breakpoints in panel

### DIFF
--- a/src/actions/file-search.js
+++ b/src/actions/file-search.js
@@ -15,6 +15,7 @@ import {
 import { isWasm, renderWasmText } from "../utils/wasm";
 import { getMatches } from "../workers/search";
 import type { Action, FileTextSearchModifier, ThunkArgs } from "./types";
+import type { WasmSource } from "../types";
 
 import {
   getSelectedSource,
@@ -108,10 +109,11 @@ export function searchContents(query: string, editor: Object) {
     }
 
     const _modifiers = modifiers.toJS();
-    const sourceId = selectedSource.id;
-    const text = isWasm(sourceId)
-      ? renderWasmText(sourceId, selectedSource.text).join("\n")
-      : selectedSource.text;
+    let text = selectedSource.text;
+
+    if (isWasm(selectedSource.id)) {
+      text = renderWasmText(((selectedSource: any): WasmSource)).join("\n");
+    }
 
     const matches = await getMatches(query, text, _modifiers);
 

--- a/src/utils/editor/source-documents.js
+++ b/src/utils/editor/source-documents.js
@@ -103,14 +103,13 @@ export function showErrorMessage(editor: Object, msg: string) {
 }
 
 function setEditorText(editor: Object, source: Source) {
-  const { text, id: sourceId } = source;
   if (source.isWasm) {
-    const wasmLines = renderWasmText(sourceId, (text: any));
+    const wasmLines = renderWasmText(source);
     // cm will try to split into lines anyway, saving memory
     const wasmText = { split: () => wasmLines, match: () => false };
     editor.setText(wasmText);
   } else {
-    editor.setText(text);
+    editor.setText(source.text);
   }
 }
 

--- a/src/utils/source.js
+++ b/src/utils/source.js
@@ -15,6 +15,8 @@ import { getUnicodeUrl } from "devtools-modules";
 import { endTruncateStr } from "./utils";
 import { truncateMiddleText } from "../utils/text";
 import { parse as parseURL } from "../utils/url";
+import { renderWasmText } from "./wasm";
+import { toEditorPosition } from "./editor";
 export { isMinified } from "./isMinified";
 import { getURL, getFileExtension } from "./sources-tree";
 import { prefs } from "./prefs";
@@ -382,12 +384,18 @@ export function isLoading(source: Source) {
 }
 
 export function getTextAtPosition(source: ?Source, location: Location) {
-  if (!source || source.isWasm || !source.text) {
+  if (!source || !source.text) {
     return "";
   }
 
   const line = location.line;
   const column = location.column || 0;
+
+  if (source.isWasm) {
+    const { line: editorLine } = toEditorPosition(location);
+    const lines = renderWasmText(source.id, source.text);
+    return lines[editorLine];
+  }
 
   const lineText = source.text.split("\n")[line - 1];
   if (!lineText) {

--- a/src/utils/source.js
+++ b/src/utils/source.js
@@ -21,7 +21,7 @@ export { isMinified } from "./isMinified";
 import { getURL, getFileExtension } from "./sources-tree";
 import { prefs } from "./prefs";
 
-import type { Source, Location } from "../types";
+import type { Source, Location, JsSource } from "../types";
 import type { SourceMetaDataType } from "../reducers/ast";
 import type { SymbolDeclarations } from "../workers/parser";
 
@@ -393,11 +393,12 @@ export function getTextAtPosition(source: ?Source, location: Location) {
 
   if (source.isWasm) {
     const { line: editorLine } = toEditorPosition(location);
-    const lines = renderWasmText(source.id, source.text);
+    const lines = renderWasmText(source);
     return lines[editorLine];
   }
 
-  const lineText = source.text.split("\n")[line - 1];
+  const text = ((source: any): JsSource).text || "";
+  const lineText = text.split("\n")[line - 1];
   if (!lineText) {
     return "";
   }

--- a/src/utils/tests/wasm.spec.js
+++ b/src/utils/tests/wasm.spec.js
@@ -33,19 +33,19 @@ describe("wasm", () => {
       expect(isWasm(sourceId)).toEqual(false);
     });
     it("should give us the true when wasm text was registered", () => {
-      const sourceId = "source.1";
-      renderWasmText(sourceId, SIMPLE_WASM);
-      expect(isWasm(sourceId)).toEqual(true);
+      const source = { id: "source.1", text: SIMPLE_WASM };
+      renderWasmText(source);
+      expect(isWasm(source.id)).toEqual(true);
       // clear shall remove
       clearWasmStates();
-      expect(isWasm(sourceId)).toEqual(false);
+      expect(isWasm(source.id)).toEqual(false);
     });
   });
 
   describe("renderWasmText", () => {
     it("render simple wasm", () => {
-      const sourceId = "source.2";
-      const lines = renderWasmText(sourceId, SIMPLE_WASM);
+      const source = { id: "source.2", text: SIMPLE_WASM };
+      const lines = renderWasmText(source);
       expect(lines.join("\n")).toEqual(SIMPLE_WASM_TEXT);
       clearWasmStates();
     });
@@ -56,9 +56,9 @@ describe("wasm", () => {
     expect(SIMPLE_WASM.binary[SIMPLE_WASM_NOP_OFFSET]).toEqual("\x01");
 
     it("get simple wasm nop offset", () => {
-      const sourceId = "source.3";
-      renderWasmText(sourceId, SIMPLE_WASM);
-      const offset = lineToWasmOffset(sourceId, SIMPLE_WASM_NOP_TEXT_LINE);
+      const source = { id: "source.3", text: SIMPLE_WASM };
+      renderWasmText(source);
+      const offset = lineToWasmOffset(source.id, SIMPLE_WASM_NOP_TEXT_LINE);
       expect(offset).toEqual(SIMPLE_WASM_NOP_OFFSET);
       clearWasmStates();
     });
@@ -66,9 +66,9 @@ describe("wasm", () => {
 
   describe("wasmOffsetToLine", () => {
     it("get simple wasm nop line", () => {
-      const sourceId = "source.4";
-      renderWasmText(sourceId, SIMPLE_WASM);
-      const line = wasmOffsetToLine(sourceId, SIMPLE_WASM_NOP_OFFSET);
+      const source = { id: "source.4", text: SIMPLE_WASM };
+      renderWasmText(source);
+      const line = wasmOffsetToLine(source.id, SIMPLE_WASM_NOP_OFFSET);
       expect(line).toEqual(SIMPLE_WASM_NOP_TEXT_LINE);
       clearWasmStates();
     });

--- a/src/utils/wasm.js
+++ b/src/utils/wasm.js
@@ -7,6 +7,7 @@
 import { BinaryReader } from "wasmparser/dist/WasmParser";
 import { WasmDisassembler, NameSectionReader } from "wasmparser/dist/WasmDis";
 
+import type { WasmSource } from "../types";
 type WasmState = {
   lines: Array<number>,
   offsets: Array<number>
@@ -137,17 +138,29 @@ export function clearWasmStates() {
   wasmStates = (Object.create(null): any);
 }
 
-export function renderWasmText(sourceId: string, { binary }: any) {
+const wasmLines: WeakMap<WasmSource, string[]> = new WeakMap();
+export function renderWasmText(source: WasmSource): string[] {
+  if (wasmLines.has(source)) {
+    return wasmLines.get(source) || [];
+  }
+
+  if (!source.text) {
+    return [];
+  }
+
   // binary does not survive as Uint8Array, converting from string
+  const { binary } = source.text;
   const data = new Uint8Array(binary.length);
   for (let i = 0; i < data.length; i++) {
     data[i] = binary.charCodeAt(i);
   }
-  const { lines } = getWasmText(sourceId, data);
+  const { lines } = getWasmText(source.id, data);
   const MAX_LINES = 1000000;
   if (lines.length > MAX_LINES) {
     lines.splice(MAX_LINES, lines.length - MAX_LINES);
     lines.push(";; .... text is truncated due to the size");
   }
+
+  wasmLines.set(source, lines);
   return lines;
 }


### PR DESCRIPTION
Fixes #6570 

### Summary of Changes

* Change `getTextAtPosition` to consider wasm sources

### Test Plan
- Add a breakpoint in wasm file

We can do it two ways, one is we can directly store the parsed text in the `source` but the downside with this is that the text will only be needed when user opens the wasm file. So the whole parsing will be a waste of time.

Currently, we delay the conversion of binary to text till the user opens the wasm file.