### PR TITLE
Update sources and tabs when workers are created and destroyed.

### DIFF
--- a/src/actions/debuggee.js
+++ b/src/actions/debuggee.js
@@ -5,10 +5,19 @@
 // @flow
 
 import type { Action, ThunkArgs } from "./types";
+import { closeTabsForMissingThreads } from "./tabs";
+import { getMainThread } from "../reducers/pause";
 
 export function updateWorkers() {
-  return async function({ dispatch, client }: ThunkArgs) {
+  return async function({ dispatch, getState, client }: ThunkArgs) {
     const { workers } = await client.fetchWorkers();
     dispatch(({ type: "SET_WORKERS", workers }: Action));
+
+    closeTabsForMissingThreads(
+      dispatch,
+      getState,
+      getMainThread(getState()),
+      workers
+    );
   };
 }

--- a/src/components/PrimaryPanes/index.js
+++ b/src/components/PrimaryPanes/index.js
@@ -14,7 +14,8 @@ import {
   getRelativeSources,
   getActiveSearch,
   getSelectedPrimaryPaneTab,
-  getWorkerDisplayName
+  getWorkerDisplayName,
+  isValidThread
 } from "../../selectors";
 import { features, prefs } from "../../utils/prefs";
 import "./Sources.css";
@@ -38,7 +39,8 @@ type Props = {
   setPrimaryPaneTab: typeof actions.setPrimaryPaneTab,
   setActiveSearch: typeof actions.setActiveSearch,
   closeActiveSearch: typeof actions.closeActiveSearch,
-  getWorkerDisplayName: string => string
+  getWorkerDisplayName: string => string,
+  isValidThread: string => boolean
 };
 
 class PrimaryPanes extends Component<Props, State> {
@@ -96,7 +98,9 @@ class PrimaryPanes extends Component<Props, State> {
 
   renderThreadSources() {
     const threads = sortBy(
-      Object.getOwnPropertyNames(this.props.sources),
+      Object.getOwnPropertyNames(this.props.sources).filter(
+        this.props.isValidThread
+      ),
       this.props.getWorkerDisplayName
     );
 
@@ -132,7 +136,8 @@ const mapStateToProps = state => ({
   selectedTab: getSelectedPrimaryPaneTab(state),
   sources: getRelativeSources(state),
   sourceSearchOn: getActiveSearch(state) === "source",
-  getWorkerDisplayName: thread => getWorkerDisplayName(state, thread)
+  getWorkerDisplayName: thread => getWorkerDisplayName(state, thread),
+  isValidThread: thread => isValidThread(state, thread)
 });
 
 const connector = connect(

--- a/src/reducers/debuggee.js
+++ b/src/reducers/debuggee.js
@@ -14,6 +14,7 @@ import type { Record } from "../utils/makeRecord";
 import type { Worker } from "../types";
 import type { Action } from "../actions/types";
 import makeRecord from "../utils/makeRecord";
+import { getMainThread } from "./pause";
 
 export type WorkersList = List<Worker>;
 
@@ -48,6 +49,18 @@ export const getWorkerDisplayName = (state: OuterState, thread: string) => {
     index++;
   }
   return "";
+};
+
+export const isValidThread = (state: OuterState, thread: string) => {
+  if (thread == getMainThread((state: any))) {
+    return true;
+  }
+  for (const { actor } of state.debuggee.workers) {
+    if (actor == thread) {
+      return true;
+    }
+  }
+  return false;
 };
 
 type OuterState = { debuggee: DebuggeeState };


### PR DESCRIPTION
### Summary of Changes

* When a worker is started, its sources are added to the sources pane.
* When a worker is destroyed, its sources are removed from the sources pane.
* When a worker is destroyed, any tabs associated with its sources are closed.

### Test Plan

Manually verified behavior is as expected.