### PR TITLE
Remove white background for source icon images in tree, also remove border

### DIFF
--- a/src/components/PrimaryPanes/Sources.css
+++ b/src/components/PrimaryPanes/Sources.css
@@ -89,10 +89,6 @@
   margin-right: 5px;
 }
 
-.sources-list .tree .focused img.arrow {
-  background-color: white;
-}
-
 .sources-list .tree .label .suffix {
   font-style: italic;
   font-size: 0.9em;
@@ -220,20 +216,12 @@
   margin-top: 2px;
 }
 
-.sources-list .managed-tree .tree .node.focused img {
-  background-color: white;
-}
-
 .theme-dark .sources-list .managed-tree .tree .node:not(.focused) img.blackBox {
   background-color: var(--theme-comment);
 }
 
 .theme-dark .sources-list .managed-tree .tree .node img.blackBox {
   background-color: var(--theme-body-color);
-}
-
-.theme-dark .sources-list .managed-tree .tree .node.focused img.blackBox {
-  background-color: white;
 }
 
 /*

--- a/src/components/shared/SourceIcon.css
+++ b/src/components/shared/SourceIcon.css
@@ -4,6 +4,7 @@
   mask-size: 100%;
   display: inline-block;
   margin-inline-end: 5px;
+  border: 0;
 }
 
 .source-icon,


### PR DESCRIPTION
@fvsch Reported the following:

![screen shot 2018-12-15 at 18 31 52](https://user-images.githubusercontent.com/46655/50045924-a533b300-0060-11e9-86c3-17f0f3bc1226.png)

Selected source icons have a white background we don't want.

This PR:
* Removes the white background
* Removes what appears to be a border around the `<img>` icons, which I'm presuming is a windows thing.

<img width="777" alt="white" src="https://user-images.githubusercontent.com/46655/50045930-cc8a8000-0060-11e9-9aba-7bb554f06018.png">

<img width="809" alt="iconbg" src="https://user-images.githubusercontent.com/46655/50045932-ceecda00-0060-11e9-9ee5-2ef6c55cf1f7.png">
