### PR TITLE
fixed xhrBreakpoints to check xhrBreakpointsVisible

### DIFF
--- a/src/components/SecondaryPanes/index.js
+++ b/src/components/SecondaryPanes/index.js
@@ -186,7 +186,7 @@ class SecondaryPanes extends Component<Props, State> {
     buttons.push(
       debugBtn(
         evt => {
-          if (prefs.expressionsVisible) {
+          if (prefs.xhrBreakpointsVisible) {
             evt.stopPropagation();
           }
           this.setState({ showXHRInput: true });


### PR DESCRIPTION
Fixes #7685

### Summary of Changes

Fixes a bug that collapsed XHR breakpoint pane whenever the XHR + button was clicked.

### Screenshots/Videos (OPTIONAL)

![jan-08-2019 10-39-23](https://user-images.githubusercontent.com/15959269/50841372-97591100-1332-11e9-8460-96429a740efb.gif)

