### PR TITLE
[symbols] stop fetching symbols when loading

### DIFF
--- a/src/actions/ast.js
+++ b/src/actions/ast.js
@@ -56,15 +56,17 @@ export function setSymbols(sourceId: SourceId) {
   return async ({ dispatch, getState, sourceMaps }: ThunkArgs) => {
     const source = getSourceFromId(getState(), sourceId);
 
-    if (source.isWasm || !isLoaded(source) || getSymbols(getState(), source)) {
+    if (source.isWasm && !isLoaded(source)) {
       return;
     }
 
-    await dispatch({
-      type: "SET_SYMBOLS",
-      sourceId,
-      [PROMISE]: parser.getSymbols(sourceId)
-    });
+    if (!getSymbols(getState(), source)) {
+      await dispatch({
+        type: "SET_SYMBOLS",
+        sourceId,
+        [PROMISE]: parser.getSymbols(sourceId)
+      });
+    }
 
     if (isPaused(getState())) {
       await dispatch(fetchExtra());

--- a/src/actions/ast.js
+++ b/src/actions/ast.js
@@ -66,15 +66,15 @@ export function setSymbols(sourceId: SourceId) {
         sourceId,
         [PROMISE]: parser.getSymbols(sourceId)
       });
+
+      await dispatch(setPausePoints(sourceId));
+      await dispatch(setSourceMetaData(sourceId));
     }
 
     if (isPaused(getState())) {
       await dispatch(fetchExtra());
       await dispatch(mapFrames());
     }
-
-    await dispatch(setPausePoints(sourceId));
-    await dispatch(setSourceMetaData(sourceId));
   };
 }
 

--- a/src/actions/ast.js
+++ b/src/actions/ast.js
@@ -56,19 +56,15 @@ export function setSymbols(sourceId: SourceId) {
   return async ({ dispatch, getState, sourceMaps }: ThunkArgs) => {
     const source = getSourceFromId(getState(), sourceId);
 
-    if (source.isWasm && !isLoaded(source)) {
+    if (source.isWasm || getSymbols(getState(), source) || !isLoaded(source)) {
       return;
     }
 
-    if (!getSymbols(getState(), source)) {
-      await dispatch({
-        type: "SET_SYMBOLS",
-        sourceId,
-        [PROMISE]: parser.getSymbols(sourceId)
-      });
-
-      await dispatch(setSourceMetaData(sourceId));
-    }
+    await dispatch({
+      type: "SET_SYMBOLS",
+      sourceId,
+      [PROMISE]: parser.getSymbols(sourceId)
+    });
 
     if (isPaused(getState())) {
       await dispatch(fetchExtra());
@@ -76,6 +72,7 @@ export function setSymbols(sourceId: SourceId) {
     }
 
     await dispatch(setPausePoints(sourceId));
+    await dispatch(setSourceMetaData(sourceId));
   };
 }
 

--- a/src/actions/ast.js
+++ b/src/actions/ast.js
@@ -91,7 +91,7 @@ export function setOutOfScopeLocations() {
     if (location.line && source && !source.isWasm && isPaused(getState())) {
       locations = await parser.findOutOfScopeLocations(
         source.id,
-        ((location: any): AstPosition)
+        ((location: any): parser.AstPosition)
       );
     }
 

--- a/src/actions/ast.js
+++ b/src/actions/ast.js
@@ -67,7 +67,6 @@ export function setSymbols(sourceId: SourceId) {
         [PROMISE]: parser.getSymbols(sourceId)
       });
 
-      await dispatch(setPausePoints(sourceId));
       await dispatch(setSourceMetaData(sourceId));
     }
 
@@ -75,6 +74,8 @@ export function setSymbols(sourceId: SourceId) {
       await dispatch(fetchExtra());
       await dispatch(mapFrames());
     }
+
+    await dispatch(setPausePoints(sourceId));
   };
 }
 

--- a/src/actions/ast.js
+++ b/src/actions/ast.js
@@ -7,7 +7,7 @@
 import {
   getSource,
   getSourceFromId,
-  hasSymbols,
+  getSymbols,
   getSelectedLocation,
   isPaused
 } from "../selectors";
@@ -21,12 +21,7 @@ import { setInScopeLines } from "./ast/setInScopeLines";
 import { setPausePoints } from "./ast/setPausePoints";
 export { setPausePoints };
 
-import {
-  getSymbols,
-  findOutOfScopeLocations,
-  getFramework,
-  type AstPosition
-} from "../workers/parser";
+import * as parser from "../workers/parser";
 
 import { isLoaded } from "../utils/source";
 
@@ -40,7 +35,7 @@ export function setSourceMetaData(sourceId: SourceId) {
       return;
     }
 
-    const framework = await getFramework(source.id);
+    const framework = await parser.getFramework(source.id);
     if (framework) {
       dispatch(updateTab(source, framework));
     }
@@ -61,14 +56,14 @@ export function setSymbols(sourceId: SourceId) {
   return async ({ dispatch, getState, sourceMaps }: ThunkArgs) => {
     const source = getSourceFromId(getState(), sourceId);
 
-    if (source.isWasm || hasSymbols(getState(), source) || !isLoaded(source)) {
+    if (source.isWasm || !isLoaded(source) || getSymbols(getState(), source)) {
       return;
     }
 
     await dispatch({
       type: "SET_SYMBOLS",
       sourceId,
-      [PROMISE]: getSymbols(sourceId)
+      [PROMISE]: parser.getSymbols(sourceId)
     });
 
     if (isPaused(getState())) {
@@ -92,7 +87,7 @@ export function setOutOfScopeLocations() {
 
     let locations = null;
     if (location.line && source && !source.isWasm && isPaused(getState())) {
-      locations = await findOutOfScopeLocations(
+      locations = await parser.findOutOfScopeLocations(
         source.id,
         ((location: any): AstPosition)
       );

--- a/src/actions/tests/preview.spec.js
+++ b/src/actions/tests/preview.spec.js
@@ -32,7 +32,8 @@ const immutableList = {
   }
 };
 
-describe("setPreview", () => {
+// previewing react components and immutable values is deprecated
+xdescribe("setPreview", () => {
   let dispatch = undefined;
   let getState = undefined;
 


### PR DESCRIPTION
### Summary of Changes

We were previously fetching symbols again when we were loading because hasSymbols ignores loading.