### PR TITLE
Improve the expand/collapse all behaviour of the Sources tree

### DIFF
--- a/packages/devtools-components/src/tree.js
+++ b/packages/devtools-components/src/tree.js
@@ -798,7 +798,7 @@ class Tree extends Component {
           // it should be scrolled into view.
           this._focus(item, { preventAutoScroll: true });
           if (this.props.isExpanded(item)) {
-            this.props.onCollapse(item);
+            this.props.onCollapse(item, e.altKey);
           } else {
             this.props.onExpand(item, e.altKey);
           }

--- a/src/components/PrimaryPanes/SourcesTree.js
+++ b/src/components/PrimaryPanes/SourcesTree.js
@@ -83,8 +83,6 @@ type State = {
   highlightItems?: any
 };
 
-type SetExpanded = (item: TreeNode, expanded: boolean, altKey: boolean) => void;
-
 class SourcesTree extends Component<Props, State> {
   mounted: boolean;
 
@@ -265,8 +263,7 @@ class SourcesTree extends Component<Props, State> {
     depth: number,
     focused: boolean,
     _,
-    expanded: boolean,
-    { setExpanded }: { setExpanded: SetExpanded }
+    expanded: boolean
   ) => {
     const { debuggeeUrl, projectRoot } = this.props;
 
@@ -281,7 +278,6 @@ class SourcesTree extends Component<Props, State> {
         source={this.getSource(item)}
         debuggeeUrl={debuggeeUrl}
         projectRoot={projectRoot}
-        setExpanded={setExpanded}
       />
     );
   };

--- a/src/components/PrimaryPanes/SourcesTreeItem.js
+++ b/src/components/PrimaryPanes/SourcesTreeItem.js
@@ -40,7 +40,6 @@ type Props = {
   expanded: boolean,
   hasMatchingGeneratedSource: boolean,
   hasSiblingOfSameName: boolean,
-  setExpanded: (TreeNode, boolean, boolean) => void,
   focusItem: TreeNode => void,
   selectItem: TreeNode => void,
   clearProjectDirectoryRoot: typeof actions.clearProjectDirectoryRoot,
@@ -83,13 +82,11 @@ class SourceTreeItem extends Component<Props, State> {
   }
 
   onClick = (e: MouseEvent) => {
-    const { expanded, item, focusItem, setExpanded, selectItem } = this.props;
+    const { item, focusItem, selectItem } = this.props;
 
     focusItem(item);
 
-    if (isDirectory(item)) {
-      setExpanded(item, !!expanded, e.altKey);
-    } else {
+    if (!isDirectory(item)) {
       selectItem(item);
     }
   };

--- a/src/components/PrimaryPanes/tests/SourcesTreeItem.spec.js
+++ b/src/components/PrimaryPanes/tests/SourcesTreeItem.spec.js
@@ -236,13 +236,11 @@ describe("SourceTreeItem", () => {
 
     it("should focus on and select item on click", async () => {
       const event = { event: "click" };
-      const setExpanded = jest.fn();
       const selectItem = jest.fn();
       const { component, instance, props } = render({
         depth: 1,
         focused: true,
         expanded: false,
-        setExpanded,
         selectItem
       });
 
@@ -250,26 +248,21 @@ describe("SourceTreeItem", () => {
       component.simulate("click", event);
       await component.simulate("keydown", { keyCode: 13 });
       expect(props.selectItem).toHaveBeenCalledWith(item);
-      expect(setExpanded).not.toHaveBeenCalled();
     });
 
-    it("should focus on and expand directory on click", async () => {
-      const setExpanded = jest.fn();
+    it("should focus on directory on click", async () => {
       const selectItem = jest.fn();
 
-      const { component, instance, props } = render({
+      const { component, props } = render({
         item: createMockDirectory(),
         source: null,
         depth: 1,
         focused: true,
         expanded: false,
-        setExpanded,
         selectItem
       });
 
-      const { item } = instance.props;
       component.simulate("click", { event: "click" });
-      expect(setExpanded).toHaveBeenCalledWith(item, false, undefined);
       expect(props.selectItem).not.toHaveBeenCalled();
     });
   });
@@ -295,7 +288,6 @@ function generateDefaults(overrides) {
     projectRoot: "",
     clearProjectDirectoryRoot: jest.fn(),
     setProjectDirectoryRoot: jest.fn(),
-    setExpanded: jest.fn(),
     selectItem: jest.fn(),
     focusItem: jest.fn(),
     ...overrides

--- a/src/components/PrimaryPanes/tests/__snapshots__/SourcesTreeItem.spec.js.snap
+++ b/src/components/PrimaryPanes/tests/__snapshots__/SourcesTreeItem.spec.js.snap
@@ -72,7 +72,6 @@ Object {
       },
       "projectRoot": "",
       "selectItem": [MockFunction],
-      "setExpanded": [MockFunction],
       "setProjectDirectoryRoot": [MockFunction],
       "source": Object {
         "contentType": "",
@@ -120,7 +119,6 @@ Object {
           }
           projectRoot=""
           selectItem={[MockFunction]}
-          setExpanded={[MockFunction]}
           setProjectDirectoryRoot={[MockFunction]}
           source={
             Object {
@@ -207,7 +205,6 @@ Object {
     },
     "projectRoot": "",
     "selectItem": [MockFunction],
-    "setExpanded": [MockFunction],
     "setProjectDirectoryRoot": [MockFunction],
     "source": Object {
       "contentType": "",
@@ -277,7 +274,6 @@ Object {
       },
       "projectRoot": "",
       "selectItem": [MockFunction],
-      "setExpanded": [MockFunction],
       "setProjectDirectoryRoot": [MockFunction],
       "source": Object {
         "contentType": "",
@@ -325,7 +321,6 @@ Object {
           }
           projectRoot=""
           selectItem={[MockFunction]}
-          setExpanded={[MockFunction]}
           setProjectDirectoryRoot={[MockFunction]}
           source={
             Object {
@@ -394,7 +389,6 @@ Object {
     },
     "projectRoot": "",
     "selectItem": [MockFunction],
-    "setExpanded": [MockFunction],
     "setProjectDirectoryRoot": [MockFunction],
     "source": Object {
       "contentType": "",
@@ -453,7 +447,6 @@ Object {
       },
       "projectRoot": "",
       "selectItem": [MockFunction],
-      "setExpanded": [MockFunction],
       "setProjectDirectoryRoot": [MockFunction],
       "source": Object {
         "contentType": "",
@@ -490,7 +483,6 @@ Object {
           }
           projectRoot=""
           selectItem={[MockFunction]}
-          setExpanded={[MockFunction]}
           setProjectDirectoryRoot={[MockFunction]}
           source={
             Object {
@@ -548,7 +540,6 @@ Object {
     },
     "projectRoot": "",
     "selectItem": [MockFunction],
-    "setExpanded": [MockFunction],
     "setProjectDirectoryRoot": [MockFunction],
     "source": Object {
       "contentType": "",
@@ -608,7 +599,6 @@ Object {
       },
       "projectRoot": "",
       "selectItem": [MockFunction],
-      "setExpanded": [MockFunction],
       "setProjectDirectoryRoot": [MockFunction],
       "source": Object {
         "contentType": "",
@@ -646,7 +636,6 @@ Object {
           }
           projectRoot=""
           selectItem={[MockFunction]}
-          setExpanded={[MockFunction]}
           setProjectDirectoryRoot={[MockFunction]}
           source={
             Object {
@@ -705,7 +694,6 @@ Object {
     },
     "projectRoot": "",
     "selectItem": [MockFunction],
-    "setExpanded": [MockFunction],
     "setProjectDirectoryRoot": [MockFunction],
     "source": Object {
       "contentType": "",
@@ -765,7 +753,6 @@ Object {
       },
       "projectRoot": "",
       "selectItem": [MockFunction],
-      "setExpanded": [MockFunction],
       "setProjectDirectoryRoot": [MockFunction],
       "source": null,
     },
@@ -792,7 +779,6 @@ Object {
           }
           projectRoot=""
           selectItem={[MockFunction]}
-          setExpanded={[MockFunction]}
           setProjectDirectoryRoot={[MockFunction]}
           source={null}
         />,
@@ -838,7 +824,6 @@ Object {
     },
     "projectRoot": "",
     "selectItem": [MockFunction],
-    "setExpanded": [MockFunction],
     "setProjectDirectoryRoot": [MockFunction],
     "source": null,
   },
@@ -885,7 +870,6 @@ Object {
       },
       "projectRoot": "",
       "selectItem": [MockFunction],
-      "setExpanded": [MockFunction],
       "setProjectDirectoryRoot": [MockFunction],
       "source": Object {
         "contentType": "",
@@ -921,7 +905,6 @@ Object {
           }
           projectRoot=""
           selectItem={[MockFunction]}
-          setExpanded={[MockFunction]}
           setProjectDirectoryRoot={[MockFunction]}
           source={
             Object {
@@ -978,7 +961,6 @@ Object {
     },
     "projectRoot": "",
     "selectItem": [MockFunction],
-    "setExpanded": [MockFunction],
     "setProjectDirectoryRoot": [MockFunction],
     "source": Object {
       "contentType": "",
@@ -1036,7 +1018,6 @@ Object {
       },
       "projectRoot": "",
       "selectItem": [MockFunction],
-      "setExpanded": [MockFunction],
       "setProjectDirectoryRoot": [MockFunction],
       "source": null,
     },
@@ -1061,7 +1042,6 @@ Object {
           }
           projectRoot=""
           selectItem={[MockFunction]}
-          setExpanded={[MockFunction]}
           setProjectDirectoryRoot={[MockFunction]}
           source={null}
         />,
@@ -1105,7 +1085,6 @@ Object {
     },
     "projectRoot": "",
     "selectItem": [MockFunction],
-    "setExpanded": [MockFunction],
     "setProjectDirectoryRoot": [MockFunction],
     "source": null,
   },
@@ -1154,7 +1133,6 @@ Object {
       },
       "projectRoot": "",
       "selectItem": [MockFunction],
-      "setExpanded": [MockFunction],
       "setProjectDirectoryRoot": [MockFunction],
       "source": null,
     },
@@ -1181,7 +1159,6 @@ Object {
           }
           projectRoot=""
           selectItem={[MockFunction]}
-          setExpanded={[MockFunction]}
           setProjectDirectoryRoot={[MockFunction]}
           source={null}
         />,
@@ -1227,7 +1204,6 @@ Object {
     },
     "projectRoot": "",
     "selectItem": [MockFunction],
-    "setExpanded": [MockFunction],
     "setProjectDirectoryRoot": [MockFunction],
     "source": null,
   },
@@ -1275,7 +1251,6 @@ Object {
       },
       "projectRoot": "",
       "selectItem": [MockFunction],
-      "setExpanded": [MockFunction],
       "setProjectDirectoryRoot": [MockFunction],
       "source": Object {
         "contentType": "",
@@ -1312,7 +1287,6 @@ Object {
           }
           projectRoot=""
           selectItem={[MockFunction]}
-          setExpanded={[MockFunction]}
           setProjectDirectoryRoot={[MockFunction]}
           source={
             Object {
@@ -1370,7 +1344,6 @@ Object {
     },
     "projectRoot": "",
     "selectItem": [MockFunction],
-    "setExpanded": [MockFunction],
     "setProjectDirectoryRoot": [MockFunction],
     "source": Object {
       "contentType": "",
@@ -1428,7 +1401,6 @@ Object {
       },
       "projectRoot": "",
       "selectItem": [MockFunction],
-      "setExpanded": [MockFunction],
       "setProjectDirectoryRoot": [MockFunction],
       "source": Object {
         "contentType": "",
@@ -1464,7 +1436,6 @@ Object {
           }
           projectRoot=""
           selectItem={[MockFunction]}
-          setExpanded={[MockFunction]}
           setProjectDirectoryRoot={[MockFunction]}
           source={
             Object {
@@ -1521,7 +1492,6 @@ Object {
     },
     "projectRoot": "",
     "selectItem": [MockFunction],
-    "setExpanded": [MockFunction],
     "setProjectDirectoryRoot": [MockFunction],
     "source": Object {
       "contentType": "",
@@ -1603,7 +1573,6 @@ Object {
       },
       "projectRoot": "",
       "selectItem": [MockFunction],
-      "setExpanded": [MockFunction],
       "setProjectDirectoryRoot": [MockFunction],
       "source": Object {
         "contentType": "",
@@ -1650,7 +1619,6 @@ Object {
           }
           projectRoot=""
           selectItem={[MockFunction]}
-          setExpanded={[MockFunction]}
           setProjectDirectoryRoot={[MockFunction]}
           source={
             Object {
@@ -1731,7 +1699,6 @@ Object {
     },
     "projectRoot": "",
     "selectItem": [MockFunction],
-    "setExpanded": [MockFunction],
     "setProjectDirectoryRoot": [MockFunction],
     "source": Object {
       "contentType": "",
@@ -1814,7 +1781,6 @@ Object {
       },
       "projectRoot": "",
       "selectItem": [MockFunction],
-      "setExpanded": [MockFunction],
       "setProjectDirectoryRoot": [MockFunction],
       "source": Object {
         "contentType": "",
@@ -1862,7 +1828,6 @@ Object {
           }
           projectRoot=""
           selectItem={[MockFunction]}
-          setExpanded={[MockFunction]}
           setProjectDirectoryRoot={[MockFunction]}
           source={
             Object {
@@ -1944,7 +1909,6 @@ Object {
     },
     "projectRoot": "",
     "selectItem": [MockFunction],
-    "setExpanded": [MockFunction],
     "setProjectDirectoryRoot": [MockFunction],
     "source": Object {
       "contentType": "",

--- a/src/components/shared/ManagedTree.js
+++ b/src/components/shared/ManagedTree.js
@@ -141,8 +141,12 @@ class ManagedTree extends Component<Props, State> {
           isExpanded={item => expanded.has(this.props.getPath(item))}
           focused={this.props.focused}
           getKey={this.props.getPath}
-          onExpand={item => this.setExpanded(item, true, false)}
-          onCollapse={item => this.setExpanded(item, false, false)}
+          onExpand={(item, shouldIncludeChildren) =>
+            this.setExpanded(item, true, shouldIncludeChildren)
+          }
+          onCollapse={(item, shouldIncludeChildren) =>
+            this.setExpanded(item, false, shouldIncludeChildren)
+          }
           onFocus={this.props.onFocus}
           renderItem={(...args) =>
             this.props.renderItem(...args, {


### PR DESCRIPTION
First, remove the expansion code in the `SourcesTreeItem` `onClick` event as the expansion is already handled in the `onClick` event of the tree component.

Next, pass the `altKey` status from the `tree onClick` event to the `ManagedTree onCollapse` function so that we know whether to collapse the children. This allows us to add the ability to collapse all children too.

Fixes #7663 

![](http://g.recordit.co/GqI439N3eM.gif)
