### PR TITLE
Add a backport script

### DIFF
--- a/bin/port.js
+++ b/bin/port.js
@@ -1,0 +1,63 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
+/*
+
+  Backport changes from the debugger directory for a given commit
+  e.g. node bin/port.js --mc ../gecko-dev --sha 029877e0
+
+*/
+
+
+const path = require("path");
+const minimist = require("minimist");
+const fs = require("fs");
+const chalk = require("chalk");
+const shell = require("shelljs");
+
+const {
+  tools: {  copyFile }
+} = require("devtools-launchpad/index");
+
+const args = minimist(process.argv.slice(1), {
+  string: ["mc", "sha"]
+});
+
+let mcPath = args.mc || "./firefox";
+const sha = args.sha || null;
+
+function exec(cmd) {
+  return shell.exec(cmd, { silent: true });
+}
+
+function copyCommitFiles({mcModulePath, mcPath, projectPath}) {
+  shell.cd(mcPath)
+
+  const { stdout: files } = exec(`git diff-tree --no-commit-id --name-only -r ${sha}`);
+  const dbgFiles = files.split("\n").filter(file => file.includes(mcModulePath))
+
+  for (const file of dbgFiles) {
+    const filePath = file.replace(mcModulePath,'').replace(/^\/(src\/)?/,'');
+
+    const mcFilePath = path.resolve(mcPath, file)
+    const dbgFilePath = path.resolve(projectPath, 'src', filePath);
+
+    // const filePath = path.relative(projectPath, mcFilePath, )
+
+    copyFile(mcFilePath, dbgFilePath, {})
+  }
+}
+
+function start() {
+  const projectPath = path.resolve(__dirname, "..");
+  const mcModulePath = "devtools/client/debugger/new";
+
+  // resolving against the project path in case it's relative. If it's absolute
+  // it will override whatever is in projectPath.
+  mcPath = path.resolve(projectPath, mcPath);
+  const config = {  mcPath, projectPath, mcModulePath };
+  copyCommitFiles(config);
+}
+
+start();


### PR DESCRIPTION
Now that we have original sources in the debugger, it should be easier to backport changes in m-c for a given sha back to github.

This script looks at a commit, filters out the files outside of the debugger, and copies the others back to github. 

I'm sure that this can be improved:

1. we will now copy any changes including dist changes
2. we will miss changes from reps...
3. we could also write a commit message if we want
4. this assumes you're using hg... we can generalize this as well...