### PR TITLE
Choose proper event to unregister editor cursor activity event

### DIFF
--- a/src/components/Editor/Footer.js
+++ b/src/components/Editor/Footer.js
@@ -63,7 +63,7 @@ class SourceFooter extends PureComponent<Props, State> {
     editor.codeMirror.on("cursorActivity", this.onCursorChange);
   }
 
-  componentDidUnMount() {
+  componentWillUnmount() {
     const { editor } = this.props;
     editor.codeMirror.off("cursorActivity", this.onCursorChange);
   }


### PR DESCRIPTION
Saw this error when opening a new source:

<img width="1275" alt="linecolerror" src="https://user-images.githubusercontent.com/46655/49264593-8bfdf600-f414-11e8-8631-17012ae7ee6f.png">

Using proper event.