### PR TITLE
Change XHR breakpoint label cursor to text to make editing intuitive

### DIFF
--- a/src/components/SecondaryPanes/XHRBreakpoints.css
+++ b/src/components/SecondaryPanes/XHRBreakpoints.css
@@ -70,7 +70,7 @@
 .xhr-label {
   max-width: calc(100% - var(--breakpoint-expression-right-clear-space));
   display: inline-block;
-  cursor: pointer;
+  cursor: text;
   flex-grow: 1;
   text-overflow: ellipsis;
   padding-inline-end: 8px;


### PR DESCRIPTION
Showing the text label hints to the user that double-clicking allows them to change the text.