### PR TITLE
Prevent removing column breakpoint from from removing line's breakpoint when there are multiple breakpoints on the same column

### DIFF
--- a/src/components/Editor/Breakpoints.js
+++ b/src/components/Editor/Breakpoints.js
@@ -5,6 +5,7 @@
 // @flow
 import { connect } from "react-redux";
 import React, { Component } from "react";
+import { uniq, isEqual } from "lodash";
 
 import Breakpoint from "./Breakpoint";
 
@@ -20,9 +21,24 @@ type Props = {
   editor: Object
 };
 
+function breakpointLinesMatch(oldBreakpoints, newBreakpoints) {
+  function getBreakpointLines(bps) {
+    return uniq(bps.map(bp => bp.location.line).filter(Boolean));
+  }
+
+  return isEqual(
+    getBreakpointLines(oldBreakpoints.breakpoints),
+    getBreakpointLines(newBreakpoints.breakpoints)
+  );
+}
+
 class Breakpoints extends Component<Props> {
   shouldComponentUpdate(nextProps: Props) {
     if (nextProps.selectedSource && !isLoaded(nextProps.selectedSource)) {
+      return false;
+    }
+
+    if (breakpointLinesMatch(this.props, nextProps)) {
       return false;
     }
 

--- a/src/components/Editor/Breakpoints.js
+++ b/src/components/Editor/Breakpoints.js
@@ -23,7 +23,7 @@ type Props = {
 
 function breakpointLinesMatch(oldBreakpoints, newBreakpoints) {
   function getBreakpointLines(bps) {
-    return uniq(bps.map(bp => bp.location.line).filter(Boolean));
+    return uniq(bps.map(bp => bp.location.line).filter(Boolean)).sort();
   }
 
   return isEqual(

--- a/src/components/Editor/Breakpoints.js
+++ b/src/components/Editor/Breakpoints.js
@@ -21,14 +21,14 @@ type Props = {
   editor: Object
 };
 
-function breakpointLinesMatch(oldBreakpoints, newBreakpoints) {
-  function getBreakpointLines(bps) {
-    return uniq(bps.map(bp => bp.location.line).filter(Boolean)).sort();
-  }
+function getBreakpointLines(bps) {
+  return uniq(bps.map(bp => bp.location.line).filter(Boolean)).sort();
+}
 
+function breakpointLinesMatch(oldBreakpoints, newBreakpoints) {
   return isEqual(
-    getBreakpointLines(oldBreakpoints.breakpoints),
-    getBreakpointLines(newBreakpoints.breakpoints)
+    getBreakpointLines(oldBreakpoints),
+    getBreakpointLines(newBreakpoints)
   );
 }
 
@@ -38,7 +38,7 @@ class Breakpoints extends Component<Props> {
       return false;
     }
 
-    if (breakpointLinesMatch(this.props, nextProps)) {
+    if (breakpointLinesMatch(this.props.breakpoints, nextProps.breakpoints)) {
       return false;
     }
 


### PR DESCRIPTION
This PR prevents the line breakpoint marker from being removed when a column breakpoint is removed when there are multiple breakpoints on a line.