### PR TITLE
Restore empty lines value to grey vars

### DIFF
--- a/src/components/Editor/Editor.css
+++ b/src/components/Editor/Editor.css
@@ -66,12 +66,12 @@ html[dir="rtl"] .editor-mount {
   --breakpoint-stroke-disabled: var(--blue-60);
 }
 
-.empty-line .CodeMirror-linenumber {
-  opacity: 0.5;
+.theme-light .cm-s-mozilla .empty-line .CodeMirror-linenumber {
+  color: var(--grey-40);
 }
 
-.theme-dark .empty-line .CodeMirror-linenumber {
-  opacity: 0.6;
+.theme-dark .cm-s-mozilla .empty-line .CodeMirror-linenumber {
+  color: var(--grey-60);
 }
 
 :not(.empty-line):not(.new-breakpoint)


### PR DESCRIPTION
This is what we had before; not sure how it got changed:

## Light
<img width="267" alt="llight" src="https://user-images.githubusercontent.com/46655/49668111-2a98e100-fa2b-11e8-9570-c55a64a4cedb.png">



## Dark
<img width="219" alt="ddark" src="https://user-images.githubusercontent.com/46655/49668119-2ec4fe80-fa2b-11e8-86e0-946f06078742.png">

This feels better than opacity color creation.
