### PR TITLE
Support destructuring assignments

### DIFF
--- a/src/workers/parser/mapAwaitExpression.js
+++ b/src/workers/parser/mapAwaitExpression.js
@@ -11,7 +11,10 @@ import { parse, hasNode } from "./utils/ast";
 import { isTopLevel } from "./utils/helpers";
 
 function hasTopLevelAwait(expression: string) {
-  const ast = parse(expression, { allowAwaitOutsideFunction: true });
+  const ast = parse(expression, {
+    allowAwaitOutsideFunction: true,
+    plugins: ["objectRestSpread"]
+  });
   const hasAwait = hasNode(
     ast,
     (node, ancestors, b) => t.isAwaitExpression(node) && isTopLevel(ancestors)

--- a/src/workers/parser/mapAwaitExpression.js
+++ b/src/workers/parser/mapAwaitExpression.js
@@ -4,7 +4,6 @@
 
 // @flow
 
-import template from "@babel/template";
 import generate from "@babel/generator";
 import * as t from "@babel/types";
 
@@ -28,15 +27,20 @@ function wrapExpression(ast) {
     .slice(0, -1)
     .concat(t.returnStatement(lastStatement.expression));
 
-  const newAst = t.arrowFunctionExpression([], t.blockStatement(body), true);
+  const newAst = t.expressionStatement(
+    t.callExpression(
+      t.arrowFunctionExpression([], t.blockStatement(body), true),
+      []
+    )
+  );
+
   return generate(newAst).code;
 }
 
 export default function mapTopLevelAwait(expression: string) {
   const ast = hasTopLevelAwait(expression);
   if (ast) {
-    const func = wrapExpression(ast);
-    return generate(template.ast(`(${func})();`)).code;
+    return wrapExpression(ast);
   }
 
   return expression;

--- a/src/workers/parser/mapAwaitExpression.js
+++ b/src/workers/parser/mapAwaitExpression.js
@@ -7,14 +7,11 @@
 import generate from "@babel/generator";
 import * as t from "@babel/types";
 
-import { parse, hasNode } from "./utils/ast";
+import { parseConsoleScript, hasNode } from "./utils/ast";
 import { isTopLevel } from "./utils/helpers";
 
 function hasTopLevelAwait(expression: string) {
-  const ast = parse(expression, {
-    allowAwaitOutsideFunction: true,
-    plugins: ["objectRestSpread"]
-  });
+  const ast = parseConsoleScript(expression);
   const hasAwait = hasNode(
     ast,
     (node, ancestors, b) => t.isAwaitExpression(node) && isTopLevel(ancestors)

--- a/src/workers/parser/mapBindings.js
+++ b/src/workers/parser/mapBindings.js
@@ -4,7 +4,7 @@
 
 // @flow
 
-import { parseScript } from "./utils/ast";
+import { parseConsoleScript } from "./utils/ast";
 import { isTopLevel } from "./utils/helpers";
 
 import generate from "@babel/generator";
@@ -94,10 +94,7 @@ export default function mapExpressionBindings(
   expression: string,
   bindings: string[] = []
 ): string {
-  const ast = parseScript(expression, {
-    allowAwaitOutsideFunction: true,
-    plugins: ["objectRestSpread"]
-  });
+  const ast = parseConsoleScript(expression);
 
   let isMapped = false;
   let shouldUpdate = true;

--- a/src/workers/parser/mapBindings.js
+++ b/src/workers/parser/mapBindings.js
@@ -133,10 +133,10 @@ export default function mapExpressionBindings(
   const ast = parseScript(expression, { allowAwaitOutsideFunction: true });
   let isMapped = false;
   let shouldUpdate = true;
+  const processedNodes = new WeakSet();
 
   t.traverse(ast, (node, ancestors) => {
-    // the isMapped check is to avoid processing the newly added nodes
-    if (isMapped) {
+    if (processedNodes.has(node)) {
       return;
     }
 
@@ -172,6 +172,9 @@ export default function mapExpressionBindings(
       const newNodes = globalizeDeclaration(node, bindings);
       isMapped = true;
       replaceNode(ancestors, newNodes);
+      for (const processNode of newNodes) {
+        processedNodes.add(processNode);
+      }
     }
   });
 

--- a/src/workers/parser/mapOriginalExpression.js
+++ b/src/workers/parser/mapOriginalExpression.js
@@ -5,7 +5,7 @@
 // @flow
 
 import type { ColumnPosition } from "../../types";
-import { parseScript } from "./utils/ast";
+import { parseScript, parseConsoleScript } from "./utils/ast";
 import { buildScopeList } from "./getScopes";
 import generate from "@babel/generator";
 import * as t from "@babel/types";
@@ -40,11 +40,7 @@ export default function mapOriginalExpression(
     [string]: string | null
   }
 ): string {
-  const ast = parseScript(expression, {
-    allowAwaitOutsideFunction: true,
-    plugins: ["objectRestSpread"]
-  });
-
+  const ast = parseConsoleScript(expression);
   const scopes = buildScopeList(ast, "");
   let shouldUpdate = false;
 

--- a/src/workers/parser/mapOriginalExpression.js
+++ b/src/workers/parser/mapOriginalExpression.js
@@ -40,7 +40,11 @@ export default function mapOriginalExpression(
     [string]: string | null
   }
 ): string {
-  const ast = parseScript(expression, { allowAwaitOutsideFunction: true });
+  const ast = parseScript(expression, {
+    allowAwaitOutsideFunction: true,
+    plugins: ["objectRestSpread"]
+  });
+
   const scopes = buildScopeList(ast, "");
   let shouldUpdate = false;
 

--- a/src/workers/parser/tests/mapBindings.spec.js
+++ b/src/workers/parser/tests/mapBindings.spec.js
@@ -48,6 +48,40 @@ describe("mapExpressionBindings", () => {
       name: "assignments with +=",
       expression: "a += 2;",
       newExpression: "self.a += 2;"
+    },
+    {
+      name: "destructuring (objects)",
+      expression: "const { a } = {}; ",
+      newExpression: "({ a: self.a } = {})"
+    },
+    {
+      name: "destructuring (arrays)",
+      expression: " var [a, ...foo] = [];",
+      newExpression: "([self.a, ...self.foo] = [])"
+    },
+    {
+      name: "destructuring (declarations)",
+      expression: "var {d,e} = {}, {f} = {}; ",
+      newExpression: `({ d: self.d, e: self.e } = {});
+        ({ f: self.f } = {})
+      `
+    },
+    {
+      name: "destructuring & declaration",
+      expression: "const { a } = {}; var b = 3",
+      newExpression: `({ a: self.a } = {});
+        self.b = 3
+      `
+    },
+    {
+      name: "destructuring assignment",
+      expression: "[a] = [3]",
+      newExpression: "[self.a] = [3]"
+    },
+    {
+      name: "destructuring assignment (declarations)",
+      expression: "[a] = [3]; var b = 4",
+      newExpression: "[self.a] = [3];\n self.b = 4"
     }
   ]);
 
@@ -83,32 +117,8 @@ describe("mapExpressionBindings", () => {
       expression: "{ var g = 5; }"
     },
     {
-      name: "destructuring assignment",
-      expression: "[a] = [3]"
-    },
-    {
-      name: "destructuring assignment (declarations)",
-      expression: "[a] = [3]; var b = 4"
-    },
-    {
       name: "for loops bindings",
       expression: "for (let foo = 4; false;){}"
-    },
-    {
-      name: "destructuring (objects)",
-      expression: "const { a } = {}; "
-    },
-    {
-      name: "destructuring (arrays)",
-      expression: " var [a, ...foo] = []; "
-    },
-    {
-      name: "destructuring (declarations)",
-      expression: "var {d,e} = {}, {f} = {}; "
-    },
-    {
-      name: "destructuring & declaration",
-      expression: "const { a } = {}; var b = 3"
     }
   ]);
 

--- a/src/workers/parser/tests/mapExpression.spec.js
+++ b/src/workers/parser/tests/mapExpression.spec.js
@@ -161,6 +161,90 @@ describe("mapExpression", () => {
       }
     },
     {
+      name: "await (destructuring with defaults, bindings)",
+      expression: "const { a = 5, c } = await b();",
+      newExpression: formatAwait(`
+        let __decl0__ = await b();
+
+        a = __decl0__.a === undefined ? 5 : __decl0__.a;
+        return (self.c = __decl0__.c);
+    `),
+      bindings: ["a", "y"],
+      mappings: {},
+      shouldMapExpression: true,
+      expectedMapped: {
+        await: true,
+        bindings: true,
+        originalExpression: false
+      }
+    },
+    {
+      name: "await (nested destructuring, bindings)",
+      expression: "const { a, c: { y } } = await b();",
+      newExpression: formatAwait(`
+        let __decl0__ = await b();
+
+        a = __decl0__.a;
+        return (y = __decl0__.c.y);
+    `),
+      bindings: ["a", "y"],
+      mappings: {},
+      shouldMapExpression: true,
+      expectedMapped: {
+        await: true,
+        bindings: true,
+        originalExpression: false
+      }
+    },
+    {
+      name: "await (nested destructuring with defaults)",
+      expression: "const { a, c: { y = 5 } = {} } = await b();",
+      newExpression: formatAwait(`
+        let __decl0__ = await b();
+
+        self.a = __decl0__.a;
+
+        let __decl0__c__ = __decl0__.c === undefined ? {} : __decl0__.c;
+
+        return (self.y = __decl0__c__.y === undefined ? 5 : __decl0__c__.y);
+    `),
+      bindings: [],
+      mappings: {},
+      shouldMapExpression: true,
+      expectedMapped: {
+        await: true,
+        bindings: true,
+        originalExpression: false
+      }
+    },
+    {
+      name: "await (very nested destructuring with defaults)",
+      expression:
+        "const { a, c: { y: { z = 10, b } = { b: 5 } } } = await b();",
+      newExpression: formatAwait(`
+        let __decl0__ = await b();
+
+        self.a = __decl0__.a;
+
+        let __decl0__y__ =__decl0__.c.y === undefined
+        ? {
+            b: 5
+          }
+        : __decl0__.c.y;
+
+        self.z = __decl0__y__.z === undefined ? 10 : __decl0__y__.z;
+        return (self.b = __decl0__y__.b);
+    `),
+      bindings: [],
+      mappings: {},
+      shouldMapExpression: true,
+      expectedMapped: {
+        await: true,
+        bindings: true,
+        originalExpression: false
+      }
+    },
+    {
       name: "simple",
       expression: "a",
       newExpression: "a",

--- a/src/workers/parser/tests/mapExpression.spec.js
+++ b/src/workers/parser/tests/mapExpression.spec.js
@@ -100,6 +100,67 @@ describe("mapExpression", () => {
       }
     },
     {
+      name: "await (destructuring)",
+      expression: "const { a, c: y } = await b()",
+      newExpression: formatAwait(`let __decl0__ = await b();
+
+      self.a = __decl0__.a;
+      return (self.y = __decl0__.c);
+    `),
+      bindings: [],
+      mappings: {},
+      shouldMapExpression: true,
+      expectedMapped: {
+        await: true,
+        bindings: true,
+        originalExpression: false
+      }
+    },
+    {
+      name: "await (destructuring, multiple statements)",
+      expression: "const { a, c: y } = await b(), { x } = await y()",
+      newExpression: formatAwait(`
+        let __decl0__ = await b();
+
+        self.a = __decl0__.a;
+        self.y = __decl0__.c;
+
+        let __decl1__ = await y();
+    
+        return (self.x = __decl1__.x);
+    `),
+      bindings: [],
+      mappings: {},
+      shouldMapExpression: true,
+      expectedMapped: {
+        await: true,
+        bindings: true,
+        originalExpression: false
+      }
+    },
+    {
+      name: "await (destructuring, bindings)",
+      expression: "const { a, c: y } = await b(), { x } = await y()",
+      newExpression: formatAwait(`
+        let __decl0__ = await b();
+
+        a = __decl0__.a;
+        y = __decl0__.c;
+
+        let __decl1__ = await y();
+    
+        return (self.x = __decl1__.x);
+    `),
+      bindings: ["a", "y"],
+      mappings: {},
+      shouldMapExpression: true,
+      expectedMapped: {
+        await: true,
+        bindings: true,
+        originalExpression: false
+      }
+    },
+    {
       name: "simple",
       expression: "a",
       newExpression: "a",
@@ -141,9 +202,37 @@ describe("mapExpression", () => {
       }
     },
     {
+      name: "declaration + destructuring",
+      expression: "var { a } = { a: 3 };",
+      newExpression: `let __decl0__ = {\n a: 3 \n}
+      self.a = __decl0__.a;`,
+      bindings: [],
+      mappings: {},
+      shouldMapExpression: true,
+      expectedMapped: {
+        await: false,
+        bindings: true,
+        originalExpression: false
+      }
+    },
+    {
       name: "bindings",
       expression: "var a = 3;",
       newExpression: "a = 3",
+      bindings: ["a"],
+      mappings: {},
+      shouldMapExpression: true,
+      expectedMapped: {
+        await: false,
+        bindings: true,
+        originalExpression: false
+      }
+    },
+    {
+      name: "bindings + destructuring",
+      expression: "var { a } = { a: 3 };",
+      newExpression: `let __decl0__ = { \n a: 3 \n }
+      a = __decl0__.a`,
       bindings: ["a"],
       mappings: {},
       shouldMapExpression: true,
@@ -167,9 +256,36 @@ describe("mapExpression", () => {
       }
     },
     {
+      name: "bindings + mappings + destructuring",
+      expression: "var { a } = { a: 4 }",
+      newExpression: `let __decl0__ = {\n a: 4 \n};
+      self.a = __decl0__.a;`,
+      bindings: ["_a"],
+      mappings: { a: "_a" },
+      shouldMapExpression: true,
+      expectedMapped: {
+        await: false,
+        bindings: true,
+        originalExpression: false
+      }
+    },
+    {
       name: "bindings without mappings",
       expression: "a = 3;",
       newExpression: "a = 3",
+      bindings: [],
+      mappings: { a: "_a" },
+      shouldMapExpression: false,
+      expectedMapped: {
+        await: false,
+        bindings: false,
+        originalExpression: false
+      }
+    },
+    {
+      name: "bindings + destructuring without mappings",
+      expression: "({ a } = { a: 4 })",
+      newExpression: "({ a } = {\n a: 4 \n})",
       bindings: [],
       mappings: { a: "_a" },
       shouldMapExpression: false,

--- a/src/workers/parser/tests/mapExpression.spec.js
+++ b/src/workers/parser/tests/mapExpression.spec.js
@@ -412,19 +412,6 @@ describe("mapExpression", () => {
         bindings: false,
         originalExpression: false
       }
-    },
-    {
-      name: "bindings + destructuring without mappings",
-      expression: "({ a } = { a: 4 })",
-      newExpression: "({ a } = {\n a: 4 \n})",
-      bindings: [],
-      mappings: { a: "_a" },
-      shouldMapExpression: false,
-      expectedMapped: {
-        await: false,
-        bindings: false,
-        originalExpression: false
-      }
     }
   ]);
 });

--- a/src/workers/parser/tests/mapExpression.spec.js
+++ b/src/workers/parser/tests/mapExpression.spec.js
@@ -375,6 +375,32 @@ describe("mapExpression", () => {
       }
     },
     {
+      name: "bindings + destructuring + rest",
+      expression: "var { a, ...foo } = {}",
+      newExpression: "({ a, ...self.foo } = {})",
+      bindings: ["a"],
+      mappings: {},
+      shouldMapExpression: true,
+      expectedMapped: {
+        await: false,
+        bindings: true,
+        originalExpression: false
+      }
+    },
+    {
+      name: "bindings + array destructuring + rest",
+      expression: "var [a, ...foo] = []",
+      newExpression: "([a, ...self.foo] = [])",
+      bindings: ["a"],
+      mappings: {},
+      shouldMapExpression: true,
+      expectedMapped: {
+        await: false,
+        bindings: true,
+        originalExpression: false
+      }
+    },
+    {
       name: "bindings + mappings",
       expression: "a = 3;",
       newExpression: "self.a = 3",

--- a/src/workers/parser/utils/ast.js
+++ b/src/workers/parser/utils/ast.js
@@ -98,6 +98,14 @@ function parseVueScript(code) {
   return ast;
 }
 
+export function parseConsoleScript(text: string, opts?: Object) {
+  return _parse(text, {
+    plugins: ["objectRestSpread"],
+    ...opts,
+    allowAwaitOutsideFunction: true
+  });
+}
+
 export function parseScript(text: string, opts?: Object) {
   return _parse(text, opts);
 }


### PR DESCRIPTION
Fixes #7222

Here's the Pull Request Doc
https://firefox-dev.tools/debugger.html/docs/pull-requests.html

### Summary of Changes

* Added support for simple top-level destructuring assignments - ~still working on the nested destructuring with default values~ (already implemented). The change affects all cases, not just the ones with await statements.
* Built an IIFE with `@babel/types` in mapAwaitExpression.js.

### Test Plan

Just by writing tests. No specific test plan.

Here's the Debugger's Testing doc
https://docs.google.com/document/d/1oBMRxV8A2ag2t22YsQOxTdEv0mXKzIg0tggJjRkU1S0/edit#.
Feel free to improve it!

### Screenshots/Videos (OPTIONAL)
