### PR TITLE
Remove formatDisplayName maxLength option.

### DIFF
--- a/src/components/SecondaryPanes/Frames/Frame.js
+++ b/src/components/SecondaryPanes/Frames/Frame.js
@@ -20,7 +20,7 @@ type FrameTitleProps = {
 };
 
 function FrameTitle({ frame, options = {} }: FrameTitleProps) {
-  const displayName = formatDisplayName(frame, { ...options, maxLength: null });
+  const displayName = formatDisplayName(frame, options);
   return <div className="title">{displayName}</div>;
 }
 

--- a/src/components/SecondaryPanes/Frames/Group.js
+++ b/src/components/SecondaryPanes/Frames/Group.js
@@ -123,7 +123,7 @@ export default class Group extends Component<Props, State> {
 
   renderDescription() {
     const frame = this.props.group[0];
-    const displayName = formatDisplayName(frame, { maxLength: null });
+    const displayName = formatDisplayName(frame);
     return (
       <li
         key={frame.id}

--- a/src/components/shared/PreviewFunction.js
+++ b/src/components/shared/PreviewFunction.js
@@ -23,7 +23,7 @@ type Props = { func: FunctionType };
 
 export default class PreviewFunction extends Component<Props> {
   renderFunctionName(func: FunctionType) {
-    const name = formatDisplayName(func, { maxLength: null });
+    const name = formatDisplayName(func);
     return <span className="function-name">{name}</span>;
   }
 

--- a/src/utils/pause/frames/displayName.js
+++ b/src/utils/pause/frames/displayName.js
@@ -7,7 +7,6 @@
 // eslint-disable-next-line max-len
 import type { LocalFrame } from "../../../components/SecondaryPanes/Frames/types";
 import { getFilename } from "../../source";
-import { endTruncateStr } from "../../../utils/utils";
 
 // Decodes an anonymous naming scheme that
 // spider monkey implements based on "Naming Anonymous JavaScript Functions"
@@ -80,12 +79,11 @@ function getFrameDisplayName(frame: LocalFrame): string {
 }
 
 type formatDisplayNameParams = {
-  shouldMapDisplayName: boolean,
-  maxLength: number
+  shouldMapDisplayName: boolean
 };
 export function formatDisplayName(
   frame: LocalFrame,
-  { shouldMapDisplayName = true, maxLength = 25 }: formatDisplayNameParams = {}
+  { shouldMapDisplayName = true }: formatDisplayNameParams = {}
 ): string {
   const { library } = frame;
   let displayName = getFrameDisplayName(frame);
@@ -93,12 +91,7 @@ export function formatDisplayName(
     displayName = mapDisplayNames(frame, library);
   }
 
-  displayName =
-    simplifyDisplayName(displayName) || L10N.getStr("anonymousFunction");
-
-  return Number.isInteger(maxLength)
-    ? endTruncateStr(displayName, maxLength)
-    : displayName;
+  return simplifyDisplayName(displayName) || L10N.getStr("anonymousFunction");
 }
 
 export function formatCopyName(frame: LocalFrame): string {

--- a/src/utils/pause/frames/tests/displayName.spec.js
+++ b/src/utils/pause/frames/tests/displayName.spec.js
@@ -48,7 +48,7 @@ describe("formatting display names", () => {
     expect(formatDisplayName(frame)).toEqual("baz");
   });
 
-  it("truncates long function names", () => {
+  it("does not truncates long function names", () => {
     const frame = {
       displayName: "bazbazbazbazbazbazbazbazbazbazbazbazbaz",
       source: {
@@ -56,29 +56,7 @@ describe("formatting display names", () => {
       }
     };
 
-    expect(formatDisplayName(frame)).toEqual("…zbazbazbazbazbazbazbazbaz");
-  });
-
-  it("truncates function names according to maxLength", () => {
-    const frame = {
-      displayName: "bazbazbazbazbazbazbazbazbazbazbazbazbaz",
-      source: {
-        url: "assets/bar.js"
-      }
-    };
-
-    expect(formatDisplayName(frame, { maxLength: 3 })).toEqual("…baz");
-  });
-
-  it("does not truncate when explicit null maxLength", () => {
-    const frame = {
-      displayName: "bazbazbazbazbazbazbazbazbazbazbazbazbaz",
-      source: {
-        url: "assets/bar.js"
-      }
-    };
-
-    expect(formatDisplayName(frame, { maxLength: null })).toEqual(
+    expect(formatDisplayName(frame)).toEqual(
       "bazbazbazbazbazbazbazbazbazbazbazbazbaz"
     );
   });


### PR DESCRIPTION
This was only used from `formatCopyName`, where it
also make sense to get the full function name and
not truncate it.
Tests are modified accordingly.
