### PR TITLE
remove unused redux-saga dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,6 @@
     "react-inlinesvg": "^0.8.1",
     "react-redux": "^5.0.7",
     "react-transition-group": "^2.2.1",
-    "redux-saga": "^0.16.1",
     "reselect": "^4.0.0",
     "svg-inline-react": "^3.0.0",
     "wasmparser": "^0.6.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9919,10 +9919,6 @@ redux-logger@=3.0.6:
   dependencies:
     deep-diff "^0.3.5"
 
-redux-saga@^0.16.1:
-  version "0.16.2"
-  resolved "https://registry.yarnpkg.com/redux-saga/-/redux-saga-0.16.2.tgz#993662e86bc945d8509ac2b8daba3a8c615cc971"
-
 redux@^3.7.2:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/redux/-/redux-3.7.2.tgz#06b73123215901d25d065be342eb026bc1c8537b"


### PR DESCRIPTION
Fixes #7093

Removes redux-saga from package.json and updates yarn.lock accordingly