### PR TITLE
Fix getSourcesUrlsInSources so it returns only matching URLs

### DIFF
--- a/src/actions/sources/tests/querystrings.spec.js
+++ b/src/actions/sources/tests/querystrings.spec.js
@@ -1,0 +1,36 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
+import {
+  actions,
+  selectors,
+  createStore,
+  makeSource
+} from "../../../utils/test-head";
+const { getSourcesUrlsInSources } = selectors;
+
+// eslint-disable-next-line max-len
+import { sourceThreadClient as threadClient } from "../../tests/helpers/threadClient.js";
+
+describe("sources - sources with querystrings", () => {
+  it("should find two sources when same source with querystring", async () => {
+    const { dispatch, getState } = createStore(threadClient);
+    await dispatch(actions.newSource(makeSource("base.js?v=1")));
+    await dispatch(actions.newSource(makeSource("base.js?v=2")));
+    await dispatch(actions.newSource(makeSource("diff.js?v=1")));
+
+    expect(
+      getSourcesUrlsInSources(
+        getState(),
+        "http://localhost:8000/examples/base.js?v=1"
+      )
+    ).toHaveLength(2);
+    expect(
+      getSourcesUrlsInSources(
+        getState(),
+        "http://localhost:8000/examples/diff.js?v=1"
+      )
+    ).toHaveLength(1);
+  });
+});

--- a/src/reducers/sources.js
+++ b/src/reducers/sources.js
@@ -439,7 +439,6 @@ export function getSourcesUrlsInSources(
   if (!url || !urls[url]) {
     return [];
   }
-
   const plainUrl = url.split("?")[0];
 
   return Object.keys(urls)

--- a/src/reducers/sources.js
+++ b/src/reducers/sources.js
@@ -431,13 +431,20 @@ function getSourcesByUrlInSources(
   return urls[url].map(id => sources[id]);
 }
 
-export function getSourcesUrlsInSources(state: OuterState, url: string) {
+export function getSourcesUrlsInSources(
+  state: OuterState,
+  url: string
+): string[] {
   const urls = getUrls(state);
   if (!url || !urls[url]) {
     return [];
   }
 
-  return [...new Set(Object.keys(urls).filter(Boolean))];
+  const plainUrl = url.split("?")[0];
+
+  return Object.keys(urls)
+    .filter(Boolean)
+    .filter(sourceUrl => sourceUrl.split("?")[0] === plainUrl);
 }
 
 export function getHasSiblingOfSameName(state: OuterState, source: ?Source) {


### PR DESCRIPTION
I noticed that `getSourcesUrlsInSources` is returning all sources and not a matching source, so querystrings are showing up in the tree when they don't need to.

This PR ensures that querystrings only display when they need to.