### PR TITLE
Use same logic for pretty print option in footer and tab

### DIFF
--- a/src/components/Editor/Tab.js
+++ b/src/components/Editor/Tab.js
@@ -18,13 +18,14 @@ import type { Source } from "../../types";
 import actions from "../../actions";
 
 import {
+  getDisplayPath,
   getFileURL,
   getRawSourceURL,
+  getSourceQueryString,
   getTruncatedFileName,
-  getDisplayPath,
-  isPretty,
-  getSourceQueryString
+  isPretty
 } from "../../utils/source";
+import { shouldShowPrettyPrint } from "../../utils/editor";
 import { copyToTheClipboard } from "../../utils/clipboard";
 import { getTabMenuItems } from "../../utils/tabs";
 
@@ -65,7 +66,8 @@ class Tab extends PureComponent<Props> {
       tabSources,
       showSource,
       togglePrettyPrint,
-      selectedSource
+      selectedSource,
+      source
     } = this.props;
 
     const tabCount = tabSources.length;
@@ -78,7 +80,6 @@ class Tab extends PureComponent<Props> {
       return;
     }
 
-    const isPrettySource = isPretty(sourceTab);
     const tabMenuItems = getTabMenuItems();
     const items = [
       {
@@ -133,14 +134,13 @@ class Tab extends PureComponent<Props> {
       }
     ];
 
-    if (!isPrettySource) {
-      items.push({
-        item: {
-          ...tabMenuItems.prettyPrint,
-          click: () => togglePrettyPrint(tab)
-        }
-      });
-    }
+    items.push({
+      item: {
+        ...tabMenuItems.prettyPrint,
+        click: () => togglePrettyPrint(tab),
+        disabled: !shouldShowPrettyPrint(source)
+      }
+    });
 
     showMenu(e, buildMenu(items));
   }

--- a/src/utils/editor/index.js
+++ b/src/utils/editor/index.js
@@ -58,22 +58,18 @@ export function endOperation() {
   codeMirror.endOperation();
 }
 
-export function shouldShowPrettyPrint(selectedSource) {
-  if (!selectedSource) {
-    return false;
-  }
-
-  return shouldPrettyPrint(selectedSource);
+export function shouldShowPrettyPrint(source) {
+  return shouldPrettyPrint(source);
 }
 
-export function shouldShowFooter(selectedSource, horizontal) {
+export function shouldShowFooter(source, horizontal) {
   if (!horizontal) {
     return true;
   }
-  if (!selectedSource) {
+  if (!source) {
     return false;
   }
-  return shouldShowPrettyPrint(selectedSource) || isOriginal(selectedSource);
+  return shouldShowPrettyPrint(source) || isOriginal(source);
 }
 
 export function traverseResults(e, ctx, query, dir, modifiers) {


### PR DESCRIPTION
References;  https://github.com/devtools-html/debugger.html/issues/7113

We're using different logic for showing the pretty print option in the tab context menu and the footer.  This PR ensures the same logic is used in both places.