### PR TITLE
Add separator between search box/navigation and modifiers

### DIFF
--- a/src/components/Editor/SearchBar.js
+++ b/src/components/Editor/SearchBar.js
@@ -291,6 +291,7 @@ class SearchBar extends Component<Props, State> {
 
     return (
       <div className="search-modifiers">
+        <span className="pipe-divider" />
         <span className="search-type-name">
           {L10N.getStr("symbolSearch.searchModifier.modifiersLabel")}
         </span>

--- a/src/components/Editor/tests/__snapshots__/SearchBar.spec.js.snap
+++ b/src/components/Editor/tests/__snapshots__/SearchBar.spec.js.snap
@@ -30,6 +30,9 @@ exports[`SearchBar should render 1`] = `
       className="search-modifiers"
     >
       <span
+        className="pipe-divider"
+      />
+      <span
         className="search-type-name"
       >
         Modifiers:
@@ -99,6 +102,9 @@ exports[`showErrorEmoji false if no query + no results 1`] = `
       className="search-modifiers"
     >
       <span
+        className="pipe-divider"
+      />
+      <span
         className="search-type-name"
       >
         Modifiers:
@@ -166,6 +172,9 @@ exports[`showErrorEmoji false if query + results 1`] = `
       className="search-modifiers"
     >
       <span
+        className="pipe-divider"
+      />
+      <span
         className="search-type-name"
       >
         Modifiers:
@@ -232,6 +241,9 @@ exports[`showErrorEmoji true if query + no results 1`] = `
     <div
       className="search-modifiers"
     >
+      <span
+        className="pipe-divider"
+      />
       <span
         className="search-type-name"
       >


### PR DESCRIPTION
This was brought up by @violasong during our meeting last week.

