### PR TITLE
Fix typo in debugger-html-react-redux-overview.md

### DIFF
--- a/assets/dictionary.txt
+++ b/assets/dictionary.txt
@@ -205,3 +205,4 @@ bytecode
 eval
 asyncStore
 CPG
+debbuger.html

--- a/assets/dictionary.txt
+++ b/assets/dictionary.txt
@@ -205,4 +205,3 @@ bytecode
 eval
 asyncStore
 CPG
-debbuger.html

--- a/docs/debugger-html-react-redux-overview.md
+++ b/docs/debugger-html-react-redux-overview.md
@@ -62,7 +62,7 @@ actual DOM will be rendered.
 # Components
 
 
-debbuger.html uses React [Components](https://github.com/devtools-html/debugger.html/tree/master/src/components) to render portions of the
+debugger.html uses React [Components](https://github.com/devtools-html/debugger.html/tree/master/src/components) to render portions of the
 application. Each component’s source code is located under the
 src/components folder. In this section we will cover how the
 presentation pieces fit together; later we will discuss


### PR DESCRIPTION
### Summary of Changes

Fixed spelling: debbuger.html -> debugger.html.

### Test Plan

Added `debbuger.html` string to dictionary.txt so that it can be caught in case the typo occurs again.