### PR TITLE
Fixing file tabs disappearing when resizing editor pane

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -242,6 +242,8 @@ class App extends Component<Props, State> {
     }));
   }
 
+  // Important so that the tabs chevron updates appropriately when
+  // the user resizes the left or right columns
   triggerEditorPaneResize() {
     const editorPane = window.document.querySelector(".editor-pane");
     if (editorPane) {

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -245,7 +245,7 @@ class App extends Component<Props, State> {
   triggerEditorPaneResize() {
     const editorPane = window.document.querySelector(".editor-pane");
     if (editorPane) {
-      editorPane.dispatchEvent(new Event("resize"));
+      editorPane.dispatchEvent(new Event("resizeend"));
     }
   }
 

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -242,6 +242,13 @@ class App extends Component<Props, State> {
     }));
   }
 
+  triggerEditorPaneResize() {
+    const editorPane = window.document.querySelector(".editor-pane");
+    if (editorPane) {
+      editorPane.dispatchEvent(new Event("resize"));
+    }
+  }
+
   renderLayout = () => {
     const { startPanelCollapsed, endPanelCollapsed } = this.props;
     const horizontal = this.isHorizontal();
@@ -278,6 +285,7 @@ class App extends Component<Props, State> {
           />
         }
         endPanelCollapsed={endPanelCollapsed}
+        onResizeEnd={this.triggerEditorPaneResize}
       />
     );
   };

--- a/src/components/Editor/Tabs.js
+++ b/src/components/Editor/Tabs.js
@@ -43,6 +43,10 @@ type State = {
   hiddenTabs: SourcesList
 };
 
+function getEditorContainer(win) {
+  return win.document.querySelector(".editor-pane");
+}
+
 class Tabs extends PureComponent<Props, State> {
   onTabContextMenu: Function;
   showContextMenu: Function;
@@ -65,6 +69,10 @@ class Tabs extends PureComponent<Props, State> {
     this.onResize = debounce(() => {
       this.updateHiddenTabs();
     });
+
+    this.onResizeEnd = debounce(() => {
+      this.updateHiddenTabs();``
+    })
   }
 
   componentDidUpdate(prevProps) {
@@ -76,10 +84,12 @@ class Tabs extends PureComponent<Props, State> {
   componentDidMount() {
     window.requestIdleCallback(this.updateHiddenTabs);
     window.addEventListener("resize", this.onResize);
+    getEditorContainer(window).addEventListener("resize", this.onResize);
   }
 
   componentWillUnmount() {
     window.removeEventListener("resize", this.onResize);
+    getEditorContainer(window).removeEventListener("resize", this.onResize);
   }
 
   /*

--- a/src/components/Editor/Tabs.js
+++ b/src/components/Editor/Tabs.js
@@ -43,10 +43,6 @@ type State = {
   hiddenTabs: SourcesList
 };
 
-function getEditorContainer(win) {
-  return win.document.querySelector(".editor-pane");
-}
-
 class Tabs extends PureComponent<Props, State> {
   onTabContextMenu: Function;
   showContextMenu: Function;
@@ -69,10 +65,6 @@ class Tabs extends PureComponent<Props, State> {
     this.onResize = debounce(() => {
       this.updateHiddenTabs();
     });
-
-    this.onResizeEnd = debounce(() => {
-      this.updateHiddenTabs();``
-    })
   }
 
   componentDidUpdate(prevProps) {
@@ -84,12 +76,12 @@ class Tabs extends PureComponent<Props, State> {
   componentDidMount() {
     window.requestIdleCallback(this.updateHiddenTabs);
     window.addEventListener("resize", this.onResize);
-    getEditorContainer(window).addEventListener("resize", this.onResize);
+    window.document.querySelector(".editor-pane").addEventListener("resizeend", this.onResize);
   }
 
   componentWillUnmount() {
     window.removeEventListener("resize", this.onResize);
-    getEditorContainer(window).removeEventListener("resize", this.onResize);
+    window.document.querySelector(".editor-pane").removeEventListener("resizeend", this.onResize);
   }
 
   /*


### PR DESCRIPTION
Fixes #7016

### Summary of Changes

* File tabs now get added/removed from the dropdown when the editor pane is resized

### Videos

![nov-17-2018 17-06-16](https://user-images.githubusercontent.com/16697942/48667470-30824e80-ea8b-11e8-97a8-d12cfdcb1c7f.gif)

