### PR TITLE
WIP: Column breakpont context menu

### DIFF
--- a/src/actions/pause/continueToHere.js
+++ b/src/actions/pause/continueToHere.js
@@ -14,7 +14,7 @@ import { resume, rewind } from "./commands";
 
 import type { ThunkArgs } from "../types";
 
-export function continueToHere(line: number) {
+export function continueToHere(line: number, column: ?number) {
   return async function({ dispatch, getState }: ThunkArgs) {
     const selectedSource = getSelectedSource(getState());
     const selectedFrame = getSelectedFrame(getState());
@@ -34,7 +34,7 @@ export function continueToHere(line: number) {
     await dispatch(
       addHiddenBreakpoint({
         line,
-        column: undefined,
+        column: column || undefined,
         sourceId: selectedSource.id
       })
     );

--- a/src/actions/ui.js
+++ b/src/actions/ui.js
@@ -155,14 +155,17 @@ export function clearHighlightLineRange() {
   };
 }
 
-export function openConditionalPanel(line: ?number) {
+export function openConditionalPanel(line: ?number, column: ?number) {
+  console.log("openConditionalPanel", line, column);
+
   if (!line) {
     return;
   }
 
   return {
     type: "OPEN_CONDITIONAL_PANEL",
-    line
+    line,
+    column
   };
 }
 

--- a/src/components/Editor/CallSite.js
+++ b/src/components/Editor/CallSite.js
@@ -32,9 +32,11 @@ export default class CallSite extends Component<Props> {
 
   addCallSite = (nextProps: ?Props) => {
     const { editor, callSite, breakpoint, source } = nextProps || this.props;
-    const className = !breakpoint ? "call-site" : "call-site-bp";
-    const sourceId = source.id;
-    const editorRange = toEditorRange(sourceId, callSite.location);
+    let className = breakpoint ? "call-site-bp" : "call-site";
+    className = `${className} cl-${callSite.location.start.line}-${
+      callSite.location.start.column
+    }`;
+    const editorRange = toEditorRange(source.id, callSite.location);
     this.marker = markText(editor, className, editorRange);
   };
 

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -322,7 +322,11 @@ class Editor extends PureComponent<Props, State> {
 
     const { setContextMenu } = this.props;
     const target: Element = (event.target: any);
-    if (target.classList.contains("CodeMirror-linenumber")) {
+    if (
+      target.classList.contains("CodeMirror-linenumber") ||
+      target.classList.contains("call-site") ||
+      target.classList.contains("call-site-bp")
+    ) {
       return setContextMenu("Gutter", event);
     }
 

--- a/src/reducers/ui.js
+++ b/src/reducers/ui.js
@@ -37,7 +37,10 @@ export type UIState = {
     end?: number,
     sourceId?: number
   },
-  conditionalPanelLine: null | number
+  conditionalPanelLine: {
+    location: number,
+    column: number
+  } | null
 };
 
 export const createUIState = makeRecord(
@@ -106,7 +109,11 @@ function update(
       return state.set("highlightedLineRange", {});
 
     case "OPEN_CONDITIONAL_PANEL":
-      return state.set("conditionalPanelLine", action.line);
+      console.warn("OPEN_CONDITIONAL_PANEL", action.line, action.column);
+      return state.set("conditionalPanelLine", {
+        line: action.line,
+        column: action.column
+      });
 
     case "CLOSE_CONDITIONAL_PANEL":
       return state.set("conditionalPanelLine", null);
@@ -172,7 +179,8 @@ export function getHighlightedLineRange(state: OuterState) {
   return state.ui.get("highlightedLineRange");
 }
 
-export function getConditionalPanelLine(state: OuterState): null | number {
+export function getConditionalPanelLine(state: OuterState): any {
+  // null | number {
   return state.ui.get("conditionalPanelLine");
 }
 


### PR DESCRIPTION
This is just a progress marker WIP.  One thing I've noticed is that the column number provided by right-clicking a marker is one off of the breakpoint position, so it's possible that the marker itself counts as a character, and thus breakpoints aren't being found because of the column number being off by however many markers are present.  Hopefully @jasonLaster' switch to widgets fixes the location issue.