### PR TITLE
Make gutter marker or breakpoint represent first breakpoint on line

### DIFF
--- a/src/components/Editor/Breakpoints.js
+++ b/src/components/Editor/Breakpoints.js
@@ -5,11 +5,12 @@
 // @flow
 import { connect } from "react-redux";
 import React, { Component } from "react";
+import { uniqBy } from "lodash";
 
 import Breakpoint from "./Breakpoint";
 
 import { getSelectedSource, getVisibleBreakpoints } from "../../selectors";
-import { makeLocationId } from "../../utils/breakpoint";
+import { makeLocationId, sortBreakpoints } from "../../utils/breakpoint";
 import { isLoaded } from "../../utils/source";
 
 import type { Breakpoint as BreakpointType, Source } from "../../types";
@@ -53,7 +54,14 @@ class Breakpoints extends Component<Props> {
   }
 }
 
-export default connect(state => ({
-  breakpoints: getVisibleBreakpoints(state),
-  selectedSource: getSelectedSource(state)
-}))(Breakpoints);
+export default connect(state => {
+  const breakpoints = uniqBy(
+    sortBreakpoints(getVisibleBreakpoints(state)),
+    bp => bp.location.line
+  );
+
+  return {
+    breakpoints,
+    selectedSource: getSelectedSource(state)
+  };
+})(Breakpoints);

--- a/src/components/Editor/Breakpoints.js
+++ b/src/components/Editor/Breakpoints.js
@@ -53,6 +53,8 @@ class Breakpoints extends Component<Props> {
 }
 
 export default connect(state => ({
+  // Retrieves only the first breakpoint per line so that the
+  // breakpoint marker represents only the first breakpoint
   breakpoints: getFirstVisibleBreakpoints(state),
   selectedSource: getSelectedSource(state)
 }))(Breakpoints);

--- a/src/components/Editor/Breakpoints.js
+++ b/src/components/Editor/Breakpoints.js
@@ -5,12 +5,10 @@
 // @flow
 import { connect } from "react-redux";
 import React, { Component } from "react";
-import { uniqBy } from "lodash";
-
 import Breakpoint from "./Breakpoint";
 
-import { getSelectedSource, getVisibleBreakpoints } from "../../selectors";
-import { makeLocationId, sortBreakpoints } from "../../utils/breakpoint";
+import { getSelectedSource, getFirstVisibleBreakpoints } from "../../selectors";
+import { makeLocationId } from "../../utils/breakpoint";
 import { isLoaded } from "../../utils/source";
 
 import type { Breakpoint as BreakpointType, Source } from "../../types";
@@ -54,14 +52,7 @@ class Breakpoints extends Component<Props> {
   }
 }
 
-export default connect(state => {
-  const breakpoints = uniqBy(
-    sortBreakpoints(getVisibleBreakpoints(state)),
-    bp => bp.location.line
-  );
-
-  return {
-    breakpoints,
-    selectedSource: getSelectedSource(state)
-  };
-})(Breakpoints);
+export default connect(state => ({
+  breakpoints: getFirstVisibleBreakpoints(state),
+  selectedSource: getSelectedSource(state)
+}))(Breakpoints);

--- a/src/components/SecondaryPanes/Breakpoints/index.js
+++ b/src/components/SecondaryPanes/Breakpoints/index.js
@@ -15,7 +15,10 @@ import BreakpointHeading from "./BreakpointHeading";
 
 import actions from "../../../actions";
 import { getDisplayPath } from "../../../utils/source";
-import { makeLocationId, sortBreakpoints } from "../../../utils/breakpoint";
+import {
+  makeLocationId,
+  sortFormattedBreakpoints
+} from "../../../utils/breakpoint";
 
 import { getSelectedSource, getBreakpointSources } from "../../../selectors";
 
@@ -79,7 +82,7 @@ class Breakpoints extends Component<Props> {
     return [
       ...breakpointSources.map(({ source, breakpoints, i }) => {
         const path = getDisplayPath(source, sources);
-        const sortedBreakpoints = sortBreakpoints(breakpoints);
+        const sortedBreakpoints = sortFormattedBreakpoints(breakpoints);
 
         return [
           <BreakpointHeading

--- a/src/selectors/index.js
+++ b/src/selectors/index.js
@@ -27,7 +27,10 @@ export {
   getBreakpointAtLocation,
   getBreakpointsAtLine
 } from "./breakpointAtLocation";
-export { getVisibleBreakpoints } from "./visibleBreakpoints";
+export {
+  getVisibleBreakpoints,
+  getFirstVisibleBreakpoints
+} from "./visibleBreakpoints";
 export { inComponent } from "./inComponent";
 export { isSelectedFrameVisible } from "./isSelectedFrameVisible";
 export { getCallStackFrames } from "./getCallStackFrames";

--- a/src/selectors/visibleBreakpoints.js
+++ b/src/selectors/visibleBreakpoints.js
@@ -4,11 +4,15 @@
 
 // @flow
 
-import { getBreakpointsList } from "../reducers/breakpoints";
-import { getSelectedSource } from "../reducers/sources";
 import { isGeneratedId } from "devtools-source-map";
 import { createSelector } from "reselect";
+import { uniqBy } from "lodash";
+
+import { getBreakpointsList } from "../reducers/breakpoints";
+import { getSelectedSource } from "../reducers/sources";
+
 import memoize from "../utils/memoize";
+import { sortBreakpoints } from "../utils/breakpoint";
 
 import type { Breakpoint, Source } from "../types";
 
@@ -54,5 +58,19 @@ export const getVisibleBreakpoints = createSelector(
     return breakpoints
       .filter(bp => isVisible(bp, selectedSource))
       .map(bp => formatBreakpoint(bp, selectedSource));
+  }
+);
+
+/*
+ * Finds the first breakpoint per line, which appear in the selected source.
+  */
+export const getFirstVisibleBreakpoints = createSelector(
+  getVisibleBreakpoints,
+  breakpoints => {
+    if (!breakpoints) {
+      return null;
+    }
+
+    return uniqBy(sortBreakpoints(breakpoints), bp => bp.location.line);
   }
 );

--- a/src/test/mochitest/browser.ini
+++ b/src/test/mochitest/browser.ini
@@ -668,6 +668,7 @@ skip-if = os == "win" # Bug 1448523, Bug 1448450
 [browser_dbg-breaking-from-console.js]
 [browser_dbg-breakpoints.js]
 [browser_dbg-breakpoints-actions.js]
+[browser_dbg-breakpoints-columns.js]
 [browser_dbg-breakpoints-cond.js]
 [browser_dbg-browser-content-toolbox.js]
 skip-if = !e10s || verify # This test is only valid in e10s

--- a/src/test/mochitest/browser_dbg-breakpoints-columns.js
+++ b/src/test/mochitest/browser_dbg-breakpoints-columns.js
@@ -1,0 +1,105 @@
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
+
+function getColumnBreakpointElements(dbg) {
+  return dbg.win.document.querySelectorAll(".column-breakpoint");
+}
+
+async function assertConditionalBreakpointIsFocused(dbg) {
+  const input = findElement(dbg, "conditionalPanelInput");
+  await waitForElementFocus(dbg, input);
+}
+
+function waitForElementFocus(dbg, el) {
+  const doc = dbg.win.document;
+  return waitFor(() => doc.activeElement == el && doc.hasFocus());
+}
+
+async function setConditionalBreakpoint(dbg, index, condition) {
+  const {
+      addConditionalBreakpoint,
+      editBreakpoint
+  } = selectors.gutterContextMenu;
+  // Make this work with either add or edit menu items
+  const selector = `${addConditionalBreakpoint},${editBreakpoint}`;
+
+  rightClickElement(dbg, "breakpointItem", index);
+  selectContextMenuItem(dbg, selector);
+  await waitForElement(dbg, "conditionalPanelInput");
+  await assertConditionalBreakpointIsFocused(dbg);
+
+  // Position cursor reliably at the end of the text.
+  pressKey(dbg, "End");
+  type(dbg, condition);
+  pressKey(dbg, "Enter");
+}
+
+function removeBreakpointViaContext(dbg, index) {
+  rightClickElement(dbg, "breakpointItem", index);
+  selectContextMenuItem(dbg, "#node-menu-delete-self");
+}
+
+// Test enabling and disabling a breakpoint using the check boxes
+add_task(async function() {
+  const dbg = await initDebugger("doc-scripts.html", "simple1");
+
+  await selectSource(dbg, "simple1");
+
+  // Scroll down to desired line so that column breakpoints render
+  getCM(dbg).setCursor({ line: 15, ch: 0 });
+
+  // Create a breakpoint at 15:undefined
+  await addBreakpoint(dbg, "simple1", 15);
+  
+  // Wait for column breakpoint markers
+  await waitForElementWithSelector(dbg, ".column-breakpoint");
+
+  let columnBreakpointMarkers = getColumnBreakpointElements(dbg);
+  ok(
+    columnBreakpointMarkers.length === 2, 
+      "2 column breakpoint markers display"
+  );
+
+  // Create a breakpoint at 15:8
+  columnBreakpointMarkers[0].click();
+
+  // Create a breakpoint at 15:28
+  columnBreakpointMarkers[1].click();
+
+  // Wait for breakpoints in right panel to render
+  await waitForState(dbg, state => {
+    return dbg.win.document.querySelectorAll(".breakpoints-list .breakpoint").length === 3;
+  })
+
+  // Scroll down in secondary pane so element we want to right-click is showing
+  dbg.win.document.querySelector(".secondary-panes").scrollTop = 100;
+
+  // Set a condition at 15:8
+  await setConditionalBreakpoint(dbg, 4, "Eight");
+
+  // Ensure column breakpoint is yellow
+  await waitForElementWithSelector(dbg, ".column-breakpoint.has-condition");
+  
+  // Remove the breakpoint from 15:undefined via the secondary pane context menu
+  removeBreakpointViaContext(dbg, 3);
+
+  // Ensure that there's still a marker on line 15
+  await waitForElementWithSelector(dbg, ".CodeMirror-code > .new-breakpoint.has-condition");
+  columnBreakpointMarkers = getColumnBreakpointElements(dbg);
+  ok(columnBreakpointMarkers[0].classList.contains("has-condition"), "First column breakpoint has conditional style");
+
+  // Remove the breakpoint from 15:8
+  removeBreakpointViaContext(dbg, 3);
+
+  // Ensure there's still a marker and it has no condition
+  await waitForElementWithSelector(dbg, ".CodeMirror-code > .new-breakpoint");
+
+  await waitForState(dbg, state => {
+    columnBreakpointMarkers = getColumnBreakpointElements(dbg);
+    const result = columnBreakpointMarkers[0].classList.contains("has-condition") === false;
+    if (result) {
+      ok(result, "First column breakpoint has no conditional style");
+      return result;
+    }
+  });
+});

--- a/src/test/mochitest/helpers.js
+++ b/src/test/mochitest/helpers.js
@@ -1052,9 +1052,10 @@ const selectors = {
   frame: i => `.frames ul li:nth-child(${i})`,
   frames: ".frames ul li",
   gutter: i => `.CodeMirror-code *:nth-child(${i}) .CodeMirror-linenumber`,
+  // These work for bobth the breakpoint listing and gutter marker
   gutterContextMenu: {
-    addConditionalBreakpoint: "#node-menu-add-conditional-breakpoint",
-    editBreakpoint: "#node-menu-edit-conditional-breakpoint"
+    addConditionalBreakpoint: "#node-menu-add-condition, #node-menu-add-conditional-breakpoint",
+    editBreakpoint: "#node-menu-edit-condition, #node-menu-edit-conditional-breakpoint"
   },
   menuitem: i => `menupopup menuitem:nth-child(${i})`,
   pauseOnExceptions: ".pause-exceptions",
@@ -1159,6 +1160,7 @@ function dblClickElement(dbg, elementName, ...args) {
 function rightClickElement(dbg, elementName, ...args) {
   const selector = getSelector(elementName, ...args);
   const doc = dbg.win.document;
+
   return EventUtils.synthesizeMouseAtCenter(
     doc.querySelector(selector),
     { type: "contextmenu" },

--- a/src/utils/breakpoint/index.js
+++ b/src/utils/breakpoint/index.js
@@ -186,10 +186,17 @@ export function createPendingBreakpoint(bp: Breakpoint) {
   };
 }
 
-export function sortBreakpoints(breakpoints: FormattedBreakpoint[]) {
+export function sortFormattedBreakpoints(breakpoints: FormattedBreakpoint[]) {
+  return _sortBreakpoints(breakpoints, "selectedLocation");
+}
+
+export function sortBreakpoints(breakpoints: Breakpoint[]) {
+  return _sortBreakpoints(breakpoints);
+}
+
+function _sortBreakpoints(breakpoints: Array<Object>, property = "location") {
   return sortBy(breakpoints, [
-    "selectedLocation.line",
-    ({ selectedLocation }) =>
-      selectedLocation.column === undefined || selectedLocation.column
+    "${property}.line",
+    bp => bp[property].column === undefined || bp[property].column
   ]);
 }

--- a/src/utils/breakpoint/index.js
+++ b/src/utils/breakpoint/index.js
@@ -196,14 +196,10 @@ export function sortBreakpoints(breakpoints: Breakpoint[]) {
 
 function _sortBreakpoints(breakpoints: Array<Object>, property: string) {
   return sortBy(breakpoints, [
-    "${property}.line",
+    // Priority: line number, undefined column, column number
+    `${property}.line`,
     bp => {
-      // Priority: line number, undefined column, column number
-      return (
-        bp[property].line ||
-        bp[property].column === undefined ||
-        bp[property].column
-      );
+      return bp[property].column === undefined || bp[property].column;
     }
   ]);
 }

--- a/src/utils/breakpoint/index.js
+++ b/src/utils/breakpoint/index.js
@@ -197,6 +197,9 @@ export function sortBreakpoints(breakpoints: Breakpoint[]) {
 function _sortBreakpoints(breakpoints: Array<Object>, property = "location") {
   return sortBy(breakpoints, [
     "${property}.line",
-    bp => bp[property].column === undefined || bp[property].column
+    bp =>
+      bp[property].line ||
+      bp[property].column === undefined ||
+      bp[property].column
   ]);
 }

--- a/src/utils/breakpoint/index.js
+++ b/src/utils/breakpoint/index.js
@@ -191,15 +191,19 @@ export function sortFormattedBreakpoints(breakpoints: FormattedBreakpoint[]) {
 }
 
 export function sortBreakpoints(breakpoints: Breakpoint[]) {
-  return _sortBreakpoints(breakpoints);
+  return _sortBreakpoints(breakpoints, "location");
 }
 
-function _sortBreakpoints(breakpoints: Array<Object>, property = "location") {
+function _sortBreakpoints(breakpoints: Array<Object>, property: string) {
   return sortBy(breakpoints, [
     "${property}.line",
-    bp =>
-      bp[property].line ||
-      bp[property].column === undefined ||
-      bp[property].column
+    bp => {
+      // Priority: line number, undefined column, column number
+      return (
+        bp[property].line ||
+        bp[property].column === undefined ||
+        bp[property].column
+      );
+    }
   ]);
 }

--- a/src/utils/breakpoint/tests/index.spec.js
+++ b/src/utils/breakpoint/tests/index.spec.js
@@ -2,11 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
-import { sortBreakpoints } from "../index";
+import { sortFormattedBreakpoints } from "../index";
 
 describe("breakpoint sorting", () => {
-  it("sortBreakpoints should sort by line number and column ", () => {
-    const sorted = sortBreakpoints([
+  it("sortFormattedBreakpoints should sort by line number and column ", () => {
+    const sorted = sortFormattedBreakpoints([
       { selectedLocation: { line: 100, column: 2 } },
       { selectedLocation: { line: 9, column: 2 } },
       { selectedLocation: { line: 2, column: undefined } },
@@ -19,5 +19,21 @@ describe("breakpoint sorting", () => {
     expect(sorted[1].selectedLocation.column).toBe(7);
     expect(sorted[2].selectedLocation.line).toBe(9);
     expect(sorted[3].selectedLocation.line).toBe(100);
+  });
+
+  it("sortBreakpoints should sort by line number and column ", () => {
+    const sorted = sortFormattedBreakpoints([
+      { location: { line: 100, column: 2 } },
+      { location: { line: 9, column: 2 } },
+      { location: { line: 2, column: undefined } },
+      { location: { line: 2, column: 7 } }
+    ]);
+
+    expect(sorted[0].location.line).toBe(2);
+    expect(sorted[0].location.column).toBe(undefined);
+    expect(sorted[1].location.line).toBe(2);
+    expect(sorted[1].location.column).toBe(7);
+    expect(sorted[2].location.line).toBe(9);
+    expect(sorted[3].location.line).toBe(100);
   });
 });

--- a/src/utils/breakpoint/tests/index.spec.js
+++ b/src/utils/breakpoint/tests/index.spec.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
-import { sortFormattedBreakpoints } from "../index";
+import { sortBreakpoints, sortFormattedBreakpoints } from "../index";
 
 describe("breakpoint sorting", () => {
   it("sortFormattedBreakpoints should sort by line number and column ", () => {
@@ -22,7 +22,7 @@ describe("breakpoint sorting", () => {
   });
 
   it("sortBreakpoints should sort by line number and column ", () => {
-    const sorted = sortFormattedBreakpoints([
+    const sorted = sortBreakpoints([
       { location: { line: 100, column: 2 } },
       { location: { line: 9, column: 2 } },
       { location: { line: 2, column: undefined } },


### PR DESCRIPTION
I'm super excited about this.

At present, a breakpoint gutter item is added for every breakpoint (whether column is `undefined` or present), which makes the gutter weird;

1.  Clicking an active column breakpoint marker removes the gutter marker, even though there are more breakpoints active on that column

2.  It's hard to understand which breakpoint that marker's context menu actually represents.

This PR makes the gutter marker represent a single column breakpoint (the first found in the list);  in the future, we'd want to sort the breakpoints first so that the gutter marker represents the first breakpoint *on that line*, instead of the first one found.

## To Do:
- [x]  Sort breakpoints before `uniqBy` (will be available once `getFirstPausePoint` lands (https://github.com/devtools-html/debugger.html/pull/7392)