### PR TITLE
[WIP] Add missing 'setBreakpointCondition' action to Breakpoint props

### DIFF
--- a/src/components/SecondaryPanes/Breakpoints/Breakpoint.js
+++ b/src/components/SecondaryPanes/Breakpoints/Breakpoint.js
@@ -49,6 +49,7 @@ type Props = {
   removeBreakpoints: typeof actions.removeBreakpoints,
   removeAllBreakpoints: typeof actions.removeAllBreakpoints,
   disableBreakpoint: typeof actions.disableBreakpoint,
+  setBreakpointCondition: typeof actions.setBreakpointCondition,
   toggleAllBreakpoints: typeof actions.toggleAllBreakpoints,
   toggleBreakpoints: typeof actions.toggleBreakpoints,
   openConditionalPanel: typeof actions.openConditionalPanel,
@@ -201,6 +202,7 @@ export default connect(
     disableBreakpoint: actions.disableBreakpoint,
     selectSpecificLocation: actions.selectSpecificLocation,
     selectLocation: actions.selectLocation,
+    setBreakpointCondition: actions.setBreakpointCondition,
     toggleAllBreakpoints: actions.toggleAllBreakpoints,
     toggleBreakpoints: actions.toggleBreakpoints,
     openConditionalPanel: actions.openConditionalPanel

--- a/src/test/mochitest/browser_dbg-breakpoints-cond.js
+++ b/src/test/mochitest/browser_dbg-breakpoints-cond.js
@@ -82,11 +82,12 @@ add_task(async function() {
   is(bp.condition, "1", "breakpoint is created with the condition");
   assertEditorBreakpoint(dbg, 5, true);
 
+  const bpCondition = waitForDispatch(dbg, "SET_BREAKPOINT_CONDITION");
   //right click breakpoint in breakpoints list
   rightClickElement(dbg, "breakpointItem", 3)
   // select "remove condition";
-  selectMenuItem(dbg, 9);
-  await waitForDispatch(dbg, "SET_BREAKPOINT_CONDITION");
+  selectMenuItem(dbg, 8);
+  await bpCondition;
   bp = findBreakpoint(dbg, "simple2", 5);
   is(bp.condition, undefined, "breakpoint condition removed");
 });

--- a/src/test/mochitest/browser_dbg-breakpoints-cond.js
+++ b/src/test/mochitest/browser_dbg-breakpoints-cond.js
@@ -81,4 +81,12 @@ add_task(async function() {
   bp = findBreakpoint(dbg, "simple2", 5);
   is(bp.condition, "1", "breakpoint is created with the condition");
   assertEditorBreakpoint(dbg, 5, true);
+
+  //right click breakpoint in breakpoints list
+  rightClickElement(dbg, "breakpointItem", 3)
+  // select "remove condition";
+  selectMenuItem(dbg, 9);
+  await waitForDispatch(dbg, "SET_BREAKPOINT_CONDITION");
+  bp = findBreakpoint(dbg, "simple2", 5);
+  is(bp.condition, undefined, "breakpoint condition removed");
 });


### PR DESCRIPTION
Fixes #7272 

In BreakpointContextMenu the `setBreakpointCondition` prop is undefined.  I added it to `mapStateToProps` in Breakpoint which passes it to BreakpointContextMenu.  I also added a mochi test.
