### PR TITLE
Restyling breakpoint colors

### DIFF
--- a/assets/images/column-marker.svg
+++ b/assets/images/column-marker.svg
@@ -1,5 +1,5 @@
 <svg width="9px" height="12px" viewBox="0 0 9 12" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <g id="columnmarkergroup" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <polygon id="columnmarker" fill="#1B1B1D" points="0 0 4 0 9 6 4 12 0 12"></polygon>
+    <g id="columnmarkergroup" stroke-width="1" fill-rule="evenodd">
+        <polygon id="columnmarker" points="0 0 4 0 9 6 4 12 0 12"></polygon>
     </g>
 </svg>

--- a/src/components/Editor/ColumnBreakpoint.js
+++ b/src/components/Editor/ColumnBreakpoint.js
@@ -26,12 +26,12 @@ type Props = {
 };
 
 const breakpointImg = document.createElement("div");
+ReactDOM.render(<Svg name={"column-marker"} />, breakpointImg);
 function makeBookmark(isActive, { onClick }) {
   const bp = breakpointImg.cloneNode(true);
   const className = isActive ? "active" : "disabled";
   bp.className = classnames("call-site", className);
   bp.onclick = onClick;
-  ReactDOM.render(<Svg name={"column-marker"} />, bp);
   return bp;
 }
 

--- a/src/components/Editor/ColumnBreakpoint.js
+++ b/src/components/Editor/ColumnBreakpoint.js
@@ -3,9 +3,11 @@
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
 // @flow
-import { PureComponent } from "react";
+import React, { PureComponent } from "react";
+import ReactDOM from "react-dom";
 import classnames from "classnames";
 import { getDocument } from "../../utils/editor";
+import Svg from "../shared/Svg";
 
 // eslint-disable-next-line max-len
 import type { ColumnBreakpoint as ColumnBreakpointType } from "../../selectors/visibleColumnBreakpoints";
@@ -26,10 +28,10 @@ type Props = {
 const breakpointImg = document.createElement("div");
 function makeBookmark(isActive, { onClick }) {
   const bp = breakpointImg.cloneNode(true);
-  bp.className = classnames("call-site", {
-    active: isActive
-  });
+  const className = isActive ? "active" : "disabled";
+  bp.className = classnames("call-site", className);
   bp.onclick = onClick;
+  ReactDOM.render(<Svg name={"column-marker"} />, bp);
   return bp;
 }
 

--- a/src/components/Editor/ColumnBreakpoints.css
+++ b/src/components/Editor/ColumnBreakpoints.css
@@ -3,40 +3,34 @@
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
 .call-site {
-  position: relative;
   display: inline;
-  cursor: pointer;
 }
 
-.call-site::before {
-  content: "";
-  mask: url(/images/column-marker.svg) no-repeat 100% 100%;
-  mask-size: contain;
-  display: inline-block;
-  background-color: var(--blue-55);
-  opacity: 0.5;
+.call-site svg {
+  display: inline;
+  cursor: pointer;
   width: 9px;
   height: 12px;
 }
 
-.call-site.active::before {
-  opacity: 1;
+.call-site.active svg {
+  fill: var(--blue-50);
+  stroke: var(--blue-60);
 }
 
-.theme-dark .call-site {
-  border-bottom: none;
+.call-site.disabled svg {
+  fill: var(--blue-50);
+  stroke: var(--blue-40);
+  fill-opacity: 0.5;
 }
 
-.theme-dark .call-site-bp {
-  border-bottom: none;
+.theme-dark .call-site.active svg {
+  fill: var(--blue-55);
+  stroke: var(--blue-40);
 }
 
-.theme-dark .call-site::before {
-  background-color: var(--blue-60);
-  opacity: 1;
-}
-
-.theme-dark .call-site-bp::before {
-  background-color: var(--blue-50);
-  opacity: 0.5;
+.theme-dark .call-site.disabled svg {
+  fill: var(--blue-50);
+  stroke: var(--blue-60);
+  fill-opacity: 0.5;
 }

--- a/src/components/Editor/ColumnBreakpoints.css
+++ b/src/components/Editor/ColumnBreakpoints.css
@@ -9,8 +9,9 @@
 .call-site svg {
   display: inline;
   cursor: pointer;
-  width: 9px;
   height: 12px;
+  width: 9px;
+  vertical-align: top;
 }
 
 .call-site.active svg {

--- a/src/components/Editor/Editor.css
+++ b/src/components/Editor/Editor.css
@@ -52,10 +52,18 @@ html[dir="rtl"] .editor-mount {
 
 .theme-light {
   --gutter-hover-background-color: #dde1e4;
+  --breakpoint-fill: var(--blue-50);
+  --breakpoint-stroke: var(--blue-60);
+  --breakpoint-fill-disabled: var(--blue-50);
+  --breakpoint-stroke-disabled: var(--blue-40);
 }
 
 .theme-dark {
   --gutter-hover-background-color: #414141;
+  --breakpoint-fill: var(--blue-55);
+  --breakpoint-stroke: var(--blue-40);
+  --breakpoint-fill-disabled: var(--blue-50);
+  --breakpoint-stroke-disabled: var(--blue-60);
 }
 
 :not(.empty-line):not(.new-breakpoint)
@@ -110,7 +118,8 @@ html[dir="rtl"] .editor-mount {
 }
 
 .editor.new-breakpoint svg {
-  fill: var(--theme-selection-background);
+  fill: var(--breakpoint-fill);
+  stroke: var(--breakpoint-stroke);
   width: 60px;
   height: 14px;
   position: absolute;
@@ -142,7 +151,9 @@ html[dir="rtl"] .editor-mount {
 }
 
 .editor.new-breakpoint.breakpoint-disabled svg {
-  opacity: 0.3;
+  fill: var(--breakpoint-fill-disabled);
+  stroke: var(--breakpoint-stroke-disabled);
+  fill-opacity: 0.5;
 }
 
 .editor.column-breakpoint svg {


### PR DESCRIPTION
### Summary of Changes

* Break point colors have been changed and a border has been added according to this mockup:
<img width="1271" alt="newdesign" src="https://user-images.githubusercontent.com/14957948/49129778-1886a800-f29f-11e8-82b8-f64961f6a800.png">

* There's still one issue that I'm not sure how to fix. The --blue-40 variable is not set, so those borders don't actually appear.

### Test Plan
- [x] Click on various breakpoints in both light and dark mode.

### Screenshots/Videos
![breakpoint](https://user-images.githubusercontent.com/14957948/49129744-eaa16380-f29e-11e8-8e30-f928b8d48381.PNG)

