### PR TITLE
Enable Syntax Highlighting for ClojureScript

### DIFF
--- a/packages/devtools-source-map/src/utils/index.js
+++ b/packages/devtools-source-map/src/utils/index.js
@@ -51,7 +51,8 @@ const contentMap = {
   vue: "text/vue",
   coffee: "text/coffeescript",
   elm: "text/elm",
-  cljs: "text/x-clojure"
+  cljc: "text/x-clojure",
+  cljs: "text/x-clojurescript"
 };
 
 /**

--- a/src/utils/source.js
+++ b/src/utils/source.js
@@ -265,6 +265,7 @@ const contentTypeModeMap = {
   "text/jsx": { name: "jsx" },
   "text/x-elm": { name: "elm" },
   "text/x-clojure": { name: "clojure" },
+  "text/x-clojurescript": { name: "clojure" },
   "text/wasm": { name: "text" },
   "text/html": { name: "htmlmixed" }
 };

--- a/src/utils/tests/source.spec.js
+++ b/src/utils/tests/source.spec.js
@@ -370,11 +370,23 @@ describe("sources", () => {
       expect(getMode(source).base.typescript).toBe(true);
     });
 
-    it("clojure", () => {
+    it("cross-platform clojure(script) with reader conditionals", () => {
       const source = {
         contentType: "text/x-clojure",
-        text: "(+ 2 3)",
-        url: ""
+        text:
+          "(defn str->int [s] " +
+          "  #?(:clj  (java.lang.Integer/parseInt s) " +
+          "     :cljs (js/parseInt s)))",
+        url: "my-clojurescript-source-with-reader-conditionals.cljc"
+      };
+      expect(getMode(source)).toEqual({ name: "clojure" });
+    });
+
+    it("clojurescript", () => {
+      const source = {
+        contentType: "text/x-clojurescript",
+        text: "(+ 1 2 3)",
+        url: "my-clojurescript-source.cljs"
       };
       expect(getMode(source)).toEqual({ name: "clojure" });
     });


### PR DESCRIPTION
Fixes #6578

### Summary of Changes

* Add correct [file name extension->content type] mappings for cljc and cljs
* Add correct [content type->CodeMiror mode] mapping for cljs

### Screenshots/Videos
The following are the "before" and "after" screenshots of syntax highlighting cljc and cljs sources.

cljc (before)
![cljc_before](https://user-images.githubusercontent.com/2316604/50372061-1fda6200-057c-11e9-9960-1f4046c3f23e.png)

cljc (after)
![cljc_after](https://user-images.githubusercontent.com/2316604/50372063-2668d980-057c-11e9-9ae9-cbb31dc23e31.png)


cljs (before)
![cljs_before](https://user-images.githubusercontent.com/2316604/50372066-2ec11480-057c-11e9-856b-edae94354c53.png)

cljs (after, there should be no change in this case)
![cljs_after](https://user-images.githubusercontent.com/2316604/50372067-32ed3200-057c-11e9-8ad9-7de0edc03050.png)
