### PR TITLE
Fix cmd/ctrl+shift+b shortcut to toggle conditional breakpoint

### DIFF
--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -433,14 +433,23 @@ class Editor extends PureComponent<Props, State> {
     const {
       conditionalPanelLocation,
       closeConditionalPanel,
-      openConditionalPanel
+      openConditionalPanel,
+      selectedSource
     } = this.props;
 
     if (conditionalPanelLocation) {
       return closeConditionalPanel();
     }
 
-    return openConditionalPanel(conditionalPanelLocation);
+    if (!selectedSource) {
+      return;
+    }
+
+    return openConditionalPanel({
+      line: line,
+      sourceId: selectedSource.id,
+      sourceUrl: selectedSource.url
+    });
   };
 
   closeConditionalPanel = () => {


### PR DESCRIPTION
Currently, if `conditionalPanelLocation` is undefined we attempt to open the conditional panel at that location. Unsurprisingly, this fails as we do not know which source file or line to open at.

This change passes the source and line at which the shortcut was triggered.

While debugging this issue I spotted that the keyboard event for the shortcut is not being fired in Firefox. If the key combination is changed to say, `CmdOrCtrl+E`, it is fired. Chrome has no such issue.

Fixes #7572 