### PR TITLE
Typecheck addBreakpoint and require breakpoint line numbers in editor gutter fns

### DIFF
--- a/src/actions/breakpoints/addBreakpoint.js
+++ b/src/actions/breakpoints/addBreakpoint.js
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
+// @flow
+
 import { isOriginalId } from "devtools-source-map";
 import {
   locationMoved,
@@ -17,9 +19,17 @@ import { getGeneratedLocation } from "../../utils/source-maps";
 import { getTextAtPosition } from "../../utils/source";
 import { recordEvent } from "../../utils/telemetry";
 
+import type { SourceLocation } from "../../types";
+import type { ThunkArgs } from "../types";
+import type { addBreakpointOptions } from "./";
+
 async function addBreakpointPromise(getState, client, sourceMaps, breakpoint) {
   const state = getState();
   const source = getSource(state, breakpoint.location.sourceId);
+
+  if (!source) {
+    throw new Error(`Unable to find source: ${breakpoint.location.sourceId}`);
+  }
 
   const location = {
     ...breakpoint.location,

--- a/src/actions/breakpoints/index.js
+++ b/src/actions/breakpoints/index.js
@@ -36,7 +36,7 @@ import type { Breakpoint, SourceLocation, XHRBreakpoint } from "../../types";
 
 import { recordEvent } from "../../utils/telemetry";
 
-type addBreakpointOptions = {
+export type addBreakpointOptions = {
   condition?: string,
   hidden?: boolean
 };

--- a/src/actions/breakpoints/index.js
+++ b/src/actions/breakpoints/index.js
@@ -264,12 +264,12 @@ export function setBreakpointCondition(
   };
 }
 
-export function toggleBreakpoint(line: ?number, column?: number) {
+export function toggleBreakpoint(line: number, column?: number) {
   return ({ dispatch, getState, client, sourceMaps }: ThunkArgs) => {
     const state = getState();
     const selectedSource = getSelectedSource(state);
 
-    if (!line || !selectedSource) {
+    if (!selectedSource) {
       return;
     }
 
@@ -307,7 +307,7 @@ export function toggleBreakpointsAtLine(line: number, column?: number) {
     const state = getState();
     const selectedSource = getSelectedSource(state);
 
-    if (!line || !selectedSource) {
+    if (!selectedSource) {
       return;
     }
 
@@ -329,11 +329,11 @@ export function toggleBreakpointsAtLine(line: number, column?: number) {
   };
 }
 
-export function addOrToggleDisabledBreakpoint(line: ?number, column?: number) {
+export function addOrToggleDisabledBreakpoint(line: number, column?: number) {
   return ({ dispatch, getState, client, sourceMaps }: ThunkArgs) => {
     const selectedSource = getSelectedSource(getState());
 
-    if (!line || !selectedSource) {
+    if (!selectedSource) {
       return;
     }
 

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -88,10 +88,10 @@ export type Props = {
   openConditionalPanel: (?number) => void,
   closeConditionalPanel: void => void,
   setContextMenu: (string, any) => void,
-  continueToHere: (?number) => void,
-  toggleBreakpoint: (?number) => void,
-  toggleBreakpointsAtLine: (?number) => void,
-  addOrToggleDisabledBreakpoint: (?number) => void,
+  continueToHere: number => void,
+  toggleBreakpoint: number => void,
+  toggleBreakpointsAtLine: number => void,
+  addOrToggleDisabledBreakpoint: number => void,
   jumpToMappedLocation: any => void,
   traverseResults: (boolean, Object) => void,
   updateViewport: void => void
@@ -263,6 +263,9 @@ class Editor extends PureComponent<Props, State> {
     }
 
     const line = this.getCurrentLine();
+    if (typeof line !== "number") {
+      return;
+    }
 
     if (e.shiftKey) {
       this.toggleConditionalPanel(line);
@@ -278,6 +281,10 @@ class Editor extends PureComponent<Props, State> {
     e.stopPropagation();
     e.preventDefault();
     const line = this.getCurrentLine();
+    if (typeof line !== "number") {
+      return;
+    }
+
     this.toggleConditionalPanel(line);
   };
 
@@ -369,6 +376,9 @@ class Editor extends PureComponent<Props, State> {
     }
 
     const sourceLine = toSourceLine(selectedSource.id, line);
+    if (typeof sourceLine !== "number") {
+      return;
+    }
 
     if (ev.metaKey) {
       return continueToHere(sourceLine);

--- a/src/utils/breakpoint/astBreakpointLocation.js
+++ b/src/utils/breakpoint/astBreakpointLocation.js
@@ -7,13 +7,12 @@
 import { getSymbols } from "../../workers/parser";
 import { findClosestFunction } from "../ast";
 
-import type { SymbolDeclarations } from "../../workers/parser";
-
 import type { SourceLocation, Source, ASTLocation } from "../../types";
+import type { Symbols } from "../../reducers/ast";
 
 export function getASTLocation(
   source: Source,
-  symbols: SymbolDeclarations,
+  symbols: ?Symbols,
   location: SourceLocation
 ): ASTLocation {
   if (source.isWasm || !symbols || symbols.loading) {


### PR DESCRIPTION
Mostly just smaller fixes to easy review of upcoming work. Typechecking is great and also enforcing the line number seems to just make sense here, since they already early-return when it is falsy anyway.