### PR TITLE
Clear the watch expression input box on blur

### DIFF
--- a/src/components/SecondaryPanes/Expressions.js
+++ b/src/components/SecondaryPanes/Expressions.js
@@ -26,6 +26,8 @@ import type { Expression } from "../../types";
 
 import "./Expressions.css";
 
+import * as parser from "../../workers/parser";
+
 const { ObjectInspector } = objectInspector;
 
 type State = {
@@ -161,10 +163,15 @@ class Expressions extends Component<Props, State> {
     }
   };
 
-  hideInput = () => {
+  hideInput = async () => {
     this.setState({ focused: false });
     this.props.onExpressionAdded();
-    this.clear();
+
+    const expressionError = await parser.hasSyntaxError(this.state.inputValue);
+
+    if (expressionError !== false) {
+      this.clear();
+    }
   };
 
   onFocus = () => {

--- a/src/components/SecondaryPanes/Expressions.js
+++ b/src/components/SecondaryPanes/Expressions.js
@@ -26,8 +26,6 @@ import type { Expression } from "../../types";
 
 import "./Expressions.css";
 
-import * as parser from "../../workers/parser";
-
 const { ObjectInspector } = objectInspector;
 
 type State = {
@@ -163,15 +161,10 @@ class Expressions extends Component<Props, State> {
     }
   };
 
-  hideInput = async () => {
+  hideInput = () => {
     this.setState({ focused: false });
     this.props.onExpressionAdded();
-
-    const expressionError = await parser.hasSyntaxError(this.state.inputValue);
-
-    if (expressionError !== false) {
-      this.clear();
-    }
+    this.props.clearExpressionError();
   };
 
   onFocus = () => {

--- a/src/components/SecondaryPanes/Expressions.js
+++ b/src/components/SecondaryPanes/Expressions.js
@@ -164,6 +164,7 @@ class Expressions extends Component<Props, State> {
   hideInput = () => {
     this.setState({ focused: false });
     this.props.onExpressionAdded();
+    this.clear();
   };
 
   onFocus = () => {


### PR DESCRIPTION
Fixes #7464

### Summary of Changes

Fixed expression-input-container so that it clears the input box on blur.

![dec-09-2018 16-49-58](https://user-images.githubusercontent.com/15959269/49705301-949fba80-fbd2-11e8-81c4-469dc8a5fb6b.gif)

