### PR TITLE
Fix sources/outline pane vertical padding

### DIFF
--- a/packages/devtools-components/src/tree.js
+++ b/packages/devtools-components/src/tree.js
@@ -806,10 +806,7 @@ class Tree extends Component {
       });
     });
 
-    const style = Object.assign({}, this.props.style || {}, {
-      padding: 0,
-      margin: 0
-    });
+    const style = Object.assign({}, this.props.style || {});
 
     return dom.div(
       {

--- a/packages/devtools-reps/src/object-inspector/tests/component/__snapshots__/classnames.js.snap
+++ b/packages/devtools-reps/src/object-inspector/tests/component/__snapshots__/classnames.js.snap
@@ -9,12 +9,7 @@ exports[`ObjectInspector - classnames has the expected class 1`] = `
   onKeyPress={[Function]}
   onKeyUp={[Function]}
   role="tree"
-  style={
-    Object {
-      "margin": 0,
-      "padding": 0,
-    }
-  }
+  style={Object {}}
   tabIndex="0"
 >
   <div
@@ -58,12 +53,7 @@ exports[`ObjectInspector - classnames has the inline class when inline prop is t
   onKeyPress={[Function]}
   onKeyUp={[Function]}
   role="tree"
-  style={
-    Object {
-      "margin": 0,
-      "padding": 0,
-    }
-  }
+  style={Object {}}
   tabIndex="0"
 >
   <div
@@ -107,12 +97,7 @@ exports[`ObjectInspector - classnames has the nowrap class when disableWrap prop
   onKeyPress={[Function]}
   onKeyUp={[Function]}
   role="tree"
-  style={
-    Object {
-      "margin": 0,
-      "padding": 0,
-    }
-  }
+  style={Object {}}
   tabIndex="0"
 >
   <div

--- a/packages/devtools-reps/src/object-inspector/tests/component/__snapshots__/window.js.snap
+++ b/packages/devtools-reps/src/object-inspector/tests/component/__snapshots__/window.js.snap
@@ -9,12 +9,7 @@ exports[`ObjectInspector - dimTopLevelWindow renders collapsed top-level window 
   onKeyPress={[Function]}
   onKeyUp={[Function]}
   role="tree"
-  style={
-    Object {
-      "margin": 0,
-      "padding": 0,
-    }
-  }
+  style={Object {}}
   tabIndex="0"
 >
   <div
@@ -68,12 +63,7 @@ exports[`ObjectInspector - dimTopLevelWindow renders sub-level window 1`] = `
   onKeyPress={[Function]}
   onKeyUp={[Function]}
   role="tree"
-  style={
-    Object {
-      "margin": 0,
-      "padding": 0,
-    }
-  }
+  style={Object {}}
   tabIndex="0"
 >
   <div
@@ -154,12 +144,7 @@ exports[`ObjectInspector - dimTopLevelWindow renders window as expected when dim
   onKeyPress={[Function]}
   onKeyUp={[Function]}
   role="tree"
-  style={
-    Object {
-      "margin": 0,
-      "padding": 0,
-    }
-  }
+  style={Object {}}
   tabIndex="0"
 >
   <div
@@ -213,12 +198,7 @@ exports[`ObjectInspector - dimTopLevelWindow renders window as expected when dim
   onKeyPress={[Function]}
   onKeyUp={[Function]}
   role="tree"
-  style={
-    Object {
-      "margin": 0,
-      "padding": 0,
-    }
-  }
+  style={Object {}}
   tabIndex="0"
 >
   <div

--- a/src/components/PrimaryPanes/OutlineFilter.css
+++ b/src/components/PrimaryPanes/OutlineFilter.css
@@ -1,6 +1,5 @@
 .outline-filter {
-  margin: 5px 0 0 0;
-  padding: 0px 10px;
+  padding: 4px 10px 0 10px;
 }
 
 .outline-filter-input {

--- a/src/components/PrimaryPanes/Sources.css
+++ b/src/components/PrimaryPanes/Sources.css
@@ -61,26 +61,17 @@
 .sources-pane {
   display: flex;
   flex: 1;
-  overflow-x: auto;
-  overflow-y: auto;
   height: 100%;
 }
 
 .sources-list {
   flex: 1;
   display: flex;
-  overflow: hidden;
 }
 
 .sources-list .managed-tree {
   flex: 1;
   display: flex;
-  overflow-x: hidden;
-  overflow-y: auto;
-}
-
-.sources-list .managed-tree .tree-node:first-child {
-  margin-top: 4px;
 }
 
 .sources-list .managed-tree .tree .node {

--- a/src/components/shared/ManagedTree.css
+++ b/src/components/shared/ManagedTree.css
@@ -10,7 +10,6 @@
   user-select: none;
 
   white-space: nowrap;
-  overflow: auto;
   min-width: 100%;
 
   display: grid;
@@ -18,6 +17,10 @@
   align-content: start;
 
   line-height: 1.4em;
+
+  padding-inline-start: 0;
+  padding: 4px 0 0 0;
+  margin: 0;
 }
 
 .managed-tree .tree button {

--- a/src/components/shared/tests/__snapshots__/ManagedTree.spec.js.snap
+++ b/src/components/shared/tests/__snapshots__/ManagedTree.spec.js.snap
@@ -244,12 +244,7 @@ exports[`ManagedTree sets expanded items 1`] = `
         onKeyPress={[Function]}
         onKeyUp={[Function]}
         role="tree"
-        style={
-          Object {
-            "margin": 0,
-            "padding": 0,
-          }
-        }
+        style={Object {}}
         tabIndex="0"
       >
         <TreeNode
@@ -456,12 +451,7 @@ exports[`ManagedTree sets expanded items 2`] = `
         onKeyPress={[Function]}
         onKeyUp={[Function]}
         role="tree"
-        style={
-          Object {
-            "margin": 0,
-            "padding": 0,
-          }
-        }
+        style={Object {}}
         tabIndex="0"
       >
         <TreeNode

--- a/src/components/test/__snapshots__/ProjectSearch.spec.js.snap
+++ b/src/components/test/__snapshots__/ProjectSearch.spec.js.snap
@@ -233,12 +233,7 @@ exports[`ProjectSearch found search results 1`] = `
               onKeyPress={[Function]}
               onKeyUp={[Function]}
               role="tree"
-              style={
-                Object {
-                  "margin": 0,
-                  "padding": 0,
-                }
-              }
+              style={Object {}}
               tabIndex="0"
             >
               <TreeNode


### PR DESCRIPTION
Specify a 4px top padding for the tree element and remove the top
margin from its first child. This fixes the gap between the list
scrollbar and the top of the container when it overflows.

Simplify the overflow styling by removing the overflow styles from
the children of .source-outline-panel. This is now the explicit
scrollable container.

Remove the margin from the outline filter and give it the same 4px
top padding to maintain consistency across tabs.

Updated the expected test results as the inline styles of the tree were changed. 
The default padding and margin of 0 were removed as they looked unnecessary.

Fixes #7536.

![](http://g.recordit.co/Xlv8QoYtOf.gif)
