### PR TITLE
Pass callstack to getLibraryFromUrl in annotateFrames.

### DIFF
--- a/src/utils/pause/frames/annotateFrames.js
+++ b/src/utils/pause/frames/annotateFrames.js
@@ -18,12 +18,12 @@ type AnnotatedFrame =
   | Frame;
 
 export function annotateFrames(frames: Frame[]): AnnotatedFrame[] {
-  const annotatedFrames = frames.map(annotateFrame);
+  const annotatedFrames = frames.map(f => annotateFrame(f, frames));
   return annotateBabelAsyncFrames(annotatedFrames);
 }
 
-function annotateFrame(frame: Frame): AnnotatedFrame {
-  const library = getLibraryFromUrl(frame);
+function annotateFrame(frame: Frame, frames: Frame[]): AnnotatedFrame {
+  const library = getLibraryFromUrl(frame, frames);
   if (library) {
     return { ...frame, library };
   }

--- a/src/utils/pause/frames/getLibraryFromUrl.js
+++ b/src/utils/pause/frames/getLibraryFromUrl.js
@@ -128,9 +128,15 @@ export function getLibraryFromUrl(frame: Frame, callStack: Array<Frame> = []) {
     o => o.contextPattern && frameUrl.match(o.contextPattern)
   );
   if (match) {
-    const contextMatch = callStack.some(f =>
-      libraryMap.find(o => frameUrl.match(o.pattern))
-    );
+    const contextMatch = callStack.some(f => {
+      const url = getFrameUrl(f);
+      if (!url) {
+        return false;
+      }
+
+      return libraryMap.some(o => url.match(o.pattern));
+    });
+
     if (contextMatch) {
       return match.label;
     }

--- a/src/utils/pause/frames/tests/annotateFrames.spec.js
+++ b/src/utils/pause/frames/tests/annotateFrames.spec.js
@@ -1,0 +1,32 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
+import { annotateFrames } from "../annotateFrames";
+
+describe("annotateFrames", () => {
+  it("should return Angular", () => {
+    const callstack = [
+      {
+        source: {
+          url: "https://cdnjs.cloudflare.com/ajax/libs/angular/angular.js"
+        }
+      },
+      {
+        source: {
+          url: "/node_modules/zone/zone.js"
+        }
+      },
+      {
+        source: {
+          url: "https://cdnjs.cloudflare.com/ajax/libs/angular/angular.js"
+        }
+      }
+    ];
+    const frames = annotateFrames(callstack);
+    expect(frames).toEqual(
+      callstack.map(f => ({ ...f, library: "Angular" })),
+      "Angular (and zone.js) callstack is annotated as expected"
+    );
+  });
+});

--- a/src/utils/pause/frames/tests/getLibraryFromUrl.spec.js
+++ b/src/utils/pause/frames/tests/getLibraryFromUrl.spec.js
@@ -145,7 +145,7 @@ describe("getLibraryFromUrl", () => {
         }
       ];
 
-      expect(getLibraryFromUrl(frame, callstack)).toEqual(null);
+      expect(getLibraryFromUrl(frame, callstack)).toEqual("Angular");
     });
   });
 });


### PR DESCRIPTION
This patch also fixes a mistake in `getLibraryFromUrl`,
which wasn't working at all, with a poorly written test.
