### PR TITLE
Remove unused debuggeeCommand function.

### DIFF
--- a/src/client/firefox/commands.js
+++ b/src/client/firefox/commands.js
@@ -263,21 +263,6 @@ function autocomplete(
   });
 }
 
-function debuggeeCommand(script: Script): ?Promise<void> {
-  tabTarget.activeConsole.evaluateJS(script, () => {}, {});
-
-  if (!debuggerClient) {
-    return;
-  }
-
-  const consoleActor = tabTarget.form.consoleActor;
-  const request = debuggerClient._activeRequests.get(consoleActor);
-  request.emit("json-reply", {});
-  debuggerClient._activeRequests.delete(consoleActor);
-
-  return Promise.resolve();
-}
-
 function navigate(url: string): Promise<*> {
   return tabTarget.activeTab.navigateTo({ url });
 }
@@ -454,7 +439,6 @@ const clientCommands = {
   evaluate,
   evaluateInFrame,
   evaluateExpressions,
-  debuggeeCommand,
   navigate,
   reload,
   getProperties,


### PR DESCRIPTION
The function does not seem to be called anywhere,
and make use of target.form, which we want to remove
in Bug 1513565.
