### PR TITLE
Remove 4px gap between the source file name and the primary pane separator

### DIFF
--- a/src/components/PrimaryPanes/Sources.css
+++ b/src/components/PrimaryPanes/Sources.css
@@ -236,12 +236,6 @@
   background-color: white;
 }
 
-.tree:not(.object-inspector)
-  .tree-node[data-expandable="false"]
-  .tree-indent:last-of-type {
-  margin-inline-end: 4px;
-}
-
 /*
   Custom root styles
 */


### PR DESCRIPTION
I looked at the PR where this came in and it's unclear why it was added.  In any event, we've changed the styling the three a lot and I don't believe we need it.