### PR TITLE
Update blackbox styles for focused node in tree

### DIFF
--- a/src/components/PrimaryPanes/Sources.css
+++ b/src/components/PrimaryPanes/Sources.css
@@ -92,8 +92,8 @@
   margin-right: 5px;
 }
 
-.sources-list .tree .focused img:not(.vue):not(.angular),
-.sources-list .managed-tree .tree .node.focused img.blackBox {
+.sources-list .tree .focused .img:not(.vue):not(.angular),
+.sources-list .managed-tree .tree .node.focused .img.blackBox {
   background: #ffffff;
 }
 
@@ -222,10 +222,6 @@
   margin-inline-end: 6px;
   margin-inline-start: 1px;
   margin-top: 2px;
-}
-
-.theme-dark .sources-list .managed-tree .tree .node:not(.focused) .img.blackBox {
-  background-color: var(--theme-comment);
 }
 
 .theme-dark .sources-list .managed-tree .tree .node .img.blackBox {


### PR DESCRIPTION
The two recent PRs to improve these icons overlapped and this PR wraps them together, fixing the highlight color for light mode icons.  yay!