### PR TITLE
[breakpoints] convert pause points to a list

### DIFF
--- a/src/actions/ast/setPausePoints.js
+++ b/src/actions/ast/setPausePoints.js
@@ -7,7 +7,7 @@
 import { getSourceFromId } from "../../selectors";
 import * as parser from "../../workers/parser";
 import { isGenerated } from "../../utils/source";
-import { mapPausePoints } from "../../utils/pause/pausePoints";
+import { convertToList } from "../../utils/pause/pausePoints";
 import { features } from "../../utils/prefs";
 import { getGeneratedLocation } from "../../utils/source-maps";
 
@@ -28,20 +28,24 @@ function compressPausePoints(pausePoints) {
 }
 
 async function mapLocations(pausePoints, state, source, sourceMaps) {
+  const pausePointList = convertToList(pausePoints);
   const sourceId = source.id;
-  return mapPausePoints(pausePoints, async ({ types, location }) => {
-    const generatedLocation = await getGeneratedLocation(
-      state,
-      source,
-      {
-        ...location,
-        sourceId
-      },
-      sourceMaps
-    );
 
-    return { types, location, generatedLocation };
-  });
+  return Promise.all(
+    pausePointList.map(async ({ types, location }) => {
+      const generatedLocation = await getGeneratedLocation(
+        state,
+        source,
+        {
+          ...location,
+          sourceId
+        },
+        sourceMaps
+      );
+
+      return { types, location, generatedLocation };
+    })
+  );
 }
 export function setPausePoints(sourceId: SourceId) {
   return async ({ dispatch, getState, client, sourceMaps }: ThunkArgs) => {
@@ -55,17 +59,18 @@ export function setPausePoints(sourceId: SourceId) {
     }
 
     let pausePoints = await parser.getPausePoints(sourceId);
+
+    if (isGenerated(source)) {
+      const compressed = compressPausePoints(pausePoints);
+      await client.setPausePoints(sourceId, compressed);
+    }
+
     pausePoints = await mapLocations(
       pausePoints,
       getState(),
       source,
       sourceMaps
     );
-
-    if (isGenerated(source)) {
-      const compressed = compressPausePoints(pausePoints);
-      await client.setPausePoints(sourceId, compressed);
-    }
 
     dispatch(
       ({

--- a/src/actions/types/ASTAction.js
+++ b/src/actions/types/ASTAction.js
@@ -4,13 +4,8 @@
 
 // @flow
 
-import type { SourceMetaDataType } from "../../reducers/ast.js";
-import type {
-  SymbolDeclarations,
-  AstLocation,
-  PausePoints
-} from "../../workers/parser";
-
+import type { SymbolDeclarations, AstLocation } from "../../workers/parser";
+import type { PausePoints, SourceMetaDataType } from "../../reducers/types";
 import type { PromiseAction } from "../utils/middleware/promise";
 
 export type ASTAction =

--- a/src/client/firefox/commands.js
+++ b/src/client/firefox/commands.js
@@ -25,7 +25,7 @@ import type {
   BPClients
 } from "./types";
 
-import type { PausePoints } from "../../workers/parser";
+import type { PausePointsMap } from "../../workers/parser";
 
 import { makePendingLocationId } from "../../utils/breakpoint";
 
@@ -361,7 +361,7 @@ function disablePrettyPrint(sourceId: SourceId): Promise<*> {
   return sourceClient.disablePrettyPrint();
 }
 
-async function setPausePoints(sourceId: SourceId, pausePoints: PausePoints) {
+async function setPausePoints(sourceId: SourceId, pausePoints: PausePointsMap) {
   return sendPacket({ to: sourceId, type: "setPausePoints", pausePoints });
 }
 

--- a/src/reducers/ast.js
+++ b/src/reducers/ast.js
@@ -226,8 +226,8 @@ export function getPausePoint(
   }
 
   for (const point of pausePoints) {
-    const { location } = point;
-    if (location.line == line && location.column == column) {
+    const { location: pointLocation } = point;
+    if (pointLocation.line == line && pointLocation.column == column) {
       return point;
     }
   }
@@ -243,7 +243,7 @@ export function getFirstPausePointLocation(
     return location;
   }
 
-  const pausesAtLine = pausePoints[String(location.line)];
+  const pausesAtLine = pausePoints[location.line];
   if (pausesAtLine) {
     const values: PausePoint[] = (Object.values(pausesAtLine): any);
     const firstPausePoint = values.find(pausePoint => pausePoint.types.break);

--- a/src/reducers/types.js
+++ b/src/reducers/types.js
@@ -45,4 +45,10 @@ export type { ActiveSearchType, OrientationType } from "./ui";
 export type { BreakpointsMap, XHRBreakpointsList } from "./breakpoints";
 export type { WorkersList } from "./debuggee";
 export type { Command } from "./pause";
-export type { SourceMetaDataMap } from "./ast";
+export type {
+  SourceMetaDataMap,
+  SourceMetaDataType,
+  PausePoints,
+  PausePointsMap,
+  PausePoint
+} from "./ast";

--- a/src/selectors/visiblePausePoints.js
+++ b/src/selectors/visiblePausePoints.js
@@ -4,7 +4,6 @@
 
 import { getSelectedSource } from "../reducers/sources";
 import { getPausePoints } from "../reducers/ast";
-import { convertToList } from "../utils/pause/pausePoints";
 
 export function getVisiblePausePoints(state) {
   const source = getSelectedSource(state);
@@ -12,6 +11,5 @@ export function getVisiblePausePoints(state) {
     return null;
   }
 
-  const pausePoints = getPausePoints(state, source.id);
-  return convertToList(pausePoints);
+  return getPausePoints(state, source.id);
 }

--- a/src/utils/ast.js
+++ b/src/utils/ast.js
@@ -5,18 +5,16 @@
 // @flow
 
 import { xor, range } from "lodash";
-import { convertToList } from "./pause/pausePoints";
-
 import type { SourceLocation, Position } from "../types";
 import type { Symbols } from "../reducers/ast";
 
 import type {
   AstPosition,
   AstLocation,
-  PausePoints,
   FunctionDeclaration,
   ClassDeclaration
 } from "../workers/parser";
+import type { PausePoints } from "../reducers/types";
 
 export function findBestMatchExpression(symbols: Symbols, tokenPos: Position) {
   if (symbols.loading) {
@@ -51,9 +49,7 @@ export function findEmptyLines(
     return [];
   }
 
-  const pausePointsList = convertToList(pausePoints);
-
-  const breakpoints = pausePointsList.filter(point => point.types.break);
+  const breakpoints = pausePoints.filter(point => point.types.break);
   const breakpointLines = breakpoints.map(point => point.location.line);
 
   if (!sourceText || breakpointLines.length == 0) {

--- a/src/utils/pause/pausePoints.js
+++ b/src/utils/pause/pausePoints.js
@@ -5,13 +5,12 @@
 // @flow
 import { reverse } from "lodash";
 
-import type { PausePoints } from "../../workers/parser";
+import type {
+  PausePoints,
+  PausePoint,
+  PausePointsMap
+} from "../../reducers/types";
 import type { Position } from "../../types";
-
-type PausePoint = {
-  location: Position,
-  types: { break: boolean, step: boolean }
-};
 
 function insertStrtAt(string, index, newString) {
   const start = string.slice(0, index);
@@ -19,7 +18,7 @@ function insertStrtAt(string, index, newString) {
   return `${start}${newString}${end}`;
 }
 
-export function convertToList(pausePoints: PausePoints): PausePoint[] {
+export function convertToList(pausePoints: PausePointsMap): PausePoints {
   const list = [];
   for (const line in pausePoints) {
     for (const column in pausePoints[line]) {
@@ -30,7 +29,7 @@ export function convertToList(pausePoints: PausePoints): PausePoint[] {
 }
 
 export function formatPausePoints(text: string, pausePoints: PausePoints) {
-  const nodes = reverse(convertToList(pausePoints));
+  const nodes = reverse(pausePoints);
   const lines = text.split("\n");
   nodes.forEach((node, index) => {
     const { line, column } = node.location;
@@ -40,23 +39,4 @@ export function formatPausePoints(text: string, pausePoints: PausePoints) {
   });
 
   return lines.join("\n");
-}
-
-export async function mapPausePoints<T>(
-  pausePoints: PausePoints,
-  iteratee: PausePoint => T
-) {
-  const results = await Promise.all(convertToList(pausePoints).map(iteratee));
-  let index = 0;
-
-  const newPausePoints = {};
-  for (const line in pausePoints) {
-    const linePoints = pausePoints[line];
-    const newLinePoints = (newPausePoints[line] = {});
-    for (const column in linePoints) {
-      newLinePoints[column] = results[index++];
-    }
-  }
-
-  return newPausePoints;
 }

--- a/src/utils/pause/pausePoints.js
+++ b/src/utils/pause/pausePoints.js
@@ -5,12 +5,7 @@
 // @flow
 import { reverse } from "lodash";
 
-import type {
-  PausePoints,
-  PausePoint,
-  PausePointsMap
-} from "../../reducers/types";
-import type { Position } from "../../types";
+import type { PausePoints, PausePointsMap } from "../../reducers/types";
 
 function insertStrtAt(string, index, newString) {
   const start = string.slice(0, index);

--- a/src/workers/parser/index.js
+++ b/src/workers/parser/index.js
@@ -7,10 +7,11 @@
 import { workerUtils } from "devtools-utils";
 const { WorkerDispatcher } = workerUtils;
 
-import type { AstLocation, AstPosition, PausePoints } from "./types";
+import type { AstLocation, AstPosition } from "./types";
 import type { SourceLocation, Source, SourceId } from "../../types";
 import type { SourceScope } from "./getScopes/visitor";
 import type { SymbolDeclarations } from "./getSymbols";
+import type { PausePointsMap } from "../../reducers/types";
 
 const dispatcher = new WorkerDispatcher();
 export const start = (url: string, win: any = window) =>
@@ -79,8 +80,9 @@ export const mapExpression = async (
 export const getFramework = async (sourceId: string): Promise<?string> =>
   dispatcher.invoke("getFramework", sourceId);
 
-export const getPausePoints = async (sourceId: string): Promise<PausePoints> =>
-  dispatcher.invoke("getPausePoints", sourceId);
+export const getPausePoints = async (
+  sourceId: string
+): Promise<PausePointsMap> => dispatcher.invoke("getPausePoints", sourceId);
 
 export type {
   SourceScope,
@@ -96,7 +98,7 @@ export type {
   AstLocation,
   AstPosition,
   PausePoint,
-  PausePoints
+  PausePointsMap
 } from "./types";
 
 export type {

--- a/src/workers/parser/pausePoints.js
+++ b/src/workers/parser/pausePoints.js
@@ -10,7 +10,7 @@ import isEqual from "lodash/isEqual";
 
 import type { BabelNode } from "@babel/types";
 import type { SimplePath } from "./utils/simple-path";
-import type { PausePoints } from "./types";
+import type { PausePointsMap } from "./types";
 
 const isForStatement = node =>
   t.isForStatement(node) || t.isForOfStatement(node);
@@ -70,7 +70,7 @@ function isFirstCall(node, parentNode, grandParentNode) {
   return children.find(child => isCall(child)) === node;
 }
 
-export function getPausePoints(sourceId: string): PausePoints {
+export function getPausePoints(sourceId: string): PausePointsMap {
   const state = {};
   traverseAst(sourceId, { enter: onEnter }, state);
   return state;

--- a/src/workers/parser/tests/pausePoints.spec.js
+++ b/src/workers/parser/tests/pausePoints.spec.js
@@ -4,7 +4,10 @@
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
 import cases from "jest-in-case";
-import { formatPausePoints } from "../../../utils/pause/pausePoints";
+import {
+  formatPausePoints,
+  convertToList
+} from "../../../utils/pause/pausePoints";
 
 import { getPausePoints } from "../pausePoints";
 import { getSource, getOriginalSource } from "./helpers";
@@ -18,7 +21,7 @@ cases(
       : getSource(file, type);
 
     setSource(source);
-    const nodes = getPausePoints(source.id);
+    const nodes = convertToList(getPausePoints(source.id));
     // console.log(formatPausePoints(source.text, nodes));
     expect(formatPausePoints(source.text, nodes)).toMatchSnapshot();
   },

--- a/src/workers/parser/tests/pausePoints.spec.js
+++ b/src/workers/parser/tests/pausePoints.spec.js
@@ -22,7 +22,6 @@ cases(
 
     setSource(source);
     const nodes = convertToList(getPausePoints(source.id));
-    // console.log(formatPausePoints(source.text, nodes));
     expect(formatPausePoints(source.text, nodes)).toMatchSnapshot();
   },
   [

--- a/src/workers/parser/types.js
+++ b/src/workers/parser/types.js
@@ -12,6 +12,7 @@ export type PausePoint = {|
   location: AstPosition,
   generatedLocation: AstPosition
 |};
-export type PausePoints = {
+
+export type PausePointsMap = {
   [line: string]: { [column: string]: PausePoint }
 };


### PR DESCRIPTION
Fixes #7485

This is a follow up to #7496 where we stop using mapLocations and restrict convertToList to one call site. This should be a nice perf win as well as generally easier to reason about code.

Some considerations:
1. accessing a single pause point will be slower (we might need to store the map if this is too slow)
2. the flow types are a bit funky because of the distinction w/ columns 