### PR TITLE
[Tests] In mochi tests, use id instead of index to select context menu items

### DIFF
--- a/src/test/mochitest/browser_dbg-breakpoints-actions.js
+++ b/src/test/mochitest/browser_dbg-breakpoints-actions.js
@@ -16,7 +16,7 @@ add_task(async function() {
 
   openFirstBreakpointContextMenu(dbg)
   // select "Remove breakpoint"
-  selectMenuItem(dbg, 1);
+  selectContextMenuItem(dbg, selectors.breakpointContextMenu.remove);
 
   await waitForState(dbg, state => dbg.selectors.getBreakpointCount(state) === 0);
   ok("successfully removed the breakpoint");
@@ -36,7 +36,7 @@ add_task(async function() {
   openFirstBreakpointContextMenu(dbg);
   // select "Disable Others"
   let dispatched = waitForDispatch(dbg, "DISABLE_BREAKPOINT", 3);
-  selectMenuItem(dbg, 7);
+  selectContextMenuItem(dbg, selectors.breakpointContextMenu.disableOthers);
   await waitForState(dbg, state =>
     dbg.selectors.getBreakpointsList(state)
       .every(bp => (bp.location.line !== 1) === bp.disabled)
@@ -47,7 +47,7 @@ add_task(async function() {
   openFirstBreakpointContextMenu(dbg);
   // select "Disable All"
   dispatched = waitForDispatch(dbg, "DISABLE_ALL_BREAKPOINTS");
-  selectMenuItem(dbg, 9);
+  selectContextMenuItem(dbg, selectors.breakpointContextMenu.disableAll);
   await waitForState(dbg, state =>
     dbg.selectors.getBreakpointsList(state).every(bp => bp.disabled)
   );
@@ -57,7 +57,7 @@ add_task(async function() {
   openFirstBreakpointContextMenu(dbg);
   // select "Enable Others"
   dispatched = waitForDispatch(dbg, "ENABLE_BREAKPOINT", 3);
-  selectMenuItem(dbg, 3);
+  selectContextMenuItem(dbg, selectors.breakpointContextMenu.enableOthers);
   await waitForState(dbg, state =>
     dbg.selectors.getBreakpointsList(state)
       .every(bp => (bp.location.line === 1) === bp.disabled)
@@ -68,7 +68,7 @@ add_task(async function() {
   openFirstBreakpointContextMenu(dbg);
   // select "Remove Others"
   dispatched = waitForDispatch(dbg, "REMOVE_BREAKPOINT", 3);
-  selectMenuItem(dbg, 6);
+  selectContextMenuItem(dbg, selectors.breakpointContextMenu.removeOthers);
   await waitForState(dbg, state =>
     dbg.selectors.getBreakpointsList(state).length === 1 &&
     dbg.selectors.getBreakpointsList(state)[0].location.line === 1

--- a/src/test/mochitest/browser_dbg-breakpoints-cond.js
+++ b/src/test/mochitest/browser_dbg-breakpoints-cond.js
@@ -93,7 +93,7 @@ add_task(async function() {
   //right click breakpoint in breakpoints list
   rightClickElement(dbg, "breakpointItem", 3)
   // select "remove condition";
-  selectContextMenuItem(dbg, "#node-menu-remove-condition");
+  selectContextMenuItem(dbg, selectors.breakpointContextMenu.removeCondition);
   await bpCondition;
   bp = findBreakpoint(dbg, "simple2", 5);
   is(bp.condition, undefined, "breakpoint condition removed");

--- a/src/test/mochitest/browser_dbg-breakpoints-cond.js
+++ b/src/test/mochitest/browser_dbg-breakpoints-cond.js
@@ -38,8 +38,15 @@ async function assertConditionalBreakpointIsFocused(dbg) {
 }
 
 async function setConditionalBreakpoint(dbg, index, condition) {
+  const {
+    addConditionalBreakpoint,
+    editBreakpoint
+  } = selectors.gutterContextMenu;
+  // Make this work with either add or edit menu items
+  const selector = `${addConditionalBreakpoint},${editBreakpoint}`;
+
   rightClickElement(dbg, "gutter", index);
-  selectMenuItem(dbg, 2);
+  selectContextMenuItem(dbg, selector);
   await waitForElement(dbg, "conditionalPanelInput");
   await assertConditionalBreakpointIsFocused(dbg);
 
@@ -86,7 +93,7 @@ add_task(async function() {
   //right click breakpoint in breakpoints list
   rightClickElement(dbg, "breakpointItem", 3)
   // select "remove condition";
-  selectMenuItem(dbg, 8);
+  selectContextMenuItem(dbg, "#node-menu-remove-condition");
   await bpCondition;
   bp = findBreakpoint(dbg, "simple2", 5);
   is(bp.condition, undefined, "breakpoint condition removed");

--- a/src/test/mochitest/helpers.js
+++ b/src/test/mochitest/helpers.js
@@ -1035,7 +1035,8 @@ const selectors = {
     disableOthers: "#node-menu-disable-others",
     enableOthers: "#node-menu-enable-others",
     remove: "#node-menu-delete-self",
-    removeOthers: "#node-menu-delete-other"
+    removeOthers: "#node-menu-delete-other",
+    removeCondition: "#node-menu-remove-condition"
   },
   scopes: ".scopes-list",
   scopeNode: i => `.scopes-list .tree-node:nth-child(${i}) .object-label`,

--- a/src/test/mochitest/helpers.js
+++ b/src/test/mochitest/helpers.js
@@ -1030,6 +1030,13 @@ const selectors = {
   scopesHeader: ".scopes-pane ._header",
   breakpointItem: i => `.breakpoints-list div:nth-of-type(${i})`,
   breakpointItems: `.breakpoints-list .breakpoint`,
+  breakpointContextMenu: {
+    disableAll: "#node-menu-disable-all",
+    disableOthers: "#node-menu-disable-others",
+    enableOthers: "#node-menu-enable-others",
+    remove: "#node-menu-delete-self",
+    removeOthers: "#node-menu-delete-other"
+  },
   scopes: ".scopes-list",
   scopeNode: i => `.scopes-list .tree-node:nth-child(${i}) .object-label`,
   scopeValue: i =>
@@ -1037,6 +1044,10 @@ const selectors = {
   frame: i => `.frames ul li:nth-child(${i})`,
   frames: ".frames ul li",
   gutter: i => `.CodeMirror-code *:nth-child(${i}) .CodeMirror-linenumber`,
+  gutterContextMenu: {
+    addConditionalBreakpoint: "#node-menu-add-conditional-breakpoint",
+    editBreakpoint: "#node-menu-edit-conditional-breakpoint"
+  },
   menuitem: i => `menupopup menuitem:nth-child(${i})`,
   pauseOnExceptions: ".pause-exceptions",
   breakpoint: ".CodeMirror-code > .new-breakpoint",
@@ -1147,14 +1158,14 @@ function rightClickElement(dbg, elementName, ...args) {
   );
 }
 
-function selectMenuItem(dbg, index) {
+function selectContextMenuItem(dbg, selector) {
   // the context menu is in the toolbox window
   const doc = dbg.toolbox.win.document;
 
   // there are several context menus, we want the one with the menu-api
   const popup = doc.querySelector('menupopup[menu-api="true"]');
 
-  const item = popup.querySelector(`menuitem:nth-child(${index})`);
+  const item = popup.querySelector(selector);
   return EventUtils.synthesizeMouseAtCenter(item, {}, dbg.toolbox.win);
 }
 


### PR DESCRIPTION
Changes the `selectMenuItem` helper function in mochi tests

- renames it to `selectContextMenuItem` to better describe which menu it is used for
- Instead of selecting a menu item by index, use a css id.  So if the menu items change the test doesn't break.  Also the id makes the test more readable compared to an arbitrary number.