### PR TITLE
Provide conditional comment styling

### DIFF
--- a/src/components/Editor/ColumnBreakpoint.js
+++ b/src/components/Editor/ColumnBreakpoint.js
@@ -26,11 +26,22 @@ type Props = {
 
 const breakpointImg = document.createElement("div");
 ReactDOM.render(<Svg name={"column-marker"} />, breakpointImg);
-function makeBookmark(isActive, { onClick }) {
+function makeBookmark(isActive, condition, { onClick }) {
   const bp = breakpointImg.cloneNode(true);
   const className = isActive ? "active" : "disabled";
-  bp.className = classnames("column-breakpoint", className);
+
+  bp.className = classnames(
+    "column-breakpoint",
+    {
+      "has-condition": condition
+    },
+    className
+  );
+  if (condition) {
+    bp.setAttribute("title", condition);
+  }
   bp.onclick = onClick;
+
   return bp;
 }
 
@@ -48,9 +59,14 @@ export default class ColumnBreakpoint extends PureComponent<Props> {
     }
 
     const { line, column } = columnBreakpoint.location;
-    const widget = makeBookmark(columnBreakpoint.enabled, {
-      onClick: this.toggleBreakpoint
-    });
+    const widget = makeBookmark(
+      columnBreakpoint.enabled,
+      columnBreakpoint.condition,
+      {
+        onClick: this.toggleBreakpoint
+      }
+    );
+
     this.bookmark = doc.setBookmark({ line: line - 1, ch: column }, { widget });
   };
 

--- a/src/components/Editor/ColumnBreakpoints.css
+++ b/src/components/Editor/ColumnBreakpoints.css
@@ -25,6 +25,11 @@
   fill-opacity: 0.5;
 }
 
+.column-breakpoint.has-condition svg {
+  fill: var(--theme-graphs-yellow);
+  stroke: var(--theme-graphs-orange);
+}
+
 .theme-dark .column-breakpoint.active svg {
   fill: var(--blue-55);
   stroke: var(--blue-40);

--- a/src/selectors/test/__snapshots__/visibleColumnBreakpoints.spec.js.snap
+++ b/src/selectors/test/__snapshots__/visibleColumnBreakpoints.spec.js.snap
@@ -3,6 +3,7 @@
 exports[`visible column breakpoints duplicate generated locations 1`] = `
 Array [
   Object {
+    "condition": undefined,
     "enabled": true,
     "location": Object {
       "column": 1,
@@ -10,6 +11,7 @@ Array [
     },
   },
   Object {
+    "condition": "",
     "enabled": false,
     "location": Object {
       "column": 3,
@@ -22,6 +24,7 @@ Array [
 exports[`visible column breakpoints ignores single breakpoints 1`] = `
 Array [
   Object {
+    "condition": undefined,
     "enabled": true,
     "location": Object {
       "column": 1,
@@ -29,6 +32,7 @@ Array [
     },
   },
   Object {
+    "condition": "",
     "enabled": false,
     "location": Object {
       "column": 3,
@@ -41,6 +45,7 @@ Array [
 exports[`visible column breakpoints only shows visible breakpoints 1`] = `
 Array [
   Object {
+    "condition": undefined,
     "enabled": true,
     "location": Object {
       "column": 1,
@@ -48,6 +53,7 @@ Array [
     },
   },
   Object {
+    "condition": "",
     "enabled": false,
     "location": Object {
       "column": 3,
@@ -60,6 +66,7 @@ Array [
 exports[`visible column breakpoints simple 1`] = `
 Array [
   Object {
+    "condition": undefined,
     "enabled": true,
     "location": Object {
       "column": 1,
@@ -67,6 +74,7 @@ Array [
     },
   },
   Object {
+    "condition": "",
     "enabled": false,
     "location": Object {
       "column": 5,

--- a/src/selectors/test/__snapshots__/visibleColumnBreakpoints.spec.js.snap
+++ b/src/selectors/test/__snapshots__/visibleColumnBreakpoints.spec.js.snap
@@ -11,7 +11,7 @@ Array [
     },
   },
   Object {
-    "condition": "",
+    "condition": null,
     "enabled": false,
     "location": Object {
       "column": 3,
@@ -32,7 +32,7 @@ Array [
     },
   },
   Object {
-    "condition": "",
+    "condition": null,
     "enabled": false,
     "location": Object {
       "column": 3,
@@ -53,7 +53,7 @@ Array [
     },
   },
   Object {
-    "condition": "",
+    "condition": null,
     "enabled": false,
     "location": Object {
       "column": 3,
@@ -74,7 +74,7 @@ Array [
     },
   },
   Object {
-    "condition": "",
+    "condition": null,
     "enabled": false,
     "location": Object {
       "column": 5,

--- a/src/selectors/visibleColumnBreakpoints.js
+++ b/src/selectors/visibleColumnBreakpoints.js
@@ -14,7 +14,8 @@ import type { SourceLocation } from "../types";
 
 export type ColumnBreakpoint = {|
   +location: SourceLocation,
-  +enabled: boolean
+  +enabled: boolean,
+  +condition: ?string
 |};
 
 function contains(location, range) {
@@ -101,10 +102,20 @@ export function getColumnBreakpoints(pausePoints, breakpoints, viewport) {
     ({ location: { line } }) => lineCount[line] > 1
   );
 
-  return columnBreakpoints.map(({ location }) => ({
-    location,
-    enabled: isEnabled(location, breakpointMap)
-  }));
+  return columnBreakpoints.map(({ location }) => {
+    const foundBreakpoint = breakpoints.find(breakpoint => {
+      return (
+        breakpoint.location.line === location.line &&
+        breakpoint.location.column === location.column
+      );
+    });
+
+    return {
+      location,
+      enabled: isEnabled(location, breakpointMap),
+      condition: foundBreakpoint ? foundBreakpoint.condition : ""
+    };
+  });
 }
 
 export const visibleColumnBreakpoints = createSelector(

--- a/src/selectors/visibleColumnBreakpoints.js
+++ b/src/selectors/visibleColumnBreakpoints.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
-import { groupBy, hasIn, sortedUniqBy } from "lodash";
+import { groupBy, get, sortedUniqBy } from "lodash";
 import { createSelector } from "reselect";
 
 import { getViewport } from "../selectors";
@@ -36,9 +36,9 @@ function groupBreakpoints(breakpoints) {
   return map;
 }
 
-function isEnabled(location, breakpointMap) {
+function findBreakpoint(location, breakpointMap) {
   const { line, column } = location;
-  return hasIn(breakpointMap, [line, column]);
+  return get(breakpointMap, [line, column]);
 }
 
 function getLineCount(columnBreakpoints) {
@@ -103,16 +103,11 @@ export function getColumnBreakpoints(pausePoints, breakpoints, viewport) {
   );
 
   return columnBreakpoints.map(({ location }) => {
-    const foundBreakpoint = breakpoints.find(breakpoint => {
-      return (
-        breakpoint.location.line === location.line &&
-        breakpoint.location.column === location.column
-      );
-    });
+    const foundBreakpoint = findBreakpoint(location, breakpointMap);
 
     return {
       location,
-      enabled: isEnabled(location, breakpointMap),
+      enabled: !!foundBreakpoint,
       condition: foundBreakpoint ? foundBreakpoint.condition : ""
     };
   });

--- a/src/selectors/visibleColumnBreakpoints.js
+++ b/src/selectors/visibleColumnBreakpoints.js
@@ -38,7 +38,11 @@ function groupBreakpoints(breakpoints) {
 
 function findBreakpoint(location, breakpointMap) {
   const { line, column } = location;
-  return get(breakpointMap, [line, column]);
+  const breakpoints = get(breakpointMap, [line, column]);
+
+  if (breakpoints) {
+    return breakpoints[0];
+  }
 }
 
 function getLineCount(columnBreakpoints) {
@@ -103,12 +107,13 @@ export function getColumnBreakpoints(pausePoints, breakpoints, viewport) {
   );
 
   return columnBreakpoints.map(({ location }) => {
+    // Find the breakpoint so if we know it's enabled and has condition
     const foundBreakpoint = findBreakpoint(location, breakpointMap);
 
     return {
       location,
       enabled: !!foundBreakpoint,
-      condition: foundBreakpoint ? foundBreakpoint.condition : ""
+      condition: foundBreakpoint ? foundBreakpoint.condition : null
     };
   });
 }


### PR DESCRIPTION
<img width="661" alt="conditionalcolumnbps" src="https://user-images.githubusercontent.com/46655/49263230-383cde00-f40f-11e8-9a88-cc7c1c683a60.png">

This lays the groundwork for having column breakpoints show the proper color when they have a condition.  You have to hardcode a condition in the code now to test until https://github.com/devtools-html/debugger.html/pull/7366 is merged.