### PR TITLE
Add tooltip to remove expression

### DIFF
--- a/assets/panel/debugger.properties
+++ b/assets/panel/debugger.properties
@@ -513,6 +513,7 @@ expressions.errorMsg=Invalid expression…
 expressions.label=Add watch expression
 expressions.accesskey=e
 expressions.key=CmdOrCtrl+Shift+E
+expressions.remove.tooltip=Remove watch expression
 
 # LOCALIZATION NOTE (xhrBreakpoints.header): The pause on any XHR breakpoints headings
 xhrBreakpoints.header=XHR Breakpoints

--- a/src/components/SecondaryPanes/Expressions.js
+++ b/src/components/SecondaryPanes/Expressions.js
@@ -247,6 +247,7 @@ class Expressions extends Component<Props, State> {
           <div className="expression-container__close-btn">
             <CloseButton
               handleClick={e => this.deleteExpression(e, expression)}
+              tooltip={L10N.getStr("expressions.remove.tooltip")}
             />
           </div>
         </div>

--- a/src/components/SecondaryPanes/tests/__snapshots__/Expressions.spec.js.snap
+++ b/src/components/SecondaryPanes/tests/__snapshots__/Expressions.spec.js.snap
@@ -38,6 +38,7 @@ exports[`Expressions should always have unique keys 1`] = `
       >
         <CloseButton
           handleClick={[Function]}
+          tooltip="Remove watch expression"
         />
       </div>
     </div>
@@ -76,6 +77,7 @@ exports[`Expressions should always have unique keys 1`] = `
       >
         <CloseButton
           handleClick={[Function]}
+          tooltip="Remove watch expression"
         />
       </div>
     </div>
@@ -148,6 +150,7 @@ exports[`Expressions should render 1`] = `
       >
         <CloseButton
           handleClick={[Function]}
+          tooltip="Remove watch expression"
         />
       </div>
     </div>
@@ -186,6 +189,7 @@ exports[`Expressions should render 1`] = `
       >
         <CloseButton
           handleClick={[Function]}
+          tooltip="Remove watch expression"
         />
       </div>
     </div>


### PR DESCRIPTION
Fixes #7199 

### Summary of Changes

* Added item to debugger.properties
* Added tooltip prop to CloseButton in `debugger.html/src/components/SecondaryPanes/Expressions.js`
