### PR TITLE
Simplify the getBreakpointsForSource selector function

### DIFF
--- a/src/reducers/breakpoints.js
+++ b/src/reducers/breakpoints.js
@@ -296,21 +296,13 @@ export function getBreakpointsForSource(
   }
 
   const isGeneratedSource = isGeneratedId(sourceId);
-  const breakpoints = getBreakpointsMap(state);
-
-  const breakpointsForSource = [];
-
-  for (const key in breakpoints) {
-    const bp = breakpoints[key];
+  const breakpoints = getBreakpointsList(state);
+  return breakpoints.filter(bp => {
     const location = isGeneratedSource
       ? bp.generatedLocation || bp.location
       : bp.location;
-    if (location.sourceId === sourceId) {
-      breakpointsForSource.push({ ...bp });
-    }
-  }
-
-  return breakpointsForSource;
+    return location.sourceId === sourceId;
+  });
 }
 
 export function getBreakpointForLine(

--- a/src/reducers/tests/breakpoints.spec.js
+++ b/src/reducers/tests/breakpoints.spec.js
@@ -37,9 +37,14 @@ describe("Breakpoints Selectors", () => {
     };
 
     const breakpoints = initializeStateWith(data);
-    expect(getBreakpointsForSource({ breakpoints }, sourceId)).toEqual(
-      Object.values(matchingBreakpoints)
+    const allBreakpoints = Object.values(matchingBreakpoints);
+    const sourceBreakpoints = getBreakpointsForSource(
+      { breakpoints },
+      sourceId
     );
+
+    expect(sourceBreakpoints).toEqual(allBreakpoints);
+    expect(sourceBreakpoints[0] === allBreakpoints[0]).toBe(true);
   });
 
   it("it gets a breakpoint for a generated source", () => {
@@ -71,8 +76,12 @@ describe("Breakpoints Selectors", () => {
 
     const breakpoints = initializeStateWith(data);
 
-    expect(getBreakpointsForSource({ breakpoints }, generatedSourceId)).toEqual(
-      Object.values(matchingBreakpoints)
+    const allBreakpoints = Object.values(matchingBreakpoints);
+    const sourceBreakpoints = getBreakpointsForSource(
+      { breakpoints },
+      generatedSourceId
     );
+
+    expect(sourceBreakpoints).toEqual(allBreakpoints);
   });
 });


### PR DESCRIPTION
A simplification of getBreakpointsForSource based on [this comment](https://github.com/devtools-html/debugger.html/pull/7226#issuecomment-437555166).  I made it so it no longer re-creates new breakpoint objects and also used getBreakpointsList instead of getBreakpointsMap so it can just use Array.filter to get the results.