### PR TITLE
Fix conditional breakpoint marker stroke

### DIFF
--- a/src/components/Editor/Editor.css
+++ b/src/components/Editor/Editor.css
@@ -146,8 +146,9 @@ html[dir="rtl"] .editor-mount {
   right: -16px;
 }
 
-.new-breakpoint.has-condition svg {
+.new-breakpoint.has-condition .CodeMirror-gutter-wrapper svg {
   fill: var(--theme-graphs-yellow);
+  stroke: var(--theme-graphs-orange);
 }
 
 .editor.new-breakpoint.breakpoint-disabled svg {


### PR DESCRIPTION
## Before

<img width="430" alt="beforecolcond" src="https://user-images.githubusercontent.com/46655/49261515-33286080-f408-11e8-9958-f28f2b669aa4.png">


## After

<img width="649" alt="orange" src="https://user-images.githubusercontent.com/46655/49261519-36bbe780-f408-11e8-989e-04fb9bbaf752.png">

The orange color used wasn't provided by @mcroud but we should address the yucky blue ASAP