### PR TITLE
Upgrade to source-map@0.8.0-beta.0 with WHATWG URL support.

### DIFF
--- a/packages/devtools-source-map/package.json
+++ b/packages/devtools-source-map/package.json
@@ -22,6 +22,6 @@
     "devtools-utils": "0.0.14",
     "md5": "^2.2.1",
     "regenerator-runtime": "^0.10.3",
-    "source-map": "^0.7.3"
+    "source-map": "0.8.0-beta.0"
   }
 }

--- a/packages/devtools-source-map/src/tests/source-map.js
+++ b/packages/devtools-source-map/src/tests/source-map.js
@@ -27,7 +27,7 @@ describe("source maps", () => {
     test("source with a url", async () => {
       const urls = await setupBundleFixture("bundle");
       expect(urls).toEqual([
-        "webpack:///webpack/bootstrap 4ef8c7ec7c1df790781e",
+        "webpack:///webpack/bootstrap%204ef8c7ec7c1df790781e",
         "webpack:///entry.js",
         "webpack:///times2.js",
         "webpack:///output.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11103,6 +11103,12 @@ source-map@0.5.x, source-map@^0.5.0, source-map@^0.5.3, source-map@^0.5.6, sourc
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
 
+source-map@0.8.0-beta.0:
+  version "0.8.0-beta.0"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.8.0-beta.0.tgz#d4c1bb42c3f7ee925f005927ba10709e0d1d1f11"
+  dependencies:
+    whatwg-url "^7.0.0"
+
 source-map@^0.4.2, source-map@^0.4.4:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.4.4.tgz#eba4f5da9c0dc999de68032d8b4f76173652036b"
@@ -11112,10 +11118,6 @@ source-map@^0.4.2, source-map@^0.4.4:
 source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
-
-source-map@^0.7.3:
-  version "0.7.3"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
 
 space-separated-tokens@^1.0.0:
   version "1.1.2"
@@ -12590,6 +12592,14 @@ whatwg-mimetype@^2.0.0, whatwg-mimetype@^2.1.0:
 whatwg-url@^6.4.0, whatwg-url@^6.4.1:
   version "6.5.0"
   resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-6.5.0.tgz#f2df02bff176fd65070df74ad5ccbb5a199965a8"
+  dependencies:
+    lodash.sortby "^4.7.0"
+    tr46 "^1.0.1"
+    webidl-conversions "^4.0.2"
+
+whatwg-url@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-7.0.0.tgz#fde926fa54a599f3adf82dff25a9f7be02dc6edd"
   dependencies:
     lodash.sortby "^4.7.0"
     tr46 "^1.0.1"


### PR DESCRIPTION
Upgrade to `source-map@0.8.0-beta.0` with https://github.com/mozilla/source-map/pull/371