### PR TITLE
Go to column when outline function is clicked

### DIFF
--- a/src/components/PrimaryPanes/Outline.js
+++ b/src/components/PrimaryPanes/Outline.js
@@ -76,9 +76,12 @@ export class Outline extends Component<Props, State> {
     if (!selectedSource) {
       return;
     }
-    const selectedSourceId = selectedSource.id;
-    const startLine = location.start.line;
-    selectLocation({ sourceId: selectedSourceId, line: startLine });
+
+    selectLocation({
+      sourceId: selectedSource.id,
+      line: location.start.line,
+      column: location.start.column
+    });
   }
 
   onContextMenu(event: SyntheticEvent<HTMLElement>, func: SymbolDeclaration) {


### PR DESCRIPTION
Clicking on a function in the outline only highlights a given line, which isn't all that useful on a generated/minified line.  Providing the column allows the editor to scroll to the given function's location.