### PR TITLE
Fix jsx-a11y/no-autofocus warnings

### DIFF
--- a/.eslintrc.jsx-a11y
+++ b/.eslintrc.jsx-a11y
@@ -31,7 +31,7 @@
     "jsx-a11y/media-has-caption": "warn",
     "jsx-a11y/mouse-events-have-key-events": "warn",
     "jsx-a11y/no-access-key": "warn",
-    "jsx-a11y/no-autofocus": "warn",
+    "jsx-a11y/no-autofocus": "error",
     "jsx-a11y/no-distracting-elements": "warn",
 
     "jsx-a11y/no-interactive-element-to-noninteractive-role": ["warn", {

--- a/src/components/SecondaryPanes/Expressions.js
+++ b/src/components/SecondaryPanes/Expressions.js
@@ -277,7 +277,7 @@ class Expressions extends Component<Props, State> {
   }
 
   renderNewExpressionInput() {
-    const { expressionError, showInput } = this.props;
+    const { expressionError } = this.props;
     const { editing, inputValue, focused } = this.state;
     const error = editing === false && expressionError === true;
     const placeholder: string = error
@@ -297,7 +297,6 @@ class Expressions extends Component<Props, State> {
             onBlur={this.hideInput}
             onKeyDown={this.handleKeyDown}
             onFocus={this.onFocus}
-            autoFocus={showInput}
             value={!editing ? inputValue : ""}
             ref={c => (this._input = c)}
             {...features.autocompleteExpression && {

--- a/src/components/SecondaryPanes/XHRBreakpoints.js
+++ b/src/components/SecondaryPanes/XHRBreakpoints.js
@@ -131,7 +131,6 @@ class XHRBreakpoints extends Component<Props, State> {
 
   renderXHRInput(onSubmit) {
     const { focused, inputValue } = this.state;
-    const { showInput } = this.props;
     const placeholder = L10N.getStr("xhrBreakpoints.placeholder");
 
     return (
@@ -147,7 +146,6 @@ class XHRBreakpoints extends Component<Props, State> {
             onChange={this.handleChange}
             onBlur={this.hideInput}
             onFocus={this.onFocus}
-            autoFocus={showInput}
             value={inputValue}
             ref={c => (this._input = c)}
           />


### PR DESCRIPTION
Remove the `autoFocus` attribute from the watch expression and xhr breakpoint input elements. These elements are both given focus manually.

Raise the severity of the jsx-a11y/no-autofocus rule from `"warn"` to `"error"` to avoid future warnings.

Fixes #7543