### PR TITLE
Revert "Update eslint-plugin-jest to the latest version 🚀"

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "eslint-plugin-file-header": "0.0.1",
     "eslint-plugin-flowtype": "^2.36.0",
     "eslint-plugin-import": "^2.8.0",
-    "eslint-plugin-jest": "^22.0.0",
+    "eslint-plugin-jest": "^21.15.1",
     "eslint-plugin-mozilla": "^0.16.1",
     "eslint-plugin-prettier": "^3.0.0",
     "eslint-plugin-react": "^7.2.1",


### PR DESCRIPTION
Reverts devtools-html/debugger.html#7243

This triggers jest issues I didn't get locally and I don't want to prioritize this right now, so I'd rather just revert.