### PR TITLE
Bug 7607 no source msg

### DIFF
--- a/src/components/PrimaryPanes/index.js
+++ b/src/components/PrimaryPanes/index.js
@@ -100,7 +100,10 @@ class PrimaryPanes extends Component<Props, State> {
       this.props.getWorkerDisplayName
     );
 
-    return threads.map(thread => thread.length > 0 && <SourcesTree thread={thread} key={thread} />);
+    return threads.map(
+      thread =>
+        thread.length > 0 && <SourcesTree thread={thread} key={thread} />
+    );
   }
 
   render() {

--- a/src/components/PrimaryPanes/index.js
+++ b/src/components/PrimaryPanes/index.js
@@ -100,7 +100,7 @@ class PrimaryPanes extends Component<Props, State> {
       this.props.getWorkerDisplayName
     );
 
-    return threads.map(thread => <SourcesTree thread={thread} key={thread} />);
+    return threads.map(thread => thread.length > 0 && <SourcesTree thread={thread} key={thread} />);
   }
 
   render() {


### PR DESCRIPTION
Fixes #7607 

### Summary of Changes

* Show source tree only for threads with valid name. Threads with "" are the threads for pretty printed sources, which need not be displayed in source tree.