### PR TITLE
Dark mode color polish

### DIFF
--- a/src/components/PrimaryPanes/Outline.css
+++ b/src/components/PrimaryPanes/Outline.css
@@ -106,3 +106,8 @@
   background: var(--theme-highlight-blue);
   color: #ffffff;
 }
+
+.theme-dark .outline-footer button.active {
+  background: var(--theme-selection-background);
+  color: #ffffff;
+}

--- a/src/components/PrimaryPanes/OutlineFilter.css
+++ b/src/components/PrimaryPanes/OutlineFilter.css
@@ -22,3 +22,7 @@
   font-style: italic;
   color: var(--theme-comment);
 }
+
+.theme-dark .outline-filter-input.focused {
+  border: 1px solid var(--blue-50);
+}


### PR DESCRIPTION
Fixes #7426 

Here's the Pull Request Doc
https://firefox-dev.tools/debugger.html/docs/pull-requests.html

### Summary of Changes

* Changed active dark mode outline-footer button background color to --theme-selection-background
* Changed focused dark mode outline-filter-input border color to --blue-50

### Test Plan

Tell us a little a bit about how you tested your patch.

Example test plan:

- [x] Command-P opens the panel
- [x] Clicking “+” opens the panel
- [x] Clicking a source navigates to the source
- [x] Clicking "x" closes the panel

Here's the Debugger's Testing doc
https://docs.google.com/document/d/1oBMRxV8A2ag2t22YsQOxTdEv0mXKzIg0tggJjRkU1S0/edit#.
Feel free to improve it!

### Screenshots/Videos (OPTIONAL)
