### PR TITLE
[breakpoints] shift+click should add a disabled breakpoint #7671

### DIFF
--- a/src/actions/breakpoints/addBreakpoint.js
+++ b/src/actions/breakpoints/addBreakpoint.js
@@ -29,7 +29,13 @@ import type { SourceLocation } from "../../types";
 import type { ThunkArgs } from "../types";
 import type { addBreakpointOptions } from "./";
 
-async function addBreakpointPromise(getState, client, sourceMaps, breakpoint, shiftKey = false) {
+async function addBreakpointPromise(
+  getState,
+  client,
+  sourceMaps,
+  breakpoint,
+  shiftKey = false
+) {
   const state = getState();
   const source = getSource(state, breakpoint.location.sourceId);
 
@@ -90,9 +96,9 @@ async function addBreakpointPromise(getState, client, sourceMaps, breakpoint, sh
     text,
     originalText
   };
-	if(!shiftKey){
-		newBreakpoint.disabled=false;
-	}
+  if (!shiftKey) {
+    newBreakpoint.disabled = false;
+  }
   assertBreakpoint(newBreakpoint);
 
   if (breakpoint.disabled && shiftKey) {
@@ -209,7 +215,13 @@ export function addDisabledBreakpoint(
     return dispatch({
       type: "ADD_BREAKPOINT",
       breakpoint,
-      [PROMISE]: addBreakpointPromise(getState, client, sourceMaps, breakpoint,true)
+      [PROMISE]: addBreakpointPromise(
+        getState,
+        client,
+        sourceMaps,
+        breakpoint,
+        true
+      )
     });
   };
 }

--- a/src/actions/breakpoints/addBreakpoint.js
+++ b/src/actions/breakpoints/addBreakpoint.js
@@ -92,6 +92,9 @@ async function addBreakpointPromise(getState, client, sourceMaps, breakpoint) {
   };
 
   assertBreakpoint(newBreakpoint);
+  if(breakpoint.disabled){
+	  await client.removeBreakpoint(newGeneratedLocation);
+  }
 
   const previousLocation = locationMoved(location, newLocation)
     ? location

--- a/src/actions/breakpoints/addBreakpoint.js
+++ b/src/actions/breakpoints/addBreakpoint.js
@@ -80,7 +80,7 @@ async function addBreakpointPromise(getState, client, sourceMaps, breakpoint) {
 
   const newBreakpoint = {
     id,
-    disabled: false,
+    disabled: breakpoint.disabled,
     hidden: breakpoint.hidden,
     loading: false,
     condition: breakpoint.condition,
@@ -166,6 +166,39 @@ export function addBreakpoint(
     }
 
     const breakpoint = createBreakpoint(location, { condition, hidden });
+
+    return dispatch({
+      type: "ADD_BREAKPOINT",
+      breakpoint,
+      [PROMISE]: addBreakpointPromise(getState, client, sourceMaps, breakpoint)
+    });
+  };
+}
+/**
+ * Add a new disabled breakpoint
+ *
+ * @memberof actions/breakpoints
+ * @static
+ * @param {String} $1.condition Conditional breakpoint condition value
+ * @param {Boolean} $1.disabled Disable value for breakpoint value
+ */
+
+export function addDisabledBreakpoint(
+  location: SourceLocation,
+  { condition, hidden }: addBreakpointOptions = {}
+) {
+  return async ({ dispatch, getState, sourceMaps, client }: ThunkArgs) => {
+    recordEvent("add_breakpoint");
+
+    if (features.columnBreakpoints && location.column === undefined) {
+      location = getFirstPausePointLocation(getState(), location);
+    }
+
+    const breakpoint = createBreakpoint(location, {
+      condition,
+      hidden,
+      disabled: true
+    });
 
     return dispatch({
       type: "ADD_BREAKPOINT",

--- a/src/actions/breakpoints/addBreakpoint.js
+++ b/src/actions/breakpoints/addBreakpoint.js
@@ -29,7 +29,7 @@ import type { SourceLocation } from "../../types";
 import type { ThunkArgs } from "../types";
 import type { addBreakpointOptions } from "./";
 
-async function addBreakpointPromise(getState, client, sourceMaps, breakpoint) {
+async function addBreakpointPromise(getState, client, sourceMaps, breakpoint, shiftKey = false) {
   const state = getState();
   const source = getSource(state, breakpoint.location.sourceId);
 
@@ -90,10 +90,13 @@ async function addBreakpointPromise(getState, client, sourceMaps, breakpoint) {
     text,
     originalText
   };
-
+	if(!shiftKey){
+		newBreakpoint.disabled=false;
+	}
   assertBreakpoint(newBreakpoint);
-  if(breakpoint.disabled){
-	  await client.removeBreakpoint(newGeneratedLocation);
+
+  if (breakpoint.disabled && shiftKey) {
+    await client.removeBreakpoint(newGeneratedLocation);
   }
 
   const previousLocation = locationMoved(location, newLocation)
@@ -206,7 +209,7 @@ export function addDisabledBreakpoint(
     return dispatch({
       type: "ADD_BREAKPOINT",
       breakpoint,
-      [PROMISE]: addBreakpointPromise(getState, client, sourceMaps, breakpoint)
+      [PROMISE]: addBreakpointPromise(getState, client, sourceMaps, breakpoint,true)
     });
   };
 }

--- a/src/actions/breakpoints/addBreakpoint.js
+++ b/src/actions/breakpoints/addBreakpoint.js
@@ -101,7 +101,7 @@ async function addBreakpointPromise(
   }
   assertBreakpoint(newBreakpoint);
 
-  if (breakpoint.disabled && shiftKey) {
+  if (shiftKey) {
     await client.removeBreakpoint(newGeneratedLocation);
   }
 

--- a/src/actions/breakpoints/index.js
+++ b/src/actions/breakpoints/index.js
@@ -23,7 +23,8 @@ import { assertBreakpoint, createXHRBreakpoint } from "../../utils/breakpoint";
 import {
   addBreakpoint,
   addHiddenBreakpoint,
-  enableBreakpoint
+  enableBreakpoint,
+  addDisabledBreakpoint
 } from "./addBreakpoint";
 import remapLocations from "./remapLocations";
 import { syncBreakpoint } from "./syncBreakpoint";
@@ -351,7 +352,7 @@ export function addOrToggleDisabledBreakpoint(line: number, column?: number) {
     }
 
     return dispatch(
-      addBreakpoint({
+      addDisabledBreakpoint({
         sourceId: selectedSource.id,
         sourceUrl: selectedSource.url,
         line: line,

--- a/src/components/SecondaryPanes/XHRBreakpoints.js
+++ b/src/components/SecondaryPanes/XHRBreakpoints.js
@@ -195,7 +195,6 @@ class XHRBreakpoints extends Component<Props, State> {
         key={path}
         title={path}
         onDoubleClick={(items, options) => this.editExpression(index)}
-        onClick={() => this.handleCheckbox(index)}
       >
         <input
           type="checkbox"

--- a/src/components/SecondaryPanes/XHRBreakpoints.js
+++ b/src/components/SecondaryPanes/XHRBreakpoints.js
@@ -195,6 +195,7 @@ class XHRBreakpoints extends Component<Props, State> {
         key={path}
         title={path}
         onDoubleClick={(items, options) => this.editExpression(index)}
+        onClick={() => this.handleCheckbox(index)}
       >
         <input
           type="checkbox"


### PR DESCRIPTION
Fixes #<issue number>

Here's the Pull Request Doc
https://firefox-dev.tools/debugger.html/docs/pull-requests.html

### Summary of Changes

* change 1
* change 2

### Test Plan

Tell us a little a bit about how you tested your patch.

Example test plan:

- [x] Command-P opens the panel
- [x] Clicking “+” opens the panel
- [x] Clicking a source navigates to the source
- [x] Clicking "x" closes the panel

Here's the Debugger's Testing doc
https://docs.google.com/document/d/1oBMRxV8A2ag2t22YsQOxTdEv0mXKzIg0tggJjRkU1S0/edit#.
Feel free to improve it!

### Screenshots/Videos (OPTIONAL)
