### PR TITLE
[breakpoints] fix context menu actions for enable and disable

### DIFF
--- a/src/components/SecondaryPanes/Breakpoints/Breakpoint.js
+++ b/src/components/SecondaryPanes/Breakpoints/Breakpoint.js
@@ -52,6 +52,7 @@ type Props = {
   setBreakpointCondition: typeof actions.setBreakpointCondition,
   toggleAllBreakpoints: typeof actions.toggleAllBreakpoints,
   toggleBreakpoints: typeof actions.toggleBreakpoints,
+  toggleDisabledBreakpoint: typeof actions.toggleDisabledBreakpoint,
   openConditionalPanel: typeof actions.openConditionalPanel,
   selectSpecificLocation: typeof actions.selectSpecificLocation
 };
@@ -205,6 +206,7 @@ export default connect(
     setBreakpointCondition: actions.setBreakpointCondition,
     toggleAllBreakpoints: actions.toggleAllBreakpoints,
     toggleBreakpoints: actions.toggleBreakpoints,
+    toggleDisabledBreakpoint: actions.toggleDisabledBreakpoint,
     openConditionalPanel: actions.openConditionalPanel
   }
 )(Breakpoint);

--- a/src/test/mochitest/browser_dbg-breakpoints.js
+++ b/src/test/mochitest/browser_dbg-breakpoints.js
@@ -44,6 +44,7 @@ function findBreakpoint(dbg, url, line) {
   return getBreakpoint(getState(), { sourceId: source.id, line });
 }
 
+// Test enabling and disabling a breakpoint using the check boxes
 add_task(async function() {
   const dbg = await initDebugger("doc-scripts.html", "simple2");
 
@@ -63,5 +64,33 @@ add_task(async function() {
   await disableBreakpoint(dbg, 1);
   await enableBreakpoint(dbg, 1);
   bp2 = findBreakpoint(dbg, "simple2", 5);
+  is(bp2.disabled, false, "second breakpoint is enabled");
+});
+
+// Test enabling and disabling a breakpoint using the context menu
+add_task(async function() {
+  const dbg = await initDebugger("doc-scripts.html");
+  await selectSource(dbg, "simple2");
+  await addBreakpoint(dbg, "simple2", 3);
+  await addBreakpoint(dbg, "simple2", 5);
+
+  rightClickElement(dbg, "breakpointItem", 3);
+  const disableBreakpointDispatch = waitForDispatch(dbg, "DISABLE_BREAKPOINT");
+  selectContextMenuItem(dbg, selectors.breakpointContextMenu.disableSelf);
+  await disableBreakpointDispatch;
+
+  let bp1 = findBreakpoint(dbg, "simple2", 3);
+  let bp2 = findBreakpoint(dbg, "simple2", 5);
+  is(bp1.disabled, true, "first breakpoint is disabled");
+  is(bp2.disabled, false, "second breakpoint is enabled");
+
+  rightClickElement(dbg, "breakpointItem", 3);
+  const enableBreakpointDispatch = waitForDispatch(dbg, "ENABLE_BREAKPOINT");
+  selectContextMenuItem(dbg, selectors.breakpointContextMenu.enableSelf);
+  await enableBreakpointDispatch;
+
+  bp1 = findBreakpoint(dbg, "simple2", 3);
+  bp2 = findBreakpoint(dbg, "simple2", 5);
+  is(bp1.disabled, false, "first breakpoint is enabled");
   is(bp2.disabled, false, "second breakpoint is enabled");
 });

--- a/src/test/mochitest/helpers.js
+++ b/src/test/mochitest/helpers.js
@@ -1031,8 +1031,10 @@ const selectors = {
   breakpointItem: i => `.breakpoints-list div:nth-of-type(${i})`,
   breakpointItems: `.breakpoints-list .breakpoint`,
   breakpointContextMenu: {
+    disableSelf: "#node-menu-disable-self",
     disableAll: "#node-menu-disable-all",
     disableOthers: "#node-menu-disable-others",
+    enableSelf: "#node-menu-enable-self",
     enableOthers: "#node-menu-enable-others",
     remove: "#node-menu-delete-self",
     removeOthers: "#node-menu-delete-other",


### PR DESCRIPTION
This fixes the "enable" and "disable" breakpoint context menu items not working in #7272.  The issue was just the `toggleDissabledBreakpoints` was not being added to the props that eventually get passed along to the BreakpointContextMenu.
