### PR TITLE
Allow to disable context menu in Frames.

### DIFF
--- a/src/components/SecondaryPanes/Frames/Frame.js
+++ b/src/components/SecondaryPanes/Frames/Frame.js
@@ -61,16 +61,18 @@ type FrameComponentProps = {
   shouldMapDisplayName: boolean,
   toggleBlackBox: Function,
   displayFullUrl: boolean,
-  getFrameTitle?: string => string
+  getFrameTitle?: string => string,
+  disableContextMenu: boolean
 };
 
 export default class FrameComponent extends Component<FrameComponentProps> {
   static defaultProps = {
     hideLocation: false,
-    shouldMapDisplayName: true
+    shouldMapDisplayName: true,
+    disableContextMenu: false
   };
 
-  onContextMenu(event: SyntheticKeyboardEvent<HTMLElement>) {
+  onContextMenu(event: SyntheticMouseEvent<HTMLElement>) {
     const {
       frame,
       copyStackTrace,
@@ -87,11 +89,11 @@ export default class FrameComponent extends Component<FrameComponentProps> {
   }
 
   onMouseDown(
-    e: SyntheticKeyboardEvent<HTMLElement>,
+    e: SyntheticMouseEvent<HTMLElement>,
     frame: Frame,
     selectedFrame: Frame
   ) {
-    if (e.which == 3) {
+    if (e.button !== 0) {
       return;
     }
     this.props.selectFrame(frame);
@@ -115,7 +117,8 @@ export default class FrameComponent extends Component<FrameComponentProps> {
       hideLocation,
       shouldMapDisplayName,
       displayFullUrl,
-      getFrameTitle
+      getFrameTitle,
+      disableContextMenu
     } = this.props;
 
     const className = classNames("frame", {
@@ -134,7 +137,7 @@ export default class FrameComponent extends Component<FrameComponentProps> {
         className={className}
         onMouseDown={e => this.onMouseDown(e, frame, selectedFrame)}
         onKeyUp={e => this.onKeyUp(e, frame, selectedFrame)}
-        onContextMenu={e => this.onContextMenu(e)}
+        onContextMenu={disableContextMenu ? null : e => this.onContextMenu(e)}
         tabIndex={0}
         title={title}
       >

--- a/src/components/SecondaryPanes/Frames/FrameMenu.js
+++ b/src/components/SecondaryPanes/Frames/FrameMenu.js
@@ -60,7 +60,7 @@ export default function FrameMenu(
   frame: LocalFrame,
   frameworkGroupingOn: boolean,
   callbacks: Object,
-  event: SyntheticKeyboardEvent<HTMLElement>
+  event: SyntheticMouseEvent<HTMLElement>
 ) {
   event.stopPropagation();
   event.preventDefault();

--- a/src/components/SecondaryPanes/Frames/Group.js
+++ b/src/components/SecondaryPanes/Frames/Group.js
@@ -45,7 +45,8 @@ type Props = {
   toggleBlackBox: Function,
   frameworkGroupingOn: boolean,
   displayFullUrl: boolean,
-  getFrameTitle?: string => string
+  getFrameTitle?: string => string,
+  disableContextMenu: boolean
 };
 
 type State = {
@@ -60,7 +61,7 @@ export default class Group extends Component<Props, State> {
     this.state = { expanded: false };
   }
 
-  onContextMenu(event: SyntheticKeyboardEvent<HTMLElement>) {
+  onContextMenu(event: SyntheticMouseEvent<HTMLElement>) {
     const {
       group,
       copyStackTrace,
@@ -91,7 +92,8 @@ export default class Group extends Component<Props, State> {
       toggleBlackBox,
       copyStackTrace,
       displayFullUrl,
-      getFrameTitle
+      getFrameTitle,
+      disableContextMenu
     } = this.props;
 
     const { expanded } = this.state;
@@ -115,6 +117,7 @@ export default class Group extends Component<Props, State> {
             toggleFrameworkGrouping={toggleFrameworkGrouping}
             displayFullUrl={displayFullUrl}
             getFrameTitle={getFrameTitle}
+            disableContextMenu={disableContextMenu}
           />
         ))}
       </div>
@@ -142,10 +145,11 @@ export default class Group extends Component<Props, State> {
 
   render() {
     const { expanded } = this.state;
+    const { disableContextMenu } = this.props;
     return (
       <div
         className={classNames("frames-group", { expanded })}
-        onContextMenu={e => this.onContextMenu(e)}
+        onContextMenu={disableContextMenu ? null : e => this.onContextMenu(e)}
       >
         {this.renderDescription()}
         {this.renderFrames()}

--- a/src/components/SecondaryPanes/Frames/index.js
+++ b/src/components/SecondaryPanes/Frames/index.js
@@ -41,6 +41,7 @@ type Props = {
   toggleBlackBox: Function,
   toggleFrameworkGrouping: Function,
   disableFrameTruncate: boolean,
+  disableContextMenu: boolean,
   displayFullUrl: boolean,
   getFrameTitle?: string => string
 };
@@ -117,7 +118,8 @@ class Frames extends Component<Props, State> {
       toggleBlackBox,
       frameworkGroupingOn,
       displayFullUrl,
-      getFrameTitle
+      getFrameTitle,
+      disableContextMenu
     } = this.props;
 
     const framesOrGroups = this.truncateFrames(this.collapseFrames(frames));
@@ -139,6 +141,7 @@ class Frames extends Component<Props, State> {
                 key={String(frameOrGroup.id)}
                 displayFullUrl={displayFullUrl}
                 getFrameTitle={getFrameTitle}
+                disableContextMenu={disableContextMenu}
               />
             ) : (
               <Group
@@ -152,6 +155,7 @@ class Frames extends Component<Props, State> {
                 key={frameOrGroup[0].id}
                 displayFullUrl={displayFullUrl}
                 getFrameTitle={getFrameTitle}
+                disableContextMenu={disableContextMenu}
               />
             )
         )}
@@ -216,6 +220,7 @@ export default connect(
     toggleBlackBox: actions.toggleBlackBox,
     toggleFrameworkGrouping: actions.toggleFrameworkGrouping,
     disableFrameTruncate: false,
+    disableContextMenu: false,
     displayFullUrl: false
   }
 )(Frames);

--- a/src/components/SecondaryPanes/Frames/tests/Frame.spec.js
+++ b/src/components/SecondaryPanes/Frames/tests/Frame.spec.js
@@ -9,7 +9,7 @@ import Frame from "../Frame.js";
 import FrameMenu from "../FrameMenu";
 jest.mock("../FrameMenu", () => jest.fn());
 
-function render(frameToSelect = {}, overrides = {}) {
+function render(frameToSelect = {}, overrides = {}, propsOverrides = {}) {
   const defaultFrame = {
     id: 1,
     source: {
@@ -35,7 +35,8 @@ function render(frameToSelect = {}, overrides = {}) {
     copyStackTrace: jest.fn(),
     contextTypes: {},
     selectFrame,
-    toggleBlackBox
+    toggleBlackBox,
+    ...propsOverrides
   };
   const component = shallow(<Frame {...props} />);
   return { component, props };
@@ -121,6 +122,17 @@ describe("Frame", () => {
   });
 
   describe("mouse events", () => {
+    it("does not call FrameMenu when disableContextMenu is true", () => {
+      const { component } = render(undefined, undefined, {
+        disableContextMenu: true
+      });
+
+      const mockEvent = "mockEvent";
+      component.simulate("contextmenu", mockEvent);
+
+      expect(FrameMenu).toHaveBeenCalledTimes(0);
+    });
+
     it("calls FrameMenu on right click", () => {
       const { component, props } = render();
       const { copyStackTrace, toggleFrameworkGrouping, toggleBlackBox } = props;

--- a/src/components/SecondaryPanes/Frames/tests/Group.spec.js
+++ b/src/components/SecondaryPanes/Frames/tests/Group.spec.js
@@ -80,6 +80,17 @@ describe("Group", () => {
   });
 
   describe("mouse events", () => {
+    it("does not call FrameMenu when disableContextMenu is true", () => {
+      const { component } = render({
+        disableContextMenu: true
+      });
+
+      const mockEvent = "mockEvent";
+      component.simulate("contextmenu", mockEvent);
+
+      expect(FrameMenu).toHaveBeenCalledTimes(0);
+    });
+
     it("calls FrameMenu on right click", () => {
       const { component, props } = render();
       const { copyStackTrace, toggleFrameworkGrouping, toggleBlackBox } = props;

--- a/src/components/SecondaryPanes/Frames/tests/__snapshots__/Frames.spec.js.snap
+++ b/src/components/SecondaryPanes/Frames/tests/__snapshots__/Frames.spec.js.snap
@@ -7,6 +7,7 @@ exports[`Frames Blackboxed Frames filters blackboxed frames 1`] = `
   <ul>
     <Frame
       copyStackTrace={[Function]}
+      disableContextMenu={false}
       frame={
         Object {
           "id": 1,
@@ -36,6 +37,7 @@ exports[`Frames Blackboxed Frames filters blackboxed frames 1`] = `
     />
     <Frame
       copyStackTrace={[Function]}
+      disableContextMenu={false}
       frame={
         Object {
           "id": 3,
@@ -74,6 +76,7 @@ exports[`Frames Library Frames groups all the Webpack-related frames 1`] = `
   <ul>
     <Frame
       copyStackTrace={[Function]}
+      disableContextMenu={false}
       frame={
         Object {
           "id": "1-appFrame",
@@ -144,6 +147,7 @@ exports[`Frames Library Frames toggling framework frames 1`] = `
   <ul>
     <Frame
       copyStackTrace={[Function]}
+      disableContextMenu={false}
       frame={
         Object {
           "id": 1,
@@ -164,6 +168,7 @@ exports[`Frames Library Frames toggling framework frames 1`] = `
     />
     <Frame
       copyStackTrace={[Function]}
+      disableContextMenu={false}
       frame={
         Object {
           "id": 2,
@@ -185,6 +190,7 @@ exports[`Frames Library Frames toggling framework frames 1`] = `
     />
     <Frame
       copyStackTrace={[Function]}
+      disableContextMenu={false}
       frame={
         Object {
           "id": 3,
@@ -206,6 +212,7 @@ exports[`Frames Library Frames toggling framework frames 1`] = `
     />
     <Frame
       copyStackTrace={[Function]}
+      disableContextMenu={false}
       frame={
         Object {
           "id": 8,
@@ -235,6 +242,7 @@ exports[`Frames Library Frames toggling framework frames 2`] = `
   <ul>
     <Frame
       copyStackTrace={[Function]}
+      disableContextMenu={false}
       frame={
         Object {
           "id": 1,
@@ -280,6 +288,7 @@ exports[`Frames Library Frames toggling framework frames 2`] = `
     />
     <Frame
       copyStackTrace={[Function]}
+      disableContextMenu={false}
       frame={
         Object {
           "id": 8,
@@ -309,6 +318,7 @@ exports[`Frames Supports different number of frames disable frame truncation 1`]
   <ul>
     <Frame
       copyStackTrace={[Function]}
+      disableContextMenu={false}
       frame={
         Object {
           "id": 1,
@@ -325,6 +335,7 @@ exports[`Frames Supports different number of frames disable frame truncation 1`]
     />
     <Frame
       copyStackTrace={[Function]}
+      disableContextMenu={false}
       frame={
         Object {
           "id": 2,
@@ -341,6 +352,7 @@ exports[`Frames Supports different number of frames disable frame truncation 1`]
     />
     <Frame
       copyStackTrace={[Function]}
+      disableContextMenu={false}
       frame={
         Object {
           "id": 3,
@@ -357,6 +369,7 @@ exports[`Frames Supports different number of frames disable frame truncation 1`]
     />
     <Frame
       copyStackTrace={[Function]}
+      disableContextMenu={false}
       frame={
         Object {
           "id": 4,
@@ -373,6 +386,7 @@ exports[`Frames Supports different number of frames disable frame truncation 1`]
     />
     <Frame
       copyStackTrace={[Function]}
+      disableContextMenu={false}
       frame={
         Object {
           "id": 5,
@@ -389,6 +403,7 @@ exports[`Frames Supports different number of frames disable frame truncation 1`]
     />
     <Frame
       copyStackTrace={[Function]}
+      disableContextMenu={false}
       frame={
         Object {
           "id": 6,
@@ -405,6 +420,7 @@ exports[`Frames Supports different number of frames disable frame truncation 1`]
     />
     <Frame
       copyStackTrace={[Function]}
+      disableContextMenu={false}
       frame={
         Object {
           "id": 7,
@@ -421,6 +437,7 @@ exports[`Frames Supports different number of frames disable frame truncation 1`]
     />
     <Frame
       copyStackTrace={[Function]}
+      disableContextMenu={false}
       frame={
         Object {
           "id": 8,
@@ -437,6 +454,7 @@ exports[`Frames Supports different number of frames disable frame truncation 1`]
     />
     <Frame
       copyStackTrace={[Function]}
+      disableContextMenu={false}
       frame={
         Object {
           "id": 9,
@@ -453,6 +471,7 @@ exports[`Frames Supports different number of frames disable frame truncation 1`]
     />
     <Frame
       copyStackTrace={[Function]}
+      disableContextMenu={false}
       frame={
         Object {
           "id": 10,
@@ -469,6 +488,7 @@ exports[`Frames Supports different number of frames disable frame truncation 1`]
     />
     <Frame
       copyStackTrace={[Function]}
+      disableContextMenu={false}
       frame={
         Object {
           "id": 11,
@@ -485,6 +505,7 @@ exports[`Frames Supports different number of frames disable frame truncation 1`]
     />
     <Frame
       copyStackTrace={[Function]}
+      disableContextMenu={false}
       frame={
         Object {
           "id": 12,
@@ -501,6 +522,7 @@ exports[`Frames Supports different number of frames disable frame truncation 1`]
     />
     <Frame
       copyStackTrace={[Function]}
+      disableContextMenu={false}
       frame={
         Object {
           "id": 13,
@@ -517,6 +539,7 @@ exports[`Frames Supports different number of frames disable frame truncation 1`]
     />
     <Frame
       copyStackTrace={[Function]}
+      disableContextMenu={false}
       frame={
         Object {
           "id": 14,
@@ -533,6 +556,7 @@ exports[`Frames Supports different number of frames disable frame truncation 1`]
     />
     <Frame
       copyStackTrace={[Function]}
+      disableContextMenu={false}
       frame={
         Object {
           "id": 15,
@@ -549,6 +573,7 @@ exports[`Frames Supports different number of frames disable frame truncation 1`]
     />
     <Frame
       copyStackTrace={[Function]}
+      disableContextMenu={false}
       frame={
         Object {
           "id": 16,
@@ -565,6 +590,7 @@ exports[`Frames Supports different number of frames disable frame truncation 1`]
     />
     <Frame
       copyStackTrace={[Function]}
+      disableContextMenu={false}
       frame={
         Object {
           "id": 17,
@@ -581,6 +607,7 @@ exports[`Frames Supports different number of frames disable frame truncation 1`]
     />
     <Frame
       copyStackTrace={[Function]}
+      disableContextMenu={false}
       frame={
         Object {
           "id": 18,
@@ -597,6 +624,7 @@ exports[`Frames Supports different number of frames disable frame truncation 1`]
     />
     <Frame
       copyStackTrace={[Function]}
+      disableContextMenu={false}
       frame={
         Object {
           "id": 19,
@@ -613,6 +641,7 @@ exports[`Frames Supports different number of frames disable frame truncation 1`]
     />
     <Frame
       copyStackTrace={[Function]}
+      disableContextMenu={false}
       frame={
         Object {
           "id": 20,
@@ -650,6 +679,7 @@ exports[`Frames Supports different number of frames one frame 1`] = `
   <ul>
     <Frame
       copyStackTrace={[Function]}
+      disableContextMenu={false}
       frame={
         Object {
           "id": 1,
@@ -679,6 +709,7 @@ exports[`Frames Supports different number of frames passes the getFrameTitle pro
   <ul>
     <Frame
       copyStackTrace={[Function]}
+      disableContextMenu={false}
       frame={
         Object {
           "displayName": "renderFoo",
@@ -712,6 +743,7 @@ exports[`Frames Supports different number of frames toggling the show more butto
   <ul>
     <Frame
       copyStackTrace={[Function]}
+      disableContextMenu={false}
       frame={
         Object {
           "id": 1,
@@ -732,6 +764,7 @@ exports[`Frames Supports different number of frames toggling the show more butto
     />
     <Frame
       copyStackTrace={[Function]}
+      disableContextMenu={false}
       frame={
         Object {
           "id": 2,
@@ -752,6 +785,7 @@ exports[`Frames Supports different number of frames toggling the show more butto
     />
     <Frame
       copyStackTrace={[Function]}
+      disableContextMenu={false}
       frame={
         Object {
           "id": 3,
@@ -772,6 +806,7 @@ exports[`Frames Supports different number of frames toggling the show more butto
     />
     <Frame
       copyStackTrace={[Function]}
+      disableContextMenu={false}
       frame={
         Object {
           "id": 4,
@@ -792,6 +827,7 @@ exports[`Frames Supports different number of frames toggling the show more butto
     />
     <Frame
       copyStackTrace={[Function]}
+      disableContextMenu={false}
       frame={
         Object {
           "id": 5,
@@ -812,6 +848,7 @@ exports[`Frames Supports different number of frames toggling the show more butto
     />
     <Frame
       copyStackTrace={[Function]}
+      disableContextMenu={false}
       frame={
         Object {
           "id": 6,
@@ -832,6 +869,7 @@ exports[`Frames Supports different number of frames toggling the show more butto
     />
     <Frame
       copyStackTrace={[Function]}
+      disableContextMenu={false}
       frame={
         Object {
           "id": 7,
@@ -852,6 +890,7 @@ exports[`Frames Supports different number of frames toggling the show more butto
     />
     <Frame
       copyStackTrace={[Function]}
+      disableContextMenu={false}
       frame={
         Object {
           "id": 8,
@@ -872,6 +911,7 @@ exports[`Frames Supports different number of frames toggling the show more butto
     />
     <Frame
       copyStackTrace={[Function]}
+      disableContextMenu={false}
       frame={
         Object {
           "id": 9,
@@ -892,6 +932,7 @@ exports[`Frames Supports different number of frames toggling the show more butto
     />
     <Frame
       copyStackTrace={[Function]}
+      disableContextMenu={false}
       frame={
         Object {
           "id": 10,

--- a/src/components/SecondaryPanes/Frames/tests/__snapshots__/Group.spec.js.snap
+++ b/src/components/SecondaryPanes/Frames/tests/__snapshots__/Group.spec.js.snap
@@ -76,6 +76,7 @@ exports[`Group passes the getFrameTitle prop to the Frame components 1`] = `
   >
     <Frame
       copyStackTrace={[MockFunction]}
+      disableContextMenu={false}
       frame={
         Object {
           "displayName": "renderFoo",
@@ -100,6 +101,7 @@ exports[`Group passes the getFrameTitle prop to the Frame components 1`] = `
     />
     <Frame
       copyStackTrace={[MockFunction]}
+      disableContextMenu={false}
       frame={
         Object {
           "displayName": "a",
@@ -125,6 +127,7 @@ exports[`Group passes the getFrameTitle prop to the Frame components 1`] = `
     />
     <Frame
       copyStackTrace={[MockFunction]}
+      disableContextMenu={false}
       frame={
         Object {
           "displayName": "b",


### PR DESCRIPTION
This will be used in mozilla-central where we might
want different entries. Until we figure out a nice
way of dealing with this kind of usage, let's disable
the context menu to not throw exceptions.
