### PR TITLE
Rename some Position/Location types.

### DIFF
--- a/flow-typed/debugger-html.js
+++ b/flow-typed/debugger-html.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
 // @flow
 
 declare module "debugger-html" {
@@ -31,7 +35,7 @@ declare module "debugger-html" {
    * @memberof types
    * @static
    */
-  declare type Location = {
+  declare type SourceLocation = {
     sourceId: SourceId,
     line: number,
     column?: number,
@@ -46,7 +50,7 @@ declare module "debugger-html" {
    */
   declare type Breakpoint = {
     id: BreakpointId,
-    location: Location,
+    location: SourceLocation,
     loading: boolean,
     disabled: boolean,
     text: string,
@@ -61,7 +65,7 @@ declare module "debugger-html" {
    */
   declare type BreakpointResult = {
     id: ActorId,
-    actualLocation: Location
+    actualLocation: SourceLocation
   };
 
   /**
@@ -95,7 +99,7 @@ declare module "debugger-html" {
   declare type Frame = {
     id: FrameId,
     displayName: string,
-    location: Location,
+    location: SourceLocation,
     source?: Source,
     scope: Scope,
     // FIXME Define this type more clearly
@@ -190,10 +194,10 @@ declare module "debugger-html" {
    */
   declare type SourceScope = {
     type: string,
-    start: Location,
-    end: Location,
+    start: SourceLocation,
+    end: SourceLocation,
     bindings: {
-      [name: string]: Location[]
+      [name: string]: SourceLocation[]
     }
   };
 
@@ -240,7 +244,7 @@ declare module "debugger-html" {
       actor: ActorId,
       class: string,
       displayName: string,
-      location: Location,
+      location: SourceLocation,
       // FIXME Define this type more clearly
       parameterNames: Array<Object>
     },

--- a/flow-typed/debugger-html.js
+++ b/flow-typed/debugger-html.js
@@ -35,12 +35,12 @@ declare module "debugger-html" {
    * @memberof types
    * @static
    */
-  declare type SourceLocation = {
+  declare type SourceLocation = {|
     sourceId: SourceId,
     line: number,
     column?: number,
     sourceUrl?: string
-  };
+  |};
 
   /**
    * Breakpoint

--- a/packages/devtools-source-map/src/source-map.js
+++ b/packages/devtools-source-map/src/source-map.js
@@ -29,7 +29,7 @@ const {
 } = require("./utils");
 const { clearWasmXScopes } = require("./utils/wasmXScopes");
 
-import type { Location, Source, SourceId } from "debugger-html";
+import type { SourceLocation, Source, SourceId } from "debugger-html";
 
 async function getOriginalURLs(generatedSource: Source) {
   const map = await fetchSourceMap(generatedSource);
@@ -98,7 +98,7 @@ async function getOriginalRanges(sourceId: SourceId, url: string) {
  * are mapped from the original range containing the location.
  */
 async function getGeneratedRanges(
-  location: Location,
+  location: SourceLocation,
   originalSource: Source
 ): Promise<
   Array<{
@@ -158,9 +158,9 @@ async function getGeneratedRanges(
 }
 
 async function getGeneratedLocation(
-  location: Location,
+  location: SourceLocation,
   originalSource: Source
-): Promise<Location> {
+): Promise<SourceLocation> {
   if (!isOriginalId(location.sourceId)) {
     return location;
   }
@@ -205,9 +205,9 @@ async function getGeneratedLocation(
 }
 
 async function getAllGeneratedLocations(
-  location: Location,
+  location: SourceLocation,
   originalSource: Source
-): Promise<Array<Location>> {
+): Promise<Array<SourceLocation>> {
   if (!isOriginalId(location.sourceId)) {
     return [];
   }
@@ -235,9 +235,9 @@ type locationOptions = {
   search?: "LEAST_UPPER_BOUND" | "GREATEST_LOWER_BOUND"
 };
 async function getOriginalLocation(
-  location: Location,
+  location: SourceLocation,
   { search }: locationOptions = {}
-): Promise<Location> {
+): Promise<SourceLocation> {
   if (!isGeneratedId(location.sourceId)) {
     return location;
   }
@@ -306,7 +306,7 @@ async function getOriginalSourceText(originalSource: Source) {
   };
 }
 
-async function hasMappedSource(location: Location): Promise<boolean> {
+async function hasMappedSource(location: SourceLocation): Promise<boolean> {
   if (isOriginalId(location.sourceId)) {
     return true;
   }

--- a/packages/devtools-source-map/src/utils/getOriginalStackFrames.js
+++ b/packages/devtools-source-map/src/utils/getOriginalStackFrames.js
@@ -4,17 +4,17 @@
 
 // @flow
 
-import type { Location } from "debugger-html";
+import type { SourceLocation } from "debugger-html";
 
 const { getWasmXScopes } = require("./wasmXScopes");
 
 // Returns expanded stack frames details based on the generated location.
 // The function return null if not information was found.
 async function getOriginalStackFrames(
-  generatedLocation: Location
+  generatedLocation: SourceLocation
 ): Promise<?Array<{
   displayName: string,
-  location?: Location
+  location?: SourceLocation
 }>> {
   const wasmXScopes = await getWasmXScopes(generatedLocation.sourceId);
   if (!wasmXScopes) {

--- a/packages/devtools-source-map/src/utils/wasmXScopes.js
+++ b/packages/devtools-source-map/src/utils/wasmXScopes.js
@@ -5,7 +5,7 @@
 // @flow
 /* eslint camelcase: 0*/
 
-import type { Location, SourceId } from "debugger-html";
+import type { SourceLocation, SourceId } from "debugger-html";
 
 const { getSourceMap } = require("./sourceMapRequests");
 const { generatedToOriginalId } = require("./index");
@@ -137,10 +137,10 @@ class XScope {
   }
 
   search(
-    generatedLocation: Location
+    generatedLocation: SourceLocation
   ): Array<{
     displayName: string,
-    location?: Location
+    location?: SourceLocation
   }> {
     const { code_section_offset, debug_info, sources, idIndex } = this.xScope;
     const pc = generatedLocation.line - (code_section_offset || 0);

--- a/src/actions/breakpoints/addBreakpoint.js
+++ b/src/actions/breakpoints/addBreakpoint.js
@@ -94,7 +94,7 @@ async function addBreakpointPromise(getState, client, sourceMaps, breakpoint) {
  * @param location
  * @return {function(ThunkArgs)}
  */
-export function addHiddenBreakpoint(location: Location) {
+export function addHiddenBreakpoint(location: SourceLocation) {
   return ({ dispatch }: ThunkArgs) => {
     return dispatch(addBreakpoint(location, { hidden: true }));
   };
@@ -106,9 +106,9 @@ export function addHiddenBreakpoint(location: Location) {
  *
  * @memberof actions/breakpoints
  * @static
- * @param {Location} $1.location Location  value
+ * @param {SourceLocation} $1.location Location  value
  */
-export function enableBreakpoint(location: Location) {
+export function enableBreakpoint(location: SourceLocation) {
   return async ({ dispatch, getState, client, sourceMaps }: ThunkArgs) => {
     const breakpoint = getBreakpoint(getState(), location);
     if (!breakpoint || breakpoint.loading) {
@@ -139,7 +139,7 @@ export function enableBreakpoint(location: Location) {
  */
 
 export function addBreakpoint(
-  location: Location,
+  location: SourceLocation,
   { condition, hidden }: addBreakpointOptions = {}
 ) {
   const breakpoint = createBreakpoint(location, { condition, hidden });

--- a/src/actions/breakpoints/index.js
+++ b/src/actions/breakpoints/index.js
@@ -32,7 +32,7 @@ import { isEmptyLineInSource } from "../../reducers/ast";
 // this will need to be changed so that addCLientBreakpoint is removed
 
 import type { ThunkArgs, Action } from "../types";
-import type { Breakpoint, Location, XHRBreakpoint } from "../../types";
+import type { Breakpoint, SourceLocation, XHRBreakpoint } from "../../types";
 
 import { recordEvent } from "../../utils/telemetry";
 
@@ -47,7 +47,7 @@ type addBreakpointOptions = {
  * @memberof actions/breakpoints
  * @static
  */
-export function removeBreakpoint(location: Location) {
+export function removeBreakpoint(location: SourceLocation) {
   return ({ dispatch, getState, client }: ThunkArgs) => {
     const bp = getBreakpoint(getState(), location);
     if (!bp || bp.loading) {
@@ -84,7 +84,7 @@ export function removeBreakpoint(location: Location) {
  * @memberof actions/breakpoints
  * @static
  */
-export function disableBreakpoint(location: Location) {
+export function disableBreakpoint(location: SourceLocation) {
   return async ({ dispatch, getState, client }: ThunkArgs) => {
     const bp = getBreakpoint(getState(), location);
 
@@ -220,14 +220,14 @@ export function remapBreakpoints(sourceId: string) {
  * @throws {Error} "not implemented"
  * @memberof actions/breakpoints
  * @static
- * @param {Location} location
+ * @param {SourceLocation} location
  *        @see DebuggerController.Breakpoints.addBreakpoint
  * @param {string} condition
  *        The condition to set on the breakpoint
  * @param {Boolean} $1.disabled Disable value for breakpoint value
  */
 export function setBreakpointCondition(
-  location: Location,
+  location: SourceLocation,
   { condition }: addBreakpointOptions = {}
 ) {
   return async ({ dispatch, getState, client, sourceMaps }: ThunkArgs) => {

--- a/src/actions/breakpoints/syncBreakpoint.js
+++ b/src/actions/breakpoints/syncBreakpoint.js
@@ -18,7 +18,7 @@ import { getSource } from "../../selectors";
 import type { ThunkArgs, Action } from "../types";
 
 import type {
-  Location,
+  SourceLocation,
   ASTLocation,
   PendingBreakpoint,
   SourceId,
@@ -26,13 +26,13 @@ import type {
 } from "../../types";
 
 type BreakpointSyncData = {
-  previousLocation: Location,
+  previousLocation: SourceLocation,
   breakpoint: ?Breakpoint
 };
 
 async function makeScopedLocation(
   { name, offset }: ASTLocation,
-  location: Location,
+  location: SourceLocation,
   source
 ) {
   const scope = await findScopeByName(source, name);
@@ -51,9 +51,9 @@ async function makeScopedLocation(
 function createSyncData(
   id: SourceId,
   pendingBreakpoint: PendingBreakpoint,
-  location: Location,
-  generatedLocation: Location,
-  previousLocation: Location,
+  location: SourceLocation,
+  generatedLocation: SourceLocation,
+  previousLocation: SourceLocation,
   text: string,
   originalText: string
 ): BreakpointSyncData {

--- a/src/actions/preview.js
+++ b/src/actions/preview.js
@@ -22,7 +22,7 @@ import { getMappedExpression } from "./expressions";
 import { getExtra } from "./pause";
 
 import type { Action, ThunkArgs } from "./types";
-import type { ColumnPosition } from "../types";
+import type { Position } from "../types";
 import type { AstLocation } from "../workers/parser";
 
 function findExpressionMatch(state, codeMirror, tokenPos) {
@@ -75,7 +75,7 @@ export function updatePreview(
 export function setPreview(
   expression: string,
   location: AstLocation,
-  tokenPos: ColumnPosition,
+  tokenPos: Position,
   cursorPos: ClientRect
 ) {
   return async ({ dispatch, getState, client, sourceMaps }: ThunkArgs) => {

--- a/src/actions/sources/newSources.js
+++ b/src/actions/sources/newSources.js
@@ -123,7 +123,12 @@ function checkSelectedSource(sourceId: string) {
       }
 
       await dispatch(
-        selectLocation({ ...pendingLocation, sourceId: source.id })
+        selectLocation({
+          sourceId: source.id,
+          line:
+            typeof pendingLocation.line === "number" ? pendingLocation.line : 0,
+          column: pendingLocation.column
+        })
       );
     }
   };

--- a/src/actions/sources/select.js
+++ b/src/actions/sources/select.js
@@ -34,7 +34,7 @@ import {
   getSelectedSource
 } from "../../selectors";
 
-import type { SourceLocation, Position, Source } from "../../types";
+import type { SourceLocation, PartialPosition, Source } from "../../types";
 import type { ThunkArgs } from "../types";
 
 export const setSelectedLocation = (
@@ -67,7 +67,10 @@ export const clearSelectedLocation = () => ({
  * @memberof actions/sources
  * @static
  */
-export function selectSourceURL(url: string, options: Position = { line: 1 }) {
+export function selectSourceURL(
+  url: string,
+  options: PartialPosition = { line: 1 }
+) {
   return async ({ dispatch, getState, sourceMaps }: ThunkArgs) => {
     const source = getSourceByURL(getState(), url);
     if (!source) {

--- a/src/actions/sources/select.js
+++ b/src/actions/sources/select.js
@@ -34,10 +34,13 @@ import {
   getSelectedSource
 } from "../../selectors";
 
-import type { Location, Position, Source } from "../../types";
+import type { SourceLocation, Position, Source } from "../../types";
 import type { ThunkArgs } from "../types";
 
-export const setSelectedLocation = (source: Source, location: Location) => ({
+export const setSelectedLocation = (
+  source: Source,
+  location: SourceLocation
+) => ({
   type: "SET_SELECTED_LOCATION",
   source,
   location
@@ -93,7 +96,7 @@ export function selectSource(sourceId: string) {
  * @static
  */
 export function selectLocation(
-  location: Location,
+  location: SourceLocation,
   { keepContext = true }: Object = {}
 ) {
   return async ({ dispatch, getState, sourceMaps, client }: ThunkArgs) => {
@@ -169,7 +172,7 @@ export function selectLocation(
  * @memberof actions/sources
  * @static
  */
-export function selectSpecificLocation(location: Location) {
+export function selectSpecificLocation(location: SourceLocation) {
   return selectLocation(location, { keepContext: false });
 }
 
@@ -177,7 +180,7 @@ export function selectSpecificLocation(location: Location) {
  * @memberof actions/sources
  * @static
  */
-export function jumpToMappedLocation(location: Location) {
+export function jumpToMappedLocation(location: SourceLocation) {
   return async function({ dispatch, getState, client, sourceMaps }: ThunkArgs) {
     if (!client) {
       return;

--- a/src/actions/types/BreakpointAction.js
+++ b/src/actions/types/BreakpointAction.js
@@ -4,12 +4,12 @@
 
 // @flow
 
-import type { Breakpoint, Location, XHRBreakpoint } from "../../types";
+import type { Breakpoint, SourceLocation, XHRBreakpoint } from "../../types";
 
 import type { PromiseAction } from "../utils/middleware/promise";
 
 type AddBreakpointResult = {
-  previousLocation: Location,
+  previousLocation: SourceLocation,
   breakpoint: Breakpoint
 };
 
@@ -67,7 +67,7 @@ export type BreakpointAction =
   | {|
       +type: "SYNC_BREAKPOINT",
       +breakpoint: ?Breakpoint,
-      +previousLocation: Location
+      +previousLocation: SourceLocation
     |}
   | PromiseAction<
       {|

--- a/src/actions/types/SourceAction.js
+++ b/src/actions/types/SourceAction.js
@@ -4,7 +4,7 @@
 
 // @flow
 
-import type { Source, Location } from "../../types";
+import type { Source, SourceLocation } from "../../types";
 import type { PromiseAction } from "../utils/middleware/promise";
 
 export type LoadSourceAction = PromiseAction<
@@ -31,7 +31,7 @@ export type SourceAction =
   | {|
       +type: "SET_SELECTED_LOCATION",
       +source: Source,
-      +location?: Location
+      +location?: SourceLocation
     |}
   | {|
       +type: "SET_PENDING_SELECTED_LOCATION",

--- a/src/actions/types/UIAction.js
+++ b/src/actions/types/UIAction.js
@@ -4,7 +4,7 @@
 
 // @flow
 
-import type { Source, Range } from "../../types";
+import type { Source, PartialRange } from "../../types";
 
 import type {
   ActiveSearchType,
@@ -78,5 +78,5 @@ export type UIAction =
     |}
   | {|
       +type: "SET_VIEWPORT",
-      +viewport: Range
+      +viewport: PartialRange
     |};

--- a/src/client/firefox/commands.js
+++ b/src/client/firefox/commands.js
@@ -9,7 +9,7 @@ import type {
   BreakpointResult,
   Frame,
   FrameId,
-  Location,
+  SourceLocation,
   Script,
   Source,
   SourceId,
@@ -129,7 +129,7 @@ function sourceContents(sourceId: SourceId): Source {
   return sourceClient.source();
 }
 
-function getBreakpointByLocation(location: Location) {
+function getBreakpointByLocation(location: SourceLocation) {
   const id = makePendingLocationId(location);
   const bpClient = bpClients[id];
 
@@ -158,7 +158,7 @@ function removeXHRBreakpoint(path: string, method: string) {
 }
 
 function setBreakpoint(
-  location: Location,
+  location: SourceLocation,
   condition: boolean,
   noSliding: boolean
 ): Promise<BreakpointResult> {
@@ -184,7 +184,7 @@ function setBreakpoint(
 }
 
 function removeBreakpoint(
-  generatedLocation: Location
+  generatedLocation: SourceLocation
 ): Promise<void> | ?BreakpointResult {
   try {
     const id = makePendingLocationId(generatedLocation);
@@ -202,7 +202,7 @@ function removeBreakpoint(
 
 function setBreakpointCondition(
   breakpointId: BreakpointId,
-  location: Location,
+  location: SourceLocation,
   condition: boolean,
   noSliding: boolean
 ) {

--- a/src/client/firefox/create.js
+++ b/src/client/firefox/create.js
@@ -5,7 +5,7 @@
 // @flow
 // This module converts Firefox specific types to the generic types
 
-import type { Frame, Source, Location } from "../../types";
+import type { Frame, Source, SourceLocation } from "../../types";
 import type {
   PausedPacket,
   FramesResponse,
@@ -78,9 +78,9 @@ export function createPause(
 // exists, otherwise use `location`.
 
 export function createBreakpointLocation(
-  location: Location,
+  location: SourceLocation,
   actualLocation?: Object
-): Location {
+): SourceLocation {
   if (!actualLocation) {
     return location;
   }

--- a/src/components/Editor/HighlightLine.js
+++ b/src/components/Editor/HighlightLine.js
@@ -16,17 +16,17 @@ import {
   getPauseCommand
 } from "../../selectors";
 
-import type { Frame, Location, Source } from "../../types";
+import type { Frame, SourceLocation, Source } from "../../types";
 import type { Command } from "../../reducers/types";
 
 type Props = {
   pauseCommand: Command,
   selectedFrame: Frame,
-  selectedLocation: Location,
+  selectedLocation: SourceLocation,
   selectedSource: Source
 };
 
-function isDebugLine(selectedFrame: Frame, selectedLocation: Location) {
+function isDebugLine(selectedFrame: Frame, selectedLocation: SourceLocation) {
   if (!selectedFrame) {
     return;
   }
@@ -54,7 +54,10 @@ export class HighlightLine extends Component<Props> {
     return this.shouldSetHighlightLine(selectedLocation, selectedSource);
   }
 
-  shouldSetHighlightLine(selectedLocation: Location, selectedSource: Source) {
+  shouldSetHighlightLine(
+    selectedLocation: SourceLocation,
+    selectedSource: Source
+  ) {
     const { sourceId, line } = selectedLocation;
     const editorLine = toEditorLine(sourceId, line);
 
@@ -90,7 +93,7 @@ export class HighlightLine extends Component<Props> {
   }
 
   setHighlightLine(
-    selectedLocation: Location,
+    selectedLocation: SourceLocation,
     selectedFrame: Frame,
     selectedSource: Source
   ) {
@@ -110,7 +113,7 @@ export class HighlightLine extends Component<Props> {
     doc.addLineClass(editorLine, "line", "highlight-line");
   }
 
-  clearHighlightLine(selectedLocation: Location, selectedSource: Source) {
+  clearHighlightLine(selectedLocation: SourceLocation, selectedSource: Source) {
     if (!isDocumentReady(selectedSource, selectedLocation)) {
       return;
     }

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -67,7 +67,7 @@ import "./Highlight.css";
 
 import type SourceEditor from "../../utils/editor/source-editor";
 import type { SymbolDeclarations } from "../../workers/parser";
-import type { Location, Source } from "../../types";
+import type { SourceLocation, Source } from "../../types";
 
 const cssVars = {
   searchbarHeight: "var(--editor-searchbar-height)",
@@ -75,7 +75,7 @@ const cssVars = {
 };
 
 export type Props = {
-  selectedLocation: ?Location,
+  selectedLocation: ?SourceLocation,
   selectedSource: ?Source,
   searchOn: boolean,
   horizontal: boolean,

--- a/src/components/ProjectSearch.js
+++ b/src/components/ProjectSearch.js
@@ -28,7 +28,7 @@ import ManagedTree from "./shared/ManagedTree";
 import SearchInput from "./shared/SearchInput";
 
 import type { List } from "immutable";
-import type { Location } from "../types";
+import type { SourceLocation } from "../types";
 import type { ActiveSearchType } from "../reducers/types";
 import type { StatusType } from "../reducers/project-text-search";
 type Editor = ?Object;
@@ -68,7 +68,7 @@ type Props = {
   closeProjectSearch: () => void,
   searchSources: (query: string) => void,
   clearSearch: () => void,
-  selectSpecificLocation: (location: Location, tabIndex?: string) => void,
+  selectSpecificLocation: (location: SourceLocation, tabIndex?: string) => void,
   setActiveSearch: (activeSearch?: ActiveSearchType) => void,
   doSearchForHighlight: (
     query: string,

--- a/src/components/ProjectSearch.js
+++ b/src/components/ProjectSearch.js
@@ -150,7 +150,11 @@ export class ProjectSearch extends Component<Props, State> {
   isProjectSearchEnabled = () => this.props.activeSearch === "project";
 
   selectMatchItem = (matchItem: Match) => {
-    this.props.selectSpecificLocation({ ...matchItem });
+    this.props.selectSpecificLocation({
+      sourceId: matchItem.sourceId,
+      line: matchItem.line,
+      column: matchItem.column
+    });
     this.props.doSearchForHighlight(
       this.state.inputValue,
       getEditor(),

--- a/src/components/QuickOpenModal.js
+++ b/src/components/QuickOpenModal.js
@@ -35,7 +35,7 @@ import type {
   QuickOpenResult
 } from "../utils/quick-open";
 
-import type { Location, Source } from "../types";
+import type { SourceLocation, Source } from "../types";
 import type { QuickOpenType } from "../reducers/quick-open";
 
 import "./QuickOpenModal.css";
@@ -50,7 +50,7 @@ type Props = {
   symbolsLoading: boolean,
   tabs: string[],
   shortcutsModalEnabled: boolean,
-  selectSpecificLocation: Location => void,
+  selectSpecificLocation: SourceLocation => void,
   setQuickOpenQuery: (query: string) => void,
   highlightLineRange: ({ start: number, end: number }) => void,
   closeQuickOpen: () => void,

--- a/src/components/SecondaryPanes/Breakpoints/Breakpoint.js
+++ b/src/components/SecondaryPanes/Breakpoints/Breakpoint.js
@@ -25,12 +25,12 @@ import type {
   Breakpoint as BreakpointType,
   Frame,
   Source,
-  Location
+  SourceLocation
 } from "../../../types";
 
 type FormattedFrame = {
   ...Frame,
-  selectedLocation: Location
+  selectedLocation: SourceLocation
 };
 
 import {

--- a/src/components/SecondaryPanes/EventListeners.js
+++ b/src/components/SecondaryPanes/EventListeners.js
@@ -10,7 +10,7 @@ import { getEventListeners, getBreakpoint } from "../../selectors";
 import { CloseButton } from "../shared/Button";
 import "./EventListeners.css";
 
-import type { Breakpoint, Location, SourceId } from "../../types";
+import type { Breakpoint, SourceLocation, SourceId } from "../../types";
 
 type Listener = {
   selector: string,
@@ -24,9 +24,9 @@ type Props = {
   listeners: Array<Listener>,
   selectLocation: ({ sourceId: SourceId, line: number }) => void,
   addBreakpoint: ({ sourceId: SourceId, line: number }) => void,
-  enableBreakpoint: Location => void,
-  disableBreakpoint: Location => void,
-  removeBreakpoint: Location => void
+  enableBreakpoint: SourceLocation => void,
+  disableBreakpoint: SourceLocation => void,
+  removeBreakpoint: SourceLocation => void
 };
 
 class EventListeners extends Component<Props> {

--- a/src/components/test/ProjectSearch.spec.js
+++ b/src/components/test/ProjectSearch.spec.js
@@ -46,7 +46,13 @@ const testResults = List([
   }
 ]);
 
-const testMatch = { match: "match1", value: "some thing match1", column: 30 };
+const testMatch = {
+  match: "match1",
+  value: "some thing match1",
+  sourceId: "some-target/source42",
+  line: 3,
+  column: 30
+};
 
 function render(overrides = {}, mounted = false) {
   const props = {
@@ -189,7 +195,11 @@ describe("ProjectSearch", () => {
     );
     component.instance().focusedItem = { match: testMatch };
     shortcuts.dispatch("Enter");
-    expect(selectSpecificLocation).toHaveBeenCalledWith(testMatch);
+    expect(selectSpecificLocation).toHaveBeenCalledWith({
+      sourceId: "some-target/source42",
+      line: 3,
+      column: 30
+    });
   });
 
   it("onEnterPress shortcut setExpanded", () => {

--- a/src/reducers/ast.js
+++ b/src/reducers/ast.js
@@ -21,7 +21,7 @@ import type {
 } from "../workers/parser";
 
 import type { Map } from "immutable";
-import type { Location, Source } from "../types";
+import type { SourceLocation, Source } from "../types";
 import type { Action, DonePromiseAction } from "../actions/types";
 import type { Record } from "../utils/makeRecord";
 
@@ -209,7 +209,7 @@ export function getPausePoints(
 
 export function getPausePoint(
   state: OuterState,
-  location: ?Location
+  location: ?SourceLocation
 ): ?PausePoint {
   if (!location) {
     return;

--- a/src/reducers/breakpoints.js
+++ b/src/reducers/breakpoints.js
@@ -14,7 +14,7 @@ import * as I from "immutable";
 import { isGeneratedId } from "devtools-source-map";
 import { makeLocationId } from "../utils/breakpoint";
 
-import type { XHRBreakpoint, Breakpoint, Location } from "../types";
+import type { XHRBreakpoint, Breakpoint, SourceLocation } from "../types";
 import type { Action, DonePromiseAction } from "../actions/types";
 
 export type BreakpointsMap = { [string]: Breakpoint };
@@ -270,7 +270,7 @@ export function getBreakpointCount(state: OuterState): number {
 
 export function getBreakpoint(
   state: OuterState,
-  location: Location
+  location: SourceLocation
 ): ?Breakpoint {
   const breakpoints = getBreakpointsMap(state);
   return breakpoints[makeLocationId(location)];
@@ -322,7 +322,9 @@ export function getHiddenBreakpoint(state: OuterState): ?Breakpoint {
   return breakpoints.find(bp => bp.hidden);
 }
 
-export function getHiddenBreakpointLocation(state: OuterState): ?Location {
+export function getHiddenBreakpointLocation(
+  state: OuterState
+): ?SourceLocation {
   const hiddenBreakpoint = getHiddenBreakpoint(state);
   if (!hiddenBreakpoint) {
     return null;

--- a/src/reducers/sources.js
+++ b/src/reducers/sources.js
@@ -20,7 +20,7 @@ import {
 import { originalToGeneratedId } from "devtools-source-map";
 import { prefs } from "../utils/prefs";
 
-import type { Source, SourceId, Location } from "../types";
+import type { Source, SourceId, SourceLocation } from "../types";
 import type { PendingSelectedLocation } from "./types";
 import type { Action, DonePromiseAction } from "../actions/types";
 import type { LoadSourceAction } from "../actions/types/SourceAction";
@@ -34,7 +34,7 @@ export type SourcesState = {
   urls: UrlsMap,
   relativeSources: SourcesMap,
   pendingSelectedLocation?: PendingSelectedLocation,
-  selectedLocation: ?Location,
+  selectedLocation: ?SourceLocation,
   projectDirectoryRoot: string
 };
 
@@ -483,7 +483,7 @@ export const getSelectedLocation = createSelector(
 export const getSelectedSource = createSelector(
   getSelectedLocation,
   getSources,
-  (selectedLocation: ?Location, sources: SourcesMap): ?Source => {
+  (selectedLocation: ?SourceLocation, sources: SourcesMap): ?Source => {
     if (!selectedLocation) {
       return;
     }

--- a/src/reducers/ui.js
+++ b/src/reducers/ui.js
@@ -12,7 +12,7 @@
 import makeRecord from "../utils/makeRecord";
 import { prefs } from "../utils/prefs";
 
-import type { Source, Range } from "../types";
+import type { Source, PartialRange } from "../types";
 
 import type { Action, panelPositionType } from "../actions/types";
 import type { Record } from "../utils/makeRecord";
@@ -23,7 +23,7 @@ export type OrientationType = "horizontal" | "vertical";
 
 export type SelectedPrimaryPaneTabType = "sources" | "outline";
 
-type Viewport = Range;
+type Viewport = PartialRange;
 
 export type UIState = {
   selectedPrimaryPaneTab: SelectedPrimaryPaneTabType,

--- a/src/selectors/breakpointSources.js
+++ b/src/selectors/breakpointSources.js
@@ -14,7 +14,12 @@ import {
 import { isGenerated, getFilename } from "../utils/source";
 import { getSelectedLocation } from "../utils/source-maps";
 
-import type { Source, Breakpoint, BreakpointId, Location } from "../types";
+import type {
+  Source,
+  Breakpoint,
+  BreakpointId,
+  SourceLocation
+} from "../types";
 import type { SourcesMap } from "../reducers/types";
 
 export type BreakpointSources = Array<{
@@ -27,7 +32,7 @@ export type FormattedBreakpoint = {|
   condition: ?string,
   disabled: boolean,
   text: string,
-  selectedLocation: Location
+  selectedLocation: SourceLocation
 |};
 
 function formatBreakpoint(

--- a/src/selectors/visibleColumnBreakpoints.js
+++ b/src/selectors/visibleColumnBreakpoints.js
@@ -9,10 +9,10 @@ import { getViewport } from "../selectors";
 import { getVisibleBreakpoints } from "./visibleBreakpoints";
 import { getVisiblePausePoints } from "./visiblePausePoints";
 
-import type { Location } from "../types";
+import type { SourceLocation } from "../types";
 
 export type ColumnBreakpoint = {|
-  +location: Location,
+  +location: SourceLocation,
   +enabled: boolean
 |};
 

--- a/src/selectors/visibleSelectedFrame.js
+++ b/src/selectors/visibleSelectedFrame.js
@@ -9,9 +9,9 @@ import { getSelectedFrame } from "../reducers/pause";
 import { isOriginalId } from "devtools-source-map";
 import { createSelector } from "reselect";
 
-import type { Frame, Location } from "../types";
+import type { Frame, SourceLocation } from "../types";
 
-function getLocation(frame: Frame, location?: Location) {
+function getLocation(frame: Frame, location?: SourceLocation) {
   if (!location) {
     return frame.location;
   }

--- a/src/types.js
+++ b/src/types.js
@@ -51,7 +51,7 @@ export type ActorId = string;
  * @memberof types
  * @static
  */
-export type Location = {
+export type SourceLocation = {
   +sourceId: SourceId,
   +line: number,
   +column?: number,
@@ -59,8 +59,8 @@ export type Location = {
 };
 
 export type MappedLocation = {
-  +location: Location,
-  +generatedLocation: Location
+  +location: SourceLocation,
+  +generatedLocation: SourceLocation
 };
 
 export type Position = {
@@ -95,9 +95,9 @@ export type ASTLocation = {|
  */
 export type Breakpoint = {|
   +id: BreakpointId,
-  +location: Location,
+  +location: SourceLocation,
   +astLocation: ?ASTLocation,
-  +generatedLocation: Location,
+  +generatedLocation: SourceLocation,
   +loading: boolean,
   +disabled: boolean,
   +hidden: boolean,
@@ -127,7 +127,7 @@ export type XHRBreakpoint = {|
  */
 export type BreakpointResult = {
   id: ActorId,
-  actualLocation: Location
+  actualLocation: SourceLocation
 };
 
 /**
@@ -162,8 +162,8 @@ export type FrameId = string;
 export type Frame = {
   id: FrameId,
   displayName: string,
-  location: Location,
-  generatedLocation: Location,
+  location: SourceLocation,
+  generatedLocation: SourceLocation,
   source?: Source,
   scope: Scope,
   // FIXME Define this type more clearly
@@ -372,7 +372,7 @@ export type Scope = {|
     actor: ActorId,
     class: string,
     displayName: string,
-    location: Location,
+    location: SourceLocation,
     parameterNames: string[]
   },
   type: string

--- a/src/types.js
+++ b/src/types.js
@@ -51,12 +51,12 @@ export type ActorId = string;
  * @memberof types
  * @static
  */
-export type SourceLocation = {
+export type SourceLocation = {|
   +sourceId: SourceId,
   +line: number,
   +column?: number,
   +sourceUrl?: string
-};
+|};
 
 export type MappedLocation = {
   +location: SourceLocation,

--- a/src/types.js
+++ b/src/types.js
@@ -73,7 +73,7 @@ export type ColumnPosition = {
   +column: number
 };
 
-export type Range = { end: PartialPosition, start: PartialPosition };
+export type PartialRange = { end: PartialPosition, start: PartialPosition };
 export type ColumnRange = { end: ColumnPosition, start: ColumnPosition };
 
 export type PendingLocation = {

--- a/src/types.js
+++ b/src/types.js
@@ -74,7 +74,7 @@ export type ColumnPosition = {
 };
 
 export type PartialRange = { end: PartialPosition, start: PartialPosition };
-export type ColumnRange = { end: ColumnPosition, start: ColumnPosition };
+export type Range = { end: ColumnPosition, start: ColumnPosition };
 
 export type PendingLocation = {
   +line: number,

--- a/src/types.js
+++ b/src/types.js
@@ -63,7 +63,7 @@ export type MappedLocation = {
   +generatedLocation: SourceLocation
 };
 
-export type Position = {
+export type PartialPosition = {
   +line: number,
   +column?: number
 };
@@ -73,7 +73,7 @@ export type ColumnPosition = {
   +column: number
 };
 
-export type Range = { end: Position, start: Position };
+export type Range = { end: PartialPosition, start: PartialPosition };
 export type ColumnRange = { end: ColumnPosition, start: ColumnPosition };
 
 export type PendingLocation = {
@@ -84,7 +84,7 @@ export type PendingLocation = {
 
 export type ASTLocation = {|
   +name: ?string,
-  +offset: Position
+  +offset: PartialPosition
 |};
 
 /**

--- a/src/types.js
+++ b/src/types.js
@@ -68,13 +68,13 @@ export type PartialPosition = {
   +column?: number
 };
 
-export type ColumnPosition = {
+export type Position = {
   +line: number,
   +column: number
 };
 
 export type PartialRange = { end: PartialPosition, start: PartialPosition };
-export type Range = { end: ColumnPosition, start: ColumnPosition };
+export type Range = { end: Position, start: Position };
 
 export type PendingLocation = {
   +line: number,

--- a/src/utils/ast.js
+++ b/src/utils/ast.js
@@ -7,7 +7,7 @@
 import { xor, range } from "lodash";
 import { convertToList } from "./pause/pausePoints";
 
-import type { Location, ColumnPosition } from "../types";
+import type { SourceLocation, ColumnPosition } from "../types";
 import type { Symbols } from "../reducers/ast";
 
 import type {
@@ -75,7 +75,7 @@ export function containsPosition(a: AstLocation, b: AstPosition) {
   return startsBefore && endsAfter;
 }
 
-function findClosestofSymbol(declarations: any[], location: Location) {
+function findClosestofSymbol(declarations: any[], location: SourceLocation) {
   if (!declarations) {
     return null;
   }
@@ -111,7 +111,7 @@ function findClosestofSymbol(declarations: any[], location: Location) {
 
 export function findClosestFunction(
   symbols: ?Symbols,
-  location: Location
+  location: SourceLocation
 ): FunctionDeclaration | null {
   if (!symbols || symbols.loading) {
     return null;
@@ -122,7 +122,7 @@ export function findClosestFunction(
 
 export function findClosestClass(
   symbols: Symbols,
-  location: Location
+  location: SourceLocation
 ): ClassDeclaration | null {
   if (!symbols || symbols.loading) {
     return null;

--- a/src/utils/ast.js
+++ b/src/utils/ast.js
@@ -7,7 +7,7 @@
 import { xor, range } from "lodash";
 import { convertToList } from "./pause/pausePoints";
 
-import type { SourceLocation, ColumnPosition } from "../types";
+import type { SourceLocation, Position } from "../types";
 import type { Symbols } from "../reducers/ast";
 
 import type {
@@ -18,10 +18,7 @@ import type {
   ClassDeclaration
 } from "../workers/parser";
 
-export function findBestMatchExpression(
-  symbols: Symbols,
-  tokenPos: ColumnPosition
-) {
+export function findBestMatchExpression(symbols: Symbols, tokenPos: Position) {
   if (symbols.loading) {
     return null;
   }

--- a/src/utils/breakpoint/astBreakpointLocation.js
+++ b/src/utils/breakpoint/astBreakpointLocation.js
@@ -9,12 +9,12 @@ import { findClosestFunction } from "../ast";
 
 import type { SymbolDeclarations } from "../../workers/parser";
 
-import type { Location, Source, ASTLocation } from "../../types";
+import type { SourceLocation, Source, ASTLocation } from "../../types";
 
 export function getASTLocation(
   source: Source,
   symbols: SymbolDeclarations,
-  location: Location
+  location: SourceLocation
 ): ASTLocation {
   if (source.isWasm || !symbols || symbols.loading) {
     return { name: undefined, offset: location };

--- a/src/utils/breakpoint/index.js
+++ b/src/utils/breakpoint/index.js
@@ -14,7 +14,7 @@ export { getASTLocation, findScopeByName } from "./astBreakpointLocation";
 
 import type { FormattedBreakpoint } from "../../selectors/breakpointSources";
 import type {
-  Location,
+  SourceLocation,
   PendingLocation,
   Breakpoint,
   PendingBreakpoint
@@ -33,24 +33,27 @@ export function firstString(...args: string[]) {
   return null;
 }
 
-export function locationMoved(location: Location, newLocation: Location) {
+export function locationMoved(
+  location: SourceLocation,
+  newLocation: SourceLocation
+) {
   return (
     location.line !== newLocation.line || location.column !== newLocation.column
   );
 }
 
-export function makeLocationId(location: Location) {
+export function makeLocationId(location: SourceLocation) {
   const { sourceId, line, column } = location;
   const columnString = column || "";
   return `${sourceId}:${line}:${columnString}`;
 }
 
-export function getLocationWithoutColumn(location: Location) {
+export function getLocationWithoutColumn(location: SourceLocation) {
   const { sourceId, line } = location;
   return `${sourceId}:${line}`;
 }
 
-export function makePendingLocationId(location: Location) {
+export function makePendingLocationId(location: SourceLocation) {
   assertPendingLocation(location);
   const { sourceUrl, line, column } = location;
   const sourceUrlString = sourceUrl || "";
@@ -69,7 +72,7 @@ export function assertPendingBreakpoint(pendingBreakpoint: PendingBreakpoint) {
   assertPendingLocation(pendingBreakpoint.generatedLocation);
 }
 
-export function assertLocation(location: Location) {
+export function assertLocation(location: SourceLocation) {
   assertPendingLocation(location);
   const { sourceId } = location;
   assert(!!sourceId, "location must have a source id");
@@ -92,7 +95,7 @@ export function assertPendingLocation(location: PendingLocation) {
 // syncing
 export function breakpointAtLocation(
   breakpoints: Breakpoint[],
-  { line, column }: Location
+  { line, column }: SourceLocation
 ) {
   return breakpoints.find(breakpoint => {
     const sameLine = breakpoint.location.line === line;
@@ -110,13 +113,13 @@ export function breakpointAtLocation(
   });
 }
 
-export function breakpointExists(state: State, location: Location) {
+export function breakpointExists(state: State, location: SourceLocation) {
   const currentBp = getBreakpoint(state, location);
   return currentBp && !currentBp.disabled;
 }
 
 export function createBreakpoint(
-  location: Location,
+  location: SourceLocation,
   overrides: Object = {}
 ): Breakpoint {
   const {

--- a/src/utils/editor/get-expression.js
+++ b/src/utils/editor/get-expression.js
@@ -4,7 +4,7 @@
 
 // @flow
 
-import type { ColumnPosition } from "../../types";
+import type { Position } from "../../types";
 
 type Token = {
   startColumn: number,
@@ -14,7 +14,7 @@ type Token = {
 
 export function tokenAtTextPosition(
   cm: any,
-  { line, column }: ColumnPosition
+  { line, column }: Position
 ): Token | null {
   if (line < 0 || line >= cm.lineCount()) {
     return null;
@@ -30,7 +30,7 @@ export function tokenAtTextPosition(
 
 // The strategy of querying codeMirror tokens was borrowed
 // from Chrome's inital implementation in JavaScriptSourceFrame.js#L414
-export function getExpressionFromCoords(cm: any, coord: ColumnPosition) {
+export function getExpressionFromCoords(cm: any, coord: Position) {
   const token = tokenAtTextPosition(cm, coord);
   if (!token) {
     return null;

--- a/src/utils/editor/get-token-location.js
+++ b/src/utils/editor/get-token-location.js
@@ -3,12 +3,12 @@
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
 // @flow
-import type { ColumnPosition } from "../../types";
+import type { Position } from "../../types";
 
 export function getTokenLocation(
   codeMirror: any,
   tokenEl: HTMLElement
-): ColumnPosition {
+): Position {
   const { left, top, width, height } = tokenEl.getBoundingClientRect();
   const { line, ch } = codeMirror.coordsChar({
     left: left + width / 2,

--- a/src/utils/editor/index.js
+++ b/src/utils/editor/index.js
@@ -18,7 +18,7 @@ import { isWasm, lineToWasmOffset, wasmOffsetToLine } from "../wasm";
 
 import type { AstLocation } from "../../workers/parser";
 import type { EditorPosition, EditorRange } from "../editor/types";
-import type { Location } from "../../types";
+import type { SourceLocation } from "../../types";
 type Editor = Object;
 
 let editor: ?Editor;
@@ -96,7 +96,7 @@ export function toEditorLine(sourceId: string, lineOrOffset: number): number {
   return lineOrOffset ? lineOrOffset - 1 : 1;
 }
 
-export function toEditorPosition(location: Location): EditorPosition {
+export function toEditorPosition(location: SourceLocation): EditorPosition {
   return {
     line: toEditorLine(location.sourceId, location.line),
     column: isWasm(location.sourceId) || !location.column ? 0 : location.column
@@ -201,7 +201,7 @@ export function lineAtHeight(_editor, sourceId, event) {
 
 export function getSourceLocationFromMouseEvent(
   _editor: Object,
-  selectedLocation: Location,
+  selectedLocation: SourceLocation,
   e: MouseEvent
 ) {
   const { line, ch } = _editor.codeMirror.coordsChar({

--- a/src/utils/location.js
+++ b/src/utils/location.js
@@ -4,7 +4,7 @@
 
 // @flow
 
-import type { Location, SourceId } from "../types";
+import type { SourceLocation, SourceId } from "../types";
 
 type IncompleteLocation = {
   sourceId: SourceId,
@@ -18,7 +18,7 @@ export function createLocation({
   line,
   column,
   sourceUrl
-}: IncompleteLocation): Location {
+}: IncompleteLocation): SourceLocation {
   return {
     sourceId,
     line: line || 0,

--- a/src/utils/pause/mapScopes/getApplicableBindingsForOriginalPosition.js
+++ b/src/utils/pause/mapScopes/getApplicableBindingsForOriginalPosition.js
@@ -9,7 +9,7 @@ import { positionCmp } from "./positionCmp";
 import { filterSortedArray } from "./filtering";
 import { mappingContains } from "./mappingContains";
 
-import type { Source, Location, Position } from "../../../types";
+import type { Source, SourceLocation, Position } from "../../../types";
 
 import type { GeneratedBindingLocation } from "./buildGeneratedBindingList";
 
@@ -31,8 +31,8 @@ export async function originalRangeStartsInside(
     start,
     end
   }: {
-    start: Location,
-    end: Location
+    start: SourceLocation,
+    end: SourceLocation
   },
   sourceMaps: any
 ) {
@@ -53,8 +53,8 @@ export async function getApplicableBindingsForOriginalPosition(
     start,
     end
   }: {
-    start: Location,
-    end: Location
+    start: SourceLocation,
+    end: SourceLocation
   },
   bindingType: BindingType,
   locationType: BindingLocationType,

--- a/src/utils/pause/mapScopes/getApplicableBindingsForOriginalPosition.js
+++ b/src/utils/pause/mapScopes/getApplicableBindingsForOriginalPosition.js
@@ -9,7 +9,7 @@ import { positionCmp } from "./positionCmp";
 import { filterSortedArray } from "./filtering";
 import { mappingContains } from "./mappingContains";
 
-import type { Source, SourceLocation, Position } from "../../../types";
+import type { Source, SourceLocation, PartialPosition } from "../../../types";
 
 import type { GeneratedBindingLocation } from "./buildGeneratedBindingList";
 
@@ -21,8 +21,8 @@ export type ApplicableBinding = {
 };
 
 type GeneratedRange = {
-  start: Position,
-  end: Position
+  start: PartialPosition,
+  end: PartialPosition
 };
 
 export async function originalRangeStartsInside(

--- a/src/utils/pause/mapScopes/index.js
+++ b/src/utils/pause/mapScopes/index.js
@@ -36,7 +36,7 @@ import {
 
 import { log } from "../../log";
 import type {
-  Position,
+  PartialPosition,
   Frame,
   Scope,
   Source,
@@ -254,7 +254,7 @@ function batchScopeMappings(
     }
   };
 }
-function buildLocationKey(loc: Position): string {
+function buildLocationKey(loc: PartialPosition): string {
   return `${loc.line}:${locColumn(loc)}`;
 }
 

--- a/src/utils/pause/mapScopes/locColumn.js
+++ b/src/utils/pause/mapScopes/locColumn.js
@@ -4,9 +4,9 @@
 
 // @flow
 
-import type { Position } from "../../../types";
+import type { PartialPosition } from "../../../types";
 
-export function locColumn(loc: Position): number {
+export function locColumn(loc: PartialPosition): number {
   if (typeof loc.column !== "number") {
     // This shouldn't really happen with locations from the AST, but
     // the datatype we are using allows null/undefined column.

--- a/src/utils/pause/mapScopes/mappingContains.js
+++ b/src/utils/pause/mapScopes/mappingContains.js
@@ -4,12 +4,12 @@
 
 // @flow
 
-import type { Position } from "../../../types";
+import type { PartialPosition } from "../../../types";
 import { positionCmp } from "./positionCmp";
 
 export function mappingContains(
-  mapped: { +start: Position, +end: Position },
-  item: { +start: Position, +end: Position }
+  mapped: { +start: PartialPosition, +end: PartialPosition },
+  item: { +start: PartialPosition, +end: PartialPosition }
 ) {
   return (
     positionCmp(item.start, mapped.start) >= 0 &&

--- a/src/utils/pause/mapScopes/positionCmp.js
+++ b/src/utils/pause/mapScopes/positionCmp.js
@@ -4,7 +4,7 @@
 
 // @flow
 
-import type { Position } from "../../../types";
+import type { PartialPosition } from "../../../types";
 import { locColumn } from "./locColumn";
 
 /**
@@ -12,7 +12,7 @@ import { locColumn } from "./locColumn";
  * * < 0 - first position before second position
  * * > 0 - first position after second position
  */
-export function positionCmp(p1: Position, p2: Position) {
+export function positionCmp(p1: PartialPosition, p2: PartialPosition) {
   if (p1.line === p2.line) {
     const l1 = locColumn(p1);
     const l2 = locColumn(p2);

--- a/src/utils/pause/mapScopes/rangeMetadata.js
+++ b/src/utils/pause/mapScopes/rangeMetadata.js
@@ -9,7 +9,7 @@ import { positionCmp } from "./positionCmp";
 import { filterSortedArray } from "./filtering";
 
 import type { SourceScope } from "../../../workers/parser";
-import type { Position, Frame, Source } from "../../../types";
+import type { PartialPosition, Frame, Source } from "../../../types";
 
 type SourceOriginalRange = {
   line: number,
@@ -118,7 +118,7 @@ export async function loadRangeMetadata(
 
 export function findMatchingRange(
   sortedOriginalRanges: Array<MappedOriginalRange>,
-  bindingRange: { +end: Position, +start: Position }
+  bindingRange: { +end: PartialPosition, +start: PartialPosition }
 ): ?MappedOriginalRange {
   return filterSortedArray(sortedOriginalRanges, range => {
     if (range.line < bindingRange.start.line) {

--- a/src/utils/pause/pausePoints.js
+++ b/src/utils/pause/pausePoints.js
@@ -6,10 +6,10 @@
 import { reverse } from "lodash";
 
 import type { PausePoints } from "../../workers/parser";
-import type { ColumnPosition } from "../../types";
+import type { Position } from "../../types";
 
 type PausePoint = {
-  location: ColumnPosition,
+  location: Position,
   types: { break: boolean, step: boolean }
 };
 

--- a/src/utils/source-maps.js
+++ b/src/utils/source-maps.js
@@ -7,15 +7,15 @@
 import { isOriginalId } from "devtools-source-map";
 import { getSource } from "../selectors";
 
-import type { Location, MappedLocation, Source } from "../types";
+import type { SourceLocation, MappedLocation, Source } from "../types";
 import { isGenerated } from "../utils/source";
 
 export async function getGeneratedLocation(
   state: Object,
   source: Source,
-  location: Location,
+  location: SourceLocation,
   sourceMaps: Object
-): Promise<Location> {
+): Promise<SourceLocation> {
   if (!isOriginalId(location.sourceId)) {
     return location;
   }
@@ -41,8 +41,8 @@ export async function getGeneratedLocation(
 export async function getMappedLocation(
   state: Object,
   sourceMaps: Object,
-  location: Location
-): Promise<Location> {
+  location: SourceLocation
+): Promise<SourceLocation> {
   const source = getSource(state, location.sourceId);
 
   if (!source) {

--- a/src/utils/source.js
+++ b/src/utils/source.js
@@ -21,7 +21,7 @@ export { isMinified } from "./isMinified";
 import { getURL, getFileExtension } from "./sources-tree";
 import { prefs } from "./prefs";
 
-import type { Source, Location, JsSource } from "../types";
+import type { Source, SourceLocation, JsSource } from "../types";
 import type { SourceMetaDataType } from "../reducers/ast";
 import type { SymbolDeclarations } from "../workers/parser";
 
@@ -387,7 +387,7 @@ export function isLoading(source: Source) {
   return source.loadedState === "loading";
 }
 
-export function getTextAtPosition(source: ?Source, location: Location) {
+export function getTextAtPosition(source: ?Source, location: SourceLocation) {
   if (!source || !source.text) {
     return "";
   }

--- a/src/workers/parser/getScopes/index.js
+++ b/src/workers/parser/getScopes/index.js
@@ -27,11 +27,11 @@ export type {
   BindingType
 };
 
-import type { Location } from "../../../types";
+import type { SourceLocation } from "../../../types";
 
 let parsedScopesCache = new Map();
 
-export default function getScopes(location: Location): SourceScope[] {
+export default function getScopes(location: SourceLocation): SourceScope[] {
   const { sourceId } = location;
   let parsedScopes = parsedScopesCache.get(sourceId);
   if (!parsedScopes) {
@@ -50,7 +50,10 @@ export { buildScopeList };
 /**
  * Searches all scopes and their bindings at the specific location.
  */
-function findScopes(scopes: ParsedScope[], location: Location): SourceScope[] {
+function findScopes(
+  scopes: ParsedScope[],
+  location: SourceLocation
+): SourceScope[] {
   // Find inner most in the tree structure.
   let searchInScopes: ?(ParsedScope[]) = scopes;
   const found = [];
@@ -82,7 +85,7 @@ function findScopes(scopes: ParsedScope[], location: Location): SourceScope[] {
   });
 }
 
-function compareLocations(a: Location, b: Location): number {
+function compareLocations(a: SourceLocation, b: SourceLocation): number {
   // According to type of Location.column can be undefined, if will not be the
   // case here, ignoring flow error.
   // $FlowIgnore

--- a/src/workers/parser/getScopes/visitor.js
+++ b/src/workers/parser/getScopes/visitor.js
@@ -5,7 +5,7 @@
 // @flow
 
 import isEmpty from "lodash/isEmpty";
-import type { SourceId, Location } from "../../../types";
+import type { SourceId, SourceLocation } from "../../../types";
 import * as t from "@babel/types";
 import type {
   Node,
@@ -65,20 +65,20 @@ export type BindingLocation = BindingDeclarationLocation | BindingRefLocation;
 
 export type BindingRefLocation = {
   type: "ref",
-  start: Location,
-  end: Location,
+  start: SourceLocation,
+  end: SourceLocation,
   meta?: BindingMetaValue | null
 };
 export type BindingDeclarationLocation = {
   type: BindingDeclarationType,
 
-  start: Location,
-  end: Location,
+  start: SourceLocation,
+  end: SourceLocation,
 
   // The overall location of the declaration that this binding is part of.
   declaration: {
-    start: Location,
-    end: Location
+    start: SourceLocation,
+    end: SourceLocation
   },
 
   // If this declaration was an import, include the name of the imported
@@ -95,20 +95,20 @@ export type BindingData = {
 export type BindingMetaValue =
   | {
       type: "inherit",
-      start: Location,
-      end: Location,
+      start: SourceLocation,
+      end: SourceLocation,
       parent: BindingMetaValue | null
     }
   | {
       type: "call",
-      start: Location,
-      end: Location,
+      start: SourceLocation,
+      end: SourceLocation,
       parent: BindingMetaValue | null
     }
   | {
       type: "member",
-      start: Location,
-      end: Location,
+      start: SourceLocation,
+      end: SourceLocation,
       property: string,
       parent: BindingMetaValue | null
     };
@@ -120,8 +120,8 @@ export type ScopeBindingList = {
 export type SourceScope = {
   type: "object" | "function" | "block",
   displayName: string,
-  start: Location,
-  end: Location,
+  start: SourceLocation,
+  end: SourceLocation,
   bindings: ScopeBindingList
 };
 
@@ -231,8 +231,8 @@ function createTempScope(
   displayName: string,
   parent: TempScope | null,
   loc: {
-    start: Location,
-    end: Location
+    start: SourceLocation,
+    end: SourceLocation
   }
 ): TempScope {
   const result = {
@@ -253,8 +253,8 @@ function pushTempScope(
   type: "object" | "function" | "function-body" | "block" | "module",
   displayName: string,
   loc: {
-    start: Location,
-    end: Location
+    start: SourceLocation,
+    end: SourceLocation
   }
 ): TempScope {
   const scope = createTempScope(type, displayName, state.scope, loc);
@@ -284,7 +284,7 @@ function getVarScope(scope: TempScope): TempScope {
 function fromBabelLocation(
   location: BabelLocation,
   sourceId: SourceId
-): Location {
+): SourceLocation {
   return {
     sourceId,
     line: location.line,

--- a/src/workers/parser/index.js
+++ b/src/workers/parser/index.js
@@ -8,7 +8,7 @@ import { workerUtils } from "devtools-utils";
 const { WorkerDispatcher } = workerUtils;
 
 import type { AstLocation, AstPosition, PausePoints } from "./types";
-import type { Location, Source, SourceId } from "../../types";
+import type { SourceLocation, Source, SourceId } from "../../types";
 import type { SourceScope } from "./getScopes/visitor";
 import type { SymbolDeclarations } from "./getSymbols";
 
@@ -26,14 +26,15 @@ export const findOutOfScopeLocations = async (
 export const getNextStep = async (
   sourceId: SourceId,
   pausedPosition: AstPosition
-): Promise<?Location> =>
+): Promise<?SourceLocation> =>
   dispatcher.invoke("getNextStep", sourceId, pausedPosition);
 
 export const clearASTs = async (): Promise<void> =>
   dispatcher.invoke("clearASTs");
 
-export const getScopes = async (location: Location): Promise<SourceScope[]> =>
-  dispatcher.invoke("getScopes", location);
+export const getScopes = async (
+  location: SourceLocation
+): Promise<SourceScope[]> => dispatcher.invoke("getScopes", location);
 
 export const clearScopes = async (): Promise<void> =>
   dispatcher.invoke("clearScopes");

--- a/src/workers/parser/mapOriginalExpression.js
+++ b/src/workers/parser/mapOriginalExpression.js
@@ -4,7 +4,7 @@
 
 // @flow
 
-import type { ColumnPosition } from "../../types";
+import type { Position } from "../../types";
 import { parseScript, parseConsoleScript } from "./utils/ast";
 import { buildScopeList } from "./getScopes";
 import generate from "@babel/generator";
@@ -30,7 +30,7 @@ function getFirstExpression(ast) {
   return statements[0].expression;
 }
 
-function locationKey(start: ColumnPosition): string {
+function locationKey(start: Position): string {
   return `${start.line}:${start.column}`;
 }
 

--- a/src/workers/parser/steps.js
+++ b/src/workers/parser/steps.js
@@ -6,7 +6,7 @@
 
 import * as t from "@babel/types";
 import type { SimplePath } from "./utils/simple-path";
-import type { Location, SourceId } from "../../types";
+import type { SourceLocation, SourceId } from "../../types";
 import type { AstPosition } from "./types";
 import { getClosestPath } from "./utils/closest";
 import { isAwaitExpression, isYieldExpression } from "./utils/helpers";
@@ -14,7 +14,7 @@ import { isAwaitExpression, isYieldExpression } from "./utils/helpers";
 export function getNextStep(
   sourceId: SourceId,
   pausedPosition: AstPosition
-): ?Location {
+): ?SourceLocation {
   const currentExpression = getSteppableExpression(sourceId, pausedPosition);
   if (!currentExpression) {
     return null;
@@ -56,7 +56,7 @@ function _getNextStep(
   statement: SimplePath,
   sourceId: string,
   position: AstPosition
-): ?Location {
+): ?SourceLocation {
   const nextStatement = statement.getSibling(1);
   if (nextStatement) {
     return {


### PR DESCRIPTION
* Added `Source` as a prefix on `Location` because I think it's otherwise easy to confuse with `Position`.
* Swapped the `Column` prefix on column positions with the `Partial` prefix for column-less positions.

This is all an effort to make it clearer where we are working with columnless positions.