### PR TITLE
Fix jsx-a11y/anchor-is-valid warnings

### DIFF
--- a/.eslintrc.jsx-a11y
+++ b/.eslintrc.jsx-a11y
@@ -12,7 +12,7 @@
     "jsx-a11y/accessible-emoji": "warn",
     "jsx-a11y/alt-text": "warn",
     "jsx-a11y/anchor-has-content": "warn",
-    "jsx-a11y/anchor-is-valid": "warn",
+    "jsx-a11y/anchor-is-valid": "error",
     "jsx-a11y/aria-activedescendant-has-tabindex": "warn",
     "jsx-a11y/aria-props": "warn",
     "jsx-a11y/aria-proptypes": "warn",

--- a/src/components/SecondaryPanes/Scopes.css
+++ b/src/components/SecondaryPanes/Scopes.css
@@ -47,7 +47,14 @@ html[dir="rtl"] .object-node {
   padding-bottom: 10px;
 }
 
-.scopes-list .scope-type-toggle a {
+.scopes-list .scope-type-toggle button {
   /* Override color so that the link doesn't turn purple */
   color: var(--theme-body-color);
+  font-size: inherit;
+  text-decoration: underline;
+  cursor: pointer;
+}
+
+.scopes-list .scope-type-toggle button:hover {
+  background: transparent;
 }

--- a/src/components/SecondaryPanes/Scopes.js
+++ b/src/components/SecondaryPanes/Scopes.js
@@ -125,8 +125,7 @@ class Scopes extends PureComponent<Props, State> {
           />
           {originalScopes ? (
             <div className="scope-type-toggle">
-              <a
-                href=""
+              <button
                 onClick={e => {
                   e.preventDefault();
                   this.setState({ showOriginal: !showOriginal });
@@ -135,7 +134,7 @@ class Scopes extends PureComponent<Props, State> {
                 {showOriginal
                   ? L10N.getStr("scopes.toggleToGenerated")
                   : L10N.getStr("scopes.toggleToOriginal")}
-              </a>
+              </button>
             </div>
           ) : null}
         </div>


### PR DESCRIPTION
Raise the severity of the `anchor-is-valid` rule to `error` to prevent any future warnings.

Change the 'Show generated/original scope' element to a use a `<button>` rather than a `<a>`. The styling of this element is updated such that it remains the same.

Fixes #7545.

![](http://g.recordit.co/MULJW4WP6J.gif)

Note - the cursor is a pointer but this doesn't appear in the gif.