### PR TITLE
Use AccessibleImage component instead of img in Workers

### DIFF
--- a/.eslintrc.jsx-a11y
+++ b/.eslintrc.jsx-a11y
@@ -10,7 +10,7 @@
     // plugin:jsx-a11y/recommended set (which they override) that has different severity
     // levels.
     "jsx-a11y/accessible-emoji": "warn",
-    "jsx-a11y/alt-text": "warn",
+    "jsx-a11y/alt-text": "error",
     "jsx-a11y/anchor-has-content": "warn",
     "jsx-a11y/anchor-is-valid": "error",
     "jsx-a11y/aria-activedescendant-has-tabindex": "warn",

--- a/src/components/SecondaryPanes/Workers.js
+++ b/src/components/SecondaryPanes/Workers.js
@@ -45,7 +45,7 @@ export class Workers extends Component<Props> {
           key={worker.actor}
           onClick={() => this.props.selectThread(worker.actor)}
         >
-          <img className="domain" />
+          <AccessibleImage className="domain" />
           {(worker.url
             ? `${this.props.getWorkerDisplayName(worker.actor)}: ${basename(
                 worker.url


### PR DESCRIPTION
Fixes #7539

### Summary of Changes

* change `jsx-a11y/alt-text` lint rule from **warn** to **error**
* fix `jsx-a11y/alt-text` error by using `AccesibleImage` instead of `img`

### Test Plan
Used inspector to check the rendered output:

Before:
![screen shot 2019-01-02 at 12 18 11 pm](https://user-images.githubusercontent.com/5035181/50612327-76a23e80-0e8e-11e9-8fa8-db4815d9ee98.png)

After:
![screen shot 2019-01-02 at 12 46 23 pm](https://user-images.githubusercontent.com/5035181/50612336-7bff8900-0e8e-11e9-8745-113f3fac2ba9.png)


Note:  There may be some other issue with this component because clicking on a worker doesn't seem to do anything.  This happens both before and after this change so I think it is unrelated to this change.
