### PR TITLE
Fixed breakpoints-issue-7184

### DIFF
--- a/src/components/SecondaryPanes/Breakpoints/Breakpoints.css
+++ b/src/components/SecondaryPanes/Breakpoints/Breakpoints.css
@@ -149,7 +149,7 @@ html[dir="rtl"] .breakpoints-list .breakpoint .breakpoint-line {
 }
 
 .breakpoints-list .breakpoint:hover .breakpoint-line {
-  display: none;
+  color: transparent;
 }
 
 .breakpoints-list .breakpoint.paused:hover {


### PR DESCRIPTION
Fixes #7184

### Summary of Changes

* display: none is changed to color: transparent on line 151 in src/components/SecondaryPanes/Breakpoints/Breakpoints.css

### Test Plan

The debugger too is launched and breakpoints are hovered.

Example test plan:

- [x] code lines are selected to feature in breakpoints
- [x] breakpoints are hovered to check if text-overflow is consistent
- [x] Clicking "x" closes the breakpoint's panel

### Screenshots/Videos (OPTIONAL)

[After fixing the issue](https://user-images.githubusercontent.com/23102198/50486818-8f9f8100-09b0-11e9-9f93-d97da0a62174.gif)
