### PR TITLE
[Breakpoints] fix breakpoint context menu logic

### DIFF
--- a/src/actions/breakpoints/tests/__snapshots__/breakpoints.spec.js.snap
+++ b/src/actions/breakpoints/tests/__snapshots__/breakpoints.spec.js.snap
@@ -38,6 +38,7 @@ Array [
       Object {
         "condition": null,
         "disabled": false,
+        "id": "hi",
         "selectedLocation": Object {
           "line": 2,
           "sourceId": "a",
@@ -105,6 +106,7 @@ Array [
       Object {
         "condition": null,
         "disabled": true,
+        "id": "hi",
         "selectedLocation": Object {
           "line": 5,
           "sourceId": "a",

--- a/src/components/SecondaryPanes/Breakpoints/BreakpointsContextMenu.js
+++ b/src/components/SecondaryPanes/Breakpoints/BreakpointsContextMenu.js
@@ -74,14 +74,14 @@ export default function showContextMenu(props) {
     "breakpointMenuItem.addCondition2.accesskey"
   );
 
-  const otherBreakpoints = breakpoints.filter(b => b !== breakpoint);
+  const otherBreakpoints = breakpoints.filter(b => b.id !== breakpoint.id);
   const enabledBreakpoints = breakpoints.filter(b => !b.disabled);
   const disabledBreakpoints = breakpoints.filter(b => b.disabled);
   const otherEnabledBreakpoints = breakpoints.filter(
-    b => !b.disabled && b !== breakpoint
+    b => !b.disabled && b.id !== breakpoint.id
   );
   const otherDisabledBreakpoints = breakpoints.filter(
-    b => b.disabled && b !== breakpoint
+    b => b.disabled && b.id !== breakpoint.id
   );
 
   const deleteSelfItem = {

--- a/src/components/SecondaryPanes/Breakpoints/tests/BreakpointsContextMenu.spec.js
+++ b/src/components/SecondaryPanes/Breakpoints/tests/BreakpointsContextMenu.spec.js
@@ -1,0 +1,126 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
+import React from "react";
+import { shallow } from "enzyme";
+
+import BreakpointsContextMenu from "../BreakpointsContextMenu";
+import { createBreakpoint } from "../../../../utils/breakpoint";
+import { buildMenu } from "devtools-contextmenu";
+
+jest.mock("devtools-contextmenu");
+
+function render(overrides = {}, disabled = false) {
+  const props = generateDefaults(overrides, disabled);
+  const component = shallow(<BreakpointsContextMenu {...props} />);
+  return { component, props };
+}
+
+function generateDefaults(overrides = {}, disabled) {
+  const breakpoints = [
+    createBreakpoint(
+      {
+        line: 1,
+        column: undefined,
+        sourceId: "server1.conn26.child3/source26",
+        sourceUrl: "https://example.com/main.js"
+      },
+      { id: "https://example.com/main.js:1:", disabled: disabled }
+    ),
+    createBreakpoint(
+      {
+        line: 2,
+        column: undefined,
+        sourceId: "server1.conn26.child3/source26",
+        sourceUrl: "https://example.com/main.js"
+      },
+      { id: "https://example.com/main.js:2:", disabled: disabled }
+    ),
+    createBreakpoint(
+      {
+        line: 3,
+        column: undefined,
+        sourceId: "server1.conn26.child3/source26",
+        sourceUrl: "https://example.com/main.js"
+      },
+      { id: "https://example.com/main.js:3:", disabled: disabled }
+    )
+  ];
+
+  const props = {
+    breakpoints,
+    breakpoint: { id: "https://example.com/main.js:1:" },
+    removeBreakpoint: jest.fn(),
+    removeBreakpoints: jest.fn(),
+    removeAllBreakpoints: jest.fn(),
+    toggleBreakpoints: jest.fn(),
+    toggleAllBreakpoints: jest.fn(),
+    toggleDisabledBreakpoint: jest.fn(),
+    selectSpecificLocation: jest.fn(),
+    setBreakpointCondition: jest.fn(),
+    openConditionalPanel: jest.fn(),
+    contextMenuEvent: { preventDefault: jest.fn() },
+    ...overrides
+  };
+  return props;
+}
+
+describe("BreakpointsContextMenu", () => {
+  afterEach(() => {
+    buildMenu.mockReset();
+  });
+
+  describe("context menu actions affecting other breakpoints", () => {
+    it("'remove others' calls removeBreakpoints with proper arguments", () => {
+      const { props } = render();
+      const menuItems = buildMenu.mock.calls[0][0];
+      const deleteOthers = menuItems.find(
+        item => item.item.id === "node-menu-delete-other"
+      );
+      deleteOthers.item.click();
+
+      expect(props.removeBreakpoints).toHaveBeenCalled();
+
+      const otherBreakpoints = [props.breakpoints[1], props.breakpoints[2]];
+      expect(props.removeBreakpoints.mock.calls[0][0]).toEqual(
+        otherBreakpoints
+      );
+    });
+
+    it("'enable others' calls toggleBreakpoints with proper arguments", () => {
+      const { props } = render({}, true);
+      const menuItems = buildMenu.mock.calls[0][0];
+      const enableOthers = menuItems.find(
+        item => item.item.id === "node-menu-enable-others"
+      );
+      enableOthers.item.click();
+
+      expect(props.toggleBreakpoints).toHaveBeenCalled();
+
+      expect(props.toggleBreakpoints.mock.calls[0][0]).toBe(false);
+
+      const otherBreakpoints = [props.breakpoints[1], props.breakpoints[2]];
+      expect(props.toggleBreakpoints.mock.calls[0][1]).toEqual(
+        otherBreakpoints
+      );
+    });
+
+    it("'disable others' calls toggleBreakpoints with proper arguments", () => {
+      const { props } = render();
+      const menuItems = buildMenu.mock.calls[0][0];
+      const disableOthers = menuItems.find(
+        item => item.item.id === "node-menu-disable-others"
+      );
+      disableOthers.item.click();
+
+      expect(props.toggleBreakpoints).toHaveBeenCalled();
+      expect(props.toggleBreakpoints.mock.calls[0][0]).toBe(true);
+
+      const otherBreakpoints = [props.breakpoints[1], props.breakpoints[2]];
+      expect(props.toggleBreakpoints.mock.calls[0][1]).toEqual(
+        otherBreakpoints
+      );
+    });
+  });
+});

--- a/src/selectors/breakpointSources.js
+++ b/src/selectors/breakpointSources.js
@@ -14,7 +14,7 @@ import {
 import { isGenerated, getFilename } from "../utils/source";
 import { getSelectedLocation } from "../utils/source-maps";
 
-import type { Source, Breakpoint, Location } from "../types";
+import type { Source, Breakpoint, BreakpointId, Location } from "../types";
 import type { SourcesMap } from "../reducers/types";
 
 export type BreakpointSources = Array<{
@@ -23,6 +23,7 @@ export type BreakpointSources = Array<{
 }>;
 
 export type FormattedBreakpoint = {|
+  id: BreakpointId,
   condition: ?string,
   disabled: boolean,
   text: string,
@@ -33,9 +34,10 @@ function formatBreakpoint(
   breakpoint: Breakpoint,
   selectedSource: Source
 ): FormattedBreakpoint {
-  const { condition, disabled } = breakpoint;
+  const { id, condition, disabled } = breakpoint;
 
   return {
+    id,
     condition,
     disabled,
     text:

--- a/src/test/mochitest/browser_dbg-breakpoints-actions.js
+++ b/src/test/mochitest/browser_dbg-breakpoints-actions.js
@@ -1,9 +1,8 @@
 /* Any copyright is dedicated to the Public Domain.
  * http://creativecommons.org/publicdomain/zero/1.0/ */
 
-async function removeBreakpoint(dbg) {
-  rightClickElement(dbg, "breakpointItem", 3)
-  selectMenuItem(dbg, 1);
+function openFirstBreakpointContextMenu(dbg){
+  rightClickElement(dbg, "breakpointItem", 3);
 }
 
 
@@ -14,8 +13,58 @@ add_task(async function() {
   await waitForSelectedSource(dbg, "simple2");
 
   await addBreakpoint(dbg, "simple2", 3);
-  await removeBreakpoint(dbg);
+
+  openFirstBreakpointContextMenu(dbg)
+  // select "Remove breakpoint"
+  selectMenuItem(dbg, 1);
 
   await waitForState(dbg, state => dbg.selectors.getBreakpointCount(state) === 0);
-  ok("successfully removed the breakpoint")
+  ok("successfully removed the breakpoint");
+});
+
+// Tests "disable others", "enable others" and "remove others" context actions
+add_task(async function() {
+  const dbg = await initDebugger("doc-scripts.html");
+  await selectSource(dbg, "simple1");
+  await waitForSelectedSource(dbg, "simple1");
+
+  await addBreakpoint(dbg, "simple1", 1);
+  await addBreakpoint(dbg, "simple1", 4);
+  await addBreakpoint(dbg, "simple1", 5);
+  await addBreakpoint(dbg, "simple1", 6);
+
+  openFirstBreakpointContextMenu(dbg)
+  // select "Disable Others"
+  selectMenuItem(dbg, 7);
+  await waitForState(dbg, state =>
+    dbg.selectors.getBreakpointsList(state)
+      .every(bp => (bp.location.line !== 1) === bp.disabled)
+  );
+  ok("breakpoint at 1 is the only enabled breakpoint");
+
+  openFirstBreakpointContextMenu(dbg)
+  // select "Disable All"
+  selectMenuItem(dbg, 9);
+  await waitForState(dbg, state =>
+    dbg.selectors.getBreakpointsList(state).every(bp => bp.disabled)
+  );
+  ok("all breakpoints are disabled")
+
+  openFirstBreakpointContextMenu(dbg)
+  // select "Enable Others"
+  selectMenuItem(dbg, 3);
+  await waitForState(dbg, state =>
+    dbg.selectors.getBreakpointsList(state)
+      .every(bp => (bp.location.line === 1) === bp.disabled)
+  );
+  ok("all breakpoints except line 1 are enabled");
+
+  openFirstBreakpointContextMenu(dbg)
+  // select "Remove Others"
+  selectMenuItem(dbg, 6);
+  await waitForState(dbg, state =>
+    dbg.selectors.getBreakpointsList(state).length === 1 &&
+    dbg.selectors.getBreakpointsList(state)[0].location.line === 1
+  );
+  ok("remaining breakpoint should be on line 1");
 });


### PR DESCRIPTION
Fixes #7268 

### Summary of Changes

* update BreakpointContextMenu.js logic that finds other breakpoints.  A formatted breakpoint object was being compared to a breakpoint object using object equality which was always returning that they were not the same breakpoint.  I changed it to compare using breakpoint id.
* added the breakpoint id property to FormattedBreakpoint objects

