### PR TITLE
Add context menu to breakpoint headings #7474

### DIFF
--- a/assets/panel/debugger.properties
+++ b/assets/panel/debugger.properties
@@ -332,6 +332,15 @@ searchPanelGoToLine=Go to line (%S)
 # filter panel popup for the variables search operation.
 searchPanelVariable=Filter variables (%S)
 
+# LOCALIZATION NOTE (breakpointHeadingMenuItem): The text for all the elements
+# that are displayed in the breakpoint headings menu item popup.
+breakpointHeadingsMenuItem.enableInSource.label=Enable breakpoints
+breakpointHeadingsMenuItem.enableInSource.accesskey=E
+breakpointHeadingsMenuItem.disableInSource.label=Disable breakpoints
+breakpointHeadingsMenuItem.disableInSource.accesskey=D
+breakpointHeadingsMenuItem.removeInSource.label=Remove breakpoints
+breakpointHeadingsMenuItem.removeInSource.accesskey=R
+
 # LOCALIZATION NOTE (breakpointMenuItem): The text for all the elements that
 # are displayed in the breakpoints menu item popup.
 breakpointMenuItem.setConditional=Configure conditional breakpoint

--- a/assets/panel/debugger.properties
+++ b/assets/panel/debugger.properties
@@ -332,7 +332,7 @@ searchPanelGoToLine=Go to line (%S)
 # filter panel popup for the variables search operation.
 searchPanelVariable=Filter variables (%S)
 
-# LOCALIZATION NOTE (breakpointHeadingMenuItem): The text for all the elements
+# LOCALIZATION NOTE (breakpointHeadingMenuItem.*): The text for all the elements
 # that are displayed in the breakpoint headings menu item popup.
 breakpointHeadingsMenuItem.enableInSource.label=Enable breakpoints
 breakpointHeadingsMenuItem.enableInSource.accesskey=E

--- a/src/components/SecondaryPanes/Breakpoints/BreakpointHeading.js
+++ b/src/components/SecondaryPanes/Breakpoints/BreakpointHeading.js
@@ -73,7 +73,6 @@ export default connect(
   mapStateToProps,
   {
     selectSource: actions.selectSource,
-    enableBreakpoint: actions.enableBreakpoint,
     enableBreakpointsInSource: actions.enableBreakpointsInSource,
     disableBreakpointsInSource: actions.disableBreakpointsInSource,
     removeBreakpointsInSource: actions.removeBreakpointsInSource

--- a/src/components/SecondaryPanes/Breakpoints/BreakpointHeading.js
+++ b/src/components/SecondaryPanes/Breakpoints/BreakpointHeading.js
@@ -12,20 +12,33 @@ import {
   getSourceQueryString,
   getFileURL
 } from "../../../utils/source";
-import { getHasSiblingOfSameName } from "../../../selectors";
+import {
+  getHasSiblingOfSameName,
+  getBreakpointsForSource
+} from "../../../selectors";
 
 import SourceIcon from "../../shared/SourceIcon";
 
-import type { Source } from "../../../types";
+import type { Source, Breakpoint } from "../../../types";
+import showContextMenu from "./BreakpointHeadingsContextMenu";
 
 type Props = {
   sources: Source[],
   source: Source,
   hasSiblingOfSameName: boolean,
+  breakpointsForSource: Breakpoint[],
+  getBreakpointsForSource: typeof actions.getBreakpointsForSource,
+  disableBreakpointsInSource: typeof actions.disableBreakpointsInSource,
+  enableBreakpointsInSource: typeof actions.enableBreakpointsInSource,
+  removeBreakpointsInSource: typeof actions.removeBreakpointsInSource,
   selectSource: typeof actions.selectSource
 };
 
 class BreakpointHeading extends PureComponent<Props> {
+  onContextMenu = e => {
+    showContextMenu({ ...this.props, contextMenuEvent: e });
+  };
+
   render() {
     const { sources, source, hasSiblingOfSameName, selectSource } = this.props;
 
@@ -37,6 +50,7 @@ class BreakpointHeading extends PureComponent<Props> {
         className="breakpoint-heading"
         title={getFileURL(source, false)}
         onClick={() => selectSource(source.id)}
+        onContextMenu={this.onContextMenu}
       >
         <SourceIcon
           source={source}
@@ -52,10 +66,17 @@ class BreakpointHeading extends PureComponent<Props> {
 }
 
 const mapStateToProps = (state, { source }) => ({
-  hasSiblingOfSameName: getHasSiblingOfSameName(state, source)
+  hasSiblingOfSameName: getHasSiblingOfSameName(state, source),
+  breakpointsForSource: getBreakpointsForSource(state, source.id)
 });
 
 export default connect(
   mapStateToProps,
-  { selectSource: actions.selectSource }
+  {
+    selectSource: actions.selectSource,
+    enableBreakpoint: actions.enableBreakpoint,
+    enableBreakpointsInSource: actions.enableBreakpointsInSource,
+    disableBreakpointsInSource: actions.disableBreakpointsInSource,
+    removeBreakpointsInSource: actions.removeBreakpointsInSource
+  }
 )(BreakpointHeading);

--- a/src/components/SecondaryPanes/Breakpoints/BreakpointHeading.js
+++ b/src/components/SecondaryPanes/Breakpoints/BreakpointHeading.js
@@ -27,7 +27,6 @@ type Props = {
   source: Source,
   hasSiblingOfSameName: boolean,
   breakpointsForSource: Breakpoint[],
-  getBreakpointsForSource: typeof actions.getBreakpointsForSource,
   disableBreakpointsInSource: typeof actions.disableBreakpointsInSource,
   enableBreakpointsInSource: typeof actions.enableBreakpointsInSource,
   removeBreakpointsInSource: typeof actions.removeBreakpointsInSource,

--- a/src/components/SecondaryPanes/Breakpoints/BreakpointHeadingsContextMenu.js
+++ b/src/components/SecondaryPanes/Breakpoints/BreakpointHeadingsContextMenu.js
@@ -12,7 +12,6 @@ import type { Breakpoint, Source } from "../../../types";
 type Props = {
   source: Source,
   breakpointsForSource: Breakpoint[],
-  getBreakpointsForSource: typeof actions.getBreakpointsForSource,
   disableBreakpointsInSource: typeof actions.disableBreakpointsInSource,
   enableBreakpointsInSource: typeof actions.enableBreakpointsInSource,
   removeBreakpointsInSource: typeof actions.removeBreakpointsInSource,

--- a/src/components/SecondaryPanes/Breakpoints/BreakpointHeadingsContextMenu.js
+++ b/src/components/SecondaryPanes/Breakpoints/BreakpointHeadingsContextMenu.js
@@ -1,0 +1,91 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
+// @flow
+
+import { buildMenu, showMenu } from "devtools-contextmenu";
+
+import actions from "../../../actions";
+import type { Breakpoint, Source } from "../../../types";
+
+type Props = {
+  source: Source,
+  breakpointsForSource: Breakpoint[],
+  getBreakpointsForSource: typeof actions.getBreakpointsForSource,
+  disableBreakpointsInSource: typeof actions.disableBreakpointsInSource,
+  enableBreakpointsInSource: typeof actions.enableBreakpointsInSource,
+  removeBreakpointsInSource: typeof actions.removeBreakpointsInSource,
+  contextMenuEvent: SyntheticEvent<HTMLElement>
+};
+
+export default function showContextMenu(props: Props) {
+  const {
+    source,
+    breakpointsForSource,
+    disableBreakpointsInSource,
+    enableBreakpointsInSource,
+    removeBreakpointsInSource,
+    contextMenuEvent
+  } = props;
+
+  contextMenuEvent.preventDefault();
+
+  const enableInSourceLabel = L10N.getStr(
+    "breakpointHeadingsMenuItem.enableInSource.label"
+  );
+  const disableInSourceLabel = L10N.getStr(
+    "breakpointHeadingsMenuItem.disableInSource.label"
+  );
+  const removeInSourceLabel = L10N.getStr(
+    "breakpointHeadingsMenuItem.removeInSource.label"
+  );
+  const enableInSourceKey = L10N.getStr(
+    "breakpointHeadingsMenuItem.enableInSource.accesskey"
+  );
+  const disableInSourceKey = L10N.getStr(
+    "breakpointHeadingsMenuItem.disableInSource.accesskey"
+  );
+  const removeInSourceKey = L10N.getStr(
+    "breakpointHeadingsMenuItem.removeInSource.accesskey"
+  );
+
+  const disableInSourceItem = {
+    id: "node-menu-disable-in-source",
+    label: disableInSourceLabel,
+    accesskey: disableInSourceKey,
+    disabled: false,
+    click: () => disableBreakpointsInSource(source)
+  };
+
+  const enableInSourceItem = {
+    id: "node-menu-enable-in-source",
+    label: enableInSourceLabel,
+    accesskey: enableInSourceKey,
+    disabled: false,
+    click: () => enableBreakpointsInSource(source)
+  };
+
+  const removeInSourceItem = {
+    id: "node-menu-enable-in-source",
+    label: removeInSourceLabel,
+    accesskey: removeInSourceKey,
+    disabled: false,
+    click: () => removeBreakpointsInSource(source)
+  };
+
+  const hideDisableInSourceItem = breakpointsForSource.every(
+    breakpoint => breakpoint.disabled
+  );
+  const hideEnableInSourceItem = breakpointsForSource.every(
+    breakpoint => !breakpoint.disabled
+  );
+
+  const items = [
+    { item: disableInSourceItem, hidden: () => hideDisableInSourceItem },
+    { item: enableInSourceItem, hidden: () => hideEnableInSourceItem },
+    { item: removeInSourceItem, hidden: () => false }
+  ];
+
+  showMenu(contextMenuEvent, buildMenu(items));
+}


### PR DESCRIPTION
Fixes #7474 

### Summary of Changes

* Created another `PureComponent` similar to `BreakpointsContextMenu.js` to show the context menu with items.
* Create `{enable,disable,remove}BreakpointsInSource` as Redux actions in `breakpoints`, using the already available `getBreakpointsForSource` function
* Connect them to `BreakpointHeading.js` and pass them through into the new `PureComponent`, to be called on `click`


![Demo video](https://i.imgur.com/VPnZDkt.gif)
