### PR TITLE
Invoke getter in the root object.

### DIFF
--- a/packages/devtools-reps/src/object-inspector/components/ObjectInspectorItem.js
+++ b/packages/devtools-reps/src/object-inspector/components/ObjectInspectorItem.js
@@ -37,7 +37,7 @@ const {
   nodeIsLongString,
   nodeHasFullText,
   nodeHasGetter,
-  getParentGripValue
+  getNonPrototypeParentGripValue
 } = Utils.node;
 
 type Props = {
@@ -167,7 +167,7 @@ class ObjectInspectorItem extends Component<Props> {
       }
 
       if (nodeHasGetter(item)) {
-        const parentGrip = getParentGripValue(item);
+        const parentGrip = getNonPrototypeParentGripValue(item);
         if (parentGrip) {
           Object.assign(repProps, {
             onInvokeGetterButtonClick: () =>

--- a/packages/devtools-reps/src/object-inspector/utils/node.js
+++ b/packages/devtools-reps/src/object-inspector/utils/node.js
@@ -895,22 +895,6 @@ function getNonPrototypeParentGripValue(item: Node | null): Node | null {
   return getValue(parentGripNode);
 }
 
-function getParentGripValue(
-  item: Node
-): RdpGrip | ObjectInspectorItemContentsValue | null {
-  const parentNode = getParent(item);
-  if (!parentNode) {
-    return null;
-  }
-
-  const parentGripNode = getClosestGripNode(parentNode);
-  if (!parentGripNode) {
-    return null;
-  }
-
-  return getValue(parentGripNode);
-}
-
 module.exports = {
   createNode,
   createGetterNode,
@@ -921,7 +905,6 @@ module.exports = {
   getClosestGripNode,
   getClosestNonBucketNode,
   getParent,
-  getParentGripValue,
   getNonPrototypeParentGripValue,
   getNumericalPropertiesCount,
   getValue,

--- a/packages/devtools-reps/src/object-inspector/utils/node.js
+++ b/packages/devtools-reps/src/object-inspector/utils/node.js
@@ -877,6 +877,24 @@ function getClosestNonBucketNode(item: Node): Node | null {
   return getClosestNonBucketNode(parent);
 }
 
+function getNonPrototypeParentGripValue(item: Node | null): Node | null {
+  const parentNode = getParent(item);
+  if (!parentNode) {
+    return null;
+  }
+
+  const parentGripNode = getClosestGripNode(parentNode);
+  if (!parentGripNode) {
+    return null;
+  }
+
+  if (getType(parentGripNode) === NODE_TYPES.PROTOTYPE) {
+    return getNonPrototypeParentGripValue(parentGripNode);
+  }
+
+  return getValue(parentGripNode);
+}
+
 function getParentGripValue(
   item: Node
 ): RdpGrip | ObjectInspectorItemContentsValue | null {
@@ -904,6 +922,7 @@ module.exports = {
   getClosestNonBucketNode,
   getParent,
   getParentGripValue,
+  getNonPrototypeParentGripValue,
   getNumericalPropertiesCount,
   getValue,
   makeNodesForEntries,


### PR DESCRIPTION
To invoke getter, we were retrieving the parent node
so we could access the getter. This works fine unless
the getter is itself somewhere in the prototype chain
and refers to a property set by an upper level.
This patch changes how we retrieve the context to
invoke the getter in to be the top-most, non-prototype
grip, which should cover this case.

Fixes #7397 

---

Still WIP as I'm trying to find ways I could break it :) 
@Loirooriol , would you have complex test cases I can test against to ensure this is a solid fix? :)
