### PR TITLE
Restyle tabs

### DIFF
--- a/src/components/Editor/Tabs.css
+++ b/src/components/Editor/Tabs.css
@@ -38,12 +38,9 @@
 }
 
 .source-tab {
-  border-left: 1px solid transparent;
-  border-right: 1px solid transparent;
   display: inline-flex;
   align-items: center;
   position: relative;
-  /* transition: all 0.15s ease; */
   min-width: 40px;
   max-width: 100%;
   overflow: hidden;
@@ -83,8 +80,6 @@
 .source-tab.active {
   color: var(--theme-toolbar-selected-color);
   border-bottom-color: transparent;
-  border-left: 1px solid transparent;
-  border-right: 1px solid transparent;
 }
 
 .source-tab.active::before {

--- a/src/components/Editor/Tabs.css
+++ b/src/components/Editor/Tabs.css
@@ -83,9 +83,8 @@
 .source-tab.active {
   color: var(--theme-toolbar-selected-color);
   border-bottom-color: transparent;
-  border-left: 1px solid var(--theme-splitter-color);
-  border-right: 1px solid var(--theme-splitter-color);
-  background-color: var(--theme-body-background);
+  border-left: 1px solid transparent;
+  border-right: 1px solid transparent;
 }
 
 .source-tab.active::before {
@@ -171,6 +170,11 @@ html[dir="rtl"] .img.moreTabs {
 
 .source-tab.active .close-btn {
   visibility: visible;
+}
+
+.source-tab.active .close {
+  visibility: visible;
+  background-color: var(--theme-toolbar-selected-color);
 }
 
 .source-tab:hover .close-btn {

--- a/src/components/Editor/Tabs.css
+++ b/src/components/Editor/Tabs.css
@@ -48,6 +48,7 @@
   cursor: default;
   height: 30px;
   font-size: 12px;
+  background-color: transparent;
 }
 
 .source-tab::before {
@@ -127,21 +128,6 @@
 
 .theme-dark .source-tab .blackBox circle {
   fill: var(--theme-body-color);
-}
-
-img.moreTabs {
-  mask: url(/images/command-chevron.svg) no-repeat;
-  mask-size: 100%;
-  width: 12px;
-  height: 12px;
-  display: block;
-  background: var(--theme-body-color);
-  margin-left: 6px;
-}
-
-html[dir="rtl"] .img.moreTabs {
-  transform: rotate(180deg);
-  margin-right: 6px;
 }
 
 .source-tab .filename {

--- a/src/components/Editor/Tabs.css
+++ b/src/components/Editor/Tabs.css
@@ -43,7 +43,7 @@
   display: inline-flex;
   align-items: center;
   position: relative;
-  transition: all 0.15s ease;
+  /* transition: all 0.15s ease; */
   min-width: 40px;
   max-width: 100%;
   overflow: hidden;

--- a/src/components/Editor/Tabs.js
+++ b/src/components/Editor/Tabs.js
@@ -165,7 +165,7 @@ class Tabs extends PureComponent<Props, State> {
     }
 
     const Panel = <ul>{hiddenTabs.map(this.renderDropdownSource)}</ul>;
-    const icon = <AccessibleImage className="moreTabs" />;
+    const icon = <AccessibleImage className="more-tabs" />;
 
     return <Dropdown panel={Panel} icon={icon} />;
   }

--- a/src/components/shared/Button/styles/CloseButton.css
+++ b/src/components/shared/Button/styles/CloseButton.css
@@ -25,6 +25,10 @@
   margin-top: 0;
 }
 
+.close-btn .close:hover {
+  background-color: var(--theme-comment);
+}
+
 .close-btn:hover .img.close {
   background-color: white;
 }

--- a/src/components/shared/Button/styles/CloseButton.css
+++ b/src/components/shared/Button/styles/CloseButton.css
@@ -20,7 +20,6 @@
   background-color: var(--theme-comment);
   width: 8px;
   height: 8px;
-  transition: all 0.15s ease-in-out;
   padding: 0;
   margin-top: 0;
 }

--- a/src/components/shared/Button/styles/CommandBarButton.css
+++ b/src/components/shared/Button/styles/CommandBarButton.css
@@ -11,6 +11,7 @@
   position: relative;
   padding: 0px 5px;
   fill: currentColor;
+  min-width: 30px;
 }
 
 .command-bar-button:disabled {

--- a/src/components/shared/Button/styles/PaneToggleButton.css
+++ b/src/components/shared/Button/styles/PaneToggleButton.css
@@ -6,10 +6,10 @@
   transform: translate(0, 0px);
   transition: transform 0.25s ease-in-out;
   padding: 5px;
-}
-
-.toggle-button .togglePanes {
-  vertical-align: -2px;
+  -webkit-border-start: 1px solid;
+  border-inline-start: 1px solid;
+  border-image: var(--separator-border-image) 1 1;
+  height: inherit;
 }
 
 .toggle-button svg {

--- a/src/components/shared/Dropdown.css
+++ b/src/components/shared/Dropdown.css
@@ -17,6 +17,10 @@
   overflow: auto;
 }
 
+html[dir="rtl"] .dropdown {
+  right: calc((var(--width) - 11px) * (-1));
+}
+
 .dropdown-block {
   padding: 0px 2px;
   position: relative;

--- a/src/components/shared/Dropdown.css
+++ b/src/components/shared/Dropdown.css
@@ -35,13 +35,18 @@
   width: 24px;
 }
 
-.moreTabs {
+.more-tabs {
   mask: url(/images/command-chevron.svg) no-repeat;
   mask-size: 100%;
   width: 12px;
   display: block;
   background: var(--theme-body-color);
   margin-left: 6px;
+}
+
+html[dir="rtl"] .img.more-tabs {
+  transform: rotate(180deg);
+  margin-right: 6px;
 }
 
 .dropdown li {

--- a/src/components/shared/Dropdown.css
+++ b/src/components/shared/Dropdown.css
@@ -17,10 +17,6 @@
   overflow: auto;
 }
 
-html[dir="rtl"] .dropdown {
-  right: calc((var(--width) - 11px) * (-1));
-}
-
 .dropdown-block {
   padding: 0px 2px;
   position: relative;
@@ -37,6 +33,15 @@ html[dir="rtl"] .dropdown {
   font-size: 14px;
   height: 100%;
   width: 24px;
+}
+
+.moreTabs {
+  mask: url(/images/command-chevron.svg) no-repeat;
+  mask-size: 100%;
+  width: 12px;
+  display: block;
+  background: var(--theme-body-color);
+  margin-left: 6px;
 }
 
 .dropdown li {

--- a/src/components/shared/Dropdown.js
+++ b/src/components/shared/Dropdown.js
@@ -45,7 +45,10 @@ export class Dropdown extends Component<Props, State> {
 
   renderButton() {
     return (
-      <button className="dropdown-button moretabs" onClick={this.toggleDropdown}>
+      <button
+        className="dropdown-button"
+        onClick={this.toggleDropdown}
+      >
         {this.props.icon}
       </button>
     );

--- a/src/components/shared/Dropdown.js
+++ b/src/components/shared/Dropdown.js
@@ -45,10 +45,9 @@ export class Dropdown extends Component<Props, State> {
 
   renderButton() {
     return (
-      <button
-        className="dropdown-button"
-        onClick={this.toggleDropdown}
-      >
+      <button 
+        className="dropdown-button" 
+        onClick={this.toggleDropdown}>
         {this.props.icon}
       </button>
     );

--- a/src/components/shared/Dropdown.js
+++ b/src/components/shared/Dropdown.js
@@ -45,7 +45,7 @@ export class Dropdown extends Component<Props, State> {
 
   renderButton() {
     return (
-      <button className="dropdown-button" onClick={this.toggleDropdown}>
+      <button className="dropdown-button moretabs" onClick={this.toggleDropdown}>
         {this.props.icon}
       </button>
     );

--- a/src/components/shared/Dropdown.js
+++ b/src/components/shared/Dropdown.js
@@ -45,9 +45,8 @@ export class Dropdown extends Component<Props, State> {
 
   renderButton() {
     return (
-      <button 
-        className="dropdown-button" 
-        onClick={this.toggleDropdown}>
+      // eslint-disable-next-line prettier/prettier
+      <button className="dropdown-button" onClick={this.toggleDropdown}>
         {this.props.icon}
       </button>
     );

--- a/src/components/shared/Dropdown.js
+++ b/src/components/shared/Dropdown.js
@@ -45,10 +45,7 @@ export class Dropdown extends Component<Props, State> {
 
   renderButton() {
     return (
-      <button
-        className="dropdown-button moretabs"
-        onClick={this.toggleDropdown}
-      >
+      <button className="dropdown-button moretabs" onClick={this.toggleDropdown}>
         {this.props.icon}
       </button>
     );

--- a/src/components/shared/Dropdown.js
+++ b/src/components/shared/Dropdown.js
@@ -45,7 +45,10 @@ export class Dropdown extends Component<Props, State> {
 
   renderButton() {
     return (
-      <button className="dropdown-button moretabs" onClick={this.toggleDropdown}>
+      <button
+        className="dropdown-button moretabs"
+        onClick={this.toggleDropdown}
+      >
         {this.props.icon}
       </button>
     );


### PR DESCRIPTION
Fixes #7494

### Summary of Changes

* Removed `left and right 1px border` from Tabs in editor's source-header.
* Added a few css properties to `toggle-button` since i tried to add `devtools-separator` but wouldn't display on correct side when panels collapsed, since icon rotates.
* Added `min-width` to `PaneToogleButton` as requested in ticket in order to align the separator to editor number's line, when displaying 2 to 3 digits lines.
* Removed CloseButton.js `transition: all ...;` property as mentioned.
* Removed `.source-tab` and `source-tab active` 1px transparent border from left and right side to reflect demo attached to issue #7585 (img-b)

 `devtools-separator as requested` 
<img width="683" alt="devtools-separator" src="https://user-images.githubusercontent.com/2627624/50413653-3aa81300-07d6-11e9-8f5f-651f9bea65b8.png">

 `The close button's cross should use the tab's text color (blue when active, gray otherwise) as requested` 
<img width="649" alt="close-btn-blue-when-active-gray on hover" src="https://user-images.githubusercontent.com/2627624/50413671-4dbae300-07d6-11e9-994b-e30207719d17.png">

As I was working through this task I realized that the "show more files dropdown icon is not showing, I redownloaded master, and discovered its not showing there either, see image attached.
<img width="445" alt="master-morefiles-icon-missing" src="https://user-images.githubusercontent.com/2627624/50413718-a5594e80-07d6-11e9-9711-c50137666efa.png">

I could go ahead in fix it or do we wanna make an additional ticket for that?


[Dropdown icon fix]
Here is fix for the show more files dropdown icon not showing. I pretty much just moved a css class from one file to another. May not be the ultimate or most ideal, please advise.

![dropdown-icon](https://user-images.githubusercontent.com/2627624/50464046-736df680-0954-11e9-9b5b-33375f9b032e.png)
