### PR TITLE
Enable line-highlighting for debugger editor

### DIFF
--- a/src/utils/editor/create-editor.js
+++ b/src/utils/editor/create-editor.js
@@ -21,7 +21,7 @@ export function createEditor() {
     readOnly: true,
     lineNumbers: true,
     theme: "mozilla",
-    styleActiveLine: false,
+    styleActiveLine: true,
     lineWrapping: false,
     matchBrackets: true,
     showAnnotationRuler: true,

--- a/src/utils/editor/tests/__snapshots__/create-editor.spec.js.snap
+++ b/src/utils/editor/tests/__snapshots__/create-editor.spec.js.snap
@@ -23,7 +23,7 @@ Object {
   "mode": "javascript",
   "readOnly": true,
   "showAnnotationRuler": true,
-  "styleActiveLine": false,
+  "styleActiveLine": true,
   "theme": "mozilla",
   "value": " ",
 }
@@ -51,7 +51,7 @@ Object {
   "mode": "javascript",
   "readOnly": true,
   "showAnnotationRuler": true,
-  "styleActiveLine": false,
+  "styleActiveLine": true,
   "theme": "mozilla",
   "value": " ",
 }


### PR DESCRIPTION
I can't decided if I like this or not.  I like the additional attention on the selected line, but when we look at interaction, we don't allow text modification so I don't know that an editor-like highlight feels right. Thoughts?

![line-highlight](https://user-images.githubusercontent.com/46655/48039053-df906300-e138-11e8-8633-8b3656aedd63.gif)
