### PR TITLE
Improve File Icon Visibility in Search Results On File Selection

### DIFF
--- a/src/components/ProjectSearch.css
+++ b/src/components/ProjectSearch.css
@@ -121,6 +121,10 @@
 
 /* Focus values */
 
+.project-text-search .file-result.focused .img.file {
+  background-color: white;
+}
+
 .project-text-search .file-result.focused,
 .project-text-search .result.focused .line-value {
   background-color: var(--theme-selection-background);


### PR DESCRIPTION
Fixes #7558 

### Summary of Changes

* Update file icon in Search Results from grey to white when a search result is selected

### Test / Reproduction

1. `yarn start`
2. Visit `localhost:8000` and open Firefox or Chrome
3. Select a sample project, and then press `cmd + shift + f` to search
4. Select one of the files (the file icon is now visible) 

### Screenshots
![icon-color-update](https://user-images.githubusercontent.com/11217831/50270258-94839400-03f6-11e9-8e48-6e98c3bee278.png)