### PR TITLE
Gutter menu fix

### DIFF
--- a/src/components/Editor/GutterMenu.js
+++ b/src/components/Editor/GutterMenu.js
@@ -154,9 +154,7 @@ class GutterContextMenuComponent extends Component {
     }).ch;
 
     const breakpoint = nextProps.breakpoints.find(
-      bp =>
-        bp.location.line === line &&
-        (bp.location.column === column || bp.location.column === undefined)
+      bp => bp.location.line === line
     );
 
     // Allow getFirstVisiblePausePoint to find the best first breakpoint

--- a/src/components/Editor/GutterMenu.js
+++ b/src/components/Editor/GutterMenu.js
@@ -152,8 +152,9 @@ class GutterContextMenuComponent extends Component {
       left: event.x,
       top: event.y
     }).ch;
+
     const breakpoint = nextProps.breakpoints.find(
-      bp => bp.location.line === line && bp.location.column === column
+      bp => bp.location.line === line
     );
 
     // Allow getFirstVisiblePausePoint to find the best first breakpoint

--- a/src/components/Editor/GutterMenu.js
+++ b/src/components/Editor/GutterMenu.js
@@ -154,7 +154,9 @@ class GutterContextMenuComponent extends Component {
     }).ch;
 
     const breakpoint = nextProps.breakpoints.find(
-      bp => bp.location.line === line
+      bp =>
+        bp.location.line === line &&
+        (bp.location.column === column || bp.location.column === undefined)
     );
 
     // Allow getFirstVisiblePausePoint to find the best first breakpoint

--- a/src/components/Editor/GutterMenu.js
+++ b/src/components/Editor/GutterMenu.js
@@ -6,6 +6,7 @@ import { Component } from "react";
 import { showMenu } from "devtools-contextmenu";
 import { connect } from "../../utils/connect";
 import { lineAtHeight } from "../../utils/editor";
+import { features } from "../../utils/prefs";
 import {
   getContextMenu,
   getEmptyLines,
@@ -153,12 +154,12 @@ class GutterContextMenuComponent extends Component {
       top: event.y
     }).ch;
     const breakpoint = nextProps.breakpoints.find(
-      bp => bp.location.line === line && bp.location.column == column
+      bp => bp.location.line === line && bp.location.column === column
     );
 
     // Allow getFirstVisiblePausePoint to find the best first breakpoint
     // position by not providing an explicit column number
-    if (!breakpoint && column === 0) {
+    if (features.columnBreakpoints && !breakpoint && column === 0) {
       column = undefined;
     }
 

--- a/src/components/Editor/GutterMenu.js
+++ b/src/components/Editor/GutterMenu.js
@@ -152,9 +152,8 @@ class GutterContextMenuComponent extends Component {
       left: event.x,
       top: event.y
     }).ch;
-
     const breakpoint = nextProps.breakpoints.find(
-      bp => bp.location.line === line
+      bp => bp.location.line === line && bp.location.column == column
     );
 
     // Allow getFirstVisiblePausePoint to find the best first breakpoint

--- a/src/test/mochitest/browser_dbg-breakpoints-cond.js
+++ b/src/test/mochitest/browser_dbg-breakpoints-cond.js
@@ -54,15 +54,16 @@ add_task(async function() {
 
   await setConditionalBreakpoint(dbg, 5, "1");
   await waitForDispatch(dbg, "ADD_BREAKPOINT");
-  
+
   let bp = findBreakpoint(dbg, "simple2", 5);
   is(bp.condition, "1", "breakpoint is created with the condition");
   assertEditorBreakpoint(dbg, 5, true);
 
+  // Edit the conditional breakpoint set above
   await setConditionalBreakpoint(dbg, 5, "2");
   await waitForDispatch(dbg, "SET_BREAKPOINT_CONDITION");
   bp = findBreakpoint(dbg, "simple2", 5);
-  is(bp.condition, "2", "breakpoint is created with the condition");
+  is(bp.condition, "12", "breakpoint is created with the condition");
   assertEditorBreakpoint(dbg, 5, true);
 
   clickElement(dbg, "gutter", 5);


### PR DESCRIPTION
Fixes an issue where the context menu list no longer changes even if a breakpoint exists (see screenshot below), meaning you can no longer remove a breakpoint, edit a conditional breakpoint etc using the context menu, once the breakpoint is added.

seems to introduced by
https://github.com/devtools-html/debugger.html/commit/9845435ee24460835732523cf72f93bc5f1b7d3b

### Summary of Changes

* stop checking `column` to show the menu for conditional breakpoints

### Screenshots/Videos (OPTIONAL)
#### Before
![](http://g.recordit.co/cJ8Q5xq2ir.gif)

#### After
![](http://g.recordit.co/1NlFFSpPD3.gif)