### PR TITLE
changed git clone url in getting-setup.md

### DIFF
--- a/docs/getting-setup.md
+++ b/docs/getting-setup.md
@@ -13,7 +13,7 @@ NPM installs the latest versions. We use [Yarn][yarn] because we want to make su
 ### Step 2. Install dependencies
 
 ```bash
-git clone git@github.com:devtools-html/debugger.html.git
+git clone https://github.com/devtools-html/debugger.html.git
 cd debugger.html
 yarn install
 ```
@@ -68,7 +68,7 @@ This setup is for people on the DevTools team and DevTools wizards.
 
 ```bash
 npm i -g yarn
-git clone git@github.com:devtools-html/debugger.html.git
+git clone https://github.com/devtools-html/debugger.html.git
 cd debugger.html
 yarn install
 # close firefox if it's already running


### PR DESCRIPTION
Fixes #7683

### Summary of Changes

* changed the git clone URL in `docs/getting-setup.md` from the SSH URL to the HTTPS URL.
