### PR TITLE
Fix Tree arrow images.

### DIFF
--- a/packages/devtools-components/src/images/arrow.svg
+++ b/packages/devtools-components/src/images/arrow.svg
@@ -1,6 +1,6 @@
 <!-- This Source Code Form is subject to the terms of the Mozilla Public
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
-<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="context-fill #9B9B9B">
   <path d="M8 13.4c-.5 0-.9-.2-1.2-.6L.4 5.2C0 4.7-.1 4.3.2 3.7S1 3 1.6 3h12.8c.6 0 1.2.1 1.4.7.3.6.2 1.1-.2 1.6l-6.4 7.6c-.3.4-.7.5-1.2.5z"/>
 </svg>

--- a/packages/devtools-components/src/tests/tree.js
+++ b/packages/devtools-components/src/tests/tree.js
@@ -593,9 +593,9 @@ describe("Tree", () => {
 
     getTreeNodes(wrapper).forEach(n => {
       if ("ABECDMN".split("").includes(getSanitizedNodeText(n))) {
-        expect(n.find("img.arrow.expanded").exists()).toBe(true);
+        expect(n.find(".arrow.expanded").exists()).toBe(true);
       } else {
-        expect(n.find("img.arrow").exists()).toBe(false);
+        expect(n.find(".arrow").exists()).toBe(false);
       }
     });
   });
@@ -605,7 +605,7 @@ describe("Tree", () => {
     expect(formatTree(wrapper)).toMatchSnapshot();
 
     getTreeNodes(wrapper).forEach(n => {
-      const arrow = n.find("img.arrow");
+      const arrow = n.find(".arrow");
       expect(arrow.exists()).toBe(true);
       expect(arrow.hasClass("expanded")).toBe(false);
     });
@@ -666,7 +666,7 @@ function formatTree(wrapper) {
     .map(node => {
       const level = (node.prop("aria-level") || 1) - 1;
       const indentStr = "|  ".repeat(level);
-      const arrow = node.find("img.arrow");
+      const arrow = node.find(".arrow");
       let arrowStr = "  ";
       if (arrow.exists()) {
         arrowStr = arrow.hasClass("expanded") ? "▼ " : "▶︎ ";

--- a/packages/devtools-components/src/tree.css
+++ b/packages/devtools-components/src/tree.css
@@ -54,24 +54,29 @@
   cursor: default;
 }
 
-.tree-node img.arrow {
-  mask: url(/images/arrow.svg) no-repeat;
-  mask-size: 100%;
+.tree-node button.arrow {
+  background:url(/images/arrow.svg) no-repeat;
+  background-size:contain;
+  background-position:center center;
   width: 9px;
   height: 9px;
+  border:0;
+  padding:0;
   margin-inline-start: 1px;
   margin-inline-end: 4px;
-  background-color: var(--theme-splitter-color, #9B9B9B);
   transform: rotate(-90deg);
+  transform-origin: center center;
   transition: transform 0.125s ease;
   align-self: center;
+  -moz-context-properties: fill;
+  fill: var(--theme-splitter-color, #9B9B9B);
 }
 
-html[dir="rtl"] .tree-node img.arrow {
+html[dir="rtl"] .tree-node button.arrow {
   transform: rotate(90deg);
 }
 
-.tree-node img.arrow.expanded.expanded {
+.tree-node button.arrow.expanded.expanded {
   transform: rotate(0deg);
  }
 
@@ -80,6 +85,6 @@ html[dir="rtl"] .tree-node img.arrow {
   background-color: var(--theme-selection-background, #0a84ff);
 }
 
-.tree-node.focused img.arrow {
-  background-color: currentColor;
+.tree-node.focused button.arrow {
+  fill: currentColor;
 }

--- a/packages/devtools-components/src/tree.js
+++ b/packages/devtools-components/src/tree.js
@@ -34,7 +34,7 @@ class ArrowExpander extends Component {
     if (expanded) {
       classNames.push("expanded");
     }
-    return dom.img({
+    return dom.button({
       className: classNames.join(" ")
     });
   }

--- a/packages/devtools-reps/src/object-inspector/index.css
+++ b/packages/devtools-reps/src/object-inspector/index.css
@@ -36,7 +36,7 @@
   color: var(--theme-comment);
 }
 
-.object-inspector .tree-node img.arrow {
+.object-inspector .tree-node .arrow {
   display: inline-block;
   vertical-align: middle;
 }

--- a/packages/devtools-reps/src/object-inspector/tests/component/__snapshots__/window.js.snap
+++ b/packages/devtools-reps/src/object-inspector/tests/component/__snapshots__/window.js.snap
@@ -30,7 +30,7 @@ exports[`ObjectInspector - dimTopLevelWindow renders collapsed top-level window 
       className="node object-node"
       onClick={[Function]}
     >
-      <img
+      <button
         className="arrow"
       />
       <span
@@ -89,7 +89,7 @@ exports[`ObjectInspector - dimTopLevelWindow renders sub-level window 1`] = `
       className="node object-node focused"
       onClick={[Function]}
     >
-      <img
+      <button
         className="arrow expanded"
       />
       <span
@@ -117,7 +117,7 @@ exports[`ObjectInspector - dimTopLevelWindow renders sub-level window 1`] = `
       className="node object-node"
       onClick={[Function]}
     >
-      <img
+      <button
         className="arrow"
       />
       <span
@@ -175,7 +175,7 @@ exports[`ObjectInspector - dimTopLevelWindow renders window as expected when dim
       className="node object-node lessen"
       onClick={[Function]}
     >
-      <img
+      <button
         className="arrow"
       />
       <span
@@ -234,7 +234,7 @@ exports[`ObjectInspector - dimTopLevelWindow renders window as expected when dim
       className="node object-node focused"
       onClick={[Function]}
     >
-      <img
+      <button
         className="arrow expanded"
       />
       <span

--- a/packages/devtools-reps/src/object-inspector/tests/component/expand.js
+++ b/packages/devtools-reps/src/object-inspector/tests/component/expand.js
@@ -261,7 +261,7 @@ describe("ObjectInspector - state", () => {
     getSelection().setMockSelection("test");
 
     const root1 = nodes.at(0);
-    root1.find("img.arrow").simulate("click");
+    root1.find(".arrow").simulate("click");
     expect(getExpandedPaths(store.getState()).has("root-1")).toBeTruthy();
     expect(formatObjectInspector(wrapper)).toMatchSnapshot();
 

--- a/packages/devtools-reps/src/object-inspector/tests/test-utils.js
+++ b/packages/devtools-reps/src/object-inspector/tests/test-utils.js
@@ -48,9 +48,9 @@ function formatObjectInspector(wrapper: Object) {
     .find(".tree-node")
     .map(node => {
       const indentStr = "|  ".repeat((node.prop("aria-level") || 1) - 1);
-      // Need to target img.arrow or Enzyme will also match the ArrowExpander
+      // Need to target .arrow or Enzyme will also match the ArrowExpander
       // component.
-      const arrow = node.find("img.arrow");
+      const arrow = node.find(".arrow");
       let arrowStr = "  ";
       if (arrow.exists()) {
         arrowStr = arrow.hasClass("expanded") ? "▼ " : "▶︎ ";


### PR DESCRIPTION
We used to render the arrows using an empty img
with a CSS mask. Due to some platform changes,
we now see a bit of the broken image asset,
which does not look great.

In order to fix that, we use buttons to render
the arrow, with a background-image, and context-fill
to style it.
