### PR TITLE
 Display <get> and <set> node as sibling as the property with accessors.

### DIFF
--- a/packages/devtools-reps/src/object-inspector/component.js
+++ b/packages/devtools-reps/src/object-inspector/component.js
@@ -359,6 +359,8 @@ class ObjectInspector extends Component<Props> {
           !expanded &&
           (nodeIsDefaultProperties(item) ||
             nodeIsPrototype(item) ||
+            nodeIsGetter(item) ||
+            nodeIsSetter(item) ||
             (dimTopLevelWindow === true && nodeIsWindow(item) && depth === 0)),
         block: nodeIsBlock(item)
       }),
@@ -460,7 +462,9 @@ class ObjectInspector extends Component<Props> {
       autoExpandDepth,
 
       isExpanded: item => expandedPaths && expandedPaths.has(item.path),
-      isExpandable: item => nodeIsPrimitive(item) === false,
+      // TODO: We don't want property with getters to be expandable until we
+      // do have a mechanism to invoke the getter (See #6140).
+      isExpandable: item => !nodeIsPrimitive(item) && !nodeHasAccessors(item),
       focused: this.focusedItem,
 
       getRoots: this.getRoots,

--- a/packages/devtools-reps/src/object-inspector/tests/component/__snapshots__/getter-setter.js.snap
+++ b/packages/devtools-reps/src/object-inspector/tests/component/__snapshots__/getter-setter.js.snap
@@ -2,22 +2,25 @@
 
 exports[`ObjectInspector - getters & setters renders getters and setters as expected 1`] = `
 "
-▼ x: Getter & Setter
-|  ▶︎ <get>: function x()
-|  ▶︎ <set>: function x()
+▼ root
+|    x: Getter & Setter
+|  ▶︎ <get x()>: function x()
+|  ▶︎ <set x()>: function x()
 "
 `;
 
 exports[`ObjectInspector - getters & setters renders getters as expected 1`] = `
 "
-▼ x: Getter
-|  ▶︎ <get>: function x()
+▼ root
+|    x: Getter
+|  ▶︎ <get x()>: function x()
 "
 `;
 
 exports[`ObjectInspector - getters & setters renders setters as expected 1`] = `
 "
-▼ x: Setter
-|  ▶︎ <set>: function x()
+▼ root
+|    x: Setter
+|  ▶︎ <set x()>: function x()
 "
 `;

--- a/packages/devtools-reps/src/object-inspector/tests/component/getter-setter.js
+++ b/packages/devtools-reps/src/object-inspector/tests/component/getter-setter.js
@@ -2,13 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
-const { mountObjectInspector } = require("../test-utils");
 const { MODE } = require("../../../reps/constants");
 const {
   formatObjectInspector,
-  waitForLoadedProperties
+  waitForLoadedProperties,
+  mountObjectInspector
 } = require("../test-utils");
 
+const { makeNodesForProperties } = require("../../utils/node");
 const accessorStubs = require("../../../reps/stubs/accessor");
 const ObjectClient = require("../__mocks__/object-client");
 
@@ -21,28 +22,29 @@ function generateDefaults(overrides) {
   };
 }
 
-function mount(props) {
+function mount(stub) {
   const client = { createObjectClient: grip => ObjectClient(grip) };
+
+  const root = { path: "root", name: "root" };
+  const nodes = makeNodesForProperties(
+    {
+      ownProperties: {
+        x: stub
+      }
+    },
+    root
+  );
+  root.contents = nodes;
 
   return mountObjectInspector({
     client,
-    props: generateDefaults(props)
+    props: generateDefaults({ roots: [root] })
   });
 }
 
 describe("ObjectInspector - getters & setters", () => {
   it("renders getters as expected", async () => {
-    const stub = accessorStubs.get("getter");
-    const { store, wrapper } = mount({
-      roots: [
-        {
-          path: "root",
-          name: "x",
-          contents: stub
-        }
-      ]
-    });
-
+    const { store, wrapper } = mount(accessorStubs.get("getter"));
     await waitForLoadedProperties(store, ["root"]);
     wrapper.update();
 
@@ -50,18 +52,7 @@ describe("ObjectInspector - getters & setters", () => {
   });
 
   it("renders setters as expected", async () => {
-    const stub = accessorStubs.get("setter");
-    const { store, wrapper } = mount({
-      autoExpandDepth: 1,
-      roots: [
-        {
-          path: "root",
-          name: "x",
-          contents: stub
-        }
-      ]
-    });
-
+    const { store, wrapper } = mount(accessorStubs.get("setter"));
     await waitForLoadedProperties(store, ["root"]);
     wrapper.update();
 
@@ -69,17 +60,7 @@ describe("ObjectInspector - getters & setters", () => {
   });
 
   it("renders getters and setters as expected", async () => {
-    const stub = accessorStubs.get("getter setter");
-    const { store, wrapper } = mount({
-      roots: [
-        {
-          path: "root",
-          name: "x",
-          contents: stub
-        }
-      ]
-    });
-
+    const { store, wrapper } = mount(accessorStubs.get("getter setter"));
     await waitForLoadedProperties(store, ["root"]);
     wrapper.update();
 

--- a/packages/devtools-reps/src/object-inspector/tests/utils/get-children.js
+++ b/packages/devtools-reps/src/object-inspector/tests/utils/get-children.js
@@ -9,55 +9,69 @@ const gripArrayStubs = require("../../../reps/stubs/grip-array");
 const gripMapEntryStubs = require("../../../reps/stubs/grip-map-entry");
 const gripStubs = require("../../../reps/stubs/grip");
 
-const { createNode, getChildren, getValue } = require("../../utils/node");
+const {
+  createNode,
+  getChildren,
+  getValue,
+  makeNodesForProperties
+} = require("../../utils/node");
+
+function createRootNodeWithAccessorProperty(accessorStub) {
+  const node = { name: "root", path: "rootpath" };
+  const nodes = makeNodesForProperties(
+    {
+      ownProperties: {
+        x: accessorStub
+      }
+    },
+    node
+  );
+  node.contents = nodes;
+
+  return createNode(node);
+}
 
 describe("getChildren", () => {
   it("accessors - getter", () => {
-    const nodes = getChildren({
-      item: createNode({
-        name: "root",
-        path: "rootpath",
-        contents: accessorStubs.get("getter")
-      })
+    const children = getChildren({
+      item: createRootNodeWithAccessorProperty(accessorStubs.get("getter"))
     });
 
-    const names = nodes.map(n => n.name);
-    const paths = nodes.map(n => n.path.toString());
+    const names = children.map(n => n.name);
+    const paths = children.map(n => n.path.toString());
 
-    expect(names).toEqual(["<get>"]);
-    expect(paths).toEqual(["Symbol(rootpath/<get>)"]);
+    expect(names).toEqual(["x", "<get x()>"]);
+    expect(paths).toEqual(["Symbol(rootpath/x)", "Symbol(rootpath/<get x()>)"]);
   });
 
   it("accessors - setter", () => {
-    const nodes = getChildren({
-      item: createNode({
-        name: "root",
-        path: "rootpath",
-        contents: accessorStubs.get("setter")
-      })
+    const children = getChildren({
+      item: createRootNodeWithAccessorProperty(accessorStubs.get("setter"))
     });
 
-    const names = nodes.map(n => n.name);
-    const paths = nodes.map(n => n.path.toString());
+    const names = children.map(n => n.name);
+    const paths = children.map(n => n.path.toString());
 
-    expect(names).toEqual(["<set>"]);
-    expect(paths).toEqual(["Symbol(rootpath/<set>)"]);
+    expect(names).toEqual(["x", "<set x()>"]);
+    expect(paths).toEqual(["Symbol(rootpath/x)", "Symbol(rootpath/<set x()>)"]);
   });
 
   it("accessors - getter & setter", () => {
-    const nodes = getChildren({
-      item: createNode({
-        name: "root",
-        path: "rootpath",
-        contents: accessorStubs.get("getter setter")
-      })
+    const children = getChildren({
+      item: createRootNodeWithAccessorProperty(
+        accessorStubs.get("getter setter")
+      )
     });
 
-    const names = nodes.map(n => n.name);
-    const paths = nodes.map(n => n.path.toString());
+    const names = children.map(n => n.name);
+    const paths = children.map(n => n.path.toString());
 
-    expect(names).toEqual(["<get>", "<set>"]);
-    expect(paths).toEqual(["Symbol(rootpath/<get>)", "Symbol(rootpath/<set>)"]);
+    expect(names).toEqual(["x", "<get x()>", "<set x()>"]);
+    expect(paths).toEqual([
+      "Symbol(rootpath/x)",
+      "Symbol(rootpath/<get x()>)",
+      "Symbol(rootpath/<set x()>)"
+    ]);
   });
 
   it("returns the expected nodes for Proxy", () => {
@@ -201,10 +215,10 @@ describe("getChildren", () => {
 
   it("adds children to cache on a node with accessors", () => {
     const cachedNodes = new Map();
-    const node = createNode({
-      name: "root",
-      contents: accessorStubs.get("getter setter")
-    });
+    const node = createRootNodeWithAccessorProperty(
+      accessorStubs.get("getter setter")
+    );
+
     const children = getChildren({
       cachedNodes,
       item: node

--- a/packages/devtools-reps/src/object-inspector/tests/utils/make-node-for-properties.js
+++ b/packages/devtools-reps/src/object-inspector/tests/utils/make-node-for-properties.js
@@ -83,11 +83,21 @@ describe("makeNodesForProperties", () => {
     const names = nodes.map(n => n.name);
     const paths = nodes.map(n => n.path.toString());
 
-    expect(names).toEqual(["bar", "baz", "foo", "<prototype>"]);
+    expect(names).toEqual([
+      "bar",
+      "baz",
+      "foo",
+      "<get bar()>",
+      "<set baz()>",
+      "<prototype>"
+    ]);
+
     expect(paths).toEqual([
       "Symbol(root/bar)",
       "Symbol(root/baz)",
       "Symbol(root/foo)",
+      "Symbol(root/<get bar()>)",
+      "Symbol(root/<set baz()>)",
       "Symbol(root/<prototype>)"
     ]);
   });

--- a/packages/devtools-reps/src/object-inspector/tests/utils/should-load-item-indexed-properties.js
+++ b/packages/devtools-reps/src/object-inspector/tests/utils/should-load-item-indexed-properties.js
@@ -5,6 +5,8 @@
 const Utils = require("../../utils");
 const {
   createNode,
+  createGetterNode,
+  createSetterNode,
   getChildren,
   makeNodesForEntries,
   nodeIsDefaultProperties
@@ -225,22 +227,20 @@ describe("shouldLoadItemIndexedProperties", () => {
   });
 
   it("returns true for an accessor <get> node", () => {
-    const accessorNode = createNode({
+    const getNode = createGetterNode({
       name: "root",
-      contents: accessorStubs.get("getter")
+      property: accessorStubs.get("getter")
     });
-    const [getNode] = getChildren({ item: accessorNode });
-    expect(getNode.name).toBe("<get>");
+    expect(getNode.name).toBe("<get root()>");
     expect(shouldLoadItemIndexedProperties(getNode)).toBeTruthy();
   });
 
   it("returns true for an accessor <set> node", () => {
-    const accessorNode = createNode({
+    const setNode = createSetterNode({
       name: "root",
-      contents: accessorStubs.get("setter")
+      property: accessorStubs.get("setter")
     });
-    const [setNode] = getChildren({ item: accessorNode });
-    expect(setNode.name).toBe("<set>");
+    expect(setNode.name).toBe("<set root()>");
     expect(shouldLoadItemIndexedProperties(setNode)).toBeTruthy();
   });
 

--- a/packages/devtools-reps/src/object-inspector/tests/utils/should-load-item-non-indexed-properties.js
+++ b/packages/devtools-reps/src/object-inspector/tests/utils/should-load-item-non-indexed-properties.js
@@ -5,6 +5,8 @@
 const Utils = require("../../utils");
 const {
   createNode,
+  createGetterNode,
+  createSetterNode,
   getChildren,
   makeNodesForEntries,
   nodeIsDefaultProperties
@@ -188,22 +190,20 @@ describe("shouldLoadItemNonIndexedProperties", () => {
   });
 
   it("returns true for an accessor <get> node", () => {
-    const accessorNode = createNode({
+    const getNode = createGetterNode({
       name: "root",
-      contents: accessorStubs.get("getter")
+      property: accessorStubs.get("getter")
     });
-    const [getNode] = getChildren({ item: accessorNode });
-    expect(getNode.name).toBe("<get>");
+    expect(getNode.name).toBe("<get root()>");
     expect(shouldLoadItemNonIndexedProperties(getNode)).toBeTruthy();
   });
 
   it("returns true for an accessor <set> node", () => {
-    const accessorNode = createNode({
+    const setNode = createSetterNode({
       name: "root",
-      contents: accessorStubs.get("setter")
+      property: accessorStubs.get("setter")
     });
-    const [setNode] = getChildren({ item: accessorNode });
-    expect(setNode.name).toBe("<set>");
+    expect(setNode.name).toBe("<set root()>");
     expect(shouldLoadItemNonIndexedProperties(setNode)).toBeTruthy();
   });
 

--- a/packages/devtools-reps/src/object-inspector/tests/utils/should-load-item-prototype.js
+++ b/packages/devtools-reps/src/object-inspector/tests/utils/should-load-item-prototype.js
@@ -5,6 +5,8 @@
 const Utils = require("../../utils");
 const {
   createNode,
+  createGetterNode,
+  createSetterNode,
   getChildren,
   makeNodesForEntries,
   nodeIsDefaultProperties
@@ -184,22 +186,20 @@ describe("shouldLoadItemPrototype", () => {
   });
 
   it("returns true for an accessor <get> node", () => {
-    const accessorNode = createNode({
+    const getNode = createGetterNode({
       name: "root",
-      contents: accessorStubs.get("getter")
+      property: accessorStubs.get("getter")
     });
-    const [getNode] = getChildren({ item: accessorNode });
-    expect(getNode.name).toBe("<get>");
+    expect(getNode.name).toBe("<get root()>");
     expect(shouldLoadItemPrototype(getNode)).toBeTruthy();
   });
 
   it("returns true for an accessor <set> node", () => {
-    const accessorNode = createNode({
+    const setNode = createSetterNode({
       name: "root",
-      contents: accessorStubs.get("setter")
+      property: accessorStubs.get("setter")
     });
-    const [setNode] = getChildren({ item: accessorNode });
-    expect(setNode.name).toBe("<set>");
+    expect(setNode.name).toBe("<set root()>");
     expect(shouldLoadItemPrototype(setNode)).toBeTruthy();
   });
 

--- a/packages/devtools-reps/src/object-inspector/tests/utils/should-load-item-symbols.js
+++ b/packages/devtools-reps/src/object-inspector/tests/utils/should-load-item-symbols.js
@@ -5,6 +5,8 @@
 const Utils = require("../../utils");
 const {
   createNode,
+  createGetterNode,
+  createSetterNode,
   getChildren,
   makeNodesForEntries,
   nodeIsDefaultProperties
@@ -184,22 +186,20 @@ describe("shouldLoadItemSymbols", () => {
   });
 
   it("returns true for an accessor <get> node", () => {
-    const accessorNode = createNode({
+    const getNode = createGetterNode({
       name: "root",
-      contents: accessorStubs.get("getter")
+      property: accessorStubs.get("getter")
     });
-    const [getNode] = getChildren({ item: accessorNode });
-    expect(getNode.name).toBe("<get>");
+    expect(getNode.name).toBe("<get root()>");
     expect(shouldLoadItemSymbols(getNode)).toBeTruthy();
   });
 
   it("returns true for an accessor <set> node", () => {
-    const accessorNode = createNode({
+    const setNode = createSetterNode({
       name: "root",
-      contents: accessorStubs.get("setter")
+      property: accessorStubs.get("setter")
     });
-    const [setNode] = getChildren({ item: accessorNode });
-    expect(setNode.name).toBe("<set>");
+    expect(setNode.name).toBe("<set root()>");
     expect(shouldLoadItemSymbols(setNode)).toBeTruthy();
   });
 

--- a/src/test/mochitest/browser_dbg-expressions-error.js
+++ b/src/test/mochitest/browser_dbg-expressions-error.js
@@ -52,5 +52,5 @@ add_task(async function() {
   is(getValue(dbg, 4), 2);
 
   await toggleExpressionNode(dbg, 1);
-  is(findAllElements(dbg, "expressionNodes").length, 20);
+  is(findAllElements(dbg, "expressionNodes").length, 37);
 });

--- a/src/test/mochitest/browser_dbg-expressions.js
+++ b/src/test/mochitest/browser_dbg-expressions.js
@@ -88,7 +88,7 @@ add_task(async function() {
   await resume(dbg);
   await addExpression(dbg, "location");
 
-  is(findAllElements(dbg, "expressionNodes").length, 17);
+  is(findAllElements(dbg, "expressionNodes").length, 34);
 
   await toggleExpressionNode(dbg, 1);
   is(findAllElements(dbg, "expressionNodes").length, 1);


### PR DESCRIPTION
Fixes #7288.

### Screenshots

<img width="396" alt="image" src="https://user-images.githubusercontent.com/578107/48634916-07988580-e9c7-11e8-8cbc-ada15278a24e.png">

---

i'm not super happy with the tests changes, but, maybe we can revamp them a bit when doing #6140 (which I will as soon as this is merged)