### PR TITLE
Always display the XHR breakpoint input if no explicit XHR breakpoints

### DIFF
--- a/src/components/SecondaryPanes/XHRBreakpoints.js
+++ b/src/components/SecondaryPanes/XHRBreakpoints.js
@@ -146,14 +146,23 @@ class XHRBreakpoints extends Component<Props, State> {
     }
   };
 
-  renderBreakpoint = ({ path, text, disabled, method }, index) => {
+  renderBreakpoint = breakpoint => {
+    const { path, text, disabled, method } = breakpoint;
     const { editIndex } = this.state;
-    const { removeXHRBreakpoint } = this.props;
+    const { removeXHRBreakpoint, xhrBreakpoints } = this.props;
+
+    // The "pause on any" checkbox
+    if (!path) {
+      return;
+    }
+
+    // Finds the xhrbreakpoint so as to not make assumptions about position
+    const index = xhrBreakpoints.findIndex(
+      bp => bp.path === path && bp.method === method
+    );
 
     if (index === editIndex) {
       return this.renderXHRInput(this.handleExistingSubmit);
-    } else if (!path) {
-      return;
     }
 
     return (
@@ -180,22 +189,27 @@ class XHRBreakpoints extends Component<Props, State> {
 
   renderBreakpoints = () => {
     const { showInput, xhrBreakpoints } = this.props;
+
+    // At present, the "Pause on any URL" checkbox creates an xhrBreakpoint
+    // of "ANY" with no path, so we can remove that before creating the list
+    const explicitXhrBreakpoints = xhrBreakpoints.filter(bp => bp.path !== "");
+
     return (
       <ul className="pane expressions-list">
-        {xhrBreakpoints.map(this.renderBreakpoint)}
-        {(showInput || !xhrBreakpoints.size) &&
+        {explicitXhrBreakpoints.map(this.renderBreakpoint)}
+        {(showInput || explicitXhrBreakpoints.size === 0) &&
           this.renderXHRInput(this.handleNewSubmit)}
       </ul>
     );
   };
 
-  renderCheckpoint = () => {
+  renderCheckbox = () => {
     const { shouldPauseOnAny, togglePauseOnAny, xhrBreakpoints } = this.props;
-    const isEmpty = xhrBreakpoints.size === 0;
+
     return (
       <div
         className={classnames("breakpoints-exceptions-options", {
-          empty: isEmpty
+          empty: xhrBreakpoints.size === 0
         })}
       >
         <ExceptionOption
@@ -211,7 +225,7 @@ class XHRBreakpoints extends Component<Props, State> {
   render() {
     return (
       <div>
-        {this.renderCheckpoint()}
+        {this.renderCheckbox()}
         {this.renderBreakpoints()}
       </div>
     );

--- a/src/reducers/breakpoints.js
+++ b/src/reducers/breakpoints.js
@@ -150,8 +150,6 @@ function updateXHRBreakpoint(state, action) {
   const { breakpoint, index } = action;
   const { xhrBreakpoints } = state;
 
-  console.log("updateXHRBreakpoint", action);
-
   return state.set("xhrBreakpoints", xhrBreakpoints.set(index, breakpoint));
 }
 

--- a/src/reducers/breakpoints.js
+++ b/src/reducers/breakpoints.js
@@ -135,6 +135,10 @@ function removeXHRBreakpoint(state, action) {
   } = action;
   const { xhrBreakpoints } = state;
 
+  if (action.status === "start") {
+    return state;
+  }
+
   const index = xhrBreakpoints.findIndex(
     bp => bp.path === path && bp.method === method
   );
@@ -145,6 +149,9 @@ function removeXHRBreakpoint(state, action) {
 function updateXHRBreakpoint(state, action) {
   const { breakpoint, index } = action;
   const { xhrBreakpoints } = state;
+
+  console.log("updateXHRBreakpoint", action);
+
   return state.set("xhrBreakpoints", xhrBreakpoints.set(index, breakpoint));
 }
 

--- a/src/test/mochitest/browser_dbg-xhr-breakpoints.js
+++ b/src/test/mochitest/browser_dbg-xhr-breakpoints.js
@@ -4,44 +4,76 @@
 
 // Tests that a basic XHR breakpoint works for get and POST is ignored
 add_task(async function() {
-    const dbg = await initDebugger("doc-xhr.html");
-    await waitForSources(dbg, "fetch.js");
-    await dbg.actions.setXHRBreakpoint("doc", "GET");
-    invokeInTab("main", "doc-xhr.html");
-    await waitForPaused(dbg);
-    assertPausedLocation(dbg);
-    resume(dbg);
+  const dbg = await initDebugger("doc-xhr.html");
+  await waitForSources(dbg, "fetch.js");
+  await dbg.actions.setXHRBreakpoint("doc", "GET");
+  invokeInTab("main", "doc-xhr.html");
+  await waitForPaused(dbg);
+  assertPausedLocation(dbg);
+  resume(dbg);
 
-    await dbg.actions.removeXHRBreakpoint(0);
-    invokeInTab("main", "doc-xhr.html");
-    assertNotPaused(dbg);
+  await dbg.actions.removeXHRBreakpoint(0);
+  invokeInTab("main", "doc-xhr.html");
+  assertNotPaused(dbg);
 
-    await dbg.actions.setXHRBreakpoint("doc-xhr.html", "POST");
-    invokeInTab("main", "doc");
-    assertNotPaused(dbg);
+  await dbg.actions.setXHRBreakpoint("doc-xhr.html", "POST");
+  invokeInTab("main", "doc");
+  assertNotPaused(dbg);
 });
 
 // Tests the "pause on any URL" checkbox works properly
 add_task(async function() {
-    const dbg = await initDebugger("doc-xhr.html");
-    await waitForSources(dbg, "fetch.js");
+  const dbg = await initDebugger("doc-xhr.html");
+  await waitForSources(dbg, "fetch.js");
 
-    // Enable pause on any URL
-    await dbg.actions.togglePauseOnAny();
-    invokeInTab("main", "doc-xhr.html");
-    await waitForPaused(dbg);
-    await resume(dbg);
+  // Enable pause on any URL
+  await dbg.actions.togglePauseOnAny();
+  invokeInTab("main", "doc-xhr.html");
+  await waitForPaused(dbg);
+  await resume(dbg);
 
-    invokeInTab("main", "fetch.js");
-    await waitForPaused(dbg);
-    await resume(dbg);
+  invokeInTab("main", "fetch.js");
+  await waitForPaused(dbg);
+  await resume(dbg);
 
-    invokeInTab("main", "README.md");
-    await waitForPaused(dbg);
-    await resume(dbg);
+  invokeInTab("main", "README.md");
+  await waitForPaused(dbg);
+  await resume(dbg);
 
-    // Disable pause on any URL
-    await dbg.actions.togglePauseOnAny();
-    invokeInTab("main", "README.md");
-    assertNotPaused(dbg);
+  // Disable pause on any URL
+  await dbg.actions.togglePauseOnAny();
+  invokeInTab("main", "README.md");
+  assertNotPaused(dbg);
+
+  // Turn off the checkbox
+  await dbg.actions.togglePauseOnAny();
+});
+
+// Tests removal works properly
+add_task(async function() {
+  const dbg = await initDebugger("doc-xhr.html");
+
+  await Promise.all([
+    dbg.actions.togglePauseOnAny(),
+    dbg.actions.setXHRBreakpoint("1", "GET"),
+    dbg.actions.setXHRBreakpoint("2", "GET"),
+    dbg.actions.setXHRBreakpoint("3", "GET"),
+    dbg.actions.setXHRBreakpoint("4", "GET"),
+  ]);
+
+  // Remove "2"
+  await dbg.actions.removeXHRBreakpoint(2);
+
+  // Ensure that the checkbox not affected by removal of text-based breakpoints
+  const xhrBreakpoints = dbg.selectors.getXHRBreakpoints(dbg.store.getState());
+  is(xhrBreakpoints.size, 4, "4 XHR breakpoints remain");
+  is(
+    xhrBreakpoints.filter(bp => bp.path ==="").size, 1, 
+    "The pause on any is still checked"
+  );
+  is(
+    xhrBreakpoints.map(bp => bp.path).join(""),
+    "134",
+    "Only the desired breakpoint was removed"
+  );
 });


### PR DESCRIPTION
References:  #7194 

This ensures text-based XHR breakpoints are checked before choosing not to display the XHR breakpoint input element.