### PR TITLE
Fix tab context menu item size checks

### DIFF
--- a/src/components/Editor/Tab.js
+++ b/src/components/Editor/Tab.js
@@ -89,9 +89,9 @@ class Tab extends PureComponent<Props> {
       {
         item: {
           ...tabMenuItems.closeOtherTabs,
-          click: () => closeTabs(otherTabURLs)
-        },
-        hidden: () => tabSources.size === 1
+          click: () => closeTabs(otherTabURLs),
+          disabled: () => tabSources.length === 1
+        }
       },
       {
         item: {
@@ -99,11 +99,11 @@ class Tab extends PureComponent<Props> {
           click: () => {
             const tabIndex = tabSources.findIndex(t => t.id == tab);
             closeTabs(tabURLs.filter((t, i) => i > tabIndex));
-          }
-        },
-        hidden: () =>
-          tabSources.size === 1 ||
-          tabSources.some((t, i) => t === tab && tabSources.size - 1 === i)
+          },
+          disabled: () =>
+            tabSources.length === 1 ||
+            tabSources.some((t, i) => t === tab && tabSources.length - 1 === i)
+        }
       },
       {
         item: { ...tabMenuItems.closeAllTabs, click: () => closeTabs(tabURLs) }

--- a/src/components/Editor/Tab.js
+++ b/src/components/Editor/Tab.js
@@ -68,6 +68,7 @@ class Tab extends PureComponent<Props> {
       selectedSource
     } = this.props;
 
+    const tabCount = tabSources.length;
     const otherTabs = tabSources.filter(t => t.id !== tab);
     const sourceTab = tabSources.find(t => t.id == tab);
     const tabURLs = tabSources.map(t => t.url);
@@ -90,7 +91,7 @@ class Tab extends PureComponent<Props> {
         item: {
           ...tabMenuItems.closeOtherTabs,
           click: () => closeTabs(otherTabURLs),
-          disabled: () => tabSources.length === 1
+          disabled: () => tabCount === 1
         }
       },
       {
@@ -101,8 +102,8 @@ class Tab extends PureComponent<Props> {
             closeTabs(tabURLs.filter((t, i) => i > tabIndex));
           },
           disabled: () =>
-            tabSources.length === 1 ||
-            tabSources.some((t, i) => t === tab && tabSources.length - 1 === i)
+            tabCount === 1 ||
+            tabSources.some((t, i) => t === tab && tabCount - 1 === i)
         }
       },
       {


### PR DESCRIPTION
The `.size` checks were undefined since we likely moved away from immutables.  Additionally, I dislike show/hide of menu items; simply disabling them keeps menu integrity while only allowing desired functionality.