### PR TITLE
Repurpose context menu

### DIFF
--- a/src/actions/pause/continueToHere.js
+++ b/src/actions/pause/continueToHere.js
@@ -14,7 +14,7 @@ import { resume, rewind } from "./commands";
 
 import type { ThunkArgs } from "../types";
 
-export function continueToHere(line: number) {
+export function continueToHere(line: number, column?: number) {
   return async function({ dispatch, getState }: ThunkArgs) {
     const selectedSource = getSelectedSource(getState());
     const selectedFrame = getSelectedFrame(getState());
@@ -34,7 +34,7 @@ export function continueToHere(line: number) {
     await dispatch(
       addHiddenBreakpoint({
         line,
-        column: undefined,
+        column: column,
         sourceId: selectedSource.id
       })
     );

--- a/src/components/Editor/GutterMenu.js
+++ b/src/components/Editor/GutterMenu.js
@@ -143,12 +143,10 @@ class GutterContextMenuComponent extends Component {
 
     const sourceId = props.selectedSource ? props.selectedSource.id : "";
     const line = lineAtHeight(props.editor, sourceId, event);
-    const column =
-      props.editor.codeMirror.coordsChar({
-        left: event.x,
-        top: event.y
-      }).ch || undefined;
-
+    const column = props.editor.codeMirror.coordsChar({
+      left: event.x,
+      top: event.y
+    }).ch;
     const breakpoint = nextProps.breakpoints.find(
       bp => bp.location.line === line && bp.location.column === column
     );

--- a/src/components/Editor/GutterMenu.js
+++ b/src/components/Editor/GutterMenu.js
@@ -143,30 +143,15 @@ class GutterContextMenuComponent extends Component {
 
     const sourceId = props.selectedSource ? props.selectedSource.id : "";
     const line = lineAtHeight(props.editor, sourceId, event);
+    const column =
+      props.editor.codeMirror.coordsChar({
+        left: event.x,
+        top: event.y
+      }).ch || undefined;
 
-    let breakpoint = nextProps.breakpoints.find(
-      bp => bp.location.line === line
+    const breakpoint = nextProps.breakpoints.find(
+      bp => bp.location.line === line && bp.location.column === column
     );
-
-    // Detect a column breakpoint
-    const coords = props.editor.codeMirror.coordsChar({
-      left: event.x,
-      top: event.y
-    });
-
-    let column = null;
-    if (coords.ch) {
-      breakpoint = null;
-      column = coords.ch;
-
-      const breakpointSearch = nextProps.breakpoints.find(
-        bp => bp.location.line === line && bp.location.column === coords.ch
-      );
-
-      if (breakpointSearch) {
-        breakpoint = breakpointSearch;
-      }
-    }
 
     if (props.emptyLines && props.emptyLines.includes(line)) {
       return;

--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -350,7 +350,11 @@ class Editor extends PureComponent<Props, State> {
 
     const { setContextMenu } = this.props;
     const target: Element = (event.target: any);
-    if (target.classList.contains("CodeMirror-linenumber")) {
+
+    if (
+      target.classList.contains("CodeMirror-linenumber") ||
+      target.getAttribute("id") === "columnmarker"
+    ) {
       return setContextMenu("Gutter", event);
     }
 


### PR DESCRIPTION
Provides the same context menu for individual column breakpoint markers as the left line/gutter marker.