### PR TITLE
Updated the "skip pausing" button to "Deactivate breakpoints".

### DIFF
--- a/assets/panel/debugger.properties
+++ b/assets/panel/debugger.properties
@@ -84,7 +84,7 @@ stepOutTooltip=Step out %S
 
 # LOCALIZATION NOTE (skipPausingTooltip): The tooltip text for disabling all
 # breakpoints and pausing triggers
-skipPausingTooltip=Skip all pausing
+skipPausingTooltip=Deactivate breakpoints
 
 # LOCALIZATION NOTE (pauseButtonItem): The label that is displayed for the dropdown pause
 # list item when the debugger is in a running state.

--- a/assets/panel/debugger.properties
+++ b/assets/panel/debugger.properties
@@ -82,9 +82,9 @@ stepInTooltip=Step in %S
 # button that steps out of a function call.
 stepOutTooltip=Step out %S
 
-# LOCALIZATION NOTE (skipPausingTooltip): The tooltip text for disabling all
+# LOCALIZATION NOTE (skipPausingTooltip.label): The tooltip text for disabling all
 # breakpoints and pausing triggers
-skipPausingTooltip=Deactivate breakpoints
+skipPausingTooltip.label=Deactivate breakpoints
 
 # LOCALIZATION NOTE (pauseButtonItem): The label that is displayed for the dropdown pause
 # list item when the debugger is in a running state.

--- a/src/components/SecondaryPanes/CommandBar.js
+++ b/src/components/SecondaryPanes/CommandBar.js
@@ -270,7 +270,7 @@ class CommandBar extends Component<Props> {
             active: skipPausing
           }
         )}
-        title={L10N.getStr("skipPausingTooltip")}
+        title={L10N.getStr("skipPausingTooltip.label")}
         onClick={toggleSkipPausing}
       >
         <img className="skipPausing" />


### PR DESCRIPTION
Fixes #7360 

Here's the Pull Request Doc
https://firefox-dev.tools/debugger.html/docs/pull-requests.html

### Summary of Changes

*  Replaced "Skip all pausing" with "Deactivate breakpoints" in assets/panel/debugger.properties

### Test Plan

* Ran ```yarn start``` and made sure it was changed to "Deactivate breakpoints". 

Here's the Debugger's Testing doc
https://docs.google.com/document/d/1oBMRxV8A2ag2t22YsQOxTdEv0mXKzIg0tggJjRkU1S0/edit#.
Feel free to improve it!

### Screenshots/Videos (OPTIONAL)

![hover](https://user-images.githubusercontent.com/34352725/49687997-8a79af80-fb31-11e8-932c-dd77e7dcd7c2.gif)
