### PR TITLE
Implement CSS containment on secondary pane and sources tree

### DIFF
--- a/src/components/PrimaryPanes/Sources.css
+++ b/src/components/PrimaryPanes/Sources.css
@@ -204,6 +204,10 @@
   overflow: auto;
 }
 
+.sources-list {
+  contain: layout size;
+}
+
 .sources-list .managed-tree .tree .node img.blackBox {
   mask: url(/images/blackBox.svg) no-repeat;
   mask-size: 100%;

--- a/src/components/SecondaryPanes/SecondaryPanes.css
+++ b/src/components/SecondaryPanes/SecondaryPanes.css
@@ -10,6 +10,7 @@
   white-space: nowrap;
   --breakpoint-expression-right-clear-space: 36px;
   --breakpoint-expression-height: 2.4em;
+  contain: layout size;
 }
 
 /*


### PR DESCRIPTION
Adding to these spaces based on:  https://wiki.mozilla.org/Platform/Layout/CSS_Containment_Best_Practices

I didn't add to Editor because that's being done in MC by `:dholbert`:  https://bugzilla.mozilla.org/show_bug.cgi?id=1502524

## To Do
- [ ] Figure out a good way to measure perf impact from this.
- [ ] Should I add to the editor's container (?) . Maybe :dholbert's work in MC isn't enough?