### PR TITLE
Fix debugger hanging with slow loading source maps

### DIFF
--- a/src/client/firefox/events.js
+++ b/src/client/firefox/events.js
@@ -32,7 +32,7 @@ function setupEvents(dependencies: Dependencies) {
   threadClient = dependencies.threadClient;
   actions = dependencies.actions;
   supportsWasm = dependencies.supportsWasm;
-  sourceQueue.initialize({ actions, supportsWasm, createSource });
+  sourceQueue.initialize(actions);
 
   if (threadClient) {
     Object.keys(clientEvents).forEach(eventName => {
@@ -98,7 +98,7 @@ function resumed(_: "resumed", packet: ResumedPacket) {
 }
 
 function newSource(_: "newSource", { source }: SourcePacket) {
-  sourceQueue.queue(source);
+  sourceQueue.queue(createSource(source, { supportsWasm }));
 }
 
 function workerListChanged() {

--- a/src/utils/source-queue.js
+++ b/src/utils/source-queue.js
@@ -2,11 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
+// @flow
+
 import { throttle } from "lodash";
+import type { Source } from "../types";
 
 let newSources;
-let createSource;
-let supportsWasm = false;
 let queuedSources;
 let currentWork;
 
@@ -14,24 +15,25 @@ async function dispatchNewSources() {
   const sources = queuedSources;
   queuedSources = [];
 
-  currentWork = await newSources(
-    sources.map(source => createSource(source, { supportsWasm }))
-  );
+  currentWork = await newSources(sources);
 }
 
 const queue = throttle(dispatchNewSources, 100);
 
 export default {
-  initialize: options => {
-    newSources = options.actions.newSources;
-    createSource = options.createSource;
-    supportsWasm = options.supportsWasm;
+  initialize: (actions: Object) => {
+    newSources = actions.newSources;
     queuedSources = [];
   },
-  queue: source => {
+  queue: (source: Source) => {
     queuedSources.push(source);
     queue();
   },
+  queueSources: (sources: Source[]) => {
+    queuedSources = queuedSources.concat(sources);
+    queue();
+  },
+
   flush: () => Promise.all([queue.flush(), currentWork]),
   clear: () => queue.cancel()
 };

--- a/src/utils/test-head.js
+++ b/src/utils/test-head.js
@@ -16,13 +16,14 @@ import actions from "../actions";
 import * as selectors from "../selectors";
 import { getHistory } from "../test/utils/history";
 import configureStore from "../actions/utils/create-store";
+import sourceQueue from "../utils/source-queue";
 
 /**
  * @memberof utils/test-head
  * @static
  */
 function createStore(client: any, initialState: any = {}, sourceMapsMock: any) {
-  return configureStore({
+  const store = configureStore({
     log: false,
     history: getHistory(),
     makeThunkArgs: args => {
@@ -33,6 +34,12 @@ function createStore(client: any, initialState: any = {}, sourceMapsMock: any) {
       };
     }
   })(combineReducers(reducers), initialState);
+  sourceQueue.clear();
+  sourceQueue.initialize({
+    newSources: sources => store.dispatch(actions.newSources(sources))
+  });
+
+  return store;
 }
 
 /**


### PR DESCRIPTION
Fixes #7301 

The fix involves:
- making newSources() not wait for source maps to be loaded
- making loadSourceMaps() add each map to the state asap, instead of doing one big add once all the source maps are loaded

I added two tests that model the current bug and that fail if the two changes above are reverted.