### PR TITLE
re-add support chrome

### DIFF
--- a/src/client/chrome.js
+++ b/src/client/chrome.js
@@ -8,7 +8,10 @@ import { setupCommands, clientCommands } from "./chrome/commands";
 import { setupEvents, clientEvents, pageEvents } from "./chrome/events";
 
 export async function onConnect(connection: any, actions: Object): Object {
-  const { tabConnection, connTarget: { type } } = connection;
+  const {
+    tabConnection,
+    connTarget: { type }
+  } = connection;
   const { Debugger, Runtime, Page } = tabConnection;
 
   Debugger.enable();

--- a/src/client/chrome.js
+++ b/src/client/chrome.js
@@ -1,0 +1,34 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
+// @flow
+
+import { setupCommands, clientCommands } from "./chrome/commands";
+import { setupEvents, clientEvents, pageEvents } from "./chrome/events";
+
+export async function onConnect(connection: any, actions: Object): Object {
+  const { tabConnection, connTarget: { type } } = connection;
+  const { Debugger, Runtime, Page } = tabConnection;
+
+  Debugger.enable();
+  Debugger.setPauseOnExceptions({ state: "none" });
+  Debugger.setAsyncCallStackDepth({ maxDepth: 0 });
+
+  if (type == "chrome") {
+    Page.frameNavigated(pageEvents.frameNavigated);
+    Page.frameStartedLoading(pageEvents.frameStartedLoading);
+    Page.frameStoppedLoading(pageEvents.frameStoppedLoading);
+  }
+
+  Debugger.scriptParsed(clientEvents.scriptParsed);
+  Debugger.scriptFailedToParse(clientEvents.scriptFailedToParse);
+  Debugger.paused(clientEvents.paused);
+  Debugger.resumed(clientEvents.resumed);
+
+  setupCommands({ Debugger, Runtime, Page });
+  setupEvents({ actions, Page, type, Runtime });
+  return {};
+}
+
+export { clientCommands, clientEvents };

--- a/src/client/chrome/commands.js
+++ b/src/client/chrome/commands.js
@@ -10,7 +10,7 @@ import {
   createLoadedObject
 } from "./create";
 
-import type { Location } from "../../types";
+import type { SourceLocation } from "../../types";
 import type { ServerLocation, Agents } from "./types";
 
 type setBreakpointResponseType = {
@@ -68,7 +68,7 @@ function sourceContents(sourceId: string) {
     }));
 }
 
-async function setBreakpoint(location: Location, condition: string) {
+async function setBreakpoint(location: SourceLocation, condition: string) {
   const {
     breakpointId,
     serverLocation

--- a/src/client/chrome/commands.js
+++ b/src/client/chrome/commands.js
@@ -1,0 +1,131 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
+// @flow
+
+import {
+  toServerLocation,
+  fromServerLocation,
+  createLoadedObject
+} from "./create";
+
+import type { Location } from "../../types";
+import type { ServerLocation, Agents } from "./types";
+
+type setBreakpointResponseType = {
+  breakpointId: string,
+  serverLocation?: ServerLocation
+};
+
+let debuggerAgent;
+let runtimeAgent;
+let pageAgent;
+
+function setupCommands({ Debugger, Runtime, Page }: Agents) {
+  debuggerAgent = Debugger;
+  runtimeAgent = Runtime;
+  pageAgent = Page;
+}
+
+function resume() {
+  return debuggerAgent.resume();
+}
+
+function stepIn() {
+  return debuggerAgent.stepInto();
+}
+
+function stepOver() {
+  return debuggerAgent.stepOver();
+}
+
+function stepOut() {
+  return debuggerAgent.stepOut();
+}
+
+function pauseOnExceptions(
+  shouldPauseOnExceptions: boolean,
+  shouldIgnoreCaughtExceptions: boolean
+) {
+  if (!shouldPauseOnExceptions) {
+    return debuggerAgent.setPauseOnExceptions({ state: "none" });
+  }
+  const state = shouldIgnoreCaughtExceptions ? "uncaught" : "all";
+  return debuggerAgent.setPauseOnExceptions({ state });
+}
+
+function breakOnNext() {
+  return debuggerAgent.pause();
+}
+
+function sourceContents(sourceId: string) {
+  return debuggerAgent
+    .getScriptSource({ scriptId: sourceId })
+    .then(({ scriptSource }) => ({
+      source: scriptSource,
+      contentType: null
+    }));
+}
+
+async function setBreakpoint(location: Location, condition: string) {
+  const {
+    breakpointId,
+    serverLocation
+  }: setBreakpointResponseType = await debuggerAgent.setBreakpoint({
+    location: toServerLocation(location),
+    columnNumber: location.column
+  });
+
+  const actualLocation = fromServerLocation(serverLocation) || location;
+
+  return {
+    id: breakpointId,
+    actualLocation: actualLocation
+  };
+}
+
+function removeBreakpoint(breakpointId: string) {
+  return debuggerAgent.removeBreakpoint({ breakpointId });
+}
+
+async function getProperties(object: any) {
+  const { result } = await runtimeAgent.getProperties({
+    objectId: object.objectId
+  });
+
+  const loadedObjects = result.map(createLoadedObject);
+
+  return { loadedObjects };
+}
+
+function evaluate(script: string) {
+  return runtimeAgent.evaluate({ expression: script });
+}
+
+function debuggeeCommand(script: string): Promise<void> {
+  evaluate(script);
+  return Promise.resolve();
+}
+
+function navigate(url: string) {
+  return pageAgent.navigate({ url });
+}
+
+const clientCommands = {
+  resume,
+  stepIn,
+  stepOut,
+  stepOver,
+  pauseOnExceptions,
+  breakOnNext,
+  sourceContents,
+  setBreakpoint,
+  removeBreakpoint,
+  evaluate,
+  debuggeeCommand,
+  navigate,
+  getProperties
+};
+
+export { setupCommands, clientCommands };

--- a/src/client/chrome/commands.js
+++ b/src/client/chrome/commands.js
@@ -112,6 +112,14 @@ function navigate(url: string) {
   return pageAgent.navigate({ url });
 }
 
+function getBreakpointByLocation(location: SourceLocation) {}
+
+function setPausePoints() {}
+
+function getFrameScopes() {}
+function evaluateInFrame() {}
+function evaluateExpressions() {}
+
 const clientCommands = {
   resume,
   stepIn,
@@ -125,7 +133,12 @@ const clientCommands = {
   evaluate,
   debuggeeCommand,
   navigate,
-  getProperties
+  getProperties,
+  getBreakpointByLocation,
+  setPausePoints,
+  getFrameScopes,
+  evaluateInFrame,
+  evaluateExpressions
 };
 
 export { setupCommands, clientCommands };

--- a/src/client/chrome/create.js
+++ b/src/client/chrome/create.js
@@ -4,10 +4,12 @@
 
 // @flow
 
-import type { Location, LoadedObject } from "../../types";
+import type { SourceLocation, LoadedObject } from "../../types";
 import type { ServerLocation } from "./types";
 
-export function fromServerLocation(serverLocation?: ServerLocation): ?Location {
+export function fromServerLocation(
+  serverLocation?: ServerLocation
+): ?SourceLocation {
   if (serverLocation) {
     return {
       sourceId: serverLocation.scriptId,
@@ -18,7 +20,7 @@ export function fromServerLocation(serverLocation?: ServerLocation): ?Location {
   }
 }
 
-export function toServerLocation(location: Location): ServerLocation {
+export function toServerLocation(location: SourceLocation): ServerLocation {
   return {
     scriptId: location.sourceId,
     lineNumber: location.line - 1

--- a/src/client/chrome/create.js
+++ b/src/client/chrome/create.js
@@ -1,0 +1,50 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
+// @flow
+
+import type { Location, LoadedObject } from "../../types";
+import type { ServerLocation } from "./types";
+
+export function fromServerLocation(serverLocation?: ServerLocation): ?Location {
+  if (serverLocation) {
+    return {
+      sourceId: serverLocation.scriptId,
+      line: serverLocation.lineNumber + 1,
+      column: serverLocation.columnNumber,
+      sourceUrl: ""
+    };
+  }
+}
+
+export function toServerLocation(location: Location): ServerLocation {
+  return {
+    scriptId: location.sourceId,
+    lineNumber: location.line - 1
+  };
+}
+
+export function createFrame(frame: any) {
+  return {
+    id: frame.callFrameId,
+    displayName: frame.functionName,
+    scopeChain: frame.scopeChain,
+    generatedLocation: frame.location,
+    location: fromServerLocation(frame.location)
+  };
+}
+
+export function createLoadedObject(
+  serverObject: any,
+  parentId: string
+): LoadedObject {
+  const { value, name } = serverObject;
+
+  return {
+    objectId: value.objectId,
+    parentId,
+    name,
+    value
+  };
+}

--- a/src/client/chrome/events.js
+++ b/src/client/chrome/events.js
@@ -1,0 +1,122 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
+// @flow
+
+import { createFrame, createLoadedObject } from "./create";
+
+let actions;
+let pageAgent;
+let clientType;
+let runtimeAgent;
+
+function setupEvents(dependencies: any) {
+  actions = dependencies.actions;
+  pageAgent = dependencies.Page;
+  clientType = dependencies.clientType;
+  runtimeAgent = dependencies.Runtime;
+}
+
+// Debugger Events
+function scriptParsed({
+  scriptId,
+  url,
+  startLine,
+  startColumn,
+  endLine,
+  endColumn,
+  executionContextId,
+  hash,
+  isContentScript,
+  isInternalScript,
+  isLiveEdit,
+  sourceMapURL,
+  hasSourceURL,
+  deprecatedCommentWasUsed
+}: any) {
+  if (isContentScript) {
+    return;
+  }
+
+  if (clientType == "node") {
+    sourceMapURL = undefined;
+  }
+
+  actions.newSource({
+    id: scriptId,
+    url,
+    sourceMapURL,
+    isPrettyPrinted: false
+  });
+}
+
+function scriptFailedToParse() {}
+
+async function paused({
+  callFrames,
+  reason,
+  data,
+  hitBreakpoints,
+  asyncStackTrace
+}: any) {
+  const frames = callFrames.map(createFrame);
+  const frame = frames[0];
+  const why = { type: reason, ...data };
+
+  const objectId = frame.scopeChain[0].object.objectId;
+  const { result } = await runtimeAgent.getProperties({
+    objectId
+  });
+
+  const loadedObjects = result.map(createLoadedObject);
+
+  if (clientType == "chrome") {
+    pageAgent.configureOverlay({ message: "Paused in debugger.html" });
+  }
+
+  await actions.paused({ frame, why, frames, loadedObjects });
+}
+
+function resumed() {
+  if (clientType == "chrome") {
+    pageAgent.configureOverlay({ suspended: false });
+  }
+
+  actions.resumed();
+}
+
+function globalObjectCleared() {}
+
+// Page Events
+function frameNavigated(frame: any) {
+  actions.navigated();
+}
+
+function frameStartedLoading() {
+  actions.willNavigate();
+}
+
+function domContentEventFired() {}
+
+function loadEventFired() {}
+
+function frameStoppedLoading() {}
+
+const clientEvents = {
+  scriptParsed,
+  scriptFailedToParse,
+  paused,
+  resumed,
+  globalObjectCleared
+};
+
+const pageEvents = {
+  frameNavigated,
+  frameStartedLoading,
+  domContentEventFired,
+  loadEventFired,
+  frameStoppedLoading
+};
+
+export { setupEvents, pageEvents, clientEvents };

--- a/src/client/chrome/types.js
+++ b/src/client/chrome/types.js
@@ -1,0 +1,22 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
+// @flow
+
+export type ServerLocation = {
+  scriptId: string,
+  lineNumber: number,
+  columnNumber?: number
+};
+
+export type Agents = {
+  Debugger: any,
+  Runtime: any,
+  Page: any
+};
+
+export type ChromeClientConnection = {
+  connectNodeClient: () => void,
+  connectNode: () => void
+};


### PR DESCRIPTION
### Summary of Changes

re-adds support for chrome's client, which will let us investigate CDP support and compare firefox and chrome's clients

![](http://g.recordit.co/aZV9pCZtcF.gif)

### Next Steps

- show debug line
- support preview
- show scopes (reps is out of scope (pun not intended))
- support watch expressions