### PR TITLE
Fix unhelpful error in top-level await malformed expression.

### DIFF
--- a/src/workers/parser/mapBindings.js
+++ b/src/workers/parser/mapBindings.js
@@ -4,7 +4,6 @@
 
 // @flow
 
-import { parseConsoleScript } from "./utils/ast";
 import { isTopLevel } from "./utils/helpers";
 
 import generate from "@babel/generator";
@@ -92,10 +91,9 @@ function replaceNode(ancestors, node) {
 
 export default function mapExpressionBindings(
   expression: string,
+  ast?: Object,
   bindings: string[] = []
 ): string {
-  const ast = parseConsoleScript(expression);
-
   let isMapped = false;
   let shouldUpdate = true;
 

--- a/src/workers/parser/mapExpression.js
+++ b/src/workers/parser/mapExpression.js
@@ -4,6 +4,7 @@
 
 // @flow
 
+import { parseConsoleScript } from "./utils/ast";
 import mapOriginalExpression from "./mapOriginalExpression";
 import mapExpressionBindings from "./mapBindings";
 import mapTopLevelAwait from "./mapAwaitExpression";
@@ -30,22 +31,23 @@ export default function mapExpression(
     originalExpression: false
   };
 
+  const ast = parseConsoleScript(expression);
   try {
-    if (mappings) {
+    if (mappings && ast) {
       const beforeOriginalExpression = expression;
-      expression = mapOriginalExpression(expression, mappings);
+      expression = mapOriginalExpression(expression, ast, mappings);
       mapped.originalExpression = beforeOriginalExpression !== expression;
     }
 
-    if (shouldMapBindings) {
+    if (shouldMapBindings && ast) {
       const beforeBindings = expression;
-      expression = mapExpressionBindings(expression, bindings);
+      expression = mapExpressionBindings(expression, ast, bindings);
       mapped.bindings = beforeBindings !== expression;
     }
 
     if (shouldMapAwait) {
       const beforeAwait = expression;
-      expression = mapTopLevelAwait(expression);
+      expression = mapTopLevelAwait(expression, ast);
       mapped.await = beforeAwait !== expression;
     }
   } catch (e) {

--- a/src/workers/parser/mapOriginalExpression.js
+++ b/src/workers/parser/mapOriginalExpression.js
@@ -5,7 +5,7 @@
 // @flow
 
 import type { Position } from "../../types";
-import { parseScript, parseConsoleScript } from "./utils/ast";
+import { parseScript } from "./utils/ast";
 import { buildScopeList } from "./getScopes";
 import generate from "@babel/generator";
 import * as t from "@babel/types";
@@ -36,11 +36,11 @@ function locationKey(start: Position): string {
 
 export default function mapOriginalExpression(
   expression: string,
+  ast: ?Object,
   mappings: {
     [string]: string | null
   }
 ): string {
-  const ast = parseConsoleScript(expression);
   const scopes = buildScopeList(ast, "");
   let shouldUpdate = false;
 

--- a/src/workers/parser/tests/mapBindings.spec.js
+++ b/src/workers/parser/tests/mapBindings.spec.js
@@ -3,6 +3,7 @@
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
 import mapExpressionBindings from "../mapBindings";
+import { parseConsoleScript } from "../utils/ast";
 import cases from "jest-in-case";
 
 const prettier = require("prettier");
@@ -12,12 +13,20 @@ function format(code) {
 }
 
 function excludedTest({ name, expression, bindings = [] }) {
-  const safeExpression = mapExpressionBindings(expression, bindings);
+  const safeExpression = mapExpressionBindings(
+    expression,
+    parseConsoleScript(expression),
+    bindings
+  );
   expect(format(safeExpression)).toEqual(format(expression));
 }
 
 function includedTest({ name, expression, newExpression, bindings }) {
-  const safeExpression = mapExpressionBindings(expression, bindings);
+  const safeExpression = mapExpressionBindings(
+    expression,
+    parseConsoleScript(expression),
+    bindings
+  );
   expect(format(safeExpression)).toEqual(format(newExpression));
 }
 

--- a/src/workers/parser/tests/mapExpression.spec.js
+++ b/src/workers/parser/tests/mapExpression.spec.js
@@ -12,7 +12,8 @@ function test({
   bindings,
   mappings,
   shouldMapExpression,
-  expectedMapped
+  expectedMapped,
+  parseExpression = true
 }) {
   const res = mapExpression(
     expression,
@@ -20,11 +21,17 @@ function test({
     bindings,
     shouldMapExpression
   );
-  expect(
-    format(res.expression, {
-      parser: "babylon"
-    })
-  ).toEqual(format(newExpression, { parser: "babylon" }));
+
+  if (parseExpression) {
+    expect(
+      format(res.expression, {
+        parser: "babylon"
+      })
+    ).toEqual(format(newExpression, { parser: "babylon" }));
+  } else {
+    expect(res.expression).toEqual(newExpression);
+  }
+
   expect(res.mapped).toEqual(expectedMapped);
 }
 
@@ -291,6 +298,20 @@ describe("mapExpression", () => {
       expectedMapped: {
         await: true,
         bindings: true,
+        originalExpression: false
+      }
+    },
+    {
+      name: "await (with SyntaxError)",
+      expression: "await new Promise())",
+      newExpression: formatAwait("await new Promise())"),
+      parseExpression: false,
+      bindings: [],
+      mappings: {},
+      shouldMapExpression: true,
+      expectedMapped: {
+        await: true,
+        bindings: false,
         originalExpression: false
       }
     },

--- a/src/workers/parser/tests/mapOriginalExpression.spec.js
+++ b/src/workers/parser/tests/mapOriginalExpression.spec.js
@@ -2,13 +2,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
-import mapOriginalExpression from "../mapOriginalExpression";
+import mapExpression from "../mapExpression";
 import { format } from "prettier";
 
 const formatOutput = output =>
   format(output, {
     parser: "babylon"
   });
+
+const mapOriginalExpression = (expression, mappings) =>
+  mapExpression(expression, mappings, null, false, false).expression;
 
 describe("mapOriginalExpression", () => {
   it("simple", () => {

--- a/src/workers/parser/utils/ast.js
+++ b/src/workers/parser/utils/ast.js
@@ -98,12 +98,16 @@ function parseVueScript(code) {
   return ast;
 }
 
-export function parseConsoleScript(text: string, opts?: Object) {
-  return _parse(text, {
-    plugins: ["objectRestSpread"],
-    ...opts,
-    allowAwaitOutsideFunction: true
-  });
+export function parseConsoleScript(text: string, opts?: Object): Object | null {
+  try {
+    return _parse(text, {
+      plugins: ["objectRestSpread"],
+      ...opts,
+      allowAwaitOutsideFunction: true
+    });
+  } catch (e) {
+    return null;
+  }
 }
 
 export function parseScript(text: string, opts?: Object) {


### PR DESCRIPTION
In mapExpression, if we fail to get an AST
from the expression this means the expression
has a syntax error in it.
In order to get a meaningful error when evaluating
top-level await expression, we still need to
wrap the expression in an async iife.
This required some changes in mapExpression in order
to not bail completely if parsing the expression
threw.
We also take this as an opportunity to only parse
the expression once for the all the transforms.
