### PR TITLE
Fix CallStack Group with anonymous function.

### DIFF
--- a/src/components/SecondaryPanes/Frames/Group.js
+++ b/src/components/SecondaryPanes/Frames/Group.js
@@ -130,7 +130,7 @@ export default class Group extends Component<Props, State> {
     const { l10n } = this.context;
 
     const frame = this.props.group[0];
-    const displayName = formatDisplayName(frame, {}, l10n);
+    const displayName = formatDisplayName(frame, undefined, l10n);
 
     const l10NEntry = this.state.expanded
       ? "callStack.group.collapseTooltip"

--- a/src/components/SecondaryPanes/Frames/Group.js
+++ b/src/components/SecondaryPanes/Frames/Group.js
@@ -127,13 +127,14 @@ export default class Group extends Component<Props, State> {
   }
 
   renderDescription() {
+    const { l10n } = this.context;
+
     const frame = this.props.group[0];
-    const displayName = formatDisplayName(frame);
+    const displayName = formatDisplayName(frame, {}, l10n);
 
     const l10NEntry = this.state.expanded
       ? "callStack.group.collapseTooltip"
       : "callStack.group.expandTooltip";
-    const { l10n } = this.context;
     const title = l10n.getFormatStr(l10NEntry, frame.library);
 
     return (

--- a/src/components/SecondaryPanes/Frames/tests/Group.spec.js
+++ b/src/components/SecondaryPanes/Frames/tests/Group.spec.js
@@ -82,6 +82,49 @@ describe("Group", () => {
     expect(component).toMatchSnapshot();
   });
 
+  it("renders group with anonymous functions", () => {
+    const group = [
+      {
+        id: 1,
+        library: "Back",
+        displayName: "",
+        location: {
+          line: 55
+        },
+        source: {
+          url: "http://myfile.com/mahscripts.js"
+        }
+      },
+      {
+        id: 2,
+        library: "Back",
+        displayName: "",
+        location: {
+          line: 55
+        },
+        source: {
+          url: "http://myfile.com/back.js"
+        }
+      },
+      {
+        id: 3,
+        library: "Back",
+        displayName: "",
+        location: {
+          line: 55
+        },
+        source: {
+          url: "http://myfile.com/back.js"
+        }
+      }
+    ];
+
+    const { component } = render({ group });
+    expect(component).toMatchSnapshot();
+    component.setState({ expanded: true });
+    expect(component).toMatchSnapshot();
+  });
+
   describe("mouse events", () => {
     it("does not call FrameMenu when disableContextMenu is true", () => {
       const { component } = render({

--- a/src/components/SecondaryPanes/Frames/tests/__snapshots__/Group.spec.js.snap
+++ b/src/components/SecondaryPanes/Frames/tests/__snapshots__/Group.spec.js.snap
@@ -151,3 +151,160 @@ exports[`Group passes the getFrameTitle prop to the Frame components 1`] = `
   </div>
 </div>
 `;
+
+exports[`Group renders group with anonymous functions 1`] = `
+<div
+  className="frames-group"
+  onContextMenu={[Function]}
+>
+  <li
+    className="group"
+    key="1"
+    onClick={[Function]}
+    tabIndex={0}
+    title="Show Back frames"
+  >
+    <span
+      className="title"
+    >
+      &lt;anonymous&gt;
+    </span>
+    <Badge>
+      3
+    </Badge>
+    <FrameLocation
+      frame={
+        Object {
+          "displayName": "",
+          "id": 1,
+          "library": "Back",
+          "location": Object {
+            "line": 55,
+          },
+          "source": Object {
+            "url": "http://myfile.com/mahscripts.js",
+          },
+        }
+      }
+    />
+  </li>
+</div>
+`;
+
+exports[`Group renders group with anonymous functions 2`] = `
+<div
+  className="frames-group expanded"
+  onContextMenu={[Function]}
+>
+  <li
+    className="group"
+    key="1"
+    onClick={[Function]}
+    tabIndex={0}
+    title="Collapse Back frames"
+  >
+    <span
+      className="title"
+    >
+      &lt;anonymous&gt;
+    </span>
+    <Badge>
+      3
+    </Badge>
+    <FrameLocation
+      frame={
+        Object {
+          "displayName": "",
+          "id": 1,
+          "library": "Back",
+          "location": Object {
+            "line": 55,
+          },
+          "source": Object {
+            "url": "http://myfile.com/mahscripts.js",
+          },
+        }
+      }
+    />
+  </li>
+  <div
+    className="frames-list"
+  >
+    <Frame
+      copyStackTrace={[MockFunction]}
+      disableContextMenu={false}
+      frame={
+        Object {
+          "displayName": "",
+          "id": 1,
+          "library": "Back",
+          "location": Object {
+            "line": 55,
+          },
+          "source": Object {
+            "url": "http://myfile.com/mahscripts.js",
+          },
+        }
+      }
+      frameworkGroupingOn={true}
+      hideLocation={true}
+      key="1"
+      selectFrame={[MockFunction]}
+      selectedFrame={Object {}}
+      shouldMapDisplayName={false}
+      toggleBlackBox={[MockFunction]}
+      toggleFrameworkGrouping={[MockFunction]}
+    />
+    <Frame
+      copyStackTrace={[MockFunction]}
+      disableContextMenu={false}
+      frame={
+        Object {
+          "displayName": "",
+          "id": 2,
+          "library": "Back",
+          "location": Object {
+            "line": 55,
+          },
+          "source": Object {
+            "url": "http://myfile.com/back.js",
+          },
+        }
+      }
+      frameworkGroupingOn={true}
+      hideLocation={true}
+      key="2"
+      selectFrame={[MockFunction]}
+      selectedFrame={Object {}}
+      shouldMapDisplayName={false}
+      toggleBlackBox={[MockFunction]}
+      toggleFrameworkGrouping={[MockFunction]}
+    />
+    <Frame
+      copyStackTrace={[MockFunction]}
+      disableContextMenu={false}
+      frame={
+        Object {
+          "displayName": "",
+          "id": 3,
+          "library": "Back",
+          "location": Object {
+            "line": 55,
+          },
+          "source": Object {
+            "url": "http://myfile.com/back.js",
+          },
+        }
+      }
+      frameworkGroupingOn={true}
+      hideLocation={true}
+      key="3"
+      selectFrame={[MockFunction]}
+      selectedFrame={Object {}}
+      shouldMapDisplayName={false}
+      toggleBlackBox={[MockFunction]}
+      toggleFrameworkGrouping={[MockFunction]}
+    />
+  </div>
+</div>
+`;

--- a/src/test/mochitest/browser_dbg-call-stack.js
+++ b/src/test/mochitest/browser_dbg-call-stack.js
@@ -17,6 +17,43 @@ function toggleButton(dbg) {
   return callStackBody.querySelector(".show-more");
 }
 
+// Create an HTTP server to simulate an angular app with anonymous functions
+// and return the URL.
+function createMockAngularPage() {
+  const httpServer = createTestHTTPServer();
+
+  httpServer.registerContentType("html", "text/html");
+  httpServer.registerContentType("js", "application/javascript");
+
+  const htmlFilename = "angular-mock.html"
+  httpServer.registerPathHandler(`/${htmlFilename}`, function(request, response) {
+      response.setStatusLine(request.httpVersion, 200, "OK");
+      response.write(`
+        <html>
+            <button class="pause">Click me</button>
+            <script type="text/javascript" src="angular.js"></script>
+        </html>`
+      );
+    }
+  );
+
+  // Register an angular.js file in order to create a Group with anonymous functions in
+  // the callstack panel.
+  httpServer.registerPathHandler("/angular.js", function(request, response) {
+    response.setHeader("Content-Type", "application/javascript");
+    response.write(`
+      document.querySelector("button.pause").addEventListener("click", () => {
+        (function() {
+          debugger;
+        })();
+      })
+    `);
+  });
+
+  const port = httpServer.identity.primaryPort;
+  return `http://localhost:${port}/${htmlFilename}`;
+}
+
 add_task(async function() {
   const dbg = await initDebugger("doc-script-switching.html");
 
@@ -51,4 +88,28 @@ add_task(async function() {
   is(button.innerText, "Collapse rows", "toggle button should be collapsed");
   is(frames.length, 22, "All of the frames should be shown");
   await waitForSelectedSource(dbg, "frames.js");
+});
+
+
+add_task(async function() {
+  const url = createMockAngularPage();
+  const tab = await addTab(url);
+  info("Open debugger");
+  const toolbox = await openToolboxForTab(tab, "jsdebugger");
+  const dbg = createDebuggerContext(toolbox);
+
+  const found = findElement(dbg, "callStackBody");
+  is(found, null, "Call stack is hidden");
+
+  ContentTask.spawn(gBrowser.selectedBrowser, null, function() {
+    content.document.querySelector("button.pause").click();
+  });
+
+  await waitForPaused(dbg);
+  const $group = findElementWithSelector(dbg, ".frames .frames-group");
+  is($group.querySelector(".title").textContent,
+    "<anonymous>", "Group has expected frame title");
+  is($group.querySelector(".badge").textContent, "2", "Group has expected badge");
+  is($group.querySelector(".location").textContent, "Angular",
+    "Group has expected location");
 });

--- a/src/utils/pause/frames/displayName.js
+++ b/src/utils/pause/frames/displayName.js
@@ -84,7 +84,7 @@ type formatDisplayNameParams = {
 export function formatDisplayName(
   frame: LocalFrame,
   { shouldMapDisplayName = true }: formatDisplayNameParams = {},
-  l10n: Object
+  l10n: typeof L10N
 ): string {
   const { library } = frame;
   let displayName = getFrameDisplayName(frame);
@@ -95,7 +95,7 @@ export function formatDisplayName(
   return simplifyDisplayName(displayName) || l10n.getStr("anonymousFunction");
 }
 
-export function formatCopyName(frame: LocalFrame, l10n: Object): string {
+export function formatCopyName(frame: LocalFrame, l10n: typeof L10N): string {
   const displayName = formatDisplayName(frame, undefined, l10n);
   const fileName = getFilename(frame.source);
   const frameLocation = frame.location.line;

--- a/src/utils/pause/frames/index.js
+++ b/src/utils/pause/frames/index.js
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
+// @flow
+
 export * from "./annotateFrames";
 export * from "./collapseFrames";
 export * from "./displayName";

--- a/src/utils/pause/scopes/getScope.js
+++ b/src/utils/pause/scopes/getScope.js
@@ -83,7 +83,7 @@ export function getScope(
     }
 
     if (vars && vars.length) {
-      const title = getScopeTitle(type, scope);
+      const title = getScopeTitle(type, scope) || "";
       vars.sort((a, b) => a.name.localeCompare(b.name));
       return {
         name: title,


### PR DESCRIPTION
`formatDisplayName` was called without the `l10n`
object, which caused an exception if the last
frame of a stack was anonymous (because we then
use `l10n`).
The fix is simple, pass the `l10n` object to
`formatDisplayName`.
A test is added to ensure we cover this case.
The test do fails without the fix in `Group.js`

Fixes #7579 

### Test Plan

1. Go to https://angular-quickstart.glitch.me/
1. Open the debugger
1. In the debugger, open `app.component.ts`
1. Put a breakpoint on the `export` line
1. Reload the debuggee tab to make the debugger pause
1. Make sure the callstack panel is expanded
1. You should see an `<anonymous> Angular` group in it
