### PR TITLE
Set min-width for left toggle to ensure line marker and toggle button border line up

### DIFF
--- a/src/components/shared/Button/styles/PaneToggleButton.css
+++ b/src/components/shared/Button/styles/PaneToggleButton.css
@@ -28,6 +28,7 @@
 
 .toggle-button.start {
   margin-inline-start: 0px;
+  min-width: 29px;
 }
 
 html:not([dir="rtl"]) .toggle-button.end svg,


### PR DESCRIPTION
Both @violasong and I noticed each time that the first tab border and the line number don't line up.  This PR makes them line up initially:

<img width="699" alt="align" src="https://user-images.githubusercontent.com/46655/49774928-030c7780-fcbc-11e8-8378-34de51f832f9.png">

When the user scrolls down to the 100+ lines, the CodeMirror vertical line number separator moves right and from that point forward the alignment is broken from the first tab.

I do believe, however, that having this aesthetically pleasing alignment upon initial open is worth this patch.