### PR TITLE
Ensure that we don't overwrite a loaded source with a loading source to fix flakiness.

### DIFF
--- a/src/actions/sources/newSources.js
+++ b/src/actions/sources/newSources.js
@@ -81,12 +81,18 @@ function loadSourceMap(sourceId: SourceId) {
     }
 
     if (!urls) {
+      // The source might have changed while we looked up the URLs, so we need
+      // to load it again before dispatching. We ran into an issue here because
+      // this was previously using 'source' and was at risk of resetting the
+      // 'loadedState' field to 'loading', putting it in an inconsistent state.
+      const currentSource = getSource(getState(), sourceId);
+
       // If this source doesn't have a sourcemap, enable it for pretty printing
       dispatch(
         ({
           type: "UPDATE_SOURCE",
           // NOTE: Flow https://github.com/facebook/flow/issues/6342 issue
-          source: (({ ...source, sourceMapURL: "" }: any): Source)
+          source: (({ ...currentSource, sourceMapURL: "" }: any): Source)
         }: Action)
       );
       return;


### PR DESCRIPTION
In release 103 we had to exclude the source-map upgrade because of flakiness on Windows. It seems to be that we were just uncovering existing flakiness in the existing test, but it varies depending on source-map timing.