### PR TITLE
Add missing arguments to copy

### DIFF
--- a/bin/copy.js
+++ b/bin/copy.js
@@ -50,7 +50,7 @@ async function copy({assets, mc, watch, symlink}) {
 
 async function start() {
   console.log(`Copying Files to ${mc} with params: `, {watch, assets, symlink})
-  return copy()
+  return copy({watch, assets, mc, symlink})
 }
 
 function missingFilesErrorMessage() {


### PR DESCRIPTION
`yarn copy` threw errors, @jasonLaster's patch