### PR TITLE
Share querystring logic with tabs & breakpoints sidebar 

### DIFF
--- a/src/components/Editor/Tab.js
+++ b/src/components/Editor/Tab.js
@@ -185,6 +185,7 @@ class Tab extends PureComponent<Props> {
     });
 
     const path = getDisplayPath(source, tabSources);
+    const query = hasSiblingOfSameName ? getSourceQueryString(source) : "";
 
     return (
       <div
@@ -194,15 +195,14 @@ class Tab extends PureComponent<Props> {
         // Accommodate middle click to close tab
         onMouseUp={e => e.button === 1 && closeTab(source)}
         onContextMenu={e => this.onTabContextMenu(e, sourceId)}
-        title={getFileURL(source)}
+        title={getFileURL(source, false)}
       >
         <SourceIcon
           source={source}
           shouldHide={icon => ["file", "javascript"].includes(icon)}
         />
         <div className="filename">
-          {getTruncatedFileName(source)}
-          {hasSiblingOfSameName && getSourceQueryString(source)}
+          {getTruncatedFileName(source, query)}
           {path && <span>{`../${path}/..`}</span>}
         </div>
         <CloseButton

--- a/src/components/Editor/Tab.js
+++ b/src/components/Editor/Tab.js
@@ -22,7 +22,8 @@ import {
   getRawSourceURL,
   getTruncatedFileName,
   getDisplayPath,
-  isPretty
+  isPretty,
+  getSourceQueryString
 } from "../../utils/source";
 import { copyToTheClipboard } from "../../utils/clipboard";
 import { getTabMenuItems } from "../../utils/tabs";
@@ -35,7 +36,6 @@ import {
 } from "../../selectors";
 
 import classnames from "classnames";
-import { parse } from "../../utils/url";
 
 type SourcesList = List<Source>;
 
@@ -185,8 +185,6 @@ class Tab extends PureComponent<Props> {
     });
 
     const path = getDisplayPath(source, tabSources);
-    const query =
-      source && hasSiblingOfSameName ? parse(source.url).search : null;
 
     return (
       <div
@@ -204,7 +202,7 @@ class Tab extends PureComponent<Props> {
         />
         <div className="filename">
           {getTruncatedFileName(source)}
-          {query}
+          {hasSiblingOfSameName && getSourceQueryString(source)}
           {path && <span>{`../${path}/..`}</span>}
         </div>
         <CloseButton

--- a/src/components/Editor/Tab.js
+++ b/src/components/Editor/Tab.js
@@ -30,10 +30,12 @@ import { getTabMenuItems } from "../../utils/tabs";
 import {
   getSelectedSource,
   getActiveSearch,
-  getSourcesForTabs
+  getSourcesForTabs,
+  getHasSiblingOfSameName
 } from "../../selectors";
 
 import classnames from "classnames";
+import { parse } from "../../utils/url";
 
 type SourcesList = List<Source>;
 
@@ -46,7 +48,8 @@ type Props = {
   closeTab: Source => void,
   closeTabs: (List<string>) => void,
   togglePrettyPrint: string => void,
-  showSource: string => void
+  showSource: string => void,
+  hasSiblingOfSameName: boolean
 };
 
 class Tab extends PureComponent<Props> {
@@ -155,7 +158,8 @@ class Tab extends PureComponent<Props> {
       selectSource,
       closeTab,
       source,
-      tabSources
+      tabSources,
+      hasSiblingOfSameName
     } = this.props;
     const sourceId = source.id;
     const active =
@@ -181,6 +185,8 @@ class Tab extends PureComponent<Props> {
     });
 
     const path = getDisplayPath(source, tabSources);
+    const query =
+      source && hasSiblingOfSameName ? parse(source.url).search : null;
 
     return (
       <div
@@ -198,6 +204,7 @@ class Tab extends PureComponent<Props> {
         />
         <div className="filename">
           {getTruncatedFileName(source)}
+          {query}
           {path && <span>{`../${path}/..`}</span>}
         </div>
         <CloseButton
@@ -215,7 +222,8 @@ const mapStateToProps = (state, { source }) => {
   return {
     tabSources: getSourcesForTabs(state),
     selectedSource: selectedSource,
-    activeSearch: getActiveSearch(state)
+    activeSearch: getActiveSearch(state),
+    hasSiblingOfSameName: getHasSiblingOfSameName(state, source)
   };
 };
 

--- a/src/components/PrimaryPanes/SourcesTreeItem.js
+++ b/src/components/PrimaryPanes/SourcesTreeItem.js
@@ -18,11 +18,13 @@ import {
 } from "../../selectors";
 import actions from "../../actions";
 
-import { isOriginal as isOriginalSource } from "../../utils/source";
+import {
+  isOriginal as isOriginalSource,
+  getSourceQueryString
+} from "../../utils/source";
 import { isDirectory } from "../../utils/sources-tree";
 import { copyToTheClipboard } from "../../utils/clipboard";
 import { features } from "../../utils/prefs";
-import { parse } from "../../utils/url";
 
 import type { TreeNode } from "../../utils/sources-tree/types";
 import type { Source } from "../../types";
@@ -181,7 +183,7 @@ class SourceTreeItem extends Component<Props, State> {
       <span className="suffix">{L10N.getStr("sourceFooter.mappedSuffix")}</span>
     ) : null;
 
-    const querystring = source ? parse(source.url).search : null;
+    const querystring = getSourceQueryString(source);
     const query =
       hasSiblingOfSameName && querystring ? (
         <span className="query">{querystring}</span>

--- a/src/components/PrimaryPanes/SourcesTreeItem.js
+++ b/src/components/PrimaryPanes/SourcesTreeItem.js
@@ -14,7 +14,7 @@ import Svg from "../shared/Svg";
 
 import {
   getGeneratedSourceByURL,
-  getSourcesUrlsInSources
+  getHasSiblingOfSameName
 } from "../../selectors";
 import actions from "../../actions";
 
@@ -212,14 +212,6 @@ function getHasMatchingGeneratedSource(state, source: ?Source) {
   }
 
   return !!getGeneratedSourceByURL(state, source.url);
-}
-
-function getHasSiblingOfSameName(state, source: ?Source) {
-  if (!source) {
-    return false;
-  }
-
-  return getSourcesUrlsInSources(state, source.url).length > 1;
 }
 
 const mapStateToProps = (state, props) => {

--- a/src/components/SecondaryPanes/Breakpoints/BreakpointHeading.js
+++ b/src/components/SecondaryPanes/Breakpoints/BreakpointHeading.js
@@ -1,0 +1,68 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
+// @flow
+import React, { PureComponent } from "react";
+import { connect } from "react-redux";
+import actions from "../../../actions";
+import {
+  getTruncatedFileName,
+  getDisplayPath,
+  getRawSourceURL,
+  getSourceQueryString
+} from "../../../utils/source";
+import { getHasSiblingOfSameName } from "../../../selectors";
+
+import SourceIcon from "../../shared/SourceIcon";
+
+import type { Source } from "../../../types";
+
+type Props = {
+  sources: Source[],
+  source: Source,
+  hasSiblingOfSameName: boolean,
+  selectSource: string => void
+};
+
+class BreakpointHeading extends PureComponent<Props> {
+  render() {
+    const { sources, source, hasSiblingOfSameName, selectSource } = this.props;
+
+    const path = getDisplayPath(source, sources);
+    const querystring = getSourceQueryString(source);
+    const query =
+      hasSiblingOfSameName && querystring ? (
+        <span className="query">{querystring}</span>
+      ) : null;
+
+    return (
+      <div
+        className="breakpoint-heading"
+        title={getRawSourceURL(source.url)}
+        onClick={() => selectSource(source.id)}
+      >
+        <SourceIcon
+          source={source}
+          shouldHide={icon => ["file", "javascript"].includes(icon)}
+        />
+        <div className="filename">
+          {getTruncatedFileName(source)}
+          {query}
+          {path && <span>{`../${path}/..`}</span>}
+        </div>
+      </div>
+    );
+  }
+}
+
+const mapStateToProps = (state, { source }) => {
+  console.log("State Sources", state.sources);
+  console.log("Source:", source);
+  return { hasSiblingOfSameName: getHasSiblingOfSameName(state, source) };
+};
+
+export default connect(
+  mapStateToProps,
+  { selectSource: actions.selectSource }
+)(BreakpointHeading);

--- a/src/components/SecondaryPanes/Breakpoints/BreakpointHeading.js
+++ b/src/components/SecondaryPanes/Breakpoints/BreakpointHeading.js
@@ -9,8 +9,8 @@ import actions from "../../../actions";
 import {
   getTruncatedFileName,
   getDisplayPath,
-  getRawSourceURL,
-  getSourceQueryString
+  getSourceQueryString,
+  getFileURL
 } from "../../../utils/source";
 import { getHasSiblingOfSameName } from "../../../selectors";
 
@@ -30,16 +30,12 @@ class BreakpointHeading extends PureComponent<Props> {
     const { sources, source, hasSiblingOfSameName, selectSource } = this.props;
 
     const path = getDisplayPath(source, sources);
-    const querystring = getSourceQueryString(source);
-    const query =
-      hasSiblingOfSameName && querystring ? (
-        <span className="query">{querystring}</span>
-      ) : null;
+    const query = hasSiblingOfSameName ? getSourceQueryString(source) : "";
 
     return (
       <div
         className="breakpoint-heading"
-        title={getRawSourceURL(source.url)}
+        title={getFileURL(source, false)}
         onClick={() => selectSource(source.id)}
       >
         <SourceIcon
@@ -47,8 +43,7 @@ class BreakpointHeading extends PureComponent<Props> {
           shouldHide={icon => ["file", "javascript"].includes(icon)}
         />
         <div className="filename">
-          {getTruncatedFileName(source)}
-          {query}
+          {getTruncatedFileName(source, query)}
           {path && <span>{`../${path}/..`}</span>}
         </div>
       </div>

--- a/src/components/SecondaryPanes/Breakpoints/BreakpointHeading.js
+++ b/src/components/SecondaryPanes/Breakpoints/BreakpointHeading.js
@@ -56,11 +56,9 @@ class BreakpointHeading extends PureComponent<Props> {
   }
 }
 
-const mapStateToProps = (state, { source }) => {
-  console.log("State Sources", state.sources);
-  console.log("Source:", source);
-  return { hasSiblingOfSameName: getHasSiblingOfSameName(state, source) };
-};
+const mapStateToProps = (state, { source }) => ({
+  hasSiblingOfSameName: getHasSiblingOfSameName(state, source)
+});
 
 export default connect(
   mapStateToProps,

--- a/src/components/SecondaryPanes/Breakpoints/Breakpoints.css
+++ b/src/components/SecondaryPanes/Breakpoints/Breakpoints.css
@@ -22,6 +22,11 @@
   align-items: center;
 }
 
+.breakpoints-list .breakpoint-heading .filename {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 .breakpoints-list .breakpoint-heading .filename span {
   opacity: 0.7;
   padding-left: 4px;

--- a/src/components/SecondaryPanes/Breakpoints/index.js
+++ b/src/components/SecondaryPanes/Breakpoints/index.js
@@ -11,14 +11,10 @@ import { connect } from "react-redux";
 import ExceptionOption from "./ExceptionOption";
 
 import Breakpoint from "./Breakpoint";
-import SourceIcon from "../../shared/SourceIcon";
+import BreakpointHeading from "./BreakpointHeading";
 
 import actions from "../../../actions";
-import {
-  getTruncatedFileName,
-  getDisplayPath,
-  getRawSourceURL
-} from "../../../utils/source";
+import { getDisplayPath } from "../../../utils/source";
 import { makeLocationId } from "../../../utils/breakpoint";
 
 import { getSelectedSource, getBreakpointSources } from "../../../selectors";
@@ -33,8 +29,7 @@ type Props = {
   selectedSource: Source,
   shouldPauseOnExceptions: boolean,
   shouldPauseOnCaughtExceptions: boolean,
-  pauseOnExceptions: Function,
-  selectSource: string => void
+  pauseOnExceptions: Function
 };
 
 class Breakpoints extends Component<Props> {
@@ -85,21 +80,12 @@ class Breakpoints extends Component<Props> {
       ...breakpointSources.map(({ source, breakpoints, i }) => {
         const path = getDisplayPath(source, sources);
         return [
-          <div
-            className="breakpoint-heading"
-            title={getRawSourceURL(source.url)}
+          <BreakpointHeading
+            source={source}
+            sources={sources}
+            path={path}
             key={source.url}
-            onClick={() => this.props.selectSource(source.id)}
-          >
-            <SourceIcon
-              source={source}
-              shouldHide={icon => ["file", "javascript"].includes(icon)}
-            />
-            <div className="filename">
-              {getTruncatedFileName(source)}
-              {path && <span>{`../${path}/..`}</span>}
-            </div>
-          </div>,
+          />,
           ...breakpoints.map(breakpoint => (
             <Breakpoint
               breakpoint={breakpoint}
@@ -130,7 +116,6 @@ const mapStateToProps = state => ({
 export default connect(
   mapStateToProps,
   {
-    pauseOnExceptions: actions.pauseOnExceptions,
-    selectSource: actions.selectSource
+    pauseOnExceptions: actions.pauseOnExceptions
   }
 )(Breakpoints);

--- a/src/reducers/sources.js
+++ b/src/reducers/sources.js
@@ -440,6 +440,14 @@ export function getSourcesUrlsInSources(state: OuterState, url: string) {
   return [...new Set(Object.keys(urls).filter(Boolean))];
 }
 
+export function getHasSiblingOfSameName(state: OuterState, source: ?Source) {
+  if (!source) {
+    return false;
+  }
+
+  return getSourcesUrlsInSources(state, source.url).length > 1;
+}
+
 export function getSourceInSources(sources: SourcesMap, id: string): ?Source {
   return sources[id];
 }

--- a/src/test/mochitest/browser_dbg-sources-querystring.js
+++ b/src/test/mochitest/browser_dbg-sources-querystring.js
@@ -30,6 +30,7 @@ add_task(async function() {
   )
 
   await clickElement(dbg, "sourceNode", 3);
+  const activeSourceLabel = getLabel(dbg, 3);
   const tab = findElement(dbg, "activeTab");
-  is(tab.innerText, "simple1.js?x=2", "Tab label is simple1.js?x=2");
+  is(tab.innerText, activeSourceLabel, `Tab label is ${activeSourceLabel}`);
 });

--- a/src/test/mochitest/browser_dbg-sources-querystring.js
+++ b/src/test/mochitest/browser_dbg-sources-querystring.js
@@ -29,8 +29,15 @@ add_task(async function() {
     "simple1.js?x=1 and simple2.jsx=2 exist"
   );
 
-  await clickElement(dbg, "sourceNode", 3);
-  const activeSourceLabel = getLabel(dbg, 3);
+  const source = findSource(dbg, "simple1.js?x=1");
+  await selectSource(dbg, source);
   const tab = findElement(dbg, "activeTab");
-  is(tab.innerText, activeSourceLabel, `Tab label is ${activeSourceLabel}`);
+  is(tab.innerText, "simple1.js?x=1", "Tab label is simple1.js?x=1");
+  await addBreakpoint(dbg, "simple1.js?x=1", 6);
+  const breakpointHeading = findElement(dbg, "breakpointItem", 2).innerText;
+  is(
+    breakpointHeading,
+    "simple1.js?x=1",
+    "Breakpoint heading is simple1.js?x=1"
+  );
 });

--- a/src/test/mochitest/browser_dbg-sources-querystring.js
+++ b/src/test/mochitest/browser_dbg-sources-querystring.js
@@ -28,4 +28,8 @@ add_task(async function() {
     true,
     "simple1.js?x=1 and simple2.jsx=2 exist"
   )
+
+  await clickElement(dbg, "sourceNode", 3);
+  const tab = findElement(dbg, "activeTab");
+  is(tab.innerText, "simple1.js?x=2", "Tab label is simple1.js?x=2");
 });

--- a/src/test/mochitest/browser_dbg-sources-querystring.js
+++ b/src/test/mochitest/browser_dbg-sources-querystring.js
@@ -27,7 +27,7 @@ add_task(async function() {
     labels.includes("simple1.js?x=1") && labels.includes("simple1.js?x=2"),
     true,
     "simple1.js?x=1 and simple2.jsx=2 exist"
-  )
+  );
 
   await clickElement(dbg, "sourceNode", 3);
   const activeSourceLabel = getLabel(dbg, 3);

--- a/src/utils/source.js
+++ b/src/utils/source.js
@@ -447,3 +447,7 @@ export function isOriginal(source: Source) {
 export function isGenerated(source: Source) {
   return isGeneratedId(source.id);
 }
+
+export function getSourceQueryString(source: ?Source) {
+  return source ? parseURL(source.url).search : null;
+}

--- a/src/utils/source.js
+++ b/src/utils/source.js
@@ -169,8 +169,12 @@ export function getFilename(source: Source) {
  * @memberof utils/source
  * @static
  */
-export function getTruncatedFileName(source: Source, length: number = 30) {
-  return truncateMiddleText(getFilename(source), length);
+export function getTruncatedFileName(
+  source: Source,
+  querystring: string = "",
+  length: number = 30
+) {
+  return truncateMiddleText(`${getFilename(source)}${querystring}`, length);
 }
 
 /* Gets path for files with same filename for editor tabs, breakpoints, etc.
@@ -449,5 +453,5 @@ export function isGenerated(source: Source) {
 }
 
 export function getSourceQueryString(source: ?Source) {
-  return source ? parseURL(source.url).search : null;
+  return source ? parseURL(source.url).search : "";
 }

--- a/src/utils/tests/source.spec.js
+++ b/src/utils/tests/source.spec.js
@@ -66,6 +66,7 @@ describe("sources", () => {
             url: "really-really-really-really-really-really-long-name.html",
             id: ""
           },
+          "",
           30
         )
       ).toBe("really-really…long-name.html");
@@ -77,6 +78,7 @@ describe("sources", () => {
             url: `${encodedUnicode.repeat(30)}.html`,
             id: ""
           },
+          "",
           30
         )
       ).toBe("測測測測測測測測測測測測測…測測測測測測測測測.html");


### PR DESCRIPTION
Fixes #7159 

### Summary of Changes
- [x] Share query string logic with tabs
- [x] Share query string logic with breakpoints sidebar

### Test Plan

1. Open the test URL https://shimmer-ostrich.glitch.me/
2. Open debugger.
3. Reload the test URL.
4. Open one of the `script.js` source and observe the query string appended to the name in the tab
5. Add a debugger to the `script.js` and observe the query string appended to the name in the breakpoints sidebar

Mochitests
- [x] Add check for querystring in tab name to `dbg-sources-querystring`
- [x] Add check for querystring in breakpoints side bar in `dbg-sources-querystring`

### Screenshots
<img width="1440" alt="screen shot 2018-11-04 at 4 45 44 pm" src="https://user-images.githubusercontent.com/5448834/47971722-463a5180-e051-11e8-8b2c-d72159bca643.png">



### Questions/Thoughts
I considered moving `https://github.com/wenincode/debugger.html/blob/7159-source-querystring-logic-tabs-sidebar/src/reducers/sources.js#L434-L449` into a separate `utils` because they aren't actual `reducers` and aren't actually being used by the `reducer` in this file. I _think_ they are in here because the code is a bit tied to the `OuterState` type. I was going to move it and change the types to just be an array of sources to try and decouple it from this file, but the more I work with it the more I see why it is the way it is now. Just seemed a bit odd to have these functions in here.

For the adding logic to sidebar stuff I am thinking of moving [this code] into a sub-component. The reasoning being that I _think_ I could leverage a similar `mapStateToProps` with `OuterState` approach as the other two areas. I am not _entirely_ sure how that all works yet, still pretty new to redux land. I just don't currently see how I can get the right state to pass into those functions in the reducer without moving this code. Just wanted to capture my thoughts before I shut down for the night 😄 
