### PR TITLE
Avoid odd scrollbar positioning in sources pane

### DIFF
--- a/src/components/PrimaryPanes/Sources.css
+++ b/src/components/PrimaryPanes/Sources.css
@@ -64,7 +64,6 @@
   overflow-x: auto;
   overflow-y: auto;
   height: 100%;
-  padding: 4px 0;
 }
 
 .sources-list {
@@ -78,6 +77,10 @@
   display: flex;
   overflow-x: hidden;
   overflow-y: auto;
+}
+
+.sources-list .managed-tree .tree-node:first-child {
+  margin-top: 4px;
 }
 
 .sources-list .managed-tree .tree .node {


### PR DESCRIPTION
It's really hard to see, but at present, the horizontal scrollbars for the sources pane starts and ends 4px before the top of the DIV, due to `display: flex` and `padding: 4 0px`.  Moving the spacing to the top of the tree is our best option.