### PR TITLE
Fix jsx label associated control

### DIFF
--- a/.eslintrc.jsx-a11y
+++ b/.eslintrc.jsx-a11y
@@ -26,8 +26,16 @@
     "jsx-a11y/interactive-supports-focus": ["warn", {
       "tabbable": ["button", "checkbox", "link", "searchbox", "spinbutton", "switch", "textbox"]
     }],
-    "jsx-a11y/label-has-for": "warn",
-    "jsx-a11y/label-has-associated-control": "error",
+    "jsx-a11y/label-has-for": ["error", {
+      "required": {
+        "some": [ "nesting", "id" ]
+      }
+    }],
+    "jsx-a11y/label-has-associated-control": ["error", {
+      "required": {
+        "some": [ "nesting", "id" ]
+      }
+    }],
     "jsx-a11y/media-has-caption": "warn",
     "jsx-a11y/mouse-events-have-key-events": "warn",
     "jsx-a11y/no-access-key": "warn",

--- a/.eslintrc.jsx-a11y
+++ b/.eslintrc.jsx-a11y
@@ -27,7 +27,7 @@
       "tabbable": ["button", "checkbox", "link", "searchbox", "spinbutton", "switch", "textbox"]
     }],
     "jsx-a11y/label-has-for": "warn",
-    "jsx-a11y/label-has-associated-control": "warn",
+    "jsx-a11y/label-has-associated-control": "error",
     "jsx-a11y/media-has-caption": "warn",
     "jsx-a11y/mouse-events-have-key-events": "warn",
     "jsx-a11y/no-access-key": "warn",

--- a/src/components/SecondaryPanes/Breakpoints/Breakpoint.js
+++ b/src/components/SecondaryPanes/Breakpoints/Breakpoint.js
@@ -149,7 +149,7 @@ class Breakpoint extends PureComponent<Props> {
         onContextMenu={this.onContextMenu}
       >
         <input
-          id={`bp-${breakpoint.id}`}
+          id={breakpoint.id}
           type="checkbox"
           className="breakpoint-checkbox"
           checked={!breakpoint.disabled}
@@ -157,11 +157,12 @@ class Breakpoint extends PureComponent<Props> {
           onClick={ev => ev.stopPropagation()}
         />
         <label
-          htmlFor={`bp-${breakpoint.id}`}
+          htmlFor={breakpoint.id}
           className="breakpoint-label cm-s-mozilla"
           title={this.getBreakpointText()}
-          dangerouslySetInnerHTML={this.highlightText()}
-        />
+        >
+          <span dangerouslySetInnerHTML={this.highlightText()} />
+        </label>
         <div className="breakpoint-line-close">
           <div className="breakpoint-line">{this.getBreakpointLocation()}</div>
           <CloseButton

--- a/src/components/SecondaryPanes/Breakpoints/Breakpoint.js
+++ b/src/components/SecondaryPanes/Breakpoints/Breakpoint.js
@@ -149,6 +149,7 @@ class Breakpoint extends PureComponent<Props> {
         onContextMenu={this.onContextMenu}
       >
         <input
+          id={`bp-${breakpoint.id}`}
           type="checkbox"
           className="breakpoint-checkbox"
           checked={!breakpoint.disabled}
@@ -156,6 +157,7 @@ class Breakpoint extends PureComponent<Props> {
           onClick={ev => ev.stopPropagation()}
         />
         <label
+          htmlFor={`bp-${breakpoint.id}`}
           className="breakpoint-label cm-s-mozilla"
           title={this.getBreakpointText()}
           dangerouslySetInnerHTML={this.highlightText()}

--- a/src/components/SecondaryPanes/Breakpoints/tests/__snapshots__/Breakpoint.spec.js.snap
+++ b/src/components/SecondaryPanes/Breakpoints/tests/__snapshots__/Breakpoint.spec.js.snap
@@ -10,6 +10,7 @@ exports[`Breakpoint disabled 1`] = `
   <input
     checked={false}
     className="breakpoint-checkbox"
+    id="bp-undefined"
     onChange={[Function]}
     onClick={[Function]}
     type="checkbox"
@@ -21,6 +22,7 @@ exports[`Breakpoint disabled 1`] = `
         "__html": "",
       }
     }
+    htmlFor="bp-undefined"
   />
   <div
     className="breakpoint-line-close"
@@ -48,6 +50,7 @@ exports[`Breakpoint paused at a different 1`] = `
   <input
     checked={true}
     className="breakpoint-checkbox"
+    id="bp-undefined"
     onChange={[Function]}
     onClick={[Function]}
     type="checkbox"
@@ -59,6 +62,7 @@ exports[`Breakpoint paused at a different 1`] = `
         "__html": "",
       }
     }
+    htmlFor="bp-undefined"
   />
   <div
     className="breakpoint-line-close"
@@ -86,6 +90,7 @@ exports[`Breakpoint paused at a generatedLocation 1`] = `
   <input
     checked={true}
     className="breakpoint-checkbox"
+    id="bp-undefined"
     onChange={[Function]}
     onClick={[Function]}
     type="checkbox"
@@ -97,6 +102,7 @@ exports[`Breakpoint paused at a generatedLocation 1`] = `
         "__html": "",
       }
     }
+    htmlFor="bp-undefined"
   />
   <div
     className="breakpoint-line-close"
@@ -124,6 +130,7 @@ exports[`Breakpoint paused at an original location 1`] = `
   <input
     checked={true}
     className="breakpoint-checkbox"
+    id="bp-undefined"
     onChange={[Function]}
     onClick={[Function]}
     type="checkbox"
@@ -135,6 +142,7 @@ exports[`Breakpoint paused at an original location 1`] = `
         "__html": "",
       }
     }
+    htmlFor="bp-undefined"
   />
   <div
     className="breakpoint-line-close"
@@ -162,6 +170,7 @@ exports[`Breakpoint simple 1`] = `
   <input
     checked={true}
     className="breakpoint-checkbox"
+    id="bp-undefined"
     onChange={[Function]}
     onClick={[Function]}
     type="checkbox"
@@ -173,6 +182,7 @@ exports[`Breakpoint simple 1`] = `
         "__html": "",
       }
     }
+    htmlFor="bp-undefined"
   />
   <div
     className="breakpoint-line-close"

--- a/src/components/SecondaryPanes/Breakpoints/tests/__snapshots__/Breakpoint.spec.js.snap
+++ b/src/components/SecondaryPanes/Breakpoints/tests/__snapshots__/Breakpoint.spec.js.snap
@@ -10,20 +10,21 @@ exports[`Breakpoint disabled 1`] = `
   <input
     checked={false}
     className="breakpoint-checkbox"
-    id="bp-undefined"
     onChange={[Function]}
     onClick={[Function]}
     type="checkbox"
   />
   <label
     className="breakpoint-label cm-s-mozilla"
-    dangerouslySetInnerHTML={
-      Object {
-        "__html": "",
+  >
+    <span
+      dangerouslySetInnerHTML={
+        Object {
+          "__html": "",
+        }
       }
-    }
-    htmlFor="bp-undefined"
-  />
+    />
+  </label>
   <div
     className="breakpoint-line-close"
   >
@@ -50,20 +51,21 @@ exports[`Breakpoint paused at a different 1`] = `
   <input
     checked={true}
     className="breakpoint-checkbox"
-    id="bp-undefined"
     onChange={[Function]}
     onClick={[Function]}
     type="checkbox"
   />
   <label
     className="breakpoint-label cm-s-mozilla"
-    dangerouslySetInnerHTML={
-      Object {
-        "__html": "",
+  >
+    <span
+      dangerouslySetInnerHTML={
+        Object {
+          "__html": "",
+        }
       }
-    }
-    htmlFor="bp-undefined"
-  />
+    />
+  </label>
   <div
     className="breakpoint-line-close"
   >
@@ -90,20 +92,21 @@ exports[`Breakpoint paused at a generatedLocation 1`] = `
   <input
     checked={true}
     className="breakpoint-checkbox"
-    id="bp-undefined"
     onChange={[Function]}
     onClick={[Function]}
     type="checkbox"
   />
   <label
     className="breakpoint-label cm-s-mozilla"
-    dangerouslySetInnerHTML={
-      Object {
-        "__html": "",
+  >
+    <span
+      dangerouslySetInnerHTML={
+        Object {
+          "__html": "",
+        }
       }
-    }
-    htmlFor="bp-undefined"
-  />
+    />
+  </label>
   <div
     className="breakpoint-line-close"
   >
@@ -130,20 +133,21 @@ exports[`Breakpoint paused at an original location 1`] = `
   <input
     checked={true}
     className="breakpoint-checkbox"
-    id="bp-undefined"
     onChange={[Function]}
     onClick={[Function]}
     type="checkbox"
   />
   <label
     className="breakpoint-label cm-s-mozilla"
-    dangerouslySetInnerHTML={
-      Object {
-        "__html": "",
+  >
+    <span
+      dangerouslySetInnerHTML={
+        Object {
+          "__html": "",
+        }
       }
-    }
-    htmlFor="bp-undefined"
-  />
+    />
+  </label>
   <div
     className="breakpoint-line-close"
   >
@@ -170,20 +174,21 @@ exports[`Breakpoint simple 1`] = `
   <input
     checked={true}
     className="breakpoint-checkbox"
-    id="bp-undefined"
     onChange={[Function]}
     onClick={[Function]}
     type="checkbox"
   />
   <label
     className="breakpoint-label cm-s-mozilla"
-    dangerouslySetInnerHTML={
-      Object {
-        "__html": "",
+  >
+    <span
+      dangerouslySetInnerHTML={
+        Object {
+          "__html": "",
+        }
       }
-    }
-    htmlFor="bp-undefined"
-  />
+    />
+  </label>
   <div
     className="breakpoint-line-close"
   >


### PR DESCRIPTION
Fixes #7541

### Summary of Changes

* changed eslint rule declaration for labels
* slightly changed structure of labels in src/components/SecondaryPanes/Breakpoints/Breakpoint.js to fulfill rules:
** had to create a child element, because the eslint plugin says ["(2) has an htmlFor attribute and that the label tag has text content."](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/label-has-associated-control.md#label-has-associated-control)

### Test Plan

Example test plan:

- [x] Open DevTools
- [x] Create breakpoints
- [x] Activating/Deactivating of breakpoints works by clicking the label next to the checkbox