### PR TITLE
🐛 Adding display css styling for splitter to hide uwanted scroll

### DIFF
--- a/src/components/App.css
+++ b/src/components/App.css
@@ -87,3 +87,11 @@ button:focus {
 .min-width-0 {
   min-width: 0;
 }
+
+/* 
+  Prevents horizontal scrollbar from displaying when 
+  right pane collapsed (#7505) 
+*/
+.split-box > .splitter:last-child {
+  display: none;
+}


### PR DESCRIPTION
Fixes #7505

### Summary of Changes

* Fixing the unwanted scrollbar when hiding the end panel in debugger

### Test Plan

Open the debugger. Close the end panel. And see if a horizontal scrollbar is visible.

### Screenshots/Videos (OPTIONAL)
#### Before
![screenshot 2018-12-14 at 16 43 58 3](https://user-images.githubusercontent.com/5429756/50012746-c0021b00-ffbf-11e8-8a2c-77dfe10eedc4.png)

#### After
![screenshot 2018-12-14 at 16 43 15](https://user-images.githubusercontent.com/5429756/50012738-baa4d080-ffbf-11e8-9575-4ce496661692.png)
