### PR TITLE
Fixes #7546

### DIFF
--- a/.eslintrc.jsx-a11y
+++ b/.eslintrc.jsx-a11y
@@ -55,7 +55,7 @@
       "roles": ["tabpanel"]
     }],
     "jsx-a11y/no-onchange": "warn",
-    "jsx-a11y/no-redundant-roles": "warn",
+    "jsx-a11y/no-redundant-roles": "error",
     "jsx-a11y/no-static-element-interactions": ["warn", {
       "handlers": ["onClick", "onMouseDown", "onMouseUp", "onKeyPress", "onKeyDown", "onKeyUp"]
     }],

--- a/src/components/shared/Accordion.js
+++ b/src/components/shared/Accordion.js
@@ -62,7 +62,7 @@ class Accordion extends Component<Props, State> {
     const { opened } = item;
 
     return (
-      <li role="listitem" className={item.className} key={i}>
+      <li className={item.className} key={i}>
         <h2
           className="_header"
           tabIndex="0"
@@ -87,7 +87,7 @@ class Accordion extends Component<Props, State> {
   };
   render() {
     return (
-      <ul role="list" className="accordion">
+      <ul className="accordion">
         {this.props.items.map(this.renderContainer)}
       </ul>
     );

--- a/src/components/shared/tests/__snapshots__/Accordion.spec.js.snap
+++ b/src/components/shared/tests/__snapshots__/Accordion.spec.js.snap
@@ -3,12 +3,10 @@
 exports[`Accordion basic render 1`] = `
 <ul
   className="accordion"
-  role="list"
 >
   <li
     className="accordion-item-1"
     key="0"
-    role="listitem"
   >
     <h2
       className="_header"
@@ -31,7 +29,6 @@ exports[`Accordion basic render 1`] = `
   <li
     className="accordion-item-2"
     key="1"
-    role="listitem"
   >
     <h2
       className="_header"
@@ -55,7 +52,6 @@ exports[`Accordion basic render 1`] = `
   <li
     className="accordion-item-3"
     key="2"
-    role="listitem"
   >
     <h2
       className="_header"


### PR DESCRIPTION
Fixes #7546 

### Summary of Changes

* Removed redundant role attributes
* Changed eslint config for `jsx-a11y/no-redundant-roles` to `error`

### Test Plan

- [x] `yarn lint:jsx-a11y | grep no-redundant-roles` has empty output
