### PR TITLE
Immediately render column breakpoints before scroll

### DIFF
--- a/src/components/Editor/ColumnBreakpoint.js
+++ b/src/components/Editor/ColumnBreakpoint.js
@@ -41,17 +41,17 @@ export default class CallSite extends PureComponent<Props> {
 
   addCallSite = (nextProps: ?Props) => {
     const { columnBreakpoint, source } = nextProps || this.props;
-    const { line, column } = columnBreakpoint.location;
-    const widget = makeBookmark(columnBreakpoint.enabled, {
-      onClick: this.toggleBreakpoint
-    });
+
     const sourceId = source.id;
     const doc = getDocument(sourceId);
-
     if (!doc) {
       return;
     }
 
+    const { line, column } = columnBreakpoint.location;
+    const widget = makeBookmark(columnBreakpoint.enabled, {
+      onClick: this.toggleBreakpoint
+    });
     this.bookmark = doc.setBookmark({ line: line - 1, ch: column }, { widget });
   };
 

--- a/src/components/Editor/ColumnBreakpoint.js
+++ b/src/components/Editor/ColumnBreakpoint.js
@@ -41,12 +41,17 @@ export default class CallSite extends PureComponent<Props> {
 
   addCallSite = (nextProps: ?Props) => {
     const { columnBreakpoint, source } = nextProps || this.props;
-    const sourceId = source.id;
     const { line, column } = columnBreakpoint.location;
     const widget = makeBookmark(columnBreakpoint.enabled, {
       onClick: this.toggleBreakpoint
     });
+    const sourceId = source.id;
     const doc = getDocument(sourceId);
+
+    if (!doc) {
+      return;
+    }
+
     this.bookmark = doc.setBookmark({ line: line - 1, ch: column }, { widget });
   };
 

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -160,7 +160,6 @@ class Editor extends PureComponent<Props, State> {
     codeMirrorWrapper.addEventListener("keydown", e => this.onKeyDown(e));
     codeMirrorWrapper.addEventListener("click", e => this.onClick(e));
     codeMirrorWrapper.addEventListener("mouseover", onMouseOver(codeMirror));
-    codeMirror.on("scroll", this.onEditorScroll);
 
     const toggleFoldMarkerVisibility = e => {
       if (node instanceof HTMLElement) {
@@ -187,6 +186,9 @@ class Editor extends PureComponent<Props, State> {
       );
     }
 
+    codeMirror.on("scroll", this.onEditorScroll);
+    this.onEditorScroll();
+
     this.setState({ editor });
     return editor;
   }
@@ -212,6 +214,7 @@ class Editor extends PureComponent<Props, State> {
   componentWillUnmount() {
     if (this.state.editor) {
       this.state.editor.destroy();
+      this.state.editor.codeMirror.off("scroll", this.onEditorScroll);
       this.setState({ editor: null });
     }
 


### PR DESCRIPTION
As it turns out now, column breakpoints don't display in the editor until you scroll, so it's imperative we trigger the scroll handler immediately upon editor setup.