### PR TITLE
[WIP] Add a utils to get the l10n object.

### DIFF
--- a/src/components/SecondaryPanes/Frames/Frame.js
+++ b/src/components/SecondaryPanes/Frames/Frame.js
@@ -9,6 +9,7 @@ import Svg from "../../shared/Svg";
 
 import { formatDisplayName } from "../../../utils/pause/frames";
 import { getFilename, getFileURL } from "../../../utils/source";
+
 import FrameMenu from "./FrameMenu";
 
 import type { Frame } from "../../../types";

--- a/src/components/SecondaryPanes/Frames/index.js
+++ b/src/components/SecondaryPanes/Frames/index.js
@@ -17,6 +17,7 @@ import renderWhyPaused from "./WhyPaused";
 import actions from "../../../actions";
 import { collapseFrames, formatCopyName } from "../../../utils/pause/frames";
 import { copyToTheClipboard } from "../../../utils/clipboard";
+import { getL10n } from "../../../utils/l10n";
 
 import {
   getFrameworkGroupingState,
@@ -160,9 +161,10 @@ class Frames extends Component<Props, State> {
   }
 
   renderToggleButton(frames: LocalFrame[]) {
+    const l10n = getL10n();
     const buttonMessage = this.state.showAllFrames
-      ? L10N.getStr("callStack.collapse")
-      : L10N.getStr("callStack.expand");
+      ? l10n.getStr("callStack.collapse")
+      : l10n.getStr("callStack.expand");
 
     frames = this.collapseFrames(frames);
     if (frames.length <= NUM_FRAMES_SHOWN) {
@@ -185,7 +187,7 @@ class Frames extends Component<Props, State> {
       return (
         <div className="pane frames">
           <div className="pane-info empty">
-            {L10N.getStr("callStack.notPaused")}
+            {getL10n().getStr("callStack.notPaused")}
           </div>
         </div>
       );

--- a/src/utils/l10n.js
+++ b/src/utils/l10n.js
@@ -1,0 +1,20 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
+import { isFirefoxPanel } from "devtools-environment";
+let l10n;
+
+export function getL10n() {
+  if (!l10n) {
+    if (isFirefoxPanel()) {
+      const { LocalizationHelper } = require("devtools/shared/l10n");
+      l10n = new LocalizationHelper(
+        "devtools/client/locales/debugger.properties"
+      );
+    } else {
+      l10n = window.L10N;
+    }
+  }
+  return l10n;
+}

--- a/src/utils/pause/frames/displayName.js
+++ b/src/utils/pause/frames/displayName.js
@@ -7,6 +7,7 @@
 // eslint-disable-next-line max-len
 import type { LocalFrame } from "../../../components/SecondaryPanes/Frames/types";
 import { getFilename } from "../../source";
+import { getL10n } from "../../l10n";
 
 // Decodes an anonymous naming scheme that
 // spider monkey implements based on "Naming Anonymous JavaScript Functions"
@@ -91,7 +92,9 @@ export function formatDisplayName(
     displayName = mapDisplayNames(frame, library);
   }
 
-  return simplifyDisplayName(displayName) || L10N.getStr("anonymousFunction");
+  return (
+    simplifyDisplayName(displayName) || getL10n().getStr("anonymousFunction")
+  );
 }
 
 export function formatCopyName(frame: LocalFrame): string {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -71,6 +71,7 @@ webpackConfig.plugins.push(new ObjectRestSpreadPlugin());
 if (!isProduction) {
   webpackConfig.module = webpackConfig.module || {};
   webpackConfig.module.rules = webpackConfig.module.rules || [];
+  webpackConfig.externals = [/devtools\/shared\/l10n/];
 } else {
   webpackConfig.output.libraryTarget = "umd";
 


### PR DESCRIPTION
Fixes #7132.

This allow us to *not* rely on a global `L10N`
property, which might not exist in some case,
for example if a  component is imported from other
panels than the debugger.