### PR TITLE
Make sources search work with query params

### DIFF
--- a/src/components/QuickOpenModal.js
+++ b/src/components/QuickOpenModal.js
@@ -37,6 +37,7 @@ import type {
 
 import type { Location, Source } from "../types";
 import type { QuickOpenType } from "../reducers/quick-open";
+import type { Tab } from "../reducers/tabs";
 
 import "./QuickOpenModal.css";
 
@@ -48,7 +49,7 @@ type Props = {
   searchType: QuickOpenType,
   symbols: FormattedSymbolDeclarations,
   symbolsLoading: boolean,
-  tabs: string[],
+  tabs: Tab[],
   shortcutsModalEnabled: boolean,
   selectSpecificLocation: Location => void,
   setQuickOpenQuery: (query: string) => void,
@@ -154,8 +155,10 @@ export class QuickOpenModal extends Component<Props, State> {
   showTopSources = () => {
     const { tabs, sources } = this.props;
     if (tabs.length > 0) {
+      const tabUrls = tabs.map((tab: Tab) => tab.url);
+
       this.setState({
-        results: sources.filter(source => tabs.includes(source.url))
+        results: sources.filter(source => tabUrls.includes(source.url))
       });
     } else {
       this.setState({ results: sources.slice(0, 100) });

--- a/src/components/test/QuickOpenModal.spec.js
+++ b/src/components/test/QuickOpenModal.spec.js
@@ -88,7 +88,7 @@ describe("QuickOpenModal", () => {
         enabled: true,
         query: "",
         sources: [{ url: "mozilla.com" }],
-        tabs: ["mozilla.com"]
+        tabs: [{ url: "mozilla.com" }]
       },
       "shallow"
     );

--- a/src/reducers/tabs.js
+++ b/src/reducers/tabs.js
@@ -26,7 +26,7 @@ import type { Action } from "../actions/types";
 import type { SourcesState } from "./sources";
 import type { Source } from "../types";
 
-type Tab = {
+export type Tab = {
   url: string,
   framework?: string | null,
   isOriginal: boolean,

--- a/src/test/mochitest/browser_dbg-sources-querystring.js
+++ b/src/test/mochitest/browser_dbg-sources-querystring.js
@@ -40,4 +40,8 @@ add_task(async function() {
     "simple1.js?x=1",
     "Breakpoint heading is simple1.js?x=1"
   );
+
+  pressKey(dbg, "quickOpen");
+  type(dbg, "simple1.js?x");
+  ok(findElement(dbg, "resultItems")[0].innerText.includes("simple.js?x=1"));
 });

--- a/src/utils/quick-open.js
+++ b/src/utils/quick-open.js
@@ -5,7 +5,12 @@
 // @flow
 import classnames from "classnames";
 import { endTruncateStr } from "./utils";
-import { isPretty, getFilename, getSourceClassnames } from "./source";
+import {
+  isPretty,
+  getFilename,
+  getSourceClassnames,
+  getSourceQueryString
+} from "./source";
 
 import type { Location as BabelLocation } from "@babel/types";
 import type { Symbols } from "../reducers/ast";
@@ -53,9 +58,13 @@ export function parseLineColumn(query: string) {
 
 export function formatSourcesForList(source: Source, tabs: TabList) {
   const title = getFilename(source);
-  const subtitle = endTruncateStr(source.relativeUrl, 100);
+  const relativeUrlWithQuery = `${source.relativeUrl}${getSourceQueryString(
+    source
+  )}`;
+  const subtitle = endTruncateStr(relativeUrlWithQuery, 100);
+  const value = relativeUrlWithQuery;
   return {
-    value: source.relativeUrl,
+    value,
     title,
     subtitle,
     icon: tabs.some(tab => tab.url == source.url)


### PR DESCRIPTION
Fixes #7217 

### Summary of Changes
- It seems like the search was expecting `tabs` to be an array of strings, but it was really a `TabList`. Updated the `showTopSources` function to convert the tab array into array of source urls for comparison. Now if you have no query in your search, it will show the top sources (open tabs).
- Updated the search source subtitle to be a truncated copy of the sources `relativeUrl` + `query`.
- Updated the search source value to be the sources `relativeUrl` + `query` so that searching by query string works.

### Test Plan
- [x] Open http://skinny-clutch.glitch.me/
- [x] Open a source file
- [x] Cmd+P to open search
- [x] with the search empty, the source in the tab should show up in the search dropdown
- [x] Search for a source with a query string
- [x] It should work!

### To Do
- [ ] Add a mochitest

### Screenshots/Videos

Before:
![screen shot 2018-11-20 at 9 02 05 am](https://user-images.githubusercontent.com/5448834/48786589-65b5b900-eca4-11e8-8c5c-1cab3db277db.png)
![searchsourcesquery-before](https://user-images.githubusercontent.com/5448834/48786604-6b130380-eca4-11e8-9885-43c3cbc79889.gif)


After:
![screen shot 2018-11-20 at 9 07 12 am](https://user-images.githubusercontent.com/5448834/48786617-71a17b00-eca4-11e8-9569-816458a5eb93.png)
![searchsourcesquery-after](https://user-images.githubusercontent.com/5448834/48786627-75350200-eca4-11e8-989b-acd5dec6f385.gif)

