### PR TITLE
Add button to evaluate getters in ObjectInspector

### DIFF
--- a/packages/devtools-reps/postcss.config.js
+++ b/packages/devtools-reps/postcss.config.js
@@ -5,24 +5,21 @@
 const mapUrl = require("postcss-url-mapper");
 const MC_PATH = "resource://devtools/client/shared/components/reps/images/";
 const EXPRESS_PATH = "/devtools-reps/images/";
+const IMAGES = ["open-inspector.svg", "jump-definition.svg", "input.svg"];
+
 
 function mapUrlProduction(url, type) {
-  const newUrl = url
-    .replace("/images/open-inspector.svg", MC_PATH + "open-inspector.svg")
-    .replace("/images/jump-definition.svg", MC_PATH + "jump-definition.svg");
-
-  return newUrl;
+  for (const img of IMAGES) {
+    url = url.replace(`/images/${img}`, `${MC_PATH}${img}`);
+  }
+  return url;
 }
 
 function mapUrlDevelopment(url) {
-  const newUrl = url
-    .replace("/images/open-inspector.svg", EXPRESS_PATH + "open-inspector.svg")
-    .replace(
-      "/images/jump-definition.svg",
-      EXPRESS_PATH + "jump-definition.svg"
-    );
-
-  return newUrl;
+  for (const img of IMAGES) {
+    url = url.replace(`/images/${img}`, `${EXPRESS_PATH}${img}`);
+  }
+  return url;
 }
 
 module.exports = ({ file, options, env }) => {

--- a/packages/devtools-reps/src/launchpad/samples.js
+++ b/packages/devtools-reps/src/launchpad/samples.js
@@ -82,7 +82,50 @@ const samples = {
 
   number: ["1", "-1", "-3.14", "0", "-0", "Infinity", "-Infinity", "NaN"],
 
-  object: ["x = {a: 2}"],
+  object: [
+    "x = {a: 2}",
+    `
+Object.create(null, Object.getOwnPropertyDescriptors({
+  get myStringGetter() {
+    return "hello"
+  },
+  get myNumberGetter() {
+    return 123;
+  },
+  get myUndefinedGetter() {
+    return undefined;
+  },
+  get myNullGetter() {
+    return null;
+  },
+  get myObjectGetter() {
+    return {foo: "bar"}
+  },
+  get myArrayGetter() {
+    return Array.from({length: 100000}, (_, i) => i)
+  },
+  get myMapGetter() {
+    return new Map([["foo", {bar: "baz"}]])
+  },
+  get mySetGetter() {
+    return new Set([1, {bar: "baz"}]);
+  },
+  get myProxyGetter() {
+    var handler = { get: function(target, name) {
+      return name in target ? target[name] : 37; }
+    };
+    return new Proxy({a: 1}, handler);
+  },
+  get myThrowingGetter() {
+    return a.b.c.d.e.f;
+  },
+  get myLongStringGetter() {
+    return "ab ".repeat(1e5)
+  },
+  set mySetterOnly(x) {}
+}))
+`
+  ],
 
   promise: [
     "Promise.resolve([1, 2, 3])",

--- a/packages/devtools-reps/src/object-inspector/actions.js
+++ b/packages/devtools-reps/src/object-inspector/actions.js
@@ -39,7 +39,7 @@ function nodeCollapse(node: Node) {
  * symbols for a given node. If we do, it will call the appropriate ObjectClient
  * functions.
  */
-function nodeLoadProperties(node: Node, actor, evaluation) {
+function nodeLoadProperties(node: Node, actor) {
   return async ({ dispatch, client, getState }: ThunkArg) => {
     const state = getState();
     const loadedProperties = getLoadedProperties(state);

--- a/packages/devtools-reps/src/object-inspector/component.js
+++ b/packages/devtools-reps/src/object-inspector/component.js
@@ -180,7 +180,7 @@ class ObjectInspector extends Component<Props> {
         : JSON.stringify(item);
 
     const { evaluations } = this.props;
-    const evaluation = evaluations && evaluations.get(item.path);
+    const evaluation = evaluations.get(item.path);
     if (evaluation) {
       key = `${key}-${evaluation.timestamp}`;
     }
@@ -198,7 +198,7 @@ class ObjectInspector extends Component<Props> {
     }
 
     const { evaluations } = this.props;
-    const evaluation = evaluations && evaluations.get(item.path);
+    const evaluation = evaluations.get(item.path);
     // A getter node should only be expandable if it was evaluated and the
     // resulting node would be expandable.
     if (
@@ -323,7 +323,7 @@ class ObjectInspector extends Component<Props> {
       isPrimitive
     ) {
       const { evaluations } = this.props;
-      const evaluation = evaluations && evaluations.get(item.path);
+      const evaluation = evaluations.get(item.path);
       const repProps = { ...this.props };
       if (depth > 0) {
         repProps.mode = this.props.mode === MODE.LONG ? MODE.SHORT : MODE.TINY;

--- a/packages/devtools-reps/src/object-inspector/component.js
+++ b/packages/devtools-reps/src/object-inspector/component.js
@@ -182,7 +182,7 @@ class ObjectInspector extends Component<Props> {
     const { evaluations } = this.props;
     const evaluation = evaluations.get(item.path);
     if (evaluation) {
-      key = `${key}-${evaluation.timestamp}`;
+      key = `${key}-evaluated`;
     }
     return key;
   }

--- a/packages/devtools-reps/src/object-inspector/index.css
+++ b/packages/devtools-reps/src/object-inspector/index.css
@@ -47,6 +47,7 @@
 }
 
 .tree-node.focused button.jump-definition,
-.tree-node.focused button.open-inspector {
+.tree-node.focused button.open-inspector,
+.tree-node.focused button.invoke-getter {
   background-color: currentColor;
 }

--- a/packages/devtools-reps/src/object-inspector/reducer.js
+++ b/packages/devtools-reps/src/object-inspector/reducer.js
@@ -9,6 +9,7 @@ function initialState() {
   return {
     expandedPaths: new Set(),
     loadedProperties: new Map(),
+    evaluations: new Map(),
     actors: new Set()
   };
 }
@@ -49,6 +50,21 @@ function reducer(
     return cloneState();
   }
 
+  if (type === "GETTER_INVOKED") {
+    return cloneState({
+      actors: data.actor
+        ? new Set(state.actors || []).add(data.result.from)
+        : state.actors,
+      evaluations: new Map(state.evaluations).set(data.node.path, {
+        timestamp: Date.now(),
+        getterValue:
+          data.result &&
+          data.result.value &&
+          (data.result.value.return || data.result.value.throw)
+      })
+    });
+  }
+
   return state;
 }
 
@@ -76,10 +92,15 @@ function getLoadedPropertyKeys(state) {
   return [...getLoadedProperties(state).keys()];
 }
 
+function getEvaluations(state) {
+  return getObjectInspectorState(state).evaluations;
+}
+
 const selectors = {
-  getExpandedPaths,
-  getExpandedPathKeys,
   getActors,
+  getEvaluations,
+  getExpandedPathKeys,
+  getExpandedPaths,
   getLoadedProperties,
   getLoadedPropertyKeys
 };

--- a/packages/devtools-reps/src/object-inspector/reducer.js
+++ b/packages/devtools-reps/src/object-inspector/reducer.js
@@ -56,7 +56,6 @@ function reducer(
         ? new Set(state.actors || []).add(data.result.from)
         : state.actors,
       evaluations: new Map(state.evaluations).set(data.node.path, {
-        timestamp: Date.now(),
         getterValue:
           data.result &&
           data.result.value &&

--- a/packages/devtools-reps/src/object-inspector/tests/component/__snapshots__/getter-setter.js.snap
+++ b/packages/devtools-reps/src/object-inspector/tests/component/__snapshots__/getter-setter.js.snap
@@ -1,5 +1,30 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`ObjectInspector - getters & setters onInvokeGetterButtonClick + getter & setter 1`] = `
+"
+▼ root
+|    x: (>>)
+|  ▶︎ <get x()>: function x()
+|  ▶︎ <set x()>: function x()
+"
+`;
+
+exports[`ObjectInspector - getters & setters onInvokeGetterButtonClick + getter 1`] = `
+"
+▼ root
+|    x: (>>)
+|  ▶︎ <get x()>: function x()
+"
+`;
+
+exports[`ObjectInspector - getters & setters onInvokeGetterButtonClick + setter 1`] = `
+"
+▼ root
+|    x: Setter
+|  ▶︎ <set x()>: function x()
+"
+`;
+
 exports[`ObjectInspector - getters & setters renders getters and setters as expected 1`] = `
 "
 ▼ root

--- a/packages/devtools-reps/src/object-inspector/tests/component/basic.js
+++ b/packages/devtools-reps/src/object-inspector/tests/component/basic.js
@@ -31,7 +31,12 @@ function mountOI(props, { initialState } = {}) {
   const obj = mountObjectInspector({
     client,
     props: generateDefaults(props),
-    initialState: { objectInspector: initialState }
+    initialState: {
+      objectInspector: {
+        ...initialState,
+        evaluations: new Map()
+      }
+    }
   });
 
   return obj;
@@ -211,8 +216,7 @@ describe("ObjectInspector - renders", () => {
                   )
                 }
               ]
-            ]),
-            evaluations: new Map()
+            ])
           }
         }
       );

--- a/packages/devtools-reps/src/object-inspector/tests/component/basic.js
+++ b/packages/devtools-reps/src/object-inspector/tests/component/basic.js
@@ -211,7 +211,8 @@ describe("ObjectInspector - renders", () => {
                   )
                 }
               ]
-            ])
+            ]),
+            evaluations: new Map()
           }
         }
       );

--- a/packages/devtools-reps/src/object-inspector/tests/component/entries.js
+++ b/packages/devtools-reps/src/object-inspector/tests/component/entries.js
@@ -63,7 +63,8 @@ describe("ObjectInspector - entries", () => {
       },
       {
         initialState: {
-          loadedProperties: new Map([["root", mapStubs.get("properties")]])
+          loadedProperties: new Map([["root", mapStubs.get("properties")]]),
+          evaluations: new Map()
         }
       }
     );
@@ -101,7 +102,8 @@ describe("ObjectInspector - entries", () => {
         initialState: {
           loadedProperties: new Map([
             ["root", { ownProperties: stub.preview.entries }]
-          ])
+          ]),
+          evaluations: new Map()
         }
       }
     );

--- a/packages/devtools-reps/src/object-inspector/tests/component/entries.js
+++ b/packages/devtools-reps/src/object-inspector/tests/component/entries.js
@@ -40,7 +40,12 @@ function mount(props, { initialState }) {
   const obj = mountObjectInspector({
     client,
     props: generateDefaults(props),
-    initialState: { objectInspector: initialState }
+    initialState: {
+      objectInspector: {
+        ...initialState,
+        evaluations: new Map()
+      }
+    }
   });
 
   return { ...obj, enumEntries };
@@ -63,8 +68,7 @@ describe("ObjectInspector - entries", () => {
       },
       {
         initialState: {
-          loadedProperties: new Map([["root", mapStubs.get("properties")]]),
-          evaluations: new Map()
+          loadedProperties: new Map([["root", mapStubs.get("properties")]])
         }
       }
     );
@@ -102,8 +106,7 @@ describe("ObjectInspector - entries", () => {
         initialState: {
           loadedProperties: new Map([
             ["root", { ownProperties: stub.preview.entries }]
-          ]),
-          evaluations: new Map()
+          ])
         }
       }
     );

--- a/packages/devtools-reps/src/object-inspector/tests/component/expand.js
+++ b/packages/devtools-reps/src/object-inspector/tests/component/expand.js
@@ -70,7 +70,12 @@ function mount(props, { initialState } = {}) {
   return mountObjectInspector({
     client,
     props: generateDefaults(props),
-    initialState: { objectInspector: initialState }
+    initialState: {
+      objectInspector: {
+        ...initialState,
+        evaluations: new Map()
+      }
+    }
   });
 }
 
@@ -82,8 +87,7 @@ describe("ObjectInspector - state", () => {
         initialState: {
           loadedProperties: new Map([
             ["root-1", gripPropertiesStubs.get("proto-properties-symbols")]
-          ]),
-          evaluations: new Map()
+          ])
         }
       }
     );
@@ -250,8 +254,7 @@ describe("ObjectInspector - state", () => {
         initialState: {
           loadedProperties: new Map([
             ["root-1", gripPropertiesStubs.get("proto-properties-symbols")]
-          ]),
-          evaluations: new Map()
+          ])
         }
       }
     );
@@ -324,8 +327,7 @@ describe("ObjectInspector - state", () => {
         initialState: {
           loadedProperties: new Map([
             ["root-1", gripPropertiesStubs.get("proto-properties-symbols")]
-          ]),
-          evaluations: new Map()
+          ])
         }
       }
     );
@@ -380,8 +382,7 @@ describe("ObjectInspector - state", () => {
         initialState: {
           loadedProperties: new Map([
             ["root-1", gripPropertiesStubs.get("longs-string-safe-getter")]
-          ]),
-          evaluations: new Map()
+          ])
         }
       }
     );

--- a/packages/devtools-reps/src/object-inspector/tests/component/expand.js
+++ b/packages/devtools-reps/src/object-inspector/tests/component/expand.js
@@ -82,7 +82,8 @@ describe("ObjectInspector - state", () => {
         initialState: {
           loadedProperties: new Map([
             ["root-1", gripPropertiesStubs.get("proto-properties-symbols")]
-          ])
+          ]),
+          evaluations: new Map()
         }
       }
     );
@@ -249,7 +250,8 @@ describe("ObjectInspector - state", () => {
         initialState: {
           loadedProperties: new Map([
             ["root-1", gripPropertiesStubs.get("proto-properties-symbols")]
-          ])
+          ]),
+          evaluations: new Map()
         }
       }
     );
@@ -322,7 +324,8 @@ describe("ObjectInspector - state", () => {
         initialState: {
           loadedProperties: new Map([
             ["root-1", gripPropertiesStubs.get("proto-properties-symbols")]
-          ])
+          ]),
+          evaluations: new Map()
         }
       }
     );
@@ -377,7 +380,8 @@ describe("ObjectInspector - state", () => {
         initialState: {
           loadedProperties: new Map([
             ["root-1", gripPropertiesStubs.get("longs-string-safe-getter")]
-          ])
+          ]),
+          evaluations: new Map()
         }
       }
     );

--- a/packages/devtools-reps/src/object-inspector/tests/component/getter-setter.js
+++ b/packages/devtools-reps/src/object-inspector/tests/component/getter-setter.js
@@ -22,7 +22,7 @@ function generateDefaults(overrides) {
   };
 }
 
-function mount(stub) {
+function mount(stub, propsOverride = {}) {
   const client = { createObjectClient: grip => ObjectClient(grip) };
 
   const root = { path: "root", name: "root" };
@@ -38,7 +38,7 @@ function mount(stub) {
 
   return mountObjectInspector({
     client,
-    props: generateDefaults({ roots: [root] })
+    props: generateDefaults({ roots: [root], ...propsOverride })
   });
 }
 
@@ -61,6 +61,39 @@ describe("ObjectInspector - getters & setters", () => {
 
   it("renders getters and setters as expected", async () => {
     const { store, wrapper } = mount(accessorStubs.get("getter setter"));
+    await waitForLoadedProperties(store, ["root"]);
+    wrapper.update();
+
+    expect(formatObjectInspector(wrapper)).toMatchSnapshot();
+  });
+
+  it("onInvokeGetterButtonClick + getter", async () => {
+    const onInvokeGetterButtonClick = jest.fn();
+    const { store, wrapper } = mount(accessorStubs.get("getter"), {
+      onInvokeGetterButtonClick
+    });
+    await waitForLoadedProperties(store, ["root"]);
+    wrapper.update();
+
+    expect(formatObjectInspector(wrapper)).toMatchSnapshot();
+  });
+
+  it("onInvokeGetterButtonClick + setter", async () => {
+    const onInvokeGetterButtonClick = jest.fn();
+    const { store, wrapper } = mount(accessorStubs.get("setter"), {
+      onInvokeGetterButtonClick
+    });
+    await waitForLoadedProperties(store, ["root"]);
+    wrapper.update();
+
+    expect(formatObjectInspector(wrapper)).toMatchSnapshot();
+  });
+
+  it("onInvokeGetterButtonClick + getter & setter", async () => {
+    const onInvokeGetterButtonClick = jest.fn();
+    const { store, wrapper } = mount(accessorStubs.get("getter setter"), {
+      onInvokeGetterButtonClick
+    });
     await waitForLoadedProperties(store, ["root"]);
     wrapper.update();
 

--- a/packages/devtools-reps/src/object-inspector/tests/component/properties.js
+++ b/packages/devtools-reps/src/object-inspector/tests/component/properties.js
@@ -62,7 +62,8 @@ describe("ObjectInspector - properties", () => {
           objectInspector: {
             loadedProperties: new Map([
               ["root", { ownProperties: stub.preview.ownProperties }]
-            ])
+            ]),
+            evaluations: new Map()
           }
         }
       }

--- a/packages/devtools-reps/src/object-inspector/tests/component/proxy.js
+++ b/packages/devtools-reps/src/object-inspector/tests/component/proxy.js
@@ -57,7 +57,8 @@ describe("ObjectInspector - Proxy", () => {
           objectInspector: {
             // Have the prototype already loaded so the component does not call
             // enumProperties for the root's properties.
-            loadedProperties: new Map([["root", { prototype: {} }]])
+            loadedProperties: new Map([["root", { prototype: {} }]]),
+            evaluations: new Map()
           }
         }
       }
@@ -77,7 +78,8 @@ describe("ObjectInspector - Proxy", () => {
           objectInspector: {
             // Have the prototype already loaded so the component does not call
             // enumProperties for the root's properties.
-            loadedProperties: new Map([["root", { prototype: {} }]])
+            loadedProperties: new Map([["root", { prototype: {} }]]),
+            evaluations: new Map()
           }
         }
       }

--- a/packages/devtools-reps/src/object-inspector/tests/component/release-actors.js
+++ b/packages/devtools-reps/src/object-inspector/tests/component/release-actors.js
@@ -45,7 +45,12 @@ function mount(props, { initialState } = {}) {
   return mountObjectInspector({
     client,
     props: generateDefaults(props),
-    initialState
+    initialState: {
+      objectInspector: {
+        ...initialState,
+        evaluations: new Map()
+      }
+    }
   });
 }
 
@@ -55,7 +60,7 @@ describe("release actors", () => {
       {},
       {
         initialState: {
-          objectInspector: { actors: new Set(["actor 1", "actor 2"]) }
+          actors: new Set(["actor 1", "actor 2"])
         }
       }
     );
@@ -74,7 +79,7 @@ describe("release actors", () => {
       },
       {
         initialState: {
-          objectInspector: { actors: new Set(["actor 3", "actor 4"]) }
+          actors: new Set(["actor 3", "actor 4"])
         }
       }
     );

--- a/packages/devtools-reps/src/object-inspector/tests/test-utils.js
+++ b/packages/devtools-reps/src/object-inspector/tests/test-utils.js
@@ -64,9 +64,12 @@ function formatObjectInspector(wrapper: Object) {
         .hasClass("block")
         ? "☲ "
         : "";
-      const text = `${indentStr}${arrowStr}${icon}${getSanitizedNodeText(
-        node
-      )}`;
+      let text = `${indentStr}${arrowStr}${icon}${getSanitizedNodeText(node)}`;
+
+      if (node.find("button.invoke-getter").exists()) {
+        text = `${text}(>>)`;
+      }
+
       if (!hasFocusedNode) {
         return text;
       }

--- a/packages/devtools-reps/src/object-inspector/types.js
+++ b/packages/devtools-reps/src/object-inspector/types.js
@@ -80,6 +80,11 @@ export type CachedNodes = Map<Path, Array<Node>>;
 
 export type LoadedProperties = Map<Path, GripProperties>;
 
+export type Evaluations = Map<
+  Path,
+  { getterValue: GripProperties, evaluation: number }
+>;
+
 export type Mode = MODE.TINY | MODE.SHORT | MODE.LONG;
 
 const { MODE } = require("../reps/constants");
@@ -128,6 +133,7 @@ export type Props = {
   expandedPaths: Set<Path>,
   focusedItem: ?Node,
   loadedProperties: LoadedProperties,
+  evaluations: Evaluations,
   loading: Map<Path, Array<Promise<GripProperties>>>
 };
 

--- a/packages/devtools-reps/src/object-inspector/utils/load-properties.js
+++ b/packages/devtools-reps/src/object-inspector/utils/load-properties.js
@@ -42,7 +42,7 @@ function loadItemProperties(
   createObjectClient: CreateObjectClient,
   createLongStringClient: CreateLongStringClient,
   loadedProperties: LoadedProperties,
-  evaluations: Evaluations
+  evaluations: Evaluations = new Map()
 ): Promise<GripProperties> {
   // If the node was evaluated, we replace the item content with the grip
   // returned by the evaluation.

--- a/packages/devtools-reps/src/object-inspector/utils/load-properties.js
+++ b/packages/devtools-reps/src/object-inspector/utils/load-properties.js
@@ -33,6 +33,7 @@ import type {
   CreateObjectClient,
   GripProperties,
   LoadedProperties,
+  Evaluations,
   Node
 } from "../types";
 
@@ -40,8 +41,16 @@ function loadItemProperties(
   item: Node,
   createObjectClient: CreateObjectClient,
   createLongStringClient: CreateLongStringClient,
-  loadedProperties: LoadedProperties
+  loadedProperties: LoadedProperties,
+  evaluations: Evaluations
 ): Promise<GripProperties> {
+  // If the node was evaluated, we replace the item content with the grip
+  // returned by the evaluation.
+  const evaluation = evaluations.get(item.path);
+  if (evaluation) {
+    item = { ...item, contents: evaluation };
+  }
+
   const gripItem = getClosestGripNode(item);
   const value = getValue(gripItem);
 

--- a/packages/devtools-reps/src/reps/accessor.js
+++ b/packages/devtools-reps/src/reps/accessor.js
@@ -19,18 +19,47 @@ Accessor.propTypes = {
 };
 
 function Accessor(props) {
-  const { object } = props;
+  const { object, evaluation, onInvokeGetterButtonClick } = props;
+
+  if (evaluation) {
+    const { Rep, Grip } = require("./rep");
+    return span(
+      {
+        className: "objectBox objectBox-accessor objectTitle"
+      },
+      Rep({
+        ...props,
+        object: evaluation.getterValue,
+        mode: props.mode || MODE.TINY,
+        defaultRep: Grip
+      })
+    );
+  }
+
+  if (hasGetter(object) && onInvokeGetterButtonClick) {
+    return dom.button({
+      className: "invoke-getter",
+      title: "Invoke getter",
+      onClick: event => {
+        onInvokeGetterButtonClick();
+        event.stopPropagation();
+      }
+    });
+  }
 
   const accessors = [];
   if (hasGetter(object)) {
     accessors.push("Getter");
   }
+
   if (hasSetter(object)) {
     accessors.push("Setter");
   }
-  const title = accessors.join(" & ");
 
-  return span({ className: "objectBox objectBox-accessor objectTitle" }, title);
+  return span(
+    { className: "objectBox objectBox-accessor objectTitle" },
+    accessors.join(" & ")
+  );
 }
 
 function hasGetter(object) {

--- a/packages/devtools-reps/src/reps/reps.css
+++ b/packages/devtools-reps/src/reps/reps.css
@@ -277,6 +277,22 @@ button.jump-definition {
 }
 
 /******************************************************************************/
+/* Invoke getter button */
+
+button.invoke-getter {
+  mask: url(/images/input.svg) no-repeat;
+  display: inline-block;
+  background-color: var(--comment-node-color);
+  height: 12px;
+  vertical-align:bottom;
+  border:none;
+}
+
+.invoke-getter:hover {
+  background-color: var(--theme-highlight-blue);
+}
+
+/******************************************************************************/
 /* "more…" ellipsis */
 .more-ellipsis {
   color: var(--comment-node-color);

--- a/packages/devtools-reps/src/reps/tests/__snapshots__/accessor.js.snap
+++ b/packages/devtools-reps/src/reps/tests/__snapshots__/accessor.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Accessor - Invoke getter does not render an icon when the object has an evaluation 1`] = `"\\"hello\\""`;

--- a/packages/devtools-reps/src/reps/tests/accessor.js
+++ b/packages/devtools-reps/src/reps/tests/accessor.js
@@ -20,6 +20,9 @@ describe("Accessor - getter", () => {
   it("Accessor rep has expected text content", () => {
     const renderedComponent = shallow(Rep({ object }));
     expect(renderedComponent.text()).toEqual("Getter");
+
+    const node = renderedComponent.find(".jump-definition");
+    expect(node.exists()).toBeFalsy();
   });
 });
 
@@ -33,6 +36,9 @@ describe("Accessor - setter", () => {
   it("Accessor rep has expected text content", () => {
     const renderedComponent = shallow(Rep({ object }));
     expect(renderedComponent.text()).toEqual("Setter");
+
+    const node = renderedComponent.find(".jump-definition");
+    expect(node.exists()).toBeFalsy();
   });
 });
 
@@ -46,5 +52,72 @@ describe("Accessor - getter & setter", () => {
   it("Accessor rep has expected text content", () => {
     const renderedComponent = shallow(Rep({ object }));
     expect(renderedComponent.text()).toEqual("Getter & Setter");
+
+    const node = renderedComponent.find(".jump-definition");
+    expect(node.exists()).toBeFalsy();
+  });
+});
+
+describe("Accessor - Invoke getter", () => {
+  it("renders an icon for getter with onInvokeGetterButtonClick", () => {
+    const onInvokeGetterButtonClick = jest.fn();
+    const object = stubs.get("getter");
+    const renderedComponent = shallow(
+      Rep({ object, onInvokeGetterButtonClick })
+    );
+
+    const node = renderedComponent.find(".invoke-getter");
+    node.simulate("click", {
+      type: "click",
+      stopPropagation: () => {}
+    });
+
+    expect(node.exists()).toBeTruthy();
+    expect(onInvokeGetterButtonClick.mock.calls).toHaveLength(1);
+  });
+
+  it("does not render an icon for a setter only", () => {
+    const onInvokeGetterButtonClick = jest.fn();
+    const object = stubs.get("setter");
+    const renderedComponent = shallow(
+      Rep({ object, onInvokeGetterButtonClick })
+    );
+    expect(renderedComponent.text()).toEqual("Setter");
+
+    const node = renderedComponent.find(".jump-definition");
+    expect(node.exists()).toBeFalsy();
+  });
+
+  it("renders an icon for getter/setter with onInvokeGetterButtonClick", () => {
+    const onInvokeGetterButtonClick = jest.fn();
+    const object = stubs.get("getter setter");
+    const renderedComponent = shallow(
+      Rep({ object, onInvokeGetterButtonClick })
+    );
+
+    const node = renderedComponent.find(".invoke-getter");
+    node.simulate("click", {
+      type: "click",
+      stopPropagation: () => {}
+    });
+
+    expect(node.exists()).toBeTruthy();
+    expect(onInvokeGetterButtonClick.mock.calls).toHaveLength(1);
+  });
+
+  it("does not render an icon when the object has an evaluation", () => {
+    const onInvokeGetterButtonClick = jest.fn();
+    const object = stubs.get("getter");
+    const renderedComponent = shallow(
+      Rep({
+        object,
+        onInvokeGetterButtonClick,
+        evaluation: { getterValue: "hello" }
+      })
+    );
+    expect(renderedComponent.text()).toMatchSnapshot();
+
+    const node = renderedComponent.find(".invoke-getter");
+    expect(node.exists()).toBeFalsy();
   });
 });

--- a/packages/devtools-reps/src/shared/images/input.svg
+++ b/packages/devtools-reps/src/shared/images/input.svg
@@ -1,0 +1,7 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 12 12" fill="context-fill #0b0b0b">
+  <path d="M11.04 5.46L7.29 1.71a.75.75 0 0 0-1.06 1.06L9.45 6 6.23 9.21a.75.75 0 1 0 1.06 1.06l3.75-3.75c.3-.3.3-.77 0-1.06z"/>
+  <path d="M6.04 5.46L2.29 1.71a.75.75 0 0 0-1.06 1.06L4.45 6 1.23 9.21a.75.75 0 1 0 1.06 1.06l3.75-3.75c.3-.3.3-.77 0-1.06z"/>
+</svg>


### PR DESCRIPTION
Fixes #6140 

Early WIP, this contains code to: 
- Add button next to getters (only on child nodes)
- Click on the button calls Object actor's `propertyValue` function
- Display the result inline in the tree-node

TODO:
- Change the name of the actions/properties: `invokedGetters` is meh
- Handle expanding a getter which has been evaluated (for now, we display a node for the `get` function)
- Proper icons for evaluation and re-evaluation
- Tests

Thanks to the new redux architecture, evaluations persist when collapsing/expanding again. I feel like this is fine, but I have mostly the console use case in mind, that might be different for the debugger.

---

![nov-09-2018 10-41-43](https://user-images.githubusercontent.com/578107/48255192-3f725c80-e40c-11e8-90d8-1a73977030ea.gif)
