### PR TITLE
Add context check in getLibraryFromUrl.

### DIFF
--- a/src/utils/pause/frames/getLibraryFromUrl.js
+++ b/src/utils/pause/frames/getLibraryFromUrl.js
@@ -78,7 +78,8 @@ const libraryMap = [
   },
   {
     label: "Angular",
-    pattern: /angular/i
+    pattern: /angular/i,
+    contextPattern: /(zone\.js)/
   },
   {
     label: "Redux",
@@ -106,14 +107,34 @@ const libraryMap = [
   }
 ];
 
-export function getLibraryFromUrl(frame: Frame) {
+export function getLibraryFromUrl(frame: Frame, callStack: Array<Frame> = []) {
   // @TODO each of these fns calls getFrameUrl, just call it once
   // (assuming there's not more complex logic to identify a lib)
   const frameUrl = getFrameUrl(frame);
-  const matches = libraryMap.filter(o => frameUrl.match(o.pattern));
-  if (matches.length == 0) {
-    return null;
+
+  // Let's first check if the frame match a defined pattern.
+  let match = libraryMap.find(o => frameUrl.match(o.pattern));
+  if (match) {
+    return match.label;
   }
 
-  return matches[0].label;
+  // If it does not, it might still be one of the case where the file is used
+  // by a library but the name has not enough specificity. In such case, we want
+  // to only return the library name if there are frames matching the library
+  // pattern in the callStack (e.g. `zone.js` is used by Angular, but the name
+  //  could be quite common and return false positive if evaluated alone. So we
+  // only return Angular if there are other frames matching Angular).
+  match = libraryMap.find(
+    o => o.contextPattern && frameUrl.match(o.contextPattern)
+  );
+  if (match) {
+    const contextMatch = callStack.some(f =>
+      libraryMap.find(o => frameUrl.match(o.pattern))
+    );
+    if (contextMatch) {
+      return match.label;
+    }
+  }
+
+  return null;
 }

--- a/src/utils/pause/frames/tests/getLibraryFromUrl.spec.js
+++ b/src/utils/pause/frames/tests/getLibraryFromUrl.spec.js
@@ -95,4 +95,57 @@ describe("getLibraryFromUrl", () => {
       });
     });
   });
+
+  describe("When zone.js is on the frame", () => {
+    it("should not return Angular when no callstack", () => {
+      const frame = {
+        displayName: "name",
+        location: {
+          line: 12
+        },
+        source: {
+          url: "/node_modules/zone/zone.js"
+        }
+      };
+
+      expect(getLibraryFromUrl(frame)).toEqual(null);
+    });
+
+    it("should not return Angular when stack without Angular frames", () => {
+      const frame = {
+        displayName: "name",
+        location: {
+          line: 12
+        },
+        source: {
+          url: "/node_modules/zone/zone.js"
+        }
+      };
+      const callstack = [frame];
+
+      expect(getLibraryFromUrl(frame, callstack)).toEqual(null);
+    });
+
+    it("should return Angular when stack with Angular frames", () => {
+      const frame = {
+        displayName: "name",
+        location: {
+          line: 12
+        },
+        source: {
+          url: "/node_modules/zone/zone.js"
+        }
+      };
+      const callstack = [
+        frame,
+        {
+          source: {
+            url: "https://cdnjs.cloudflare.com/ajax/libs/angular/angular.js"
+          }
+        }
+      ];
+
+      expect(getLibraryFromUrl(frame, callstack)).toEqual(null);
+    });
+  });
 });


### PR DESCRIPTION
Some file used by libraries can't get really be identified
as part of the framework since their name can be quite
common (like zone.js).
In those case, it would be nice to check the whole callstack
to find if there's at least another frame matching a library.
(for zone.js, we should identify as Angular only if there's
another frame identified as an Angular frame).

---

See [Bug 1507327 🐛](https://bugzilla.mozilla.org/show_bug.cgi?id=1507327)
