### PR TITLE
Pass explicit column values for non-breakpoint location usage.

### DIFF
--- a/packages/devtools-source-map/src/utils/wasmXScopes.js
+++ b/packages/devtools-source-map/src/utils/wasmXScopes.js
@@ -161,6 +161,7 @@ class XScope {
         displayName: i.name || "",
         location: {
           line: i.line || 0,
+          column: 0,
           sourceId
         }
       };

--- a/src/actions/sources/newSources.js
+++ b/src/actions/sources/newSources.js
@@ -129,7 +129,10 @@ function checkSelectedSource(sourceId: string) {
           sourceId: source.id,
           line:
             typeof pendingLocation.line === "number" ? pendingLocation.line : 0,
-          column: pendingLocation.column
+          column:
+            typeof pendingLocation.column === "number"
+              ? pendingLocation.column
+              : 0
         })
       );
     }

--- a/src/client/firefox/types.js
+++ b/src/client/firefox/types.js
@@ -73,7 +73,7 @@ export type FramePacket = {
   depth?: number,
   oldest?: boolean,
   type: "pause" | "call",
-  where: ActualLocation
+  where: FrameLocation
 };
 
 /**
@@ -137,6 +137,12 @@ export type PausedPacket = {
 export type ResumedPacket = {
   from: ActorId,
   type: string
+};
+
+export type FrameLocation = {
+  source: SourcePayload,
+  line: number,
+  column: number
 };
 
 /**

--- a/src/components/QuickOpenModal.js
+++ b/src/components/QuickOpenModal.js
@@ -252,7 +252,7 @@ export class QuickOpenModal extends Component<Props, State> {
       selectSpecificLocation({
         sourceId,
         line: location.line,
-        column: location.column
+        column: typeof location.column === "number" ? location.column : 0
       });
       this.closeModal();
     }

--- a/src/components/test/QuickOpenModal.spec.js
+++ b/src/components/test/QuickOpenModal.spec.js
@@ -424,7 +424,7 @@ describe("QuickOpenModal", () => {
       };
       wrapper.find("SearchInput").simulate("keydown", event);
       expect(props.selectSpecificLocation).toHaveBeenCalledWith({
-        column: undefined,
+        column: 0,
         sourceId: id,
         line: 0
       });
@@ -454,7 +454,7 @@ describe("QuickOpenModal", () => {
       };
       wrapper.find("SearchInput").simulate("keydown", event);
       expect(props.selectSpecificLocation).toHaveBeenCalledWith({
-        column: undefined,
+        column: 0,
         line: 0,
         sourceId: ""
       });

--- a/src/test/mochitest/browser_dbg-quick-open.js
+++ b/src/test/mochitest/browser_dbg-quick-open.js
@@ -112,7 +112,7 @@ add_task(async function() {
 
   info("Testing goto line:column");
   assertLine(dbg, 0);
-  assertColumn(dbg, null);
+  assertColumn(dbg, 0);
   quickOpen(dbg, ":7:12");
   pressKey(dbg, "Enter");
   assertLine(dbg, 7);

--- a/src/utils/location.js
+++ b/src/utils/location.js
@@ -22,7 +22,7 @@ export function createLocation({
   return {
     sourceId,
     line: line || 0,
-    column,
+    column: column || 0,
     sourceUrl: sourceUrl || ""
   };
 }

--- a/src/utils/source-maps.js
+++ b/src/utils/source-maps.js
@@ -33,7 +33,12 @@ export async function getGeneratedLocation(
   return {
     line,
     sourceId,
-    column: column === 0 ? undefined : column,
+    // If the input location didn't have a column number, and we got back
+    // the start of the line, we consider the result to also not have a column.
+    // This is so that we can preserve our current behavior of having
+    // breakpoints with optional columns, while allowing operations on
+    // locations unrelated to breakpoints to always have a column.
+    column: location.column === undefined && column === 0 ? undefined : column,
     sourceUrl: generatedSource.url
   };
 }


### PR DESCRIPTION
More prep work around breakpoint column. This defaults to `column: 0` for all the places that reference file locations but _aren't_ breakpoints.