### PR TITLE
Shortcuts

### DIFF
--- a/src/components/WelcomeBox.css
+++ b/src/components/WelcomeBox.css
@@ -62,7 +62,7 @@
   font-family: var(--monospace-font-family);
   font-size: 14px;
   line-height: 18px;
-  color: var(--theme-body-color)
+  color: var(--theme-body-color);
 }
 
 .shortcutLabel {

--- a/src/components/WelcomeBox.css
+++ b/src/components/WelcomeBox.css
@@ -59,12 +59,17 @@
 .shortcutKey {
   text-align: right;
   padding-right: 10px;
-  font-family: Courier;
+  font-family: var(--monospace-font-family);
+  font-size: 14px;
+  line-height: 18px;
+  color: var(--theme-body-color)
 }
 
 .shortcutLabel {
   text-align: left;
   padding-left: 10px;
+  font-size: 14px;
+  line-height: 18px;
 }
 
 .shortcutFunction {


### PR DESCRIPTION
Fixes #7498 

### Summary of Changes

* Change font-family: Courier to font-family: var(--monospace-font-family) for keyboard shortcut
* Set line-height and text-size same for both labels and shortcuts to make it proportionate
* Change color for the keyboard shortcut to make it contrast with the label and look nice