### PR TITLE
Show column breakpoints when line breakpoint is set, remove Alt/Option key dependency

### DIFF
--- a/assets/panel/prefs.js
+++ b/assets/panel/prefs.js
@@ -49,7 +49,7 @@ pref("devtools.debugger.skip-pausing", false);
 pref("devtools.debugger.features.wasm", true);
 pref("devtools.debugger.features.shortcuts", true);
 pref("devtools.debugger.features.root", true);
-pref("devtools.debugger.features.column-breakpoints", false);
+pref("devtools.debugger.features.column-breakpoints", true);
 pref("devtools.debugger.features.chrome-scopes", false);
 pref("devtools.debugger.features.map-scopes", true);
 pref("devtools.debugger.features.remove-command-bar-options", false);

--- a/src/components/Editor/CallSites.js
+++ b/src/components/Editor/CallSites.js
@@ -142,17 +142,34 @@ class CallSites extends Component {
       });
     }
   }
+  filterCallSites() {
+    const { callSites, breakpoints } = this.props;
+
+    const breakpointLines = new Set();
+    if (breakpoints._root !== undefined) {
+      for (const key in breakpoints._root.entries) {
+        breakpointLines.add(breakpoints._root.entries[key][1].location.line);
+      }
+    }
+
+    return callSites.filter(({ location }) =>
+      breakpointLines.has(location.start.line)
+    );
+  }
 
   render() {
     const { editor, callSites, selectedSource } = this.props;
     const { showCallSites } = this.state;
+
     let sites;
     if (!callSites) {
       return null;
     }
 
+    const callSitesFiltered = this.filterCallSites();
+
     editor.codeMirror.operation(() => {
-      const childCallSites = callSites.map((callSite, index) => {
+      const childCallSites = callSitesFiltered.map((callSite, index) => {
         const props = {
           key: index,
           callSite,

--- a/src/components/Editor/CallSites.js
+++ b/src/components/Editor/CallSites.js
@@ -115,7 +115,10 @@ class CallSites extends Component {
       });
     }
   }
-  filterCallSites() {
+
+  // Return the call sites that are on the same line as an
+  // existing line breakpoint
+  filterCallSitesByLineNumber() {
     const { callSites, breakpoints } = this.props;
 
     const breakpointLines = new Set(
@@ -135,7 +138,7 @@ class CallSites extends Component {
       return null;
     }
 
-    const callSitesFiltered = this.filterCallSites();
+    const callSitesFiltered = this.filterCallSitesByLineNumber();
 
     editor.codeMirror.operation(() => {
       const childCallSites = callSitesFiltered.map((callSite, index) => {

--- a/src/components/Editor/CallSites.js
+++ b/src/components/Editor/CallSites.js
@@ -44,21 +44,11 @@ class CallSites extends Component {
     selectedLocation: Object
   };
 
-  constructor(props) {
-    super(props);
-
-    this.state = {
-      showCallSites: false
-    };
-  }
-
   componentDidMount() {
     const { editor } = this.props;
     const codeMirrorWrapper = editor.codeMirror.getWrapperElement();
 
     codeMirrorWrapper.addEventListener("click", e => this.onTokenClick(e));
-    document.body.addEventListener("keydown", this.onKeyDown);
-    document.body.addEventListener("keyup", this.onKeyUp);
   }
 
   componentWillUnmount() {
@@ -66,32 +56,15 @@ class CallSites extends Component {
     const codeMirrorWrapper = editor.codeMirror.getWrapperElement();
 
     codeMirrorWrapper.removeEventListener("click", e => this.onTokenClick(e));
-    document.body.removeEventListener("keydown", this.onKeyDown);
-    document.body.removeEventListener("keyup", this.onKeyUp);
   }
-
-  onKeyUp = e => {
-    if (e.key === "Alt") {
-      e.preventDefault();
-      this.setState({ showCallSites: false });
-    }
-  };
-
-  onKeyDown = e => {
-    if (e.key === "Alt") {
-      e.preventDefault();
-      this.setState({ showCallSites: true });
-    }
-  };
 
   onTokenClick(e) {
     const { target } = e;
     const { editor, selectedLocation } = this.props;
 
     if (
-      (!e.altKey && !target.classList.contains("call-site-bp")) ||
-      (!target.classList.contains("call-site") &&
-        !target.classList.contains("call-site-bp"))
+      !target.classList.contains("call-site") &&
+      !target.classList.contains("call-site-bp")
     ) {
       return;
     }
@@ -145,12 +118,9 @@ class CallSites extends Component {
   filterCallSites() {
     const { callSites, breakpoints } = this.props;
 
-    const breakpointLines = new Set();
-    if (breakpoints._root !== undefined) {
-      for (const key in breakpoints._root.entries) {
-        breakpointLines.add(breakpoints._root.entries[key][1].location.line);
-      }
-    }
+    const breakpointLines = new Set(
+      breakpoints.toIndexedSeq().map(bp => bp.location.line)
+    );
 
     return callSites.filter(({ location }) =>
       breakpointLines.has(location.start.line)
@@ -159,7 +129,6 @@ class CallSites extends Component {
 
   render() {
     const { editor, callSites, selectedSource } = this.props;
-    const { showCallSites } = this.state;
 
     let sites;
     if (!callSites) {
@@ -176,7 +145,7 @@ class CallSites extends Component {
           editor,
           source: selectedSource,
           breakpoint: callSite.breakpoint,
-          showCallSite: showCallSites
+          showCallSite: true
         };
         return <CallSite {...props} />;
       });

--- a/src/components/SecondaryPanes/Breakpoints/tests/__snapshots__/Breakpoint.spec.js.snap
+++ b/src/components/SecondaryPanes/Breakpoints/tests/__snapshots__/Breakpoint.spec.js.snap
@@ -28,7 +28,7 @@ exports[`Breakpoint disabled 1`] = `
     <div
       className="breakpoint-line"
     >
-      53
+      53:73
     </div>
     <CloseButton
       handleClick={[Function]}
@@ -66,7 +66,7 @@ exports[`Breakpoint paused at a different 1`] = `
     <div
       className="breakpoint-line"
     >
-      53
+      53:73
     </div>
     <CloseButton
       handleClick={[Function]}
@@ -104,7 +104,7 @@ exports[`Breakpoint paused at a generatedLocation 1`] = `
     <div
       className="breakpoint-line"
     >
-      53
+      53:73
     </div>
     <CloseButton
       handleClick={[Function]}
@@ -142,7 +142,7 @@ exports[`Breakpoint paused at an original location 1`] = `
     <div
       className="breakpoint-line"
     >
-      5
+      5:7
     </div>
     <CloseButton
       handleClick={[Function]}
@@ -180,7 +180,7 @@ exports[`Breakpoint simple 1`] = `
     <div
       className="breakpoint-line"
     >
-      53
+      53:73
     </div>
     <CloseButton
       handleClick={[Function]}

--- a/src/test/mochitest/helpers.js
+++ b/src/test/mochitest/helpers.js
@@ -339,8 +339,10 @@ function assertDebugLine(dbg, line) {
   ok(isVisibleInEditor(dbg, debugLine), "debug line is visible");
 
   const markedSpans = lineInfo.handle.markedSpans;
-  if (markedSpans && markedSpans.length > 0) {
-    const marker = markedSpans[0].marker;
+  if (markedSpans && markedSpans.length > 1) {
+    const markerIndex = Services.prefs.getBoolPref("devtools.debugger.features.column-breakpoints") ? 1 : 0;
+    const marker = markedSpans[markerIndex].marker;
+    
     ok(
       marker.className.includes("debug-expression"),
       "expression is highlighted as paused"

--- a/src/test/mochitest/helpers.js
+++ b/src/test/mochitest/helpers.js
@@ -339,10 +339,10 @@ function assertDebugLine(dbg, line) {
   ok(isVisibleInEditor(dbg, debugLine), "debug line is visible");
 
   const markedSpans = lineInfo.handle.markedSpans;
-  if (markedSpans && markedSpans.length > 1) {
-    const markerIndex = Services.prefs.getBoolPref("devtools.debugger.features.column-breakpoints") ? 1 : 0;
+  if (markedSpans && markedSpans.length > 0) {
+    const markerIndex = Services.prefs.getBoolPref("devtools.debugger.features.column-breakpoints") ? markedSpans.length - 1 : 0;
     const marker = markedSpans[markerIndex].marker;
-    
+
     ok(
       marker.className.includes("debug-expression"),
       "expression is highlighted as paused"

--- a/src/utils/prefs.js
+++ b/src/utils/prefs.js
@@ -52,7 +52,7 @@ if (isDevelopment()) {
   pref("devtools.debugger.features.event-listeners", false);
   pref("devtools.debugger.features.code-folding", false);
   pref("devtools.debugger.features.outline", true);
-  pref("devtools.debugger.features.column-breakpoints", false);
+  pref("devtools.debugger.features.column-breakpoints", true);
   pref("devtools.debugger.features.pause-points", true);
   pref("devtools.debugger.features.skip-pausing", true);
   pref("devtools.debugger.features.component-pane", false);


### PR DESCRIPTION
### Summary of Changes

* Pressing Option/Alt only shows column breakpoints on lines that have a breakpoint already set.

### Screenshots/Videos (OPTIONAL)
![column-breakpoints](https://user-images.githubusercontent.com/14957948/48013132-9bc63b00-e0f1-11e8-8e47-49441aed041c.gif)