### PR TITLE
original source thread should be same as generated source thread

### DIFF
--- a/src/actions/sources/newSources.js
+++ b/src/actions/sources/newSources.js
@@ -40,7 +40,7 @@ function createOriginalSource(
     url: originalUrl,
     relativeUrl: originalUrl,
     id: generatedToOriginalId(generatedSource.id, originalUrl),
-    thread: "",
+    thread: generatedSource.thread,
     isPrettyPrinted: false,
     isWasm: false,
     isBlackBoxed: false,


### PR DESCRIPTION
Fixes #7633 

### Summary of Changes

* original source thread should be same as generated source thread

### Test Plan

- [x] Open any site with source maps - say https://w2x2oypmqk.codesandbox.io/
- [x] Webpack sources should appear in source tree

### Screenshot
<img width="378" alt="screenshot 2019-01-02 at 12 05 54 pm" src="https://user-images.githubusercontent.com/8366397/50582236-e1e81280-0e86-11e9-9e95-06c983ebdde1.png">
