### PR TITLE
Prevent the breakpoint exception labels from being highlighted

### DIFF
--- a/src/components/SecondaryPanes/Breakpoints/Breakpoints.css
+++ b/src/components/SecondaryPanes/Breakpoints/Breakpoints.css
@@ -56,6 +56,7 @@
 .breakpoints-exceptions {
   padding-bottom: 0.5em;
   padding-top: 0.5em;
+  user-select: none;
 }
 
 .breakpoints-list .breakpoint {


### PR DESCRIPTION
I just noticed that clicking the "Pause on Exception" and "Pause on any xhr" checkboxes quickly results in their text being highlighted, which we don't want.  