### PR TITLE
fixed breakpoint.svg

### DIFF
--- a/assets/images/breakpoint.svg
+++ b/assets/images/breakpoint.svg
@@ -2,5 +2,5 @@
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 60 14">
-  <path id="base-path" d="M53.07.5H1.5a1 1 0 0 0-1 1v11a1 1 0 0 0 1 1h51.57a2 2 0 0 0 1.53-.7L59.3 7l-4.7-5.8a2 2 0 0 0-1.53-.7z/>
+  <path id="base-path" d="M53.07.5H1.5a1 1 0 0 0-1 1v11a1 1 0 0 0 1 1h51.57a2 2 0 0 0 1.53-.7L59.3 7l-4.7-5.8a2 2 0 0 0-1.53-.7z"/>
 </svg>


### PR DESCRIPTION
Fixes #7659

The arrow was being cut off because the SVG mask was missing a `"`. Added it back.

![jan-04-2019 18-12-28](https://user-images.githubusercontent.com/15959269/50716089-f3c7e200-104d-11e9-9164-f10cd7a24a7b.gif)

