### PR TITLE
Prevent duplicated generated locations from displaying in call sites

### DIFF
--- a/src/actions/ast.js
+++ b/src/actions/ast.js
@@ -18,7 +18,7 @@ import { updateTab } from "./tabs";
 import { PROMISE } from "./utils/middleware/promise";
 
 import { setInScopeLines } from "./ast/setInScopeLines";
-import { updateSymbolLocations } from "./utils/symbols.js";
+import { updateSymbolLocations } from "./utils/symbols";
 import {
   getSymbols,
   findOutOfScopeLocations,

--- a/src/actions/utils/symbols.js
+++ b/src/actions/utils/symbols.js
@@ -16,11 +16,12 @@ function updateSymbolLocation(
   source: Source,
   sourceMaps: any
 ) {
-  site.location.start.sourceId = source.id;
   return sourceMaps
-    .getGeneratedLocation(site.location.start, source)
+    .getGeneratedLocation(
+      { ...site.location.start, sourceId: source.id },
+      source
+    )
     .then(loc => {
-      // site.generatedLocation = { line: loc.line, column: loc.column };
       return {
         ...site,
         generatedLocation: { line: loc.line, column: loc.column }
@@ -44,5 +45,6 @@ export async function updateSymbolLocations(
   );
 
   const newSymbols = { ...symbols, callExpressions: mappedCallExpressions };
+
   return Promise.resolve(newSymbols);
 }

--- a/src/actions/utils/symbols.js
+++ b/src/actions/utils/symbols.js
@@ -43,9 +43,6 @@ export async function updateSymbolLocations(
     )
   );
 
-  symbols.callExpressions = mappedCallExpressions;
-
-  console.log(mappedCallExpressions);
-
-  Promise.resolve(symbols);
+  const newSymbols = { ...symbols, callExpressions: mappedCallExpressions };
+  return Promise.resolve(newSymbols);
 }

--- a/src/actions/utils/symbols.js
+++ b/src/actions/utils/symbols.js
@@ -1,0 +1,51 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
+// @flow
+
+import {
+  type SymbolDeclaration,
+  type SymbolDeclarations
+} from "../../workers/parser";
+
+import type { Source } from "../../types";
+
+function updateSymbolLocation(
+  site: SymbolDeclaration,
+  source: Source,
+  sourceMaps: any
+) {
+  site.location.start.sourceId = source.id;
+  return sourceMaps
+    .getGeneratedLocation(site.location.start, source)
+    .then(loc => {
+      // site.generatedLocation = { line: loc.line, column: loc.column };
+      return {
+        ...site,
+        generatedLocation: { line: loc.line, column: loc.column }
+      };
+    });
+}
+
+export async function updateSymbolLocations(
+  symbols: SymbolDeclarations,
+  source: Source,
+  sourceMaps: any
+): Promise<SymbolDeclarations> {
+  if (!symbols || !symbols.callExpressions) {
+    return Promise.resolve(symbols);
+  }
+
+  const mappedCallExpressions = await Promise.all(
+    symbols.callExpressions.map(site =>
+      updateSymbolLocation(site, source, sourceMaps)
+    )
+  );
+
+  symbols.callExpressions = mappedCallExpressions;
+
+  console.log(mappedCallExpressions);
+
+  Promise.resolve(symbols);
+}

--- a/src/components/Editor/CallSites.js
+++ b/src/components/Editor/CallSites.js
@@ -124,9 +124,15 @@ class CallSites extends Component {
     const breakpointLines = new Set(breakpoints.map(bp => bp.location.line));
 
     // Find all callsites that have a breakpoint set on their start line
-    const callSitesForBreakpointLines = callSites.filter(({ location }) =>
-      breakpointLines.has(location.start.line)
-    );
+    const callSitesForBreakpointLines = callSites
+      .filter(({ location }) => breakpointLines.has(location.start.line))
+      // Filter by only lines with multiple column breakpoints
+      .filter(({ location }, index, arr) => {
+        return (
+          arr.filter(site => site.location.start.line === location.start.line)
+            .length > 1
+        );
+      });
 
     // Prevent problematic line-based mappings from being shown multiple times
     // Allows the first
@@ -145,6 +151,11 @@ class CallSites extends Component {
     }
 
     const callSitesFiltered = this.filterCallSitesByLineNumber();
+
+    // Only display column breakpoints if there are more than one
+    if (callSitesFiltered.length < 2) {
+      return null;
+    }
 
     editor.codeMirror.operation(() => {
       const childCallSites = callSitesFiltered.map((callSite, index) => {

--- a/src/components/Editor/CallSites.js
+++ b/src/components/Editor/CallSites.js
@@ -5,7 +5,7 @@
 import React, { Component } from "react";
 import { connect } from "react-redux";
 
-import { range, keyBy, isEqualWith } from "lodash";
+import { range, keyBy, isEqualWith, uniq } from "lodash";
 
 import CallSite from "./CallSite";
 
@@ -132,7 +132,7 @@ class CallSites extends Component {
     const { editor, callSites, selectedSource } = this.props;
 
     let sites;
-    if (!callSites || (selectedSource && selectedSource.isPrettyPrinted)) {
+    if (!callSites || hasConflictingGeneratedPosition(callSites)) {
       return null;
     }
 
@@ -154,6 +154,10 @@ class CallSites extends Component {
     });
     return sites;
   }
+}
+
+function hasConflictingGeneratedPosition(callSites) {
+  return uniq(callSites.map(site => site.generatedLocation.line)).length > 0;
 }
 
 function getCallSites(symbols, breakpoints) {

--- a/src/components/Editor/CallSites.js
+++ b/src/components/Editor/CallSites.js
@@ -149,10 +149,9 @@ class CallSites extends Component {
   }
 
   render() {
-    const { editor, callSites, selectedSource } = this.props;
+    const { editor, callSites, selectedSource, breakpoints } = this.props;
 
-    let sites;
-    if (!callSites) {
+    if (!callSites || breakpoints.length === 0) {
       return null;
     }
 
@@ -163,6 +162,7 @@ class CallSites extends Component {
       return null;
     }
 
+    let sites;
     editor.codeMirror.operation(() => {
       const childCallSites = callSitesFiltered.map((callSite, index) => {
         const props = {

--- a/src/workers/parser/getSymbols.js
+++ b/src/workers/parser/getSymbols.js
@@ -30,7 +30,8 @@ type AstLocation = { end: AstPosition, start: AstPosition };
 
 export type SymbolDeclaration = {
   name: string,
-  location: AstLocation
+  location: AstLocation,
+  generatedLocation?: AstPosition
 };
 
 export type ClassDeclaration = SymbolDeclaration & {


### PR DESCRIPTION
Fixes #7248

This is far enough along that I need eyes on it @loganfsmyth @jasonLaster ; ignore the flow errors.

I used @jasonLaster's `hasConflictingGeneratedPosition` suggestion but I'd like more scrutiny on that.