### PR TITLE
Avoid text selection in welcome box modal

### DIFF
--- a/src/components/ShortcutsModal.css
+++ b/src/components/ShortcutsModal.css
@@ -6,6 +6,7 @@
   padding: 15px;
   column-width: 250px;
   cursor: default;
+  user-select: none;
 }
 
 .shortcuts-content h2 {


### PR DESCRIPTION
At present you can highlight text in the welcome box modal, which has no value.  Let's prevent that.