### PR TITLE
Fix sources tree not displaying when custom root

### DIFF
--- a/src/components/PrimaryPanes/Sources.css
+++ b/src/components/PrimaryPanes/Sources.css
@@ -208,6 +208,10 @@
   overflow: auto;
 }
 
+.source-outline-panel.has-root > div {
+  height: 100%;
+}
+
 .sources-list .managed-tree .tree .node .img.blackBox {
   mask: url(/images/blackBox.svg) no-repeat;
   mask-size: 100%;

--- a/src/components/PrimaryPanes/index.js
+++ b/src/components/PrimaryPanes/index.js
@@ -12,6 +12,7 @@ import actions from "../../actions";
 import {
   getRelativeSources,
   getActiveSearch,
+  getProjectDirectoryRoot,
   getSelectedPrimaryPaneTab,
   getThreads
 } from "../../selectors";
@@ -36,6 +37,7 @@ type Props = {
   selectedTab: SelectedPrimaryPaneTabType,
   sources: SourcesMapByThread,
   horizontal: boolean,
+  projectRoot: string,
   sourceSearchOn: boolean,
   setPrimaryPaneTab: typeof actions.setPrimaryPaneTab,
   setActiveSearch: typeof actions.setActiveSearch,
@@ -103,7 +105,7 @@ class PrimaryPanes extends Component<Props, State> {
   }
 
   render() {
-    const { selectedTab } = this.props;
+    const { selectedTab, projectRoot } = this.props;
     const activeIndex = selectedTab === "sources" ? 0 : 1;
 
     return (
@@ -115,7 +117,12 @@ class PrimaryPanes extends Component<Props, State> {
         <TabList className="source-outline-tabs">
           {this.renderOutlineTabs()}
         </TabList>
-        <TabPanels className="source-outline-panel" hasFocusableContent>
+        <TabPanels
+          className={classnames("source-outline-panel", {
+            "has-root": projectRoot
+          })}
+          hasFocusableContent
+        >
           <div>{this.renderThreadSources()}</div>
           <Outline
             alphabetizeOutline={this.state.alphabetizeOutline}
@@ -131,7 +138,8 @@ const mapStateToProps = state => ({
   selectedTab: getSelectedPrimaryPaneTab(state),
   sources: getRelativeSources(state),
   sourceSearchOn: getActiveSearch(state) === "source",
-  threads: getThreads(state)
+  threads: getThreads(state),
+  projectRoot: getProjectDirectoryRoot(state)
 });
 
 const connector = connect(


### PR DESCRIPTION
The PR to add worker sources to the tree (https://github.com/devtools-html/debugger.html/commit/efcda91d682b3e3818ed53e2f430ae70f1a7ac60) sort of broke the sources tree -> custom root functionality.

When a custom root is set, the tree portion of the panel appears empty.  It's not actually empty but the newly introduced `<div>{this.renderThreadSources()}</div>` wrapper displays at 0 height.

This PR fixes that issue.