### PR TITLE
7283/fix :formatted showing in tabs/breakpoints sidebar

### DIFF
--- a/src/components/PrimaryPanes/SourcesTreeItem.js
+++ b/src/components/PrimaryPanes/SourcesTreeItem.js
@@ -183,7 +183,11 @@ class SourceTreeItem extends Component<Props, State> {
       <span className="suffix">{L10N.getStr("sourceFooter.mappedSuffix")}</span>
     ) : null;
 
-    const querystring = getSourceQueryString(source);
+    let querystring;
+    if (hasSiblingOfSameName) {
+      querystring = getSourceQueryString(source);
+    }
+
     const query =
       hasSiblingOfSameName && querystring ? (
         <span className="query">{querystring}</span>

--- a/src/reducers/sources.js
+++ b/src/reducers/sources.js
@@ -19,6 +19,7 @@ import {
 } from "../utils/source";
 import { originalToGeneratedId } from "devtools-source-map";
 import { prefs } from "../utils/prefs";
+import { parse as parseURL } from "../utils/url";
 
 import type { Source, SourceId, SourceLocation } from "../types";
 import type { PendingSelectedLocation } from "./types";
@@ -451,7 +452,9 @@ export function getHasSiblingOfSameName(state: OuterState, source: ?Source) {
     return false;
   }
 
-  return getSourcesUrlsInSources(state, source.url).length > 1;
+  const urls = getSourcesUrlsInSources(state, source.url);
+  const { origin, pathname } = parseURL(source.url);
+  return urls.filter(url => url.includes(`${origin}${pathname}`)).length > 1;
 }
 
 export function getSourceInSources(sources: SourcesMap, id: string): ?Source {

--- a/src/reducers/sources.js
+++ b/src/reducers/sources.js
@@ -19,7 +19,6 @@ import {
 } from "../utils/source";
 import { originalToGeneratedId } from "devtools-source-map";
 import { prefs } from "../utils/prefs";
-import { parse as parseURL } from "../utils/url";
 
 import type { Source, SourceId, SourceLocation } from "../types";
 import type { PendingSelectedLocation } from "./types";
@@ -452,9 +451,7 @@ export function getHasSiblingOfSameName(state: OuterState, source: ?Source) {
     return false;
   }
 
-  const urls = getSourcesUrlsInSources(state, source.url);
-  const { origin, pathname } = parseURL(source.url);
-  return urls.filter(url => url.includes(`${origin}${pathname}`)).length > 1;
+  return getSourcesUrlsInSources(state, source.url).length > 1;
 }
 
 export function getSourceInSources(sources: SourcesMap, id: string): ?Source {

--- a/src/test/mochitest/browser_dbg-sources-querystring.js
+++ b/src/test/mochitest/browser_dbg-sources-querystring.js
@@ -39,6 +39,14 @@ add_task(async function() {
     "Breakpoint heading is simple1.js?x=1"
   );
 
+  // pretty print the source and check the tab text
+  clickElement(dbg, "prettyPrintButton");
+  await waitForSource(dbg, "simple1.js?x=1:formatted");
+  const prettyTab = findElement(dbg, "activeTab");
+  is(prettyTab.innerText, "simple1.js?x=1", "Tab label is simple1.js?x=1");
+  ok(prettyTab.querySelector("img.prettyPrint"));
+
+  // assert quick open works with queries
   pressKey(dbg, "quickOpen");
   type(dbg, "simple1.js?x");
   ok(findElement(dbg, "resultItems")[0].innerText.includes("simple.js?x=1"));

--- a/src/test/mochitest/browser_dbg-sources-querystring.js
+++ b/src/test/mochitest/browser_dbg-sources-querystring.js
@@ -9,6 +9,11 @@ function getLabel(dbg, index) {
     .replace(/^[\s\u200b]*/g, "");
 }
 
+function assertBreakpointHeading(dbg, label, index) {
+  const breakpointHeading = findElement(dbg, "breakpointItem", index).innerText;
+  is(breakpointHeading, label, `Breakpoint heading is ${label}`);
+}
+
 add_task(async function() {
   const dbg = await initDebugger("doc-sources-querystring.html", "simple1.js?x=1", "simple1.js?x=2");
   const {
@@ -32,19 +37,16 @@ add_task(async function() {
   const tab = findElement(dbg, "activeTab");
   is(tab.innerText, "simple1.js?x=1", "Tab label is simple1.js?x=1");
   await addBreakpoint(dbg, "simple1.js?x=1", 6);
-  const breakpointHeading = findElement(dbg, "breakpointItem", 2).innerText;
-  is(
-    breakpointHeading,
-    "simple1.js?x=1",
-    "Breakpoint heading is simple1.js?x=1"
-  );
+  assertBreakpointHeading(dbg, "simple1.js?x=1", 2);
 
   // pretty print the source and check the tab text
   clickElement(dbg, "prettyPrintButton");
   await waitForSource(dbg, "simple1.js?x=1:formatted");
+
   const prettyTab = findElement(dbg, "activeTab");
   is(prettyTab.innerText, "simple1.js?x=1", "Tab label is simple1.js?x=1");
   ok(prettyTab.querySelector("img.prettyPrint"));
+  assertBreakpointHeading(dbg, "simple1.js?x=1", 2);
 
   // assert quick open works with queries
   pressKey(dbg, "quickOpen");

--- a/src/utils/quick-open.js
+++ b/src/utils/quick-open.js
@@ -63,7 +63,7 @@ export function formatSourcesForList(source: Source, tabs: TabList) {
   const title = getFilename(source);
   const relativeUrlWithQuery = `${source.relativeUrl}${getSourceQueryString(
     source
-  )}`;
+  ) || ""}`;
   const subtitle = endTruncateStr(relativeUrlWithQuery, 100);
   const value = relativeUrlWithQuery;
   return {

--- a/src/utils/source.js
+++ b/src/utils/source.js
@@ -461,6 +461,9 @@ export function isGenerated(source: Source) {
 }
 
 export function getSourceQueryString(source: ?Source) {
-  const query = source ? parseURL(source.url).search : "";
-  return query.replace(/:formatted$/, "");
+  if (!source) {
+    return;
+  }
+
+  return parseURL(getRawSourceURL(source.url)).search;
 }

--- a/src/utils/source.js
+++ b/src/utils/source.js
@@ -461,5 +461,6 @@ export function isGenerated(source: Source) {
 }
 
 export function getSourceQueryString(source: ?Source) {
-  return source ? parseURL(source.url).search : "";
+  const query = source ? parseURL(source.url).search : "";
+  return query.replace(/:formatted$/, "");
 }


### PR DESCRIPTION
Fixes #7283 

### Summary of Changes
* `getHasSiblingOfSameName` was returning true if there was ever more than one source returned from `getSourcesUrlsInSources`, which means that it would be true in almost any case. I've updated it to only return true if there is actually a match. I would like to write a unit test for this function, but I was having a hard time understanding how to build the initial `OuterState`
* Update `getSourceQueryString` to return the sources query string, with any `:formatted` stripped from the end. I was going to check `source.isPrettyPrinted` before replacing, but I believe that value is set using pretty much the same regex I was using.

### Test Plan
Added the following to the existing query string mochitest:
* Pretty print a source and ensure the tab has the query string still, but no `:formatted`

Hands-on QA:
1. Open https://skinny-clutch.glitch.me/
2. In the debugger, select `/script.js?s=13`
3. Click the pretty print button
4. the active (pretty print) tab should still show `script.js?s=13` but with no `:formatted`

### Screenshots
<img width="1552" alt="screen shot 2018-11-17 at 4 08 14 pm" src="https://user-images.githubusercontent.com/5448834/48666649-180e3600-ea83-11e8-8f43-3baf22decb34.png">
