### PR TITLE
Show only column breakpoints in viewport

### DIFF
--- a/src/components/Editor/CallSites.js
+++ b/src/components/Editor/CallSites.js
@@ -101,9 +101,7 @@ class CallSites extends Component {
     // Update state which should trigger appropriate re-renders
     const leftColumn = Math.floor(scrollLeft > 0 ? scrollLeft / charWidth : 0);
     const rightPosition = scrollLeft + (scrollArea.clientWidth - 30);
-    const rightCharacter = Math.floor(
-      rightPosition > 0 ? rightPosition / charWidth : 0
-    );
+    const rightCharacter = Math.floor(rightPosition / charWidth);
 
     return {
       start: {
@@ -233,11 +231,20 @@ class CallSites extends Component {
       callSitesFilteredByLine
     );
 
+    console.log(
+      "callSitesInViewport: ",
+      callSitesInViewport.length,
+      JSON.stringify(this.state),
+      JSON.stringify(callSitesInViewport)
+    );
+
     let sites;
     editor.codeMirror.operation(() => {
-      const childCallSites = callSitesInViewport.map((callSite, index) => {
+      const childCallSites = callSitesInViewport.map(callSite => {
         const props = {
-          key: index,
+          key: `${callSite.location.start.line}:${
+            callSite.location.start.column
+          }`,
           callSite,
           editor,
           source: selectedSource,

--- a/src/components/Editor/CallSites.js
+++ b/src/components/Editor/CallSites.js
@@ -64,8 +64,6 @@ class CallSites extends Component {
 
     codeMirrorWrapper.addEventListener("click", e => this.onTokenClick(e));
     editor.codeMirror.on("scroll", this.onEditorScroll);
-
-    console.log("componentDidMount!", Date.now());
   }
 
   componentWillUnmount() {
@@ -83,7 +81,6 @@ class CallSites extends Component {
   }
 
   onEditorScroll = debounce(e => {
-    const viewport = this.getEditorViewport();
     this.setState(this.getEditorViewport());
   }, 200);
 
@@ -179,17 +176,12 @@ class CallSites extends Component {
   }
 
   filterCallSitesByViewport(callSites) {
-    // console.warn("Checking the following callSites: ", callSites.length);
-
     return callSites.filter(({ location }) => {
       const result =
         location.start.line >= this.state.start.line &&
         location.start.line <= this.state.end.line &&
         location.start.column >= this.state.start.column &&
         location.start.column <= this.state.end.column;
-
-      // console.log(JSON.stringify(location), result, JSON.stringify(this.state));
-
       return result;
     });
   }

--- a/src/utils/editor/index.js
+++ b/src/utils/editor/index.js
@@ -170,7 +170,6 @@ export function getLocationsInViewport(_editor: any) {
     "window"
   );
 
-  // Update state which should trigger appropriate re-renders
   const leftColumn = Math.floor(scrollLeft > 0 ? scrollLeft / charWidth : 0);
   const rightPosition = scrollLeft + (scrollArea.clientWidth - 30);
   const rightCharacter = Math.floor(rightPosition / charWidth);

--- a/src/utils/editor/index.js
+++ b/src/utils/editor/index.js
@@ -158,6 +158,35 @@ function isVisible(codeMirror: any, top: number, left: number) {
   return inXView && inYView;
 }
 
+export function getLocationsInViewport(_editor: any) {
+  // Get scroll position
+  const charWidth = _editor.codeMirror.defaultCharWidth();
+  const scrollArea = _editor.codeMirror.getScrollInfo();
+  const { scrollLeft } = _editor.codeMirror.doc;
+  const rect = _editor.codeMirror.getWrapperElement().getBoundingClientRect();
+  const topVisibleLine = _editor.codeMirror.lineAtHeight(rect.top, "window");
+  const bottomVisibleLine = _editor.codeMirror.lineAtHeight(
+    rect.bottom,
+    "window"
+  );
+
+  // Update state which should trigger appropriate re-renders
+  const leftColumn = Math.floor(scrollLeft > 0 ? scrollLeft / charWidth : 0);
+  const rightPosition = scrollLeft + (scrollArea.clientWidth - 30);
+  const rightCharacter = Math.floor(rightPosition / charWidth);
+
+  return {
+    start: {
+      line: topVisibleLine,
+      column: leftColumn
+    },
+    end: {
+      line: bottomVisibleLine,
+      column: rightCharacter
+    }
+  };
+}
+
 export function markText(_editor: any, className, { start, end }: EditorRange) {
   return _editor.codeMirror.markText(
     { ch: start.column, line: start.line },


### PR DESCRIPTION
CodeMirror has a really hard time when we inject every marker for a given line if the line is very long:

<img width="1369" alt="codemirrorperf" src="https://user-images.githubusercontent.com/46655/48729330-fafd7280-ebfc-11e8-84a9-bfb427455ff4.png">

One idea was to "cut off" column breakpoints after a certain column value (https://github.com/devtools-html/debugger.html/pull/7291), but this may be a better, more flexible solution, as I attempt to accommodate only lines and characters in range of the view port.  It debounces for additional perf win.

This already feels way better than current performance, when there's massive lag when switching between tabs.

## To Do
- [x] The initial state is arbitrary values that we can get real values for
- [x] I don't yet trust my column calculation -- I need to find a more scientific way of managing that.
- [x] Figure out why sometimes column breakpoints don't display upon initial page load when breakpoints exist.

