### PR TITLE
Fix 6121 - Crop attributes and provide title after specified length

### DIFF
--- a/packages/devtools-reps/src/reps/attribute.js
+++ b/packages/devtools-reps/src/reps/attribute.js
@@ -29,7 +29,7 @@ function Attribute(props) {
     },
     span({ className: "attrName" }, getTitle(object)),
     span({ className: "attrEqual" }, "="),
-    StringRep({ className: "attrValue", object: value })
+    StringRep({ className: "attrValue", object: value, title: value })
   );
 }
 

--- a/packages/devtools-reps/src/reps/element-node.js
+++ b/packages/devtools-reps/src/reps/element-node.js
@@ -14,6 +14,8 @@ const nodeConstants = require("../shared/dom-node-constants");
 const dom = require("react-dom-factories");
 const { span } = dom;
 
+const maxAttributeLength = 50;
+
 /**
  * Renders DOM element node.
  */
@@ -144,7 +146,12 @@ function getElements(grip, mode) {
       {},
       span({ className: "attrName" }, name),
       span({ className: "attrEqual" }, "="),
-      StringRep({ className: "attrValue", object: value })
+      StringRep({
+        className: "attrValue",
+        object: value,
+        cropLimit: maxAttributeLength,
+        title: value.length > maxAttributeLength ? value : null
+      })
     );
 
     return arr.concat([" ", attribute]);

--- a/packages/devtools-reps/src/reps/element-node.js
+++ b/packages/devtools-reps/src/reps/element-node.js
@@ -7,14 +7,14 @@ const PropTypes = require("prop-types");
 
 // Utils
 const { isGrip, wrapRender } = require("./rep-utils");
-const { rep: StringRep } = require("./string");
+const { rep: StringRep, isLongString } = require("./string");
 const { MODE } = require("./constants");
 const nodeConstants = require("../shared/dom-node-constants");
 
 const dom = require("react-dom-factories");
 const { span } = dom;
 
-const maxAttributeLength = 50;
+const MAX_ATTRIBUTE_LENGTH = 50;
 
 /**
  * Renders DOM element node.
@@ -142,6 +142,12 @@ function getElements(grip, mode) {
   }
   const attributeElements = attributeKeys.reduce((arr, name, i, keys) => {
     const value = attributes[name];
+
+    let title = isLongString(value) ? value.initial : value;
+    if (title.length < MAX_ATTRIBUTE_LENGTH) {
+      title = null;
+    }
+
     const attribute = span(
       {},
       span({ className: "attrName" }, name),
@@ -149,8 +155,8 @@ function getElements(grip, mode) {
       StringRep({
         className: "attrValue",
         object: value,
-        cropLimit: maxAttributeLength,
-        title: value.length > maxAttributeLength ? value : null
+        cropLimit: MAX_ATTRIBUTE_LENGTH,
+        title
       })
     );
 
@@ -177,6 +183,7 @@ function supportsObject(object, noGrip = false) {
 
 // Exports from this module
 module.exports = {
-  rep: wrapRender(ElementNode),
-  supportsObject
+  rep: wrapRender(Element, Node),
+  supportsObject,
+  MAX_ATTRIBUTE_LENGTH
 };

--- a/packages/devtools-reps/src/reps/element-node.js
+++ b/packages/devtools-reps/src/reps/element-node.js
@@ -183,7 +183,7 @@ function supportsObject(object, noGrip = false) {
 
 // Exports from this module
 module.exports = {
-  rep: wrapRender(Element, Node),
+  rep: wrapRender(ElementNode),
   supportsObject,
   MAX_ATTRIBUTE_LENGTH
 };

--- a/packages/devtools-reps/src/reps/string.js
+++ b/packages/devtools-reps/src/reps/string.js
@@ -33,7 +33,7 @@ StringRep.propTypes = {
   object: PropTypes.object.isRequired,
   openLink: PropTypes.func,
   className: PropTypes.string,
-  title: PropTypes.title
+  title: PropTypes.string
 };
 
 function StringRep(props) {

--- a/packages/devtools-reps/src/reps/string.js
+++ b/packages/devtools-reps/src/reps/string.js
@@ -32,7 +32,8 @@ StringRep.propTypes = {
   member: PropTypes.object,
   object: PropTypes.object.isRequired,
   openLink: PropTypes.func,
-  className: PropTypes.string
+  className: PropTypes.string,
+  title: PropTypes.title
 };
 
 function StringRep(props) {
@@ -44,7 +45,8 @@ function StringRep(props) {
     useQuotes = true,
     escapeWhitespace = true,
     member,
-    openLink
+    openLink,
+    title
   } = props;
 
   let text = object;
@@ -79,7 +81,8 @@ function StringRep(props) {
   const config = getElementConfig({
     className,
     style,
-    actor: object.actor
+    actor: object.actor,
+    title
   });
 
   if (!isLong) {
@@ -127,12 +130,16 @@ function formatText(opts, text) {
 }
 
 function getElementConfig(opts) {
-  const { className, style, actor } = opts;
+  const { className, style, actor, title } = opts;
 
   const config = {};
 
   if (actor) {
     config["data-link-actor-id"] = actor;
+  }
+
+  if (title) {
+    config.title = title;
   }
 
   const classNames = ["objectBox", "objectBox-string"];

--- a/packages/devtools-reps/src/reps/stubs/element-node.js
+++ b/packages/devtools-reps/src/reps/stubs/element-node.js
@@ -206,6 +206,22 @@ stubs.set("SvgNodeInXHTML", {
   }
 });
 
+stubs.set("NodeWithLongAttribute", {
+  type: "object",
+  actor: "server1.conn1.child1/obj32",
+  class: "HTMLParagraphElement",
+  ownPropertyLength: 0,
+  preview: {
+    kind: "DOMNode",
+    nodeType: 1,
+    nodeName: "p",
+    attributes: {
+      "data-test": "a".repeat(100)
+    },
+    attributesLength: 1
+  }
+});
+
 const initialText = "a".repeat(1000);
 stubs.set("NodeWithLongStringAttribute", {
   type: "object",

--- a/packages/devtools-reps/src/reps/tests/element-node.js
+++ b/packages/devtools-reps/src/reps/tests/element-node.js
@@ -7,6 +7,7 @@ const { mount, shallow } = require("enzyme");
 const { JSDOM } = require("jsdom");
 const { REPS, getRep } = require("../rep");
 const { MODE } = require("../constants");
+const { MAX_ATTRIBUTE_LENGTH } = require("../element-node");
 const { ElementNode } = REPS;
 const {
   expectActorAttribute,
@@ -391,7 +392,7 @@ describe("ElementNode - Element with longString attribute", () => {
     );
 
     expect(renderedComponent.text()).toEqual(
-      `<div data-test="${"a".repeat(1000)}${ELLIPSIS}">`
+      `<div data-test="${"a".repeat(MAX_ATTRIBUTE_LENGTH)}${ELLIPSIS}">`
     );
   });
 
@@ -404,6 +405,48 @@ describe("ElementNode - Element with longString attribute", () => {
     );
 
     expect(renderedComponent.text()).toEqual("div");
+  });
+});
+
+describe("ElementNode - Element attribute title values", () => {
+  it("renders no title attribute for short attribute", () => {
+    const stub = stubs.get("LotsOfAttributes");
+
+    const renderedComponent = shallow(
+      ElementNode.rep({
+        object: stub
+      })
+    );
+
+    expect(renderedComponent.prop("id")).toEqual("lots-of-attributes");
+  });
+
+  it("renders partial value as title attribute for long attribute", () => {
+    const stub = stubs.get("NodeWithLongAttribute");
+
+    const renderedComponent = shallow(
+      ElementNode.rep({
+        object: stub
+      })
+    );
+
+    expect(renderedComponent.prop("title")).toEqual(
+      `${"a".repeat(MAX_ATTRIBUTE_LENGTH)}${ELLIPSIS}`
+    );
+  });
+
+  it("renders partial value as title attribute for LongString", () => {
+    const stub = stubs.get("NodeWithLongStringAttribute");
+
+    const renderedComponent = shallow(
+      ElementNode.rep({
+        object: stub
+      })
+    );
+
+    expect(renderedComponent.prop("title")).toEqual(
+      `${"a".repeat(MAX_ATTRIBUTE_LENGTH)}${ELLIPSIS}`
+    );
   });
 });
 

--- a/packages/devtools-reps/src/reps/tests/element-node.js
+++ b/packages/devtools-reps/src/reps/tests/element-node.js
@@ -408,20 +408,23 @@ describe("ElementNode - Element with longString attribute", () => {
   });
 });
 
-describe("ElementNode - Element attribute title values", () => {
+describe("ElementNode - Element attribute cropping", () => {
   it("renders no title attribute for short attribute", () => {
-    const stub = stubs.get("LotsOfAttributes");
-
+    const stub = stubs.get("NodeWithSpacesInClassName");
     const renderedComponent = shallow(
       ElementNode.rep({
         object: stub
       })
     );
-
-    expect(renderedComponent.prop("id")).toEqual("lots-of-attributes");
+    expect(
+      renderedComponent
+        .first()
+        .find("span.attrValue")
+        .prop("title")
+    ).toBe(undefined);
   });
 
-  it("renders partial value as title attribute for long attribute", () => {
+  it("renders partial value for long attribute", () => {
     const stub = stubs.get("NodeWithLongAttribute");
 
     const renderedComponent = shallow(
@@ -430,12 +433,18 @@ describe("ElementNode - Element attribute title values", () => {
       })
     );
 
-    expect(renderedComponent.prop("title")).toEqual(
-      `${"a".repeat(MAX_ATTRIBUTE_LENGTH)}${ELLIPSIS}`
+    expect(renderedComponent.text()).toEqual(
+      '<p data-test="aaaaaaaaaaaaaaaaaaaaaaaa…aaaaaaaaaaaaaaaaaaaaaaa">'
     );
+    expect(
+      renderedComponent
+        .first()
+        .find("span.attrValue")
+        .prop("title")
+    ).toBe("a".repeat(100));
   });
 
-  it("renders partial value as title attribute for LongString", () => {
+  it("renders partial attribute for LongString", () => {
     const stub = stubs.get("NodeWithLongStringAttribute");
 
     const renderedComponent = shallow(
@@ -444,9 +453,15 @@ describe("ElementNode - Element attribute title values", () => {
       })
     );
 
-    expect(renderedComponent.prop("title")).toEqual(
-      `${"a".repeat(MAX_ATTRIBUTE_LENGTH)}${ELLIPSIS}`
+    expect(renderedComponent.text()).toEqual(
+      '<div data-test="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa…">'
     );
+    expect(
+      renderedComponent
+        .first()
+        .find("span.attrValue")
+        .prop("title")
+    ).toBe("a".repeat(1000));
   });
 });
 


### PR DESCRIPTION
Fixes #6121

This PR crops long attributes and provides a `title` attribute for the attribute itself.

## To Do
- [x] Test
- [x] Despite having a `title` attribute, I don't see the tooltip every display when I hover or move around