### PR TITLE
Step In Button Shortcuts differs in Linux, Windows (#7306)

### DIFF
--- a/src/components/SecondaryPanes/CommandBar.js
+++ b/src/components/SecondaryPanes/CommandBar.js
@@ -47,8 +47,8 @@ const KEYS = {
   Linux: {
     resume: "F8",
     stepOver: "F10",
-    stepIn: "Ctrl+F11",
-    stepOut: "Ctrl+Shift+F11"
+    stepIn: "F11",
+    stepOut: "Shift+F11"
   }
 };
 


### PR DESCRIPTION
Fixes #7306 

## Aim
Same shortcuts in Linux and Windows.

## What I did
Changed the Linux keys and tested with the new shortcuts. 

## Test platform
Operating System: Manjaro Linux 
KDE Plasma Version: 5.14.3
Qt Version: 5.11.2
KDE Frameworks Version: 5.52.0
Kernel Version: 4.19.1-1-MANJARO
OS Type: 64-bit
