### PR TITLE
Provide title text for line and column position

### DIFF
--- a/assets/panel/debugger.properties
+++ b/assets/panel/debugger.properties
@@ -601,11 +601,11 @@ sourceFooter.codeCoverage=Code coverage
 
 # LOCALIZATION NOTE (sourceFooter.currentCursorPosition): Text associated
 # with the current cursor line and column
-sourceFooter.currentCursorPosition=(%S, %S)
+sourceFooter.currentCursorPosition.label=(%1$S, %2$S)
 
 # LOCALIZATION NOTE (sourceFooter.currentCursorPosition.tooltip): Text associated
 # with the current cursor line and column
-sourceFooter.currentCursorPosition.tooltip=(Line %S, column %S)
+sourceFooter.currentCursorPosition.tooltip=(Line %1$S, column %2$S)
 
 # LOCALIZATION NOTE (sourceTabs.closeTabButtonTooltip): The tooltip that is displayed
 # for close tab button in source tabs.

--- a/assets/panel/debugger.properties
+++ b/assets/panel/debugger.properties
@@ -603,6 +603,10 @@ sourceFooter.codeCoverage=Code coverage
 # with the current cursor line and column
 sourceFooter.currentCursorPosition=(%S, %S)
 
+# LOCALIZATION NOTE (sourceFooter.currentCursorPosition.tooltip): Text associated
+# with the current cursor line and column
+sourceFooter.currentCursorPosition.tooltip=(Line %S, column %S)
+
 # LOCALIZATION NOTE (sourceTabs.closeTabButtonTooltip): The tooltip that is displayed
 # for close tab button in source tabs.
 sourceTabs.closeTabButtonTooltip=Close tab

--- a/assets/panel/debugger.properties
+++ b/assets/panel/debugger.properties
@@ -601,7 +601,7 @@ sourceFooter.codeCoverage=Code coverage
 
 # LOCALIZATION NOTE (sourceFooter.currentCursorPosition): Text associated
 # with the current cursor line and column
-sourceFooter.currentCursorPosition.label=(%1$S, %2$S)
+sourceFooter.currentCursorPosition=(%1$S, %2$S)
 
 # LOCALIZATION NOTE (sourceFooter.currentCursorPosition.tooltip): Text associated
 # with the current cursor line and column

--- a/src/components/Editor/Footer.js
+++ b/src/components/Editor/Footer.js
@@ -214,7 +214,16 @@ class SourceFooter extends PureComponent<Props, State> {
       cursorPosition.line + 1,
       cursorPosition.column + 1
     );
-    return <span className="cursor-position">{text}</span>;
+    const title = L10N.getFormatStr(
+      "sourceFooter.currentCursorPosition.tooltip",
+      cursorPosition.line + 1,
+      cursorPosition.column + 1
+    );
+    return (
+      <span className="cursor-position" title={title}>
+        {text}
+      </span>
+    );
   }
 
   render() {

--- a/src/components/Editor/Footer.js
+++ b/src/components/Editor/Footer.js
@@ -210,7 +210,7 @@ class SourceFooter extends PureComponent<Props, State> {
     const { cursorPosition } = this.state;
 
     const text = L10N.getFormatStr(
-      "sourceFooter.currentCursorPosition.label",
+      "sourceFooter.currentCursorPosition",
       cursorPosition.line + 1,
       cursorPosition.column + 1
     );

--- a/src/components/Editor/Footer.js
+++ b/src/components/Editor/Footer.js
@@ -210,7 +210,7 @@ class SourceFooter extends PureComponent<Props, State> {
     const { cursorPosition } = this.state;
 
     const text = L10N.getFormatStr(
-      "sourceFooter.currentCursorPosition",
+      "sourceFooter.currentCursorPosition.label",
       cursorPosition.line + 1,
       cursorPosition.column + 1
     );

--- a/src/components/Editor/tests/__snapshots__/Footer.spec.js.snap
+++ b/src/components/Editor/tests/__snapshots__/Footer.spec.js.snap
@@ -12,6 +12,7 @@ exports[`SourceFooter Component default case should render 1`] = `
   />
   <span
     className="cursor-position"
+    title="(Line 2, column 2)"
   >
     (2, 2)
   </span>
@@ -30,6 +31,7 @@ exports[`SourceFooter Component move cursor should render new cursor position 1`
   />
   <span
     className="cursor-position"
+    title="(Line 6, column 11)"
   >
     (6, 11)
   </span>


### PR DESCRIPTION
I can see how the line and column text could be confusing or meaningless to some devs.  This tooltip lets them know what the numbers mean.