### PR TITLE
Sort breakpoints by line number, then column number

### DIFF
--- a/src/components/SecondaryPanes/Breakpoints/index.js
+++ b/src/components/SecondaryPanes/Breakpoints/index.js
@@ -7,6 +7,7 @@
 import React, { Component } from "react";
 import classnames from "classnames";
 import { connect } from "react-redux";
+import { sortBy } from "lodash";
 
 import ExceptionOption from "./ExceptionOption";
 
@@ -79,6 +80,15 @@ class Breakpoints extends Component<Props> {
     return [
       ...breakpointSources.map(({ source, breakpoints, i }) => {
         const path = getDisplayPath(source, sources);
+        const sortedBreakpoints = sortBy(
+          breakpoints,
+          ({ selectedLocation }) => [
+            selectedLocation.line,
+            (selectedLocation.column || 0).toString().length,
+            selectedLocation.column || 0
+          ]
+        );
+
         return [
           <BreakpointHeading
             source={source}
@@ -86,7 +96,7 @@ class Breakpoints extends Component<Props> {
             path={path}
             key={source.url}
           />,
-          ...breakpoints.map(breakpoint => (
+          ...sortedBreakpoints.map(breakpoint => (
             <Breakpoint
               breakpoint={breakpoint}
               source={source}

--- a/src/components/SecondaryPanes/Breakpoints/index.js
+++ b/src/components/SecondaryPanes/Breakpoints/index.js
@@ -7,7 +7,6 @@
 import React, { Component } from "react";
 import classnames from "classnames";
 import { connect } from "react-redux";
-import { sortBy } from "lodash";
 
 import ExceptionOption from "./ExceptionOption";
 
@@ -16,7 +15,7 @@ import BreakpointHeading from "./BreakpointHeading";
 
 import actions from "../../../actions";
 import { getDisplayPath } from "../../../utils/source";
-import { makeLocationId } from "../../../utils/breakpoint";
+import { makeLocationId, sortBreakpoints } from "../../../utils/breakpoint";
 
 import { getSelectedSource, getBreakpointSources } from "../../../selectors";
 
@@ -80,14 +79,7 @@ class Breakpoints extends Component<Props> {
     return [
       ...breakpointSources.map(({ source, breakpoints, i }) => {
         const path = getDisplayPath(source, sources);
-        const sortedBreakpoints = sortBy(
-          breakpoints,
-          ({ selectedLocation }) => [
-            selectedLocation.line,
-            (selectedLocation.column || 0).toString().length,
-            selectedLocation.column || 0
-          ]
-        );
+        const sortedBreakpoints = sortBreakpoints(breakpoints);
 
         return [
           <BreakpointHeading

--- a/src/utils/breakpoint/index.js
+++ b/src/utils/breakpoint/index.js
@@ -4,12 +4,15 @@
 
 // @flow
 
+import { sortBy } from "lodash";
+
 import { getBreakpoint } from "../../selectors";
 import assert from "../assert";
 import { features } from "../prefs";
 
 export { getASTLocation, findScopeByName } from "./astBreakpointLocation";
 
+import type { FormattedBreakpoint } from "../../selectors/breakpointSources";
 import type {
   Location,
   PendingLocation,
@@ -178,4 +181,21 @@ export function createPendingBreakpoint(bp: Breakpoint) {
     astLocation: bp.astLocation,
     generatedLocation: pendingGeneratedLocation
   };
+}
+
+export function sortBreakpoints(breakpoints: FormattedBreakpoint[]) {
+  breakpoints = breakpoints.map(bp => ({
+    ...bp,
+    selectedLocation: {
+      ...bp.selectedLocation,
+      // If a breakpoint has an undefined column, we must provide a 0 value
+      // or the breakpoint will display after all explicit column numbers
+      column: bp.selectedLocation.column || 0
+    }
+  }));
+
+  return sortBy(breakpoints, [
+    "selectedLocation.line",
+    "selectedLocation.column"
+  ]);
 }

--- a/src/utils/breakpoint/tests/index.spec.js
+++ b/src/utils/breakpoint/tests/index.spec.js
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
+import { sortBreakpoints } from "../index";
+
+describe("breakpoint sorting", () => {
+  it("sortBreakpoints should sort by line number and column ", () => {
+    const sorted = sortBreakpoints([
+      { selectedLocation: { line: 100, column: 2 } },
+      { selectedLocation: { line: 9, column: 2 } },
+      { selectedLocation: { line: 2, column: undefined } },
+      { selectedLocation: { line: 2, column: 7 } }
+    ]);
+
+    expect(sorted[0].selectedLocation.line).toBe(2);
+    expect(sorted[0].selectedLocation.column).toBe(0);
+    expect(sorted[1].selectedLocation.line).toBe(2);
+    expect(sorted[1].selectedLocation.column).toBe(7);
+    expect(sorted[2].selectedLocation.line).toBe(9);
+    expect(sorted[3].selectedLocation.line).toBe(100);
+  });
+});


### PR DESCRIPTION
This sorts breakpoints in the right sidebar by: line number, line number length (so `143` is after `62`), and line number.