### PR TITLE
Simplify the Sources Tree  icon highlight color

### DIFF
--- a/src/components/PrimaryPanes/Sources.css
+++ b/src/components/PrimaryPanes/Sources.css
@@ -89,6 +89,10 @@
   margin-right: 5px;
 }
 
+.sources-list .tree .focused img.arrow {
+  background-color: white;
+}
+
 .sources-list .tree .label .suffix {
   font-style: italic;
   font-size: 0.9em;
@@ -216,12 +220,20 @@
   margin-top: 2px;
 }
 
+.sources-list .managed-tree .tree .node.focused img {
+  background-color: white;
+}
+
 .theme-dark .sources-list .managed-tree .tree .node:not(.focused) img.blackBox {
   background-color: var(--theme-comment);
 }
 
 .theme-dark .sources-list .managed-tree .tree .node img.blackBox {
   background-color: var(--theme-body-color);
+}
+
+.theme-dark .sources-list .managed-tree .tree .node.focused img.blackBox {
+  background-color: white;
 }
 
 /*

--- a/src/components/PrimaryPanes/Sources.css
+++ b/src/components/PrimaryPanes/Sources.css
@@ -89,8 +89,9 @@
   margin-right: 5px;
 }
 
-.sources-list .tree .focused img.arrow {
-  background-color: white;
+.sources-list .tree .focused img:not(.vue):not(.angular),
+.sources-list .managed-tree .tree .node.focused img.blackBox {
+  background: #ffffff;
 }
 
 .sources-list .tree .label .suffix {
@@ -220,20 +221,12 @@
   margin-top: 2px;
 }
 
-.sources-list .managed-tree .tree .node.focused img {
-  background-color: white;
-}
-
 .theme-dark .sources-list .managed-tree .tree .node:not(.focused) img.blackBox {
   background-color: var(--theme-comment);
 }
 
 .theme-dark .sources-list .managed-tree .tree .node img.blackBox {
   background-color: var(--theme-body-color);
-}
-
-.theme-dark .sources-list .managed-tree .tree .node.focused img.blackBox {
-  background-color: white;
 }
 
 /*

--- a/src/components/shared/SourceIcon.css
+++ b/src/components/shared/SourceIcon.css
@@ -4,7 +4,6 @@
   mask-size: 100%;
   display: inline-block;
   margin-inline-end: 5px;
-  border: 0;
 }
 
 .source-icon,


### PR DESCRIPTION
My last attempt at this wasn't helpful in our current image/border predicament, so we should remove it.  This is much simpler.