### PR TITLE
Bug 1505701 - Propagate all errors from promiseMiddleware.

### DIFF
--- a/src/actions/utils/middleware/promise.js
+++ b/src/actions/utils/middleware/promise.js
@@ -82,26 +82,22 @@ function promiseMiddleware({
 
     // Return the promise so action creators can still compose if they
     // want to.
-    return new Promise((resolve, reject) => {
-      promiseInst.then(
+    return Promise.resolve(promiseInst)
+      .finally(() => new Promise(resolve => executeSoon(resolve)))
+      .then(
         value => {
-          executeSoon(() => {
-            dispatch({ ...action, status: "done", value: value });
-            resolve(value);
-          });
+          dispatch({ ...action, status: "done", value: value });
+          return value;
         },
         error => {
-          executeSoon(() => {
-            dispatch({
-              ...action,
-              status: "error",
-              error: error.message || error
-            });
-            reject(error);
+          dispatch({
+            ...action,
+            status: "error",
+            error: error.message || error
           });
+          return Promise.reject(error);
         }
       );
-    });
   };
 }
 


### PR DESCRIPTION
Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1505701

### Summary of Changes

Changed `promiseMiddleware` to propagate error which is thrown from `executeSoon`
this can happen if the window that executes `setTimeout` (`executeSoon`'s impl) is closed
before the timeout happens.

The file that needs fix for https://bugzilla.mozilla.org/show_bug.cgi?id=1505701 is only  src/actions/utils/middleware/promise.js , but I've applied the same fix to packages/devtools-reps/src/launchpad/utils/redux/middleware/promise.js given it looks like another copy of the same file which has the same issue.

### Test Plan

This has no testcase, given the case this patch handles is already inside existing testcase in m-c:
    * devtools/client/canvasdebugger/test/browser_canvas-frontend-call-stack-01.js
    * devtools/client/inspector/markup/test/browser_markup_links_06.js

The detail of the issue is described in https://bugzilla.mozilla.org/show_bug.cgi?id=1505701
and they hit error if I fix https://bugzilla.mozilla.org/show_bug.cgi?id=1498775
