### PR TITLE
[Breakponts] remove immutable.js wrappers

### DIFF
--- a/src/actions/breakpoints/index.js
+++ b/src/actions/breakpoints/index.js
@@ -242,7 +242,6 @@ export function setBreakpointCondition(
 
     if (bp.disabled) {
       await dispatch(enableBreakpoint(location));
-      bp.disabled = !bp.disabled;
     }
 
     await client.setBreakpointCondition(
@@ -252,7 +251,7 @@ export function setBreakpointCondition(
       isOriginalId(bp.location.sourceId)
     );
 
-    const newBreakpoint = { ...bp, condition };
+    const newBreakpoint = { ...bp, disabled: false, condition };
 
     assertBreakpoint(newBreakpoint);
 

--- a/src/actions/breakpoints/index.js
+++ b/src/actions/breakpoints/index.js
@@ -13,7 +13,7 @@ import { isOriginalId } from "devtools-source-map";
 import { PROMISE } from "../utils/middleware/promise";
 import {
   getBreakpoint,
-  getBreakpoints,
+  getBreakpointsList,
   getXHRBreakpoints,
   getSelectedSource,
   getBreakpointAtLocation,
@@ -33,7 +33,6 @@ import { isEmptyLineInSource } from "../../reducers/ast";
 
 import type { ThunkArgs, Action } from "../types";
 import type { Breakpoint, Location, XHRBreakpoint } from "../../types";
-import type { BreakpointsMap } from "../../reducers/types";
 
 import { recordEvent } from "../../utils/telemetry";
 
@@ -113,11 +112,11 @@ export function disableBreakpoint(location: Location) {
  */
 export function toggleAllBreakpoints(shouldDisableBreakpoints: boolean) {
   return async ({ dispatch, getState, client }: ThunkArgs) => {
-    const breakpoints = getBreakpoints(getState());
+    const breakpoints = getBreakpointsList(getState());
 
     const modifiedBreakpoints = [];
 
-    for (const [, breakpoint] of breakpoints) {
+    for (const breakpoint of breakpoints) {
       if (shouldDisableBreakpoints) {
         await client.removeBreakpoint(breakpoint.generatedLocation);
         const newBreakpoint: Breakpoint = { ...breakpoint, disabled: true };
@@ -154,18 +153,15 @@ export function toggleAllBreakpoints(shouldDisableBreakpoints: boolean) {
  */
 export function toggleBreakpoints(
   shouldDisableBreakpoints: boolean,
-  breakpoints: BreakpointsMap
+  breakpoints: Breakpoint[]
 ) {
   return async ({ dispatch }: ThunkArgs) => {
-    const promises = breakpoints
-      .valueSeq()
-      .toJS()
-      .map(
-        ([, breakpoint]) =>
-          shouldDisableBreakpoints
-            ? dispatch(disableBreakpoint(breakpoint.location))
-            : dispatch(enableBreakpoint(breakpoint.location))
-      );
+    const promises = breakpoints.map(
+      breakpoint =>
+        shouldDisableBreakpoints
+          ? dispatch(disableBreakpoint(breakpoint.location))
+          : dispatch(enableBreakpoint(breakpoint.location))
+    );
 
     await Promise.all(promises);
   };
@@ -179,9 +175,7 @@ export function toggleBreakpoints(
  */
 export function removeAllBreakpoints() {
   return async ({ dispatch, getState }: ThunkArgs) => {
-    const breakpointList = getBreakpoints(getState())
-      .valueSeq()
-      .toJS();
+    const breakpointList = getBreakpointsList(getState());
     return Promise.all(
       breakpointList.map(bp => dispatch(removeBreakpoint(bp.location)))
     );
@@ -194,18 +188,17 @@ export function removeAllBreakpoints() {
  * @memberof actions/breakpoints
  * @static
  */
-export function removeBreakpoints(breakpoints: BreakpointsMap) {
+export function removeBreakpoints(breakpoints: Breakpoint[]) {
   return async ({ dispatch }: ThunkArgs) => {
-    const breakpointList = breakpoints.valueSeq().toJS();
     return Promise.all(
-      breakpointList.map(bp => dispatch(removeBreakpoint(bp.location)))
+      breakpoints.map(bp => dispatch(removeBreakpoint(bp.location)))
     );
   };
 }
 
 export function remapBreakpoints(sourceId: string) {
   return async ({ dispatch, getState, sourceMaps }: ThunkArgs) => {
-    const breakpoints = getBreakpoints(getState());
+    const breakpoints = getBreakpointsList(getState());
     const newBreakpoints = await remapLocations(
       breakpoints,
       sourceId,
@@ -322,7 +315,7 @@ export function toggleBreakpointsAtLine(line: number, column?: number) {
     const bps = getBreakpointsAtLine(state, line);
     const isEmptyLine = isEmptyLineInSource(state, line, selectedSource.id);
 
-    if (bps.size === 0 && !isEmptyLine) {
+    if (bps.length === 0 && !isEmptyLine) {
       return dispatch(
         addBreakpoint({
           sourceId: selectedSource.id,

--- a/src/actions/breakpoints/remapLocations.js
+++ b/src/actions/breakpoints/remapLocations.js
@@ -5,14 +5,13 @@
 // @flow
 
 import type { Breakpoint } from "../../types";
-import type { BreakpointsMap } from "../../selectors";
 
 export default function remapLocations(
   breakpoints: Breakpoint[],
   sourceId: string,
   sourceMaps: Object
 ) {
-  const sourceBreakpoints: BreakpointsMap = breakpoints.map(
+  const sourceBreakpoints: Promise<Breakpoint>[] = breakpoints.map(
     async breakpoint => {
       if (breakpoint.location.sourceId !== sourceId) {
         return breakpoint;
@@ -24,5 +23,5 @@ export default function remapLocations(
     }
   );
 
-  return Promise.all(sourceBreakpoints.valueSeq());
+  return Promise.all(sourceBreakpoints);
 }

--- a/src/actions/breakpoints/tests/breakpoints.spec.js
+++ b/src/actions/breakpoints/tests/breakpoints.spec.js
@@ -28,9 +28,8 @@ describe("breakpoints", () => {
     await dispatch(actions.loadSourceText(makeSource("a")));
     await dispatch(actions.addBreakpoint(loc1));
 
-    const bps = selectors.getBreakpoints(getState());
+    expect(selectors.getBreakpointCount(getState())).toEqual(1);
     const bp = selectors.getBreakpoint(getState(), loc1);
-    expect(bps.size).toBe(1);
     expect(bp.location).toEqual(loc1);
     expect(getTelemetryEvents("add_breakpoint")).toHaveLength(1);
 
@@ -49,9 +48,8 @@ describe("breakpoints", () => {
     await dispatch(actions.loadSourceText(makeSource("a")));
     await dispatch(actions.addBreakpoint(loc1));
 
-    const bps = selectors.getBreakpoints(getState());
+    expect(selectors.getBreakpointCount(getState())).toEqual(1);
     const bp = selectors.getBreakpoint(getState(), loc1);
-    expect(bps.size).toBe(1);
     expect(bp.location).toEqual(loc1);
     expect(selectors.getBreakpointSources(getState())).toMatchSnapshot();
   });
@@ -68,9 +66,8 @@ describe("breakpoints", () => {
     await dispatch(actions.addBreakpoint(loc1));
     await dispatch(actions.disableBreakpoint(loc1));
 
-    const bps = selectors.getBreakpoints(getState());
+    expect(selectors.getBreakpointCount(getState())).toEqual(1);
     const bp = selectors.getBreakpoint(getState(), loc1);
-    expect(bps.size).toBe(1);
     expect(bp.location).toEqual(loc1);
     expect(selectors.getBreakpointSources(getState())).toMatchSnapshot();
   });
@@ -87,14 +84,12 @@ describe("breakpoints", () => {
     await dispatch(actions.loadSourceText(makeSource("a")));
 
     await dispatch(actions.addBreakpoint(loc1));
-    let bps = selectors.getBreakpoints(getState());
+    expect(selectors.getBreakpointCount(getState())).toEqual(1);
     const bp = selectors.getBreakpoint(getState(), loc1);
-    expect(bps.size).toBe(1);
     expect(bp.location).toEqual(loc1);
 
     await dispatch(actions.addBreakpoint(loc1));
-    bps = selectors.getBreakpoints(getState());
-    expect(bps.size).toBe(1);
+    expect(selectors.getBreakpointCount(getState())).toEqual(1);
   });
 
   describe("adding a breakpoint to an invalid location", async () => {
@@ -115,9 +110,8 @@ describe("breakpoints", () => {
 
       await dispatch(actions.addBreakpoint(invalidLocation));
       const state = getState();
-      const bps = selectors.getBreakpoints(state);
+      expect(selectors.getBreakpointCount(state)).toEqual(1);
       const bp = selectors.getBreakpoint(state, correctedLocation);
-      expect(bps.size).toBe(1);
       expect(bp).toMatchSnapshot();
     });
   });
@@ -148,7 +142,7 @@ describe("breakpoints", () => {
 
     await dispatch(actions.removeBreakpoint(loc1));
 
-    expect(selectors.getBreakpoints(getState()).size).toBe(1);
+    expect(selectors.getBreakpointCount(getState())).toEqual(1);
   });
 
   it("should disable a breakpoint", async () => {
@@ -385,7 +379,7 @@ describe("breakpoints", () => {
     await dispatch(actions.addBreakpoint(loc));
     await dispatch(actions.togglePrettyPrint("a.js"));
 
-    const breakpoint = selectors.getBreakpoints(getState()).first();
+    const breakpoint = selectors.getBreakpointsList(getState())[0];
 
     expect(breakpoint.location.sourceUrl.includes("formatted")).toBe(true);
     expect(breakpoint).toMatchSnapshot();

--- a/src/actions/breakpoints/tests/syncing.spec.js
+++ b/src/actions/breakpoints/tests/syncing.spec.js
@@ -121,8 +121,7 @@ describe("loading the debugger", () => {
     const reloadedSource = makeSource("magic.js");
     await dispatch(actions.newSource(reloadedSource));
 
-    const breakpoints = selectors.getBreakpoints(getState());
-    expect(breakpoints.size).toBe(0);
+    expect(selectors.getBreakpointCount(getState())).toEqual(0);
     // manually sync
     const update = await syncBreakpointPromise(
       getState,
@@ -152,8 +151,7 @@ describe("loading the debugger", () => {
     const reloadedSource = makeSource("magic.js");
     await dispatch(actions.newSource(reloadedSource));
 
-    const breakpoints = selectors.getBreakpoints(getState());
-    expect(breakpoints.size).toBe(0);
+    expect(selectors.getBreakpointCount(getState())).toEqual(0);
     // manually sync
     const update = await syncBreakpointPromise(
       getState,

--- a/src/actions/breakpoints/tests/toggleBreakpointsAtLine.spec.js
+++ b/src/actions/breakpoints/tests/toggleBreakpointsAtLine.spec.js
@@ -42,7 +42,7 @@ describe("toggleBreakpointsAtLine", () => {
     await dispatch(actions.toggleBreakpointsAtLine(5));
     await waitForState(
       store,
-      state => selectors.getBreakpoints(state).size == 0
+      state => selectors.getBreakpointCount(state) === 0
     );
   });
 
@@ -65,7 +65,7 @@ describe("toggleBreakpointsAtLine", () => {
 
     await waitForState(
       store,
-      state => selectors.getBreakpoints(state).size == 0
+      state => selectors.getBreakpointCount(state) === 0
     );
   });
 });

--- a/src/actions/tests/pending-breakpoints.spec.js
+++ b/src/actions/tests/pending-breakpoints.spec.js
@@ -256,7 +256,7 @@ describe("initializing with disabled pending breakpoints in prefs", () => {
 
     await waitForState(store, state => {
       const bps = selectors.getBreakpointsForSource(state, "bar.js");
-      return bps && bps.size > 0;
+      return bps && Object.values(bps).length > 0;
     });
 
     const bp = selectors.getBreakpointForLine(getState(), "bar.js", 5);
@@ -270,20 +270,15 @@ describe("adding sources", () => {
     const store = createStore(simpleMockThreadClient, loadInitialState());
     const { getState, dispatch } = store;
 
-    let bps = selectors.getBreakpoints(getState());
-    expect(bps.size).toBe(0);
+    expect(selectors.getBreakpointCount(getState())).toEqual(0);
 
     const source = makeSource("bar.js");
     await dispatch(actions.newSource(source));
     await dispatch(actions.loadSourceText(makeSource("bar.js")));
 
-    await waitForState(
-      store,
-      state => selectors.getBreakpoints(state).size > 0
-    );
+    await waitForState(store, state => selectors.getBreakpointCount(state) > 0);
 
-    bps = selectors.getBreakpoints(getState());
-    expect(bps.size).toBe(1);
+    expect(selectors.getBreakpointCount(getState())).toEqual(1);
   });
 
   it("corresponding breakpoints are added to the original source", async () => {
@@ -301,26 +296,20 @@ describe("adding sources", () => {
 
     const { getState, dispatch } = store;
 
-    let bps = selectors.getBreakpoints(getState());
-    expect(bps.size).toBe(0);
+    expect(selectors.getBreakpointCount(getState())).toEqual(0);
 
     await dispatch(actions.newSource(source));
 
-    await waitForState(
-      store,
-      state => selectors.getBreakpoints(state).size > 0
-    );
+    await waitForState(store, state => selectors.getBreakpointCount(state) > 0);
 
-    bps = selectors.getBreakpoints(getState());
-    expect(bps.size).toBe(1);
+    expect(selectors.getBreakpointCount(getState())).toEqual(1);
   });
 
   it("add corresponding breakpoints for multiple sources", async () => {
     const store = createStore(simpleMockThreadClient, loadInitialState());
     const { getState, dispatch } = store;
 
-    let bps = selectors.getBreakpoints(getState());
-    expect(bps.size).toBe(0);
+    expect(selectors.getBreakpointCount(getState())).toEqual(0);
 
     const source1 = makeSource("bar.js");
     const source2 = makeSource("foo.js");
@@ -328,13 +317,9 @@ describe("adding sources", () => {
     await dispatch(actions.loadSourceText(makeSource("foo.js")));
     await dispatch(actions.loadSourceText(makeSource("bar.js")));
 
-    await waitForState(
-      store,
-      state => selectors.getBreakpoints(state).size > 0
-    );
+    await waitForState(store, state => selectors.getBreakpointCount(state) > 0);
 
-    bps = selectors.getBreakpoints(getState());
-    expect(bps.size).toBe(1);
+    expect(selectors.getBreakpointCount(getState())).toEqual(1);
   });
 });
 

--- a/src/components/Editor/Breakpoints.js
+++ b/src/components/Editor/Breakpoints.js
@@ -12,12 +12,11 @@ import { getSelectedSource, getVisibleBreakpoints } from "../../selectors";
 import { makeLocationId } from "../../utils/breakpoint";
 import { isLoaded } from "../../utils/source";
 
-import type { BreakpointsMap } from "../../reducers/types";
-import type { Source } from "../../types";
+import type { Breakpoint as BreakpointType, Source } from "../../types";
 
 type Props = {
   selectedSource: Source,
-  breakpoints: BreakpointsMap,
+  breakpoints: BreakpointType[],
   editor: Object
 };
 
@@ -39,7 +38,7 @@ class Breakpoints extends Component<Props> {
 
     return (
       <div>
-        {breakpoints.valueSeq().map(bp => {
+        {breakpoints.map(bp => {
           return (
             <Breakpoint
               key={makeLocationId(bp.location)}

--- a/src/components/Editor/CallSites.js
+++ b/src/components/Editor/CallSites.js
@@ -121,9 +121,7 @@ class CallSites extends Component {
   filterCallSitesByLineNumber() {
     const { callSites, breakpoints } = this.props;
 
-    const breakpointLines = new Set(
-      breakpoints.toIndexedSeq().map(bp => bp.location.line)
-    );
+    const breakpointLines = new Set(breakpoints.map(bp => bp.location.line));
 
     return callSites.filter(({ location }) =>
       breakpointLines.has(location.start.line)

--- a/src/components/Editor/CallSites.js
+++ b/src/components/Editor/CallSites.js
@@ -169,7 +169,7 @@ function getCallSites(symbols, breakpoints) {
   // to speed up the lookups. Hopefully we'll fix the
   // inconsistency with column offsets so that we can expect
   // a breakpoint to be added at the beginning of a call expression.
-  const bpLocationMap = keyBy(breakpoints.valueSeq().toJS(), ({ location }) =>
+  const bpLocationMap = keyBy(breakpoints, ({ location }) =>
     locationKey(location)
   );
 

--- a/src/components/Editor/tests/Breakpoints.spec.js
+++ b/src/components/Editor/tests/Breakpoints.spec.js
@@ -34,18 +34,18 @@ function render(overrides = {}) {
 describe("Breakpoints Component", () => {
   it("should render breakpoints without columns", async () => {
     const sourceId = "server1.conn1.child1/source1";
-    const breakpoints = I.Map({ id1: { location: { sourceId } } });
+    const breakpoints = [{ location: { sourceId } }];
 
     const { component, props } = render({ breakpoints });
-    expect(component.find("Breakpoint")).toHaveLength(props.breakpoints.size);
+    expect(component.find("Breakpoint")).toHaveLength(props.breakpoints.length);
   });
 
   it("should render breakpoints with columns", async () => {
     const sourceId = "server1.conn1.child1/source1";
-    const breakpoints = I.Map({ id1: { location: { column: 2, sourceId } } });
+    const breakpoints = [{ location: { column: 2, sourceId } }];
 
     const { component, props } = render({ breakpoints });
-    expect(component.find("Breakpoint")).toHaveLength(props.breakpoints.size);
+    expect(component.find("Breakpoint")).toHaveLength(props.breakpoints.length);
     expect(component).toMatchSnapshot();
   });
 });

--- a/src/components/SecondaryPanes/Breakpoints/Breakpoint.js
+++ b/src/components/SecondaryPanes/Breakpoints/Breakpoint.js
@@ -19,10 +19,14 @@ import { getSelectedLocation } from "../../../utils/source-maps";
 import { features } from "../../../utils/prefs";
 import { getEditor } from "../../../utils/editor";
 
-import type { BreakpointsMap } from "../../../reducers/types";
 import type { FormattedBreakpoint } from "../../../selectors/breakpointSources";
 
-import type { Frame, Source, Location } from "../../../types";
+import type {
+  Breakpoint as BreakpointType,
+  Frame,
+  Source,
+  Location
+} from "../../../types";
 
 type FormattedFrame = {
   ...Frame,
@@ -30,14 +34,14 @@ type FormattedFrame = {
 };
 
 import {
-  getBreakpoints,
+  getBreakpointsList,
   getSelectedFrame,
   getSelectedSource
 } from "../../../selectors";
 
 type Props = {
   breakpoint: FormattedBreakpoint,
-  breakpoints: BreakpointsMap,
+  breakpoints: BreakpointType[],
   source: Source,
   frame: ?FormattedFrame,
   enableBreakpoint: typeof actions.enableBreakpoint,
@@ -183,7 +187,7 @@ const getFormattedFrame = createSelector(
 );
 
 const mapStateToProps = state => ({
-  breakpoints: getBreakpoints(state),
+  breakpoints: getBreakpointsList(state),
   frame: getFormattedFrame(state)
 });
 

--- a/src/components/SecondaryPanes/Breakpoints/BreakpointsContextMenu.js
+++ b/src/components/SecondaryPanes/Breakpoints/BreakpointsContextMenu.js
@@ -184,10 +184,10 @@ export default function showContextMenu(props) {
   };
 
   const hideEnableSelfItem = !breakpoint.disabled;
-  const hideEnableAllItem = disabledBreakpoints.size === 0;
-  const hideEnableOthersItem = otherDisabledBreakpoints.size === 0;
-  const hideDisableAllItem = enabledBreakpoints.size === 0;
-  const hideDisableOthersItem = otherEnabledBreakpoints.size === 0;
+  const hideEnableAllItem = disabledBreakpoints.length === 0;
+  const hideEnableOthersItem = otherDisabledBreakpoints.length === 0;
+  const hideDisableAllItem = enabledBreakpoints.length === 0;
+  const hideDisableOthersItem = otherEnabledBreakpoints.length === 0;
   const hideDisableSelfItem = breakpoint.disabled;
 
   const items = [
@@ -201,7 +201,7 @@ export default function showContextMenu(props) {
     },
     { item: deleteSelfItem },
     { item: deleteAllItem },
-    { item: deleteOthersItem, hidden: () => breakpoints.size === 1 },
+    { item: deleteOthersItem, hidden: () => breakpoints.length === 1 },
     {
       item: { type: "separator" },
       hidden: () =>

--- a/src/components/SecondaryPanes/index.js
+++ b/src/components/SecondaryPanes/index.js
@@ -11,7 +11,7 @@ import { List } from "immutable";
 import actions from "../../actions";
 import {
   getTopFrame,
-  getBreakpoints,
+  getBreakpointsList,
   getBreakpointsDisabled,
   getBreakpointsLoading,
   getExpressions,
@@ -118,7 +118,7 @@ class SecondaryPanes extends Component<Props, State> {
     const isIndeterminate =
       !breakpointsDisabled && breakpoints.some(x => x.disabled);
 
-    if (features.skipPausing || breakpoints.size == 0) {
+    if (features.skipPausing || breakpoints.length === 0) {
       return null;
     }
 
@@ -438,7 +438,7 @@ const mapStateToProps = state => ({
   expressions: getExpressions(state),
   extra: getExtra(state),
   hasFrames: !!getTopFrame(state),
-  breakpoints: getBreakpoints(state),
+  breakpoints: getBreakpointsList(state),
   breakpointsDisabled: getBreakpointsDisabled(state),
   breakpointsLoading: getBreakpointsLoading(state),
   isWaitingOnBreak: getIsWaitingOnBreak(state),

--- a/src/reducers/breakpoints.js
+++ b/src/reducers/breakpoints.js
@@ -290,15 +290,15 @@ export function getBreakpointsLoading(state: OuterState): boolean {
 export function getBreakpointsForSource(
   state: OuterState,
   sourceId: string
-): BreakpointsMap {
+): Breakpoint[] {
   if (!sourceId) {
-    return {};
+    return [];
   }
 
   const isGeneratedSource = isGeneratedId(sourceId);
   const breakpoints = getBreakpointsMap(state);
 
-  const breakpointsForSource = {};
+  const breakpointsForSource = [];
 
   for (const key in breakpoints) {
     const bp = breakpoints[key];
@@ -306,7 +306,7 @@ export function getBreakpointsForSource(
       ? bp.generatedLocation || bp.location
       : bp.location;
     if (location.sourceId === sourceId) {
-      breakpointsForSource[key] = { ...bp };
+      breakpointsForSource.push({ ...bp });
     }
   }
 

--- a/src/reducers/breakpoints.js
+++ b/src/reducers/breakpoints.js
@@ -10,16 +10,14 @@
  */
 
 import * as I from "immutable";
-import makeRecord from "../utils/makeRecord";
 
 import { isGeneratedId } from "devtools-source-map";
 import { makeLocationId } from "../utils/breakpoint";
 
 import type { XHRBreakpoint, Breakpoint, Location } from "../types";
 import type { Action, DonePromiseAction } from "../actions/types";
-import type { Record } from "../utils/makeRecord";
 
-export type BreakpointsMap = I.Map<string, Breakpoint>;
+export type BreakpointsMap = { [string]: Breakpoint };
 export type XHRBreakpointsList = I.List<XHRBreakpoint>;
 
 export type BreakpointsState = {
@@ -29,20 +27,18 @@ export type BreakpointsState = {
 
 export function initialBreakpointsState(
   xhrBreakpoints?: any[] = []
-): Record<BreakpointsState> {
-  return makeRecord(
-    ({
-      breakpoints: I.Map(),
-      xhrBreakpoints: I.List(xhrBreakpoints),
-      breakpointsDisabled: false
-    }: BreakpointsState)
-  )();
+): BreakpointsState {
+  return {
+    breakpoints: {},
+    xhrBreakpoints: I.List(xhrBreakpoints),
+    breakpointsDisabled: false
+  };
 }
 
 function update(
-  state: Record<BreakpointsState> = initialBreakpointsState(),
+  state: BreakpointsState = initialBreakpointsState(),
   action: Action
-) {
+): BreakpointsState {
   switch (action.type) {
     case "ADD_BREAKPOINT": {
       return addBreakpoint(state, action);
@@ -118,12 +114,15 @@ function addXHRBreakpoint(state, action) {
   );
 
   if (existingBreakpointIndex === -1) {
-    return state.set("xhrBreakpoints", xhrBreakpoints.push(breakpoint));
+    return {
+      ...state,
+      xhrBreakpoints: xhrBreakpoints.push(breakpoint)
+    };
   } else if (xhrBreakpoints.get(existingBreakpointIndex) !== breakpoint) {
-    return state.set(
-      "xhrBreakpoints",
-      xhrBreakpoints.set(existingBreakpointIndex, breakpoint)
-    );
+    return {
+      ...state,
+      xhrBreakpoints: xhrBreakpoints.set(existingBreakpointIndex, breakpoint)
+    };
   }
 
   return state;
@@ -143,21 +142,42 @@ function removeXHRBreakpoint(state, action) {
     bp => bp.path === path && bp.method === method
   );
 
-  return state.set("xhrBreakpoints", xhrBreakpoints.delete(index));
+  return {
+    ...state,
+    xhrBreakpoints: xhrBreakpoints.delete(index)
+  };
 }
 
 function updateXHRBreakpoint(state, action) {
   const { breakpoint, index } = action;
   const { xhrBreakpoints } = state;
-
-  return state.set("xhrBreakpoints", xhrBreakpoints.set(index, breakpoint));
+  return {
+    ...state,
+    xhrBreakpoints: xhrBreakpoints.set(index, breakpoint)
+  };
 }
 
-function addBreakpoint(state, action) {
+function setBreakpoint(state, locationId, breakpoint) {
+  return {
+    ...state,
+    breakpoints: { ...state.breakpoints, [locationId]: breakpoint }
+  };
+}
+
+function unsetBreakpoint(state, locationId) {
+  const breakpoints = { ...state.breakpoints };
+  delete breakpoints[locationId];
+  return {
+    ...state,
+    breakpoints: { ...breakpoints }
+  };
+}
+
+function addBreakpoint(state, action): BreakpointsState {
   if (action.status === "start" && action.breakpoint) {
     const { breakpoint } = action;
     const locationId = makeLocationId(breakpoint.location);
-    return state.setIn(["breakpoints", locationId], breakpoint);
+    return setBreakpoint(state, locationId, breakpoint);
   }
 
   // when the action completes, we can commit the breakpoint
@@ -169,17 +189,21 @@ function addBreakpoint(state, action) {
   // Remove the optimistic update
   if (action.status === "error" && action.breakpoint) {
     const locationId = makeLocationId(action.breakpoint.location);
-    return state.deleteIn(["breakpoints", locationId]);
+    return unsetBreakpoint(state, locationId);
   }
 
   return state;
 }
 
-function syncBreakpoint(state, data) {
+function syncBreakpoint(state, data): BreakpointsState {
   const { breakpoint, previousLocation } = data;
 
   if (previousLocation) {
-    state = state.deleteIn(["breakpoints", makeLocationId(previousLocation)]);
+    state = {
+      ...state,
+      breakpoints: { ...state.breakpoints }
+    };
+    delete state.breakpoints[makeLocationId(previousLocation)];
   }
 
   if (!breakpoint) {
@@ -187,25 +211,29 @@ function syncBreakpoint(state, data) {
   }
 
   const locationId = makeLocationId(breakpoint.location);
-  return state.setIn(["breakpoints", locationId], breakpoint);
+  return setBreakpoint(state, locationId, breakpoint);
 }
 
-function updateBreakpoint(state, action) {
+function updateBreakpoint(state, action): BreakpointsState {
   const { breakpoint } = action;
   const locationId = makeLocationId(breakpoint.location);
-  return state.setIn(["breakpoints", locationId], breakpoint);
+  return setBreakpoint(state, locationId, breakpoint);
 }
 
-function updateAllBreakpoints(state, action) {
+function updateAllBreakpoints(state, action): BreakpointsState {
   const { breakpoints } = action;
+  state = {
+    ...state,
+    breakpoints: { ...state.breakpoints }
+  };
   breakpoints.forEach(breakpoint => {
     const locationId = makeLocationId(breakpoint.location);
-    state = state.setIn(["breakpoints", locationId], breakpoint);
+    state.breakpoints[locationId] = breakpoint;
   });
   return state;
 }
 
-function remapBreakpoints(state, action) {
+function remapBreakpoints(state, action): BreakpointsState {
   const breakpoints = action.breakpoints.reduce(
     (updatedBreakpoints, breakpoint) => {
       const locationId = makeLocationId(breakpoint.location);
@@ -214,60 +242,75 @@ function remapBreakpoints(state, action) {
     {}
   );
 
-  return state.set("breakpoints", I.Map(breakpoints));
+  return { ...state, breakpoints };
 }
 
-function removeBreakpoint(state, action) {
+function removeBreakpoint(state, action): BreakpointsState {
   const { breakpoint } = action;
   const id = makeLocationId(breakpoint.location);
-  return state.deleteIn(["breakpoints", id]);
+  return unsetBreakpoint(state, id);
 }
 
 // Selectors
 // TODO: these functions should be moved out of the reducer
 
-type OuterState = { breakpoints: Record<BreakpointsState> };
+type OuterState = { breakpoints: BreakpointsState };
 
-export function getBreakpoints(state: OuterState) {
+export function getBreakpointsMap(state: OuterState): BreakpointsMap {
   return state.breakpoints.breakpoints;
+}
+
+export function getBreakpointsList(state: OuterState): Breakpoint[] {
+  return (Object.values(getBreakpointsMap(state)): any);
+}
+
+export function getBreakpointCount(state: OuterState): number {
+  return getBreakpointsList(state).length;
 }
 
 export function getBreakpoint(
   state: OuterState,
   location: Location
-): Breakpoint {
-  const breakpoints = getBreakpoints(state);
-  return breakpoints.get(makeLocationId(location));
+): ?Breakpoint {
+  const breakpoints = getBreakpointsMap(state);
+  return breakpoints[makeLocationId(location)];
 }
 
 export function getBreakpointsDisabled(state: OuterState): boolean {
-  return state.breakpoints.breakpoints.every(x => x.disabled);
+  const breakpoints = getBreakpointsList(state);
+  return breakpoints.every(breakpoint => breakpoint.disabled);
 }
 
-export function getBreakpointsLoading(state: OuterState) {
-  const breakpoints = getBreakpoints(state);
-  const isLoading = !!breakpoints
-    .valueSeq()
-    .filter(bp => bp.loading)
-    .first();
-
-  return breakpoints.size > 0 && isLoading;
+export function getBreakpointsLoading(state: OuterState): boolean {
+  const breakpoints = getBreakpointsList(state);
+  const isLoading = breakpoints.some(breakpoint => breakpoint.loading);
+  return breakpoints.length > 0 && isLoading;
 }
 
-export function getBreakpointsForSource(state: OuterState, sourceId: string) {
+export function getBreakpointsForSource(
+  state: OuterState,
+  sourceId: string
+): BreakpointsMap {
   if (!sourceId) {
-    return I.Map();
+    return {};
   }
 
   const isGeneratedSource = isGeneratedId(sourceId);
-  const breakpoints = getBreakpoints(state);
+  const breakpoints = getBreakpointsMap(state);
 
-  return breakpoints.filter(bp => {
+  const breakpointsForSource = {};
+
+  for (const key in breakpoints) {
+    const bp = breakpoints[key];
     const location = isGeneratedSource
       ? bp.generatedLocation || bp.location
       : bp.location;
-    return location.sourceId === sourceId;
-  });
+    if (location.sourceId === sourceId) {
+      breakpointsForSource[key] = { ...bp };
+    }
+  }
+
+  return breakpointsForSource;
 }
 
 export function getBreakpointForLine(
@@ -276,20 +319,18 @@ export function getBreakpointForLine(
   line: number | null
 ): ?Breakpoint {
   if (!sourceId) {
-    return I.Map();
+    return undefined;
   }
-  const breakpoints = getBreakpointsForSource(state, sourceId);
+  const breakpoints = getBreakpointsList(state);
   return breakpoints.find(breakpoint => breakpoint.location.line === line);
 }
 
-export function getHiddenBreakpoint(state: OuterState) {
-  return getBreakpoints(state)
-    .valueSeq()
-    .filter(breakpoint => breakpoint.hidden)
-    .first();
+export function getHiddenBreakpoint(state: OuterState): ?Breakpoint {
+  const breakpoints = getBreakpointsList(state);
+  return breakpoints.find(bp => bp.hidden);
 }
 
-export function getHiddenBreakpointLocation(state: OuterState) {
+export function getHiddenBreakpointLocation(state: OuterState): ?Location {
   const hiddenBreakpoint = getHiddenBreakpoint(state);
   if (!hiddenBreakpoint) {
     return null;

--- a/src/reducers/tests/breakpoints.spec.js
+++ b/src/reducers/tests/breakpoints.spec.js
@@ -11,20 +11,66 @@ import {
   getBreakpointsForSource,
   initialBreakpointsState
 } from "../breakpoints";
-import * as I from "immutable";
 
 function initializeStateWith(data) {
-  const mappedData = I.Map(data);
   const state = initialBreakpointsState();
-  return state.set("breakpoints", mappedData);
+  state.breakpoints = data;
+  return state;
 }
 
 describe("Breakpoints Selectors", () => {
   it("it gets a breakpoint for an original source", () => {
     const sourceId = "server1.conn1.child1/source1/originalSource";
-    const matchingBreakpoints = { id1: { location: { sourceId } } };
+    const matchingBreakpoints = {
+      id1: {
+        id: "id1",
+        location: {
+          sourceId: sourceId,
+          line: 1
+        },
+        generatedLocation: {
+          sourceId: sourceId,
+          line: 1
+        },
+        astLocation: {
+          name: sourceId,
+          offset: {
+            line: 1
+          }
+        },
+        loading: false,
+        disabled: false,
+        hidden: false,
+        text: "string",
+        originalText: "string",
+        condition: null
+      }
+    };
+
     const otherBreakpoints = {
-      id2: { location: { sourceId: "not-this-source" } }
+      id2: {
+        id: "id2",
+        location: {
+          sourceId: "not-this-source",
+          line: 2
+        },
+        generatedLocation: {
+          sourceId: "not-this-source",
+          line: 2
+        },
+        astLocation: {
+          name: "not-this-source",
+          offset: {
+            line: 2
+          }
+        },
+        loading: false,
+        disabled: false,
+        hidden: false,
+        text: "",
+        originalText: "",
+        condition: null
+      }
     };
 
     const data = {
@@ -35,7 +81,7 @@ describe("Breakpoints Selectors", () => {
     const breakpoints = initializeStateWith(data);
 
     expect(getBreakpointsForSource({ breakpoints }, sourceId)).toEqual(
-      I.Map(matchingBreakpoints)
+      matchingBreakpoints
     );
   });
 
@@ -43,14 +89,53 @@ describe("Breakpoints Selectors", () => {
     const generatedSourceId = "random-source";
     const matchingBreakpoints = {
       id1: {
-        location: { sourceId: "original-source-id-1" },
-        generatedLocation: { sourceId: generatedSourceId }
+        id: "id1",
+        location: {
+          sourceId: "original-source-id-1",
+          line: 1
+        },
+        generatedLocation: {
+          sourceId: generatedSourceId,
+          line: 1
+        },
+        astLocation: {
+          name: "original-source-id-1",
+          offset: {
+            line: 1
+          }
+        },
+        loading: false,
+        disabled: false,
+        hidden: false,
+        text: "string",
+        originalText: "string",
+        condition: null
       }
     };
+
     const otherBreakpoints = {
       id2: {
-        location: { sourceId: "original-source-id-2" },
-        generatedLocation: { sourceId: "not-this-source" }
+        id: "id2",
+        location: {
+          sourceId: "original-source-id-2",
+          line: 1
+        },
+        generatedLocation: {
+          sourceId: "not-this-source",
+          line: 1
+        },
+        astLocation: {
+          name: "original-source-id-2",
+          offset: {
+            line: 1
+          }
+        },
+        loading: false,
+        disabled: false,
+        hidden: false,
+        text: "string",
+        originalText: "string",
+        condition: null
       }
     };
 
@@ -62,7 +147,7 @@ describe("Breakpoints Selectors", () => {
     const breakpoints = initializeStateWith(data);
 
     expect(getBreakpointsForSource({ breakpoints }, generatedSourceId)).toEqual(
-      I.Map(matchingBreakpoints)
+      matchingBreakpoints
     );
   });
 });

--- a/src/reducers/tests/breakpoints.spec.js
+++ b/src/reducers/tests/breakpoints.spec.js
@@ -12,6 +12,8 @@ import {
   initialBreakpointsState
 } from "../breakpoints";
 
+import { createBreakpoint } from "../../utils/breakpoint";
+
 function initializeStateWith(data) {
   const state = initialBreakpointsState();
   state.breakpoints = data;
@@ -22,55 +24,11 @@ describe("Breakpoints Selectors", () => {
   it("it gets a breakpoint for an original source", () => {
     const sourceId = "server1.conn1.child1/source1/originalSource";
     const matchingBreakpoints = {
-      id1: {
-        id: "id1",
-        location: {
-          sourceId: sourceId,
-          line: 1
-        },
-        generatedLocation: {
-          sourceId: sourceId,
-          line: 1
-        },
-        astLocation: {
-          name: sourceId,
-          offset: {
-            line: 1
-          }
-        },
-        loading: false,
-        disabled: false,
-        hidden: false,
-        text: "string",
-        originalText: "string",
-        condition: null
-      }
+      id1: createBreakpoint({ line: 1, sourceId: sourceId })
     };
 
     const otherBreakpoints = {
-      id2: {
-        id: "id2",
-        location: {
-          sourceId: "not-this-source",
-          line: 2
-        },
-        generatedLocation: {
-          sourceId: "not-this-source",
-          line: 2
-        },
-        astLocation: {
-          name: "not-this-source",
-          offset: {
-            line: 2
-          }
-        },
-        loading: false,
-        disabled: false,
-        hidden: false,
-        text: "",
-        originalText: "",
-        condition: null
-      }
+      id2: createBreakpoint({ line: 1, sourceId: "not-this-source" })
     };
 
     const data = {
@@ -79,64 +37,31 @@ describe("Breakpoints Selectors", () => {
     };
 
     const breakpoints = initializeStateWith(data);
-
     expect(getBreakpointsForSource({ breakpoints }, sourceId)).toEqual(
-      matchingBreakpoints
+      Object.values(matchingBreakpoints)
     );
   });
 
   it("it gets a breakpoint for a generated source", () => {
     const generatedSourceId = "random-source";
     const matchingBreakpoints = {
-      id1: {
-        id: "id1",
-        location: {
-          sourceId: "original-source-id-1",
-          line: 1
+      id1: createBreakpoint(
+        {
+          line: 1,
+          sourceId: "original-source-id-1"
         },
-        generatedLocation: {
-          sourceId: generatedSourceId,
-          line: 1
-        },
-        astLocation: {
-          name: "original-source-id-1",
-          offset: {
-            line: 1
-          }
-        },
-        loading: false,
-        disabled: false,
-        hidden: false,
-        text: "string",
-        originalText: "string",
-        condition: null
-      }
+        { generatedLocation: { line: 1, sourceId: generatedSourceId } }
+      )
     };
 
     const otherBreakpoints = {
-      id2: {
-        id: "id2",
-        location: {
-          sourceId: "original-source-id-2",
-          line: 1
+      id2: createBreakpoint(
+        {
+          line: 1,
+          sourceId: "original-source-id-2"
         },
-        generatedLocation: {
-          sourceId: "not-this-source",
-          line: 1
-        },
-        astLocation: {
-          name: "original-source-id-2",
-          offset: {
-            line: 1
-          }
-        },
-        loading: false,
-        disabled: false,
-        hidden: false,
-        text: "string",
-        originalText: "string",
-        condition: null
-      }
+        { generatedLocation: { line: 1, sourceId: "not-this-source" } }
+      )
     };
 
     const data = {
@@ -147,7 +72,7 @@ describe("Breakpoints Selectors", () => {
     const breakpoints = initializeStateWith(data);
 
     expect(getBreakpointsForSource({ breakpoints }, generatedSourceId)).toEqual(
-      matchingBreakpoints
+      Object.values(matchingBreakpoints)
     );
   });
 });

--- a/src/reducers/types.js
+++ b/src/reducers/types.js
@@ -23,7 +23,7 @@ import type { UIState } from "./ui";
 
 export type State = {
   ast: Record<ASTState>,
-  breakpoints: Record<BreakpointsState>,
+  breakpoints: BreakpointsState,
   expressions: Record<ExpressionState>,
   fileSearch: Record<FileSearchState>,
   pause: PauseState,

--- a/src/selectors/breakpointAtLocation.js
+++ b/src/selectors/breakpointAtLocation.js
@@ -3,7 +3,7 @@
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
 import { getSelectedSource } from "../reducers/sources";
-import { getBreakpoints } from "../reducers/breakpoints";
+import { getBreakpointsList } from "../reducers/breakpoints";
 import { isGenerated } from "../utils/source";
 
 function getColumn(column, selectedSource) {
@@ -20,8 +20,11 @@ function getLocation(bp, selectedSource) {
     : bp.location;
 }
 
-function getBreakpointsForSource(state: OuterState, selectedSource: Source) {
-  const breakpoints = getBreakpoints(state);
+function getBreakpointsForSource(
+  state: OuterState,
+  selectedSource: Source
+): Breakpoint[] {
+  const breakpoints = getBreakpointsList(state);
 
   return breakpoints.filter(bp => {
     const location = getLocation(bp, selectedSource);

--- a/src/selectors/breakpoints.js
+++ b/src/selectors/breakpoints.js
@@ -7,9 +7,8 @@
 import { createSelector } from "reselect";
 
 import type { BreakpointsState } from "../reducers/breakpoints";
-import type { Record } from "../utils/makeRecord";
 
-type OuterState = { breakpoints: Record<BreakpointsState> };
+type OuterState = { breakpoints: BreakpointsState };
 
 export function getXHRBreakpoints(state: OuterState) {
   return state.breakpoints.xhrBreakpoints;

--- a/src/selectors/visibleBreakpoints.js
+++ b/src/selectors/visibleBreakpoints.js
@@ -4,14 +4,13 @@
 
 // @flow
 
-import { getBreakpoints } from "../reducers/breakpoints";
+import { getBreakpointsList } from "../reducers/breakpoints";
 import { getSelectedSource } from "../reducers/sources";
 import { isGeneratedId } from "devtools-source-map";
 import { createSelector } from "reselect";
 import memoize from "../utils/memoize";
 
-import type { BreakpointsMap } from "../reducers/types";
-import type { Source } from "../types";
+import type { Breakpoint, Source } from "../types";
 
 function getLocation(breakpoint, isGeneratedSource) {
   return isGeneratedSource
@@ -46,8 +45,8 @@ function isVisible(breakpoint, selectedSource) {
   */
 export const getVisibleBreakpoints = createSelector(
   getSelectedSource,
-  getBreakpoints,
-  (selectedSource: Source, breakpoints: BreakpointsMap) => {
+  getBreakpointsList,
+  (selectedSource: Source, breakpoints: Breakpoint[]) => {
     if (!selectedSource) {
       return null;
     }

--- a/src/test/mochitest/browser_dbg-breakpoints-actions.js
+++ b/src/test/mochitest/browser_dbg-breakpoints-actions.js
@@ -16,6 +16,6 @@ add_task(async function() {
   await addBreakpoint(dbg, "simple2", 3);
   await removeBreakpoint(dbg);
 
-  await waitForState(dbg, state => dbg.selectors.getBreakpoints(state).size == 0);
+  await waitForState(dbg, state => dbg.selectors.getBreakpointCount(state) === 0);
   ok("successfully removed the breakpoint")
 });

--- a/src/test/mochitest/browser_dbg-breakpoints.js
+++ b/src/test/mochitest/browser_dbg-breakpoints.js
@@ -44,14 +44,6 @@ function findBreakpoint(dbg, url, line) {
   return getBreakpoint(getState(), { sourceId: source.id, line });
 }
 
-function findBreakpoints(dbg) {
-  const {
-    selectors: { getBreakpoints },
-    getState
-  } = dbg;
-  return getBreakpoints(getState());
-}
-
 add_task(async function() {
   const dbg = await initDebugger("doc-scripts.html");
 

--- a/src/test/mochitest/browser_dbg-editor-gutter.js
+++ b/src/test/mochitest/browser_dbg-editor-gutter.js
@@ -28,7 +28,7 @@ function assertEditorBreakpoint(dbg, line, shouldExist) {
 add_task(async function() {
   const dbg = await initDebugger("doc-scripts.html");
   const {
-    selectors: { getBreakpoints, getBreakpoint },
+    selectors: { getBreakpoint, getBreakpointCount },
     getState
   } = dbg;
   const source = findSource(dbg, "simple1.js");
@@ -38,13 +38,13 @@ add_task(async function() {
   // Make sure that clicking the gutter creates a breakpoint icon.
   clickGutter(dbg, 4);
   await waitForDispatch(dbg, "ADD_BREAKPOINT");
-  is(getBreakpoints(getState()).size, 1, "One breakpoint exists");
+  is(getBreakpointCount(getState()), 1, "One breakpoint exists");
   assertEditorBreakpoint(dbg, 4, true);
 
   // Make sure clicking at the same place removes the icon.
   clickGutter(dbg, 4);
   await waitForDispatch(dbg, "REMOVE_BREAKPOINT");
-  is(getBreakpoints(getState()).size, 0, "No breakpoints exist");
+  is(getBreakpointCount(getState()), 0, "No breakpoints exist");
   assertEditorBreakpoint(dbg, 4, false);
 
   // Ensure that clicking the gutter removes all breakpoints on a given line
@@ -52,6 +52,6 @@ add_task(async function() {
   await addBreakpoint(dbg, source, 4, 1);
   await addBreakpoint(dbg, source, 4, 2);
   clickGutter(dbg, 4);
-  await waitForState(dbg, state => dbg.selectors.getBreakpoints(state).size == 0);
+  await waitForState(dbg, state => dbg.selectors.getBreakpointCount(state) === 0);
   assertEditorBreakpoint(dbg, 4, false);
 });

--- a/src/test/mochitest/browser_dbg-reload.js
+++ b/src/test/mochitest/browser_dbg-reload.js
@@ -32,8 +32,7 @@ add_task(async function() {
 
   await waitForBreakpoint(dbg, location);
 
-  const breakpoints = dbg.selectors.getBreakpoints(dbg.getState());
-  const breakpointList = breakpoints.valueSeq().toJS();
+  const breakpointList = dbg.selectors.getBreakpointsList(dbg.getState());
   const breakpoint = breakpointList[0];
 
   is(breakpointList.length, 1);

--- a/src/test/mochitest/browser_dbg-sourcemaps-reload.js
+++ b/src/test/mochitest/browser_dbg-sourcemaps-reload.js
@@ -18,8 +18,7 @@ async function waitForBreakpoint(dbg, location) {
 }
 
 function getBreakpoints(dbg) {
-  const breakpoints = dbg.selectors.getBreakpoints(dbg.getState());
-  return breakpoints.valueSeq().toJS();
+  return dbg.selectors.getBreakpointsList(dbg.getState());
 }
 
 add_task(async function() {

--- a/src/test/mochitest/browser_dbg-sourcemaps-reloading.js
+++ b/src/test/mochitest/browser_dbg-sourcemaps-reloading.js
@@ -5,7 +5,7 @@ requestLongerTimeout(2);
 async function waitForBreakpointCount(dbg, count) {
   return waitForState(
     dbg,
-    state => dbg.selectors.getBreakpoints(state).size === count
+    state => dbg.selectors.getBreakpointCount(state) === count
   );
 }
 
@@ -13,7 +13,7 @@ add_task(async function() {
   // NOTE: the CORS call makes the test run times inconsistent
   const dbg = await initDebugger("doc-sourcemaps.html");
   const {
-    selectors: { getBreakpoint, getBreakpoints },
+    selectors: { getBreakpoint, getBreakpointCount },
     getState
   } = dbg;
 
@@ -32,7 +32,7 @@ add_task(async function() {
   // Test that breakpoint sliding is not attempted. The breakpoint
   // should not move anywhere.
   await addBreakpoint(dbg, entrySrc, 13);
-  is(getBreakpoints(getState()).size, 1, "One breakpoint exists");
+  is(getBreakpointCount(getState()), 1, "One breakpoint exists");
 
   ok(
     getBreakpoint(getState(), { sourceId: entrySrc.id, line: 13 }),
@@ -52,7 +52,7 @@ add_task(async function() {
   assertPausedLocation(dbg);
 
   await waitForBreakpointCount(dbg, 3);
-  is(getBreakpoints(getState()).size, 3, "Three breakpoints exist");
+  is(getBreakpointCount(getState()), 3, "Three breakpoints exist");
 
   ok(
     getBreakpoint(getState(), { sourceId: entrySrc.id, line: 13 }),

--- a/src/test/mochitest/browser_dbg-sourcemaps.js
+++ b/src/test/mochitest/browser_dbg-sourcemaps.js
@@ -41,7 +41,7 @@ add_task(async function() {
   // NOTE: the CORS call makes the test run times inconsistent
   const dbg = await initDebugger("doc-sourcemaps.html");
   const {
-    selectors: { getBreakpoint, getBreakpoints },
+    selectors: { getBreakpoint, getBreakpointCount },
     getState
   } = dbg;
 
@@ -57,7 +57,7 @@ add_task(async function() {
 
   await clickGutter(dbg, 13);
   await waitForDispatch(dbg, "REMOVE_BREAKPOINT");
-  is(getBreakpoints(getState()).size, 0, "No breakpoints exists");
+  is(getBreakpointCount(getState()), 0, "No breakpoints exists");
 
   const entrySrc = findSource(dbg, "entry.js");
 
@@ -71,7 +71,7 @@ add_task(async function() {
 
   // Test breaking on a breakpoint
   await addBreakpoint(dbg, "entry.js", 15);
-  is(getBreakpoints(getState()).size, 1, "One breakpoint exists");
+  is(getBreakpointCount(getState()), 1, "One breakpoint exists");
   assertBreakpointExists(dbg, entrySrc, 15);
 
   invokeInTab("keepMeAlive");

--- a/src/test/mochitest/browser_dbg-sourcemaps2.js
+++ b/src/test/mochitest/browser_dbg-sourcemaps2.js
@@ -20,7 +20,7 @@ add_task(async function() {
   // NOTE: the CORS call makes the test run times inconsistent
   const dbg = await initDebugger("doc-sourcemaps2.html");
   const {
-    selectors: { getBreakpoint, getBreakpoints },
+    selectors: { getBreakpoint, getBreakpointCount },
     getState
   } = dbg;
 
@@ -33,7 +33,7 @@ add_task(async function() {
 
   // Test that breakpoint is not off by a line.
   await addBreakpoint(dbg, mainSrc, 4);
-  is(getBreakpoints(getState()).size, 1, "One breakpoint exists");
+  is(getBreakpointCount(getState()), 1, "One breakpoint exists");
   ok(
     getBreakpoint(getState(), { sourceId: mainSrc.id, line: 4, column: 2 }),
     "Breakpoint has correct line"

--- a/src/test/mochitest/browser_dbg-sourcemaps3.js
+++ b/src/test/mochitest/browser_dbg-sourcemaps3.js
@@ -12,7 +12,7 @@ add_task(async function() {
 
   const dbg = await initDebugger("doc-sourcemaps3.html");
   const {
-    selectors: { getBreakpoint, getBreakpoints },
+    selectors: { getBreakpoint, getBreakpointCount },
     getState
   } = dbg;
 
@@ -25,7 +25,7 @@ add_task(async function() {
 
   // Test that breakpoint is not off by a line.
   await addBreakpoint(dbg, sortedSrc, 9);
-  is(getBreakpoints(getState()).size, 1, "One breakpoint exists");
+  is(getBreakpointCount(getState()), 1, "One breakpoint exists");
   ok(
     getBreakpoint(getState(), { sourceId: sortedSrc.id, line: 9, column: 4 }),
     "Breakpoint has correct line"

--- a/src/test/mochitest/helpers.js
+++ b/src/test/mochitest/helpers.js
@@ -724,7 +724,7 @@ function disableBreakpoint(dbg, source, line, column) {
 
 async function loadAndAddBreakpoint(dbg, filename, line, column) {
   const {
-    selectors: { getBreakpoint, getBreakpoints },
+    selectors: { getBreakpoint, getBreakpointCount, getBreakpointsMap },
     getState
   } = dbg;
 
@@ -738,9 +738,9 @@ async function loadAndAddBreakpoint(dbg, filename, line, column) {
   // Test that breakpoint is not off by a line.
   await addBreakpoint(dbg, source, line);
 
-  is(getBreakpoints(getState()).size, 1, "One breakpoint exists");
+  is(getBreakpointCount(getState()), 1, "One breakpoint exists");
   if (!getBreakpoint(getState(), { sourceId: source.id, line, column })) {
-    const breakpoints = getBreakpoints(getState()).toJS();
+    const breakpoints = getBreakpointsMap(getState());
     const id = Object.keys(breakpoints).pop();
     const loc = breakpoints[id].location;
     ok(
@@ -760,7 +760,7 @@ async function invokeWithBreakpoint(
   handler
 ) {
   const {
-    selectors: { getBreakpoints },
+    selectors: { getBreakpointCount },
     getState
   } = dbg;
 
@@ -781,7 +781,7 @@ async function invokeWithBreakpoint(
 
   await removeBreakpoint(dbg, source.id, line, column);
 
-  is(getBreakpoints(getState()).size, 0, "Breakpoint reverted");
+  is(getBreakpointCount(getState()), 0, "Breakpoint reverted");
 
   await handler(source);
 

--- a/src/types.js
+++ b/src/types.js
@@ -52,10 +52,10 @@ export type ActorId = string;
  * @static
  */
 export type Location = {
-  sourceId: SourceId,
-  line: number,
-  column?: number,
-  sourceUrl?: string
+  +sourceId: SourceId,
+  +line: number,
+  +column?: number,
+  +sourceUrl?: string
 };
 
 export type MappedLocation = {
@@ -64,27 +64,27 @@ export type MappedLocation = {
 };
 
 export type Position = {
-  line: number,
-  column?: number
+  +line: number,
+  +column?: number
 };
 
 export type ColumnPosition = {
-  line: number,
-  column: number
+  +line: number,
+  +column: number
 };
 
 export type Range = { end: Position, start: Position };
 export type ColumnRange = { end: ColumnPosition, start: ColumnPosition };
 
 export type PendingLocation = {
-  line: number,
-  column?: number,
-  sourceUrl?: string
+  +line: number,
+  +column?: number,
+  +sourceUrl?: string
 };
 
 export type ASTLocation = {|
-  name: ?string,
-  offset: Position
+  +name: ?string,
+  +offset: Position
 |};
 
 /**
@@ -112,11 +112,11 @@ export type Breakpoint = {|
  * @static
  */
 export type XHRBreakpoint = {|
-  path: string,
-  method: "GET" | "POST" | "DELETE" | "ANY",
-  loading: boolean,
-  disabled: boolean,
-  text: string
+  +path: string,
+  +method: "GET" | "POST" | "DELETE" | "ANY",
+  +loading: boolean,
+  +disabled: boolean,
+  +text: string
 |};
 
 /**
@@ -137,13 +137,13 @@ export type BreakpointResult = {
  * @static
  */
 export type PendingBreakpoint = {
-  location: PendingLocation,
-  astLocation: ASTLocation,
-  generatedLocation: PendingLocation,
-  loading: boolean,
-  disabled: boolean,
-  text: string,
-  condition: ?string
+  +location: PendingLocation,
+  +astLocation: ASTLocation,
+  +generatedLocation: PendingLocation,
+  +loading: boolean,
+  +disabled: boolean,
+  +text: string,
+  +condition: ?string
 };
 
 /**

--- a/src/types.js
+++ b/src/types.js
@@ -59,8 +59,8 @@ export type Location = {
 };
 
 export type MappedLocation = {
-  location: Location,
-  generatedLocation: Location
+  +location: Location,
+  +generatedLocation: Location
 };
 
 export type Position = {
@@ -93,31 +93,31 @@ export type ASTLocation = {|
  * @memberof types
  * @static
  */
-export type Breakpoint = {
-  id: BreakpointId,
-  location: Location,
-  astLocation: ?ASTLocation,
-  generatedLocation: Location,
-  loading: boolean,
-  disabled: boolean,
-  hidden: boolean,
-  text: string,
-  originalText: string,
-  condition: ?string
-};
+export type Breakpoint = {|
+  +id: BreakpointId,
+  +location: Location,
+  +astLocation: ?ASTLocation,
+  +generatedLocation: Location,
+  +loading: boolean,
+  +disabled: boolean,
+  +hidden: boolean,
+  +text: string,
+  +originalText: string,
+  +condition: ?string
+|};
 
 /**
  * XHR Breakpoint
  * @memberof types
  * @static
  */
-export type XHRBreakpoint = {
+export type XHRBreakpoint = {|
   path: string,
   method: "GET" | "POST" | "DELETE" | "ANY",
   loading: boolean,
   disabled: boolean,
   text: string
-};
+|};
 
 /**
  * Breakpoint Result is the return from an add/modify Breakpoint request


### PR DESCRIPTION
Fixes #7202

Updates breakpoint reducer to not use immutable.js wrappers.  Also updates anything that uses the reducer and selectors to work with the updated data structures.