### PR TITLE
Allow closing source tabs via keyboard

### DIFF
--- a/assets/panel/debugger.properties
+++ b/assets/panel/debugger.properties
@@ -542,6 +542,7 @@ pauseOnAnyXHR=Pause on any URL
 # for closing the selected tab below the mouse.
 sourceTabs.closeTab=Close tab
 sourceTabs.closeTab.accesskey=c
+sourceTabs.closeTab.key=CmdOrCtrl+W
 
 # LOCALIZATION NOTE (sourceTabs.closeOtherTabs): Editor source tab context menu item
 # for closing the other tabs.

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -212,10 +212,10 @@ class Editor extends PureComponent<Props, State> {
   }
 
   onClosePress = (key, e: KeyboardEvent) => {
-    e.preventDefault();
-    e.stopPropagation();
     const { selectedSource } = this.props;
     if (selectedSource) {
+      e.preventDefault();
+      e.stopPropagation();
       this.props.closeTab(selectedSource);
     }
   };

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -94,7 +94,8 @@ export type Props = {
   addOrToggleDisabledBreakpoint: number => void,
   jumpToMappedLocation: any => void,
   traverseResults: (boolean, Object) => void,
-  updateViewport: void => void
+  updateViewport: void => void,
+  closeTab: Source => void
 };
 
 type State = {
@@ -204,10 +205,20 @@ class Editor extends PureComponent<Props, State> {
       L10N.getStr("toggleCondPanel.key"),
       this.onToggleConditionalPanel
     );
+    shortcuts.on(L10N.getStr("sourceTabs.closeTab.key"), this.onClosePress);
     shortcuts.on("Esc", this.onEscape);
     shortcuts.on(searchAgainPrevKey, this.onSearchAgain);
     shortcuts.on(searchAgainKey, this.onSearchAgain);
   }
+
+  onClosePress = (key, e: KeyboardEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    const { selectedSource } = this.props;
+    if (selectedSource) {
+      this.props.closeTab(selectedSource);
+    }
+  };
 
   componentWillUnmount() {
     if (this.state.editor) {
@@ -220,6 +231,7 @@ class Editor extends PureComponent<Props, State> {
       "sourceSearch.search.againPrev.key2"
     );
     const shortcuts = this.context.shortcuts;
+    shortcuts.off(L10N.getStr("sourceTabs.closeTab.key"));
     shortcuts.off(L10N.getStr("toggleBreakpoint.key"));
     shortcuts.off(L10N.getStr("toggleCondPanel.key"));
     shortcuts.off(searchAgainPrevKey);
@@ -626,6 +638,7 @@ export default connect(
     addOrToggleDisabledBreakpoint: actions.addOrToggleDisabledBreakpoint,
     jumpToMappedLocation: actions.jumpToMappedLocation,
     traverseResults: actions.traverseResults,
-    updateViewport: actions.updateViewport
+    updateViewport: actions.updateViewport,
+    closeTab: actions.closeTab
   }
 )(Editor);

--- a/src/test/mochitest/browser.ini
+++ b/src/test/mochitest/browser.ini
@@ -746,6 +746,7 @@ skip-if = true
 [browser_dbg-stepping.js]
 skip-if = debug || (verify && (os == 'win')) || (os == "win" && os_version == "6.1")
 [browser_dbg-tabs.js]
+[browser_dbg-tabs-keyboard.js]
 [browser_dbg-tabs-pretty-print.js]
 [browser_dbg-tabs-without-urls.js]
 [browser_dbg-toggling-tools.js]

--- a/src/test/mochitest/browser_dbg-tabs-keyboard.js
+++ b/src/test/mochitest/browser_dbg-tabs-keyboard.js
@@ -1,0 +1,20 @@
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
+
+// Tests removing tabs with keyboard shortcuts
+
+add_task(async function() {
+  const dbg = await initDebugger("doc-scripts.html", "simple1", "simple2");
+
+  await selectSource(dbg, "simple1");
+  await selectSource(dbg, "simple2");
+  is(countTabs(dbg), 2);
+  
+  pressKey(dbg, "close");
+  waitForDispatch(dbg, "CLOSE_TAB");
+  is(countTabs(dbg), 1);
+
+  pressKey(dbg, "close");
+  waitForDispatch(dbg, "CLOSE_TAB");
+  is(countTabs(dbg), 0);
+});

--- a/src/test/mochitest/browser_dbg-tabs-without-urls.js
+++ b/src/test/mochitest/browser_dbg-tabs-without-urls.js
@@ -1,10 +1,6 @@
 /* Any copyright is dedicated to the Public Domain.
  * http://creativecommons.org/publicdomain/zero/1.0/ */
 
-function countTabs(dbg) {
-  return findElement(dbg, "sourceTabs").children.length;
-}
-
 // Test that URL-less sources have tabs added to the UI but 
 // do not persist upon reload
 add_task(async function() {

--- a/src/test/mochitest/browser_dbg-tabs.js
+++ b/src/test/mochitest/browser_dbg-tabs.js
@@ -3,10 +3,6 @@
 
 // Tests adding and removing tabs
 
-function countTabs(dbg) {
-  return findElement(dbg, "sourceTabs").children.length;
-}
-
 add_task(async function() {
   const dbg = await initDebugger("doc-scripts.html", "simple1", "simple2");
 

--- a/src/test/mochitest/helpers.js
+++ b/src/test/mochitest/helpers.js
@@ -601,6 +601,10 @@ async function closeTab(dbg, url) {
   await dbg.actions.closeTab(findSource(dbg, url));
 }
 
+function countTabs(dbg) {
+  return findElement(dbg, "sourceTabs").children.length;
+}
+
 /**
  * Steps over.
  *
@@ -918,6 +922,7 @@ const startKey = isMac
   : { code: "VK_HOME" };
 
 const keyMappings = {
+  close: { code: "w", modifiers: cmdOrCtrl },
   debugger: { code: "s", modifiers: shiftOrAlt },
   inspector: { code: "c", modifiers: shiftOrAlt },
   quickOpen: { code: "p", modifiers: cmdOrCtrl },


### PR DESCRIPTION
I try doing this all the time.  Since it's a tabbed interface, it seems to make sense to me that C+W would close a tab.  This doesn't work in launchpad but does in panel.

## ToDo
- [x] Test
- [x] Discussion:  Do we even want this?