### PR TITLE
Ignore module manifest unless forced

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 /assets/build
+/assets/module-manifest.json
 node_modules
 configs/local.json
 npm-debug.log


### PR DESCRIPTION
We've been getting loads of PRs with errant changes to this file, so IMO we should ignore it and then force-update it when we do a release.