### PR TITLE
[CallStack] Adjust height for WhyPaused and ExpandRows

### DIFF
--- a/src/components/SecondaryPanes/Frames/Frames.css
+++ b/src/components/SecondaryPanes/Frames/Frames.css
@@ -91,7 +91,8 @@
   text-align: center;
   border: 1px solid var(--theme-splitter-color);
   background-color: var(--theme-tab-toolbar-background);
-  width: 100%;
+  margin: 0 auto;
+  border-radius:2px;
   font-size: inherit;
   color: inherit;
 }

--- a/src/components/SecondaryPanes/Frames/Frames.css
+++ b/src/components/SecondaryPanes/Frames/Frames.css
@@ -83,12 +83,11 @@
 
 .show-more-container {
   display: flex;
-  height: 28.5667px;
-  padding: 3px 10px;
+  height: 28px;
+  padding: 4px 0;
 }
 
 .show-more {
-  text-align: center;
   border: 1px solid var(--theme-splitter-color);
   background-color: var(--theme-tab-toolbar-background);
   margin: 0 auto;

--- a/src/components/SecondaryPanes/Frames/Frames.css
+++ b/src/components/SecondaryPanes/Frames/Frames.css
@@ -92,7 +92,7 @@
   border: 1px solid var(--theme-splitter-color);
   background-color: var(--theme-tab-toolbar-background);
   margin: 0 auto;
-  border-radius:2px;
+  border-radius: 2px;
   font-size: inherit;
   color: inherit;
 }

--- a/src/components/SecondaryPanes/Frames/Frames.css
+++ b/src/components/SecondaryPanes/Frames/Frames.css
@@ -83,15 +83,17 @@
 
 .show-more-container {
   display: flex;
-  height: 28px;
+  min-height: 24px;
   padding: 4px 0;
 }
 
 .show-more {
+  text-align: center;
+  padding: 8px 0px;
+  margin: 7px 10px 7px 7px;
   border: 1px solid var(--theme-splitter-color);
   background-color: var(--theme-tab-toolbar-background);
-  margin: 0 auto;
-  border-radius: 2px;
+  width: 100%;
   font-size: inherit;
   color: inherit;
 }

--- a/src/components/SecondaryPanes/Frames/Frames.css
+++ b/src/components/SecondaryPanes/Frames/Frames.css
@@ -83,12 +83,12 @@
 
 .show-more-container {
   display: flex;
+  height: 28.5667px;
+  padding: 3px 10px;
 }
 
 .show-more {
   text-align: center;
-  padding: 8px 0px;
-  margin: 7px 10px 7px 7px;
   border: 1px solid var(--theme-splitter-color);
   background-color: var(--theme-tab-toolbar-background);
   width: 100%;

--- a/src/components/SecondaryPanes/Frames/WhyPaused.css
+++ b/src/components/SecondaryPanes/Frames/WhyPaused.css
@@ -3,17 +3,20 @@
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
 .why-paused {
+  display: flex;
   background-color: var(--theme-body-background);
   color: var(--theme-body-color);
-  padding: 7px 10px 7px 20px;
-  white-space: normal;
   opacity: 0.6;
   font-size: 12px;
-  flex: 0 1 auto;
   text-align: center;
   font-style: italic;
   font-weight: 300;
   cursor: default;
+  min-height: 24px;
+}
+
+.why-paused > div {
+  margin: auto;
 }
 
 .theme-dark .secondary-panes .why-paused {
@@ -21,6 +24,7 @@
 }
 
 .why-paused .message {
+  padding: 4px;
   font-size: 10px;
 }
 

--- a/src/components/SecondaryPanes/Frames/WhyPaused.css
+++ b/src/components/SecondaryPanes/Frames/WhyPaused.css
@@ -5,7 +5,7 @@
 .why-paused {
   background-color: var(--theme-body-background);
   color: var(--theme-body-color);
-  padding: 10px 10px 10px 20px;
+  padding: 7px 10px 7px 20px;
   white-space: normal;
   opacity: 0.6;
   font-size: 12px;

--- a/src/components/SecondaryPanes/Frames/WhyPaused.js
+++ b/src/components/SecondaryPanes/Frames/WhyPaused.js
@@ -48,8 +48,10 @@ export default function renderWhyPaused(why: Object) {
 
   return (
     <div className={"pane why-paused"}>
-      <div>{L10N.getStr(reason)}</div>
-      {renderMessage(why)}
+      <div>
+        <div>{L10N.getStr(reason)}</div>
+        {renderMessage(why)}
+      </div>
     </div>
   );
 }

--- a/src/components/test/__snapshots__/WhyPaused.spec.js.snap
+++ b/src/components/test/__snapshots__/WhyPaused.spec.js.snap
@@ -5,12 +5,14 @@ exports[`WhyPaused should pause reason with message 1`] = `
   className="pane why-paused"
 >
   <div>
-    Paused on breakpoint
-  </div>
-  <div
-    className="message"
-  >
-    bla is hit
+    <div>
+      Paused on breakpoint
+    </div>
+    <div
+      className="message"
+    >
+      bla is hit
+    </div>
   </div>
 </div>
 `;
@@ -20,12 +22,14 @@ exports[`WhyPaused should show pause reason with exception details 1`] = `
   className="pane why-paused"
 >
   <div>
-    Paused on exception
-  </div>
-  <div
-    className="message warning"
-  >
-    ReferenceError: o is not defined
+    <div>
+      Paused on exception
+    </div>
+    <div
+      className="message warning"
+    >
+      ReferenceError: o is not defined
+    </div>
   </div>
 </div>
 `;
@@ -35,12 +39,14 @@ exports[`WhyPaused should show pause reason with exception string 1`] = `
   className="pane why-paused"
 >
   <div>
-    Paused on exception
-  </div>
-  <div
-    className="message warning"
-  >
-    Not Available
+    <div>
+      Paused on exception
+    </div>
+    <div
+      className="message warning"
+    >
+      Not Available
+    </div>
   </div>
 </div>
 `;


### PR DESCRIPTION
Fixes #7136

In the Call Stack ui, the `<li>` for each stack frame are 28.5667px high.  I changed the height for the "paused on breakpoint" text from 35px to 28.5667  and changed the "expand rows" button height from 47px to 28.5667 so everything is uniform and about 25px of space is saved.

Before and After:
<img width="1019" alt="screen shot 2018-10-29 at 1 27 36 pm" src="https://user-images.githubusercontent.com/5035181/47680499-294edb80-db84-11e8-910a-0867b7ffeab6.png">

