### PR TITLE
Hide column breakpoints when source is blackboxed

### DIFF
--- a/src/components/Editor/CallSites.js
+++ b/src/components/Editor/CallSites.js
@@ -192,6 +192,10 @@ class CallSites extends Component {
       return null;
     }
 
+    if (!selectedSource || selectedSource.isBlackBoxed) {
+      return null;
+    }
+
     // Filter by desired line numbers
     const callSitesFilteredByLine = this.filterCallSitesByLineNumber();
 


### PR DESCRIPTION
I noticed that the breakpoint markers don't display when a source is blackboxed, so nor should their column breakpoint markers.