### PR TITLE
Remove unnecessary tree spacing

### DIFF
--- a/src/components/PrimaryPanes/Sources.css
+++ b/src/components/PrimaryPanes/Sources.css
@@ -263,3 +263,7 @@
   > .tree-node[data-expandable="false"][aria-level="0"] {
   padding-inline-start: 4px;
 }
+
+.sources-list .tree-node[data-expandable="false"] .tree-indent:last-of-type {
+  margin-inline-end: 0;
+}


### PR DESCRIPTION
Before:

<img width="287" alt="treebefore" src="https://user-images.githubusercontent.com/46655/49706894-354fa380-fbee-11e8-86b0-9278376b4c66.png">


After:

<img width="331" alt="treeafter" src="https://user-images.githubusercontent.com/46655/49706893-3254b300-fbee-11e8-9d08-5bda15e9f4d6.png">
