### PR TITLE
Fix Angular icon in dark mode

### DIFF
--- a/src/components/SecondaryPanes/Frames/Frames.css
+++ b/src/components/SecondaryPanes/Frames/Frames.css
@@ -108,6 +108,6 @@
   margin-inline-start: 4px;
 }
 
-:root.theme-dark .annotation-logo svg path {
+:root.theme-dark .annotation-logo:not(.angular) svg path {
   fill: var(--theme-highlight-blue);
 }


### PR DESCRIPTION
In dark mode, the Angular icon wasn't legible: 

![image](https://user-images.githubusercontent.com/578107/48904994-93dff800-ee60-11e8-9364-cd668549ac6f.png)

The fix is to remove the case for angular since the icon looks fine in dark mode too.