### PR TITLE
Tooltip to add XHR breakpoint should use correct l10n string (#7626)

### DIFF
--- a/src/components/SecondaryPanes/index.js
+++ b/src/components/SecondaryPanes/index.js
@@ -194,7 +194,7 @@ class SecondaryPanes extends Component<Props, State> {
         },
         "plus",
         "plus",
-        L10N.getStr("xhrBreakpoints.placeholder")
+        L10N.getStr("xhrBreakpoints.label")
       )
     );
 


### PR DESCRIPTION
Fixes #7626

### Summary of Changes

Use xhrBreakpoints.label instead of xhrBreakpoints.placeholder for tooltip of button to add XHR breakpoint.

### Test Plan

Tell us a little a bit about how you tested your patch.

Example test plan:

1. Open debugger.
2. In right column, go to "XHR breakpoints".
3. Move mouse over "+" button to add breakpoint.
