### PR TITLE
Update yarn-copy so that assets are accurately created

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
   global:
     - DISPLAY=':99.0'
     - YARN_VERSION='1.9.4'
-    - MC_COMMIT='d71404ed02ef' # https://hg.mozilla.org/mozilla-central/shortlog
+    - MC_COMMIT='05331fb8f533' # https://hg.mozilla.org/mozilla-central/shortlog
 
 notifications:
   slack:

--- a/assets/images/command-chevron.svg
+++ b/assets/images/command-chevron.svg
@@ -1,6 +1,6 @@
 <!-- This Source Code Form is subject to the terms of the Mozilla Public
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
-<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 16 16">
+<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 16 16" v="2">
   <path fill="context-fill" d="M8.707 7.293l-5-5a1 1 0 0 0-1.414 1.414L6.586 8l-4.293 4.293a1 1 0 1 0 1.414 1.414l5-5a1 1 0 0 0 0-1.414zm6 0l-5-5a1 1 0 0 0-1.414 1.414L12.586 8l-4.293 4.293a1 1 0 1 0 1.414 1.414l5-5a1 1 0 0 0 0-1.414z"></path>
 </svg>

--- a/assets/images/help.svg
+++ b/assets/images/help.svg
@@ -1,0 +1,7 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" v="2">
+  <path fill="context-fill" d="M13.15 17a1.15 1.15 0 1 1-2.3 0 1.15 1.15 0 0 1 2.3 0zM10.5 9.5c0-.764.616-1.5 1.5-1.5s1.5.736 1.5 1.5c0 .311-.144.635-.408.974-.199.254-.386.43-.57.6-.077.072-.153.143-.23.219a1.676 1.676 0 0 1-.048.045c-.13.117-.466.42-.698.757C11.22 12.569 11 13.18 11 14a1 1 0 1 0 2 0c0-.431.106-.645.194-.772.051-.074.114-.144.197-.225.04-.039.08-.075.129-.12l.003-.002.009-.008c.05-.045.114-.104.175-.166l.086-.08a8.13 8.13 0 0 0 .876-.924c.4-.512.831-1.264.831-2.203C15.5 7.764 14.116 6 12 6S8.5 7.764 8.5 9.5a1 1 0 1 0 2 0z"></path>
+  <path fill="context-fill" fill-rule="evenodd" clip-rule="evenodd" d="M12 22c5.523 0 10-4.477 10-10S17.523 2 12 2 2 6.477 2 12s4.477 10 10 10zm0-2a8 8 0 1 0 0-16 8 8 0 0 0 0 16z"></path>
+</svg>

--- a/assets/panel/moz.build
+++ b/assets/panel/moz.build
@@ -5,6 +5,7 @@
 
 DIRS += [
   'dist',
+  'images',
   'src',
 ]
 

--- a/packages/devtools-components/postcss.config.js
+++ b/packages/devtools-components/postcss.config.js
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 const mapUrl = require("postcss-url-mapper");
-const MC_PATH = "chrome://devtools/skin/images/devtools-components/";
+const MC_PATH = "resource://devtools/client/debugger/new/images/";
 const EXPRESS_PATH = "/devtools-components/images/";
 
 function mapUrlProduction(url, type) {

--- a/packages/devtools-reps/postcss.config.js
+++ b/packages/devtools-reps/postcss.config.js
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 const mapUrl = require("postcss-url-mapper");
-const MC_PATH = "chrome://devtools/skin/images/devtools-reps/";
+const MC_PATH = "resource://devtools/client/shared/components/reps/images/";
 const EXPRESS_PATH = "/devtools-reps/images/";
 
 function mapUrlProduction(url, type) {

--- a/packages/devtools-splitter/src/SplitBox.css
+++ b/packages/devtools-splitter/src/SplitBox.css
@@ -48,7 +48,8 @@
 }
 
 .split-box.vert > .splitter {
-  min-width: var(--devtools-vertical-splitter-min-width);
+  min-width: calc(var(--devtools-splitter-inline-start-width) +
+    var(--devtools-splitter-inline-end-width) + 1px);
 
   border-left-width: var(--devtools-splitter-inline-start-width);
   border-right-width: var(--devtools-splitter-inline-end-width);
@@ -60,11 +61,8 @@
 }
 
 .split-box.horz > .splitter {
-  /* Emphasize the horizontal splitter width and color */
-  min-height: var(--devtools-emphasized-horizontal-splitter-min-height);
-
-  background-color: var(--theme-emphasized-splitter-color);
-
+  min-height: calc(var(--devtools-splitter-top-width) +
+    var(--devtools-splitter-bottom-width) + 1px);
   border-top-width: var(--devtools-splitter-top-width);
   border-bottom-width: var(--devtools-splitter-bottom-width);
 
@@ -72,11 +70,6 @@
   margin-bottom: calc(-1 * var(--devtools-splitter-bottom-width));
 
   cursor: ns-resize;
-}
-
-/* Emphasized splitter has the hover style. */
-.split-box.horz > .splitter:hover {
-  background-color: var(--theme-emphasized-splitter-color-hover);
 }
 
 .split-box.disabled {

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -6,9 +6,10 @@ var mapUrl = require("postcss-url-mapper");
 const debug = require("debug")("launchpad");
 
 function mapUrlProduction(url) {
-  const newUrl = url
-    .replace(/\/images\//, "chrome://devtools/skin/images/debugger/")
-    .replace(/\/mc\//, "chrome://devtools/skin/images/");
+  const newUrl = url.replace(
+    /\/images\//,
+    "resource://devtools/client/debugger/new/images/"
+  );
 
   debug("map url", { url, newUrl });
   return newUrl;
@@ -16,7 +17,6 @@ function mapUrlProduction(url) {
 
 function mapUrlDevelopment(url) {
   const newUrl = url
-    .replace(/mc/, "mc/devtools/client/themes/images")
     .replace(/(chrome:\/\/|resource:\/\/)/, "/mc/")
     .replace(/devtools\/skin/, "devtools/client/themes")
     .replace(/devtools\/content/, "devtools/client");

--- a/src/components/Editor/Tabs.css
+++ b/src/components/Editor/Tabs.css
@@ -136,7 +136,7 @@
 }
 
 img.moreTabs {
-  mask: url(/mc/command-chevron.svg) no-repeat;
+  mask: url(/images/command-chevron.svg) no-repeat;
   mask-size: 100%;
   width: 12px;
   height: 12px;

--- a/src/components/SecondaryPanes/CommandBar.css
+++ b/src/components/SecondaryPanes/CommandBar.css
@@ -81,7 +81,7 @@ img.skipPausing {
 }
 
 .command-bar img.shortcuts {
-  mask: url(/mc/help.svg) no-repeat;
+  mask: url(/images/help.svg) no-repeat;
   mask-size: contain;
 }
 

--- a/src/test/mochitest/browser.ini
+++ b/src/test/mochitest/browser.ini
@@ -661,6 +661,7 @@ skip-if = (os == "win" && ccov) # Bug 1453549
 [browser_dbg-sourcemapped-scopes.js]
 skip-if = ccov || (verify && debug && (os == 'linux')) # Bug 1441545
 [browser_dbg-sourcemapped-stepping.js]
+skip-if = (os == 'win' && os_version == '10.0' && ccov) # Bug 1480680
 [browser_dbg-sourcemapped-preview.js]
 skip-if = os == "win" # Bug 1448523, Bug 1448450
 [browser_dbg-breaking.js]


### PR DESCRIPTION

### Summary of Changes
- this updates yarn copy so that the next release uses the new images format
- `v=2` was a silly hack so that 2 SVGs could be in debugge/new/images and devtools/client/themes even though they are the same
- `updateManifest` will copy the manifest over so that we don't get crazy bundle changes when we run `yarn copy`