### PR TITLE
Make the Frames component copy-friendly

### DIFF
--- a/assets/module-manifest.json
+++ b/assets/module-manifest.json
@@ -20574,7 +20574,415 @@
       "../../parse5/lib/serializer/serializer_stream.js": 1752,
       "../../parse5/lib/sax/index.js": 1753,
       "../../parse5/lib/sax/dev_null_stream.js": 1754,
-      "../../parse5/lib/sax/parser_feedback_simulator.js": 1755
+      "../../parse5/lib/sax/parser_feedback_simulator.js": 1755,
+      "external \"devtools/client/shared/vendor/react-prop-types\"": 1758,
+      "external \"devtools/client/shared/vendor/react-dom-factories\"": 1759,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/selectors/index.js": 1760,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/rep-utils.js": 1761,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/constants.js": 1762,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/connect.js": 1763,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-source-map/src/index.js": 1764,
+      "../../@babel/types/lib/index.js": 1765,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-utils/index.js": 1766,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/rep.js": 1767,
+      "../../@babel/types/lib/validators/generated/index.js": 1768,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../devtools-environment/index.js": 1769,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/string.js": 1770,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-utils/src/privileged-network-request.js": 1771,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-utils/src/worker-utils.js": 1772,
+      "../../reselect/es/index.js": 1773,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/components/shared/AccessibleImage.js": 1774,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/array.js": 1775,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/prop-rep.js": 1776,
+      "../../@babel/types/lib/builders/generated/index.js": 1777,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/components/shared/Button/index.js": 1778,
+      "../../@babel/types/lib/definitions/index.js": 1779,
+      "../../../packages/devtools-source-map/node_modules/whatwg-url/lib/url-state-machine.js": 1780,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-source-map/src/utils/index.js": 1781,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/index.js": 1782,
+      "../../@babel/types/lib/definitions/utils.js": 1783,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/grip.js": 1784,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/object-inspector/utils/node.js": 1785,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/object-inspector/reducer.js": 1786,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/object-inspector/utils/index.js": 1787,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/actions/sources/index.js": 1788,
+      "../../@babel/types/lib/constants/index.js": 1789,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/pause/frames/index.js": 1790,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-components/index.js": 1791,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/actions/breakpoints/index.js": 1792,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/telemetry.js": 1793,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/function.js": 1794,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/shared/dom-node-constants.js": 1795,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/error.js": 1796,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/grip-array.js": 1797,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/shared/grip-length-bubble.js": 1798,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/grip-map.js": 1799,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/grip-map-entry.js": 1800,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-components/src/tree.js": 1801,
+      "../../extract-text-webpack-plugin/dist/loader.js??ref--3-0!../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../packages/devtools-components/src/tree.css": 1802,
+      "external \"devtools/client/shared/vendor/react-redux\"": 1803,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/object-inspector/utils/load-properties.js": 1804,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/object-inspector/utils/client.js": 1805,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/source-queue.js": 1806,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/pause/mapScopes/locColumn.js": 1807,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../react-aria-components/src/tabs/tab-list.js": 1808,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../react-aria-components/src/tabs/tab.js": 1809,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../react-aria-components/src/tabs/tab-panels.js": 1810,
+      "../../@babel/types/lib/validators/isValidIdentifier.js": 1811,
+      "../../@babel/types/lib/clone/cloneNode.js": 1812,
+      "external \"devtools/client/shared/vendor/immutable\"": 1813,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/url.js": 1814,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/workers.js": 1815,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/pause/frames/getFrameUrl.js": 1816,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/actions/tabs.js": 1817,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/pause/index.js": 1818,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-splitter/index.js": 1819,
+      "../../@babel/types/lib/retrievers/getBindingIdentifiers.js": 1820,
+      "../../@babel/generator/lib/index.js": 1821,
+      "../../../packages/devtools-source-map/node_modules/source-map/source-map.js": 1822,
+      "../../../packages/devtools-source-map/node_modules/source-map/lib/util.js": 1823,
+      "../../../packages/devtools-source-map/node_modules/whatwg-url/lib/urlencoded.js": 1824,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../devtools-modules/src/utils/text.js": 1825,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../devtools-modules/src/async-storage.js": 1826,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../devtools-modules/src/source-utils.js": 1827,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../devtools-modules/src/utils/telemetry.js": 1828,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../devtools-modules/src/unicode-url.js": 1829,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/build-query.js": 1830,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/reducers/tabs.js": 1831,
+      "../../lodash-move/lib/index.js": 1832,
+      "../../extract-text-webpack-plugin/dist/loader.js??ref--3-0!../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../packages/devtools-reps/src/reps/reps.css": 1833,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/undefined.js": 1834,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/null.js": 1835,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/number.js": 1836,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/object.js": 1837,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/symbol.js": 1838,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/infinity.js": 1839,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/nan.js": 1840,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/accessor.js": 1841,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/accessible.js": 1842,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/attribute.js": 1843,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/date-time.js": 1844,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/document.js": 1845,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/document-type.js": 1846,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/event.js": 1847,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/promise.js": 1848,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/regexp.js": 1849,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/stylesheet.js": 1850,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/comment-node.js": 1851,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/element-node.js": 1852,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/text-node.js": 1853,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/window.js": 1854,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/object-with-text.js": 1855,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/object-with-url.js": 1856,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/object-inspector/index.js": 1857,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/object-inspector/components/ObjectInspector.js": 1858,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/object-inspector/actions.js": 1859,
+      "../../extract-text-webpack-plugin/dist/loader.js??ref--3-0!../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../packages/devtools-reps/src/object-inspector/components/ObjectInspector.css": 1860,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/object-inspector/components/ObjectInspectorItem.js": 1861,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/object-inspector/utils/selection.js": 1862,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/pause/mapScopes/positionCmp.js": 1863,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/actions/sources/prettyPrint.js": 1864,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/actions/sources/select.js": 1865,
+      "../../react-lifecycles-compat/react-lifecycles-compat.es.js": 1866,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-splitter/src/SplitBox.js": 1867,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-splitter/src/Draggable.js": 1868,
+      "../../extract-text-webpack-plugin/dist/loader.js??ref--3-0!../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../packages/devtools-splitter/src/SplitBox.css": 1869,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../images/Svg.js": 1870,
+      "../../svg-inline-react/lib/index.js": 1871,
+      "../../svg-inline-react/lib/util.js": 1872,
+      "../../svg-inline-loader/index.js!../../../images/angle-brackets.svg": 1873,
+      "../../svg-inline-loader/index.js!../../../images/angular.svg": 1874,
+      "../../svg-inline-loader/index.js!../../../images/arrow.svg": 1875,
+      "../../svg-inline-loader/index.js!../../../images/babel.svg": 1876,
+      "../../svg-inline-loader/index.js!../../../images/backbone.svg": 1877,
+      "../../svg-inline-loader/index.js!../../../images/blackBox.svg": 1878,
+      "../../svg-inline-loader/index.js!../../../images/breadcrumbs-divider.svg": 1879,
+      "../../svg-inline-loader/index.js!../../../images/breakpoint.svg": 1880,
+      "../../svg-inline-loader/index.js!../../../images/column-breakpoint.svg": 1881,
+      "../../svg-inline-loader/index.js!../../../images/column-marker.svg": 1882,
+      "../../svg-inline-loader/index.js!../../../images/case-match.svg": 1883,
+      "../../svg-inline-loader/index.js!../../../images/choo.svg": 1884,
+      "../../svg-inline-loader/index.js!../../../images/close.svg": 1885,
+      "../../svg-inline-loader/index.js!../../../images/coffeescript.svg": 1886,
+      "../../svg-inline-loader/index.js!../../../images/dojo.svg": 1887,
+      "../../svg-inline-loader/index.js!../../../images/domain.svg": 1888,
+      "../../svg-inline-loader/index.js!../../../images/extension.svg": 1889,
+      "../../svg-inline-loader/index.js!../../../images/file.svg": 1890,
+      "../../svg-inline-loader/index.js!../../../images/folder.svg": 1891,
+      "../../svg-inline-loader/index.js!../../../images/globe.svg": 1892,
+      "../../svg-inline-loader/index.js!../../../images/home.svg": 1893,
+      "../../svg-inline-loader/index.js!../../../images/javascript.svg": 1894,
+      "../../svg-inline-loader/index.js!../../../images/jquery.svg": 1895,
+      "../../svg-inline-loader/index.js!../../../images/underscore.svg": 1896,
+      "../../svg-inline-loader/index.js!../../../images/lodash.svg": 1897,
+      "../../svg-inline-loader/index.js!../../../images/ember.svg": 1898,
+      "../../svg-inline-loader/index.js!../../../images/vuejs.svg": 1899,
+      "../../svg-inline-loader/index.js!../../../images/magnifying-glass.svg": 1900,
+      "../../svg-inline-loader/index.js!../../../images/arrow-up.svg": 1901,
+      "../../svg-inline-loader/index.js!../../../images/arrow-down.svg": 1902,
+      "../../svg-inline-loader/index.js!../../../images/pause.svg": 1903,
+      "../../svg-inline-loader/index.js!../../../images/pause-exceptions.svg": 1904,
+      "../../svg-inline-loader/index.js!../../../images/plus.svg": 1905,
+      "../../svg-inline-loader/index.js!../../../images/preact.svg": 1906,
+      "../../svg-inline-loader/index.js!../../../images/aframe.svg": 1907,
+      "../../svg-inline-loader/index.js!../../../images/prettyPrint.svg": 1908,
+      "../../svg-inline-loader/index.js!../../../images/react.svg": 1909,
+      "../../svg-inline-loader/index.js!../../../images/regex-match.svg": 1910,
+      "../../svg-inline-loader/index.js!../../../images/redux.svg": 1911,
+      "../../svg-inline-loader/index.js!../../../images/immutable.svg": 1912,
+      "../../svg-inline-loader/index.js!../../../images/resume.svg": 1913,
+      "../../svg-inline-loader/index.js!../../../images/settings.svg": 1914,
+      "../../svg-inline-loader/index.js!../../../images/stepIn.svg": 1915,
+      "../../svg-inline-loader/index.js!../../../images/stepOut.svg": 1916,
+      "../../svg-inline-loader/index.js!../../../images/stepOver.svg": 1917,
+      "../../svg-inline-loader/index.js!../../../images/subSettings.svg": 1918,
+      "../../svg-inline-loader/index.js!../../../images/tab.svg": 1919,
+      "../../svg-inline-loader/index.js!../../../images/toggle-breakpoints.svg": 1920,
+      "../../svg-inline-loader/index.js!../../../images/toggle-panes.svg": 1921,
+      "../../svg-inline-loader/index.js!../../../images/typescript.svg": 1922,
+      "../../svg-inline-loader/index.js!../../../images/whole-word-match.svg": 1923,
+      "../../svg-inline-loader/index.js!../../../images/worker.svg": 1924,
+      "../../svg-inline-loader/index.js!../../../images/webpack.svg": 1925,
+      "../../svg-inline-loader/index.js!../../../images/node.svg": 1926,
+      "../../svg-inline-loader/index.js!../../../images/express.svg": 1927,
+      "../../svg-inline-loader/index.js!../../../images/pug.svg": 1928,
+      "../../svg-inline-loader/index.js!../../../images/sencha-extjs.svg": 1929,
+      "../../svg-inline-loader/index.js!../../../images/mobx.svg": 1930,
+      "../../svg-inline-loader/index.js!../../../images/marko.svg": 1931,
+      "../../svg-inline-loader/index.js!../../../images/nextjs.svg": 1932,
+      "../../svg-inline-loader/index.js!../../../images/showSources.svg": 1933,
+      "../../svg-inline-loader/index.js!../../../images/showOutline.svg": 1934,
+      "../../svg-inline-loader/index.js!../../../images/nuxtjs.svg": 1935,
+      "../../svg-inline-loader/index.js!../../../images/rxjs.svg": 1936,
+      "../../svg-inline-loader/index.js!../../../images/loader.svg": 1937,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/components/shared/Button/CommandBarButton.js": 1938,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../react-aria-components/src/tabs/index.js": 1939,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../react-aria-components/src/prop-types/ref.js": 1940,
+      "../../extract-text-webpack-plugin/dist/loader.js??ref--3-0!../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../react-aria-components/src/tabs/tab.css": 1941,
+      "../../extract-text-webpack-plugin/dist/loader.js??ref--3-0!../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../react-aria-components/src/tabs/tab-list.css": 1942,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../react-aria-components/src/tabs/tabs.js": 1943,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../react-aria-components/src/utils/unique-id.js": 1944,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/components/shared/SourceIcon.js": 1945,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/tabs.js": 1946,
+      "../../@babel/types/lib/utils/shallowEqual.js": 1947,
+      "../../@babel/types/lib/definitions/core.js": 1948,
+      "../../@babel/types/lib/validators/is.js": 1949,
+      "../../@babel/types/lib/validators/isType.js": 1950,
+      "../../@babel/types/lib/definitions/es2015.js": 1951,
+      "../../@babel/types/lib/utils/inherit.js": 1952,
+      "../../@babel/generator/lib/generators/types.js": 1953,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-source-map/src/utils/sourceMapRequests.js": 1954,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/pause/frames/getLibraryFromUrl.js": 1955,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/selectors/visiblePausePoints.js": 1956,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/pause/pausePoints.js": 1957,
+      "external \"devtools/client/shared/vendor/redux\"": 1958,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/log.js": 1959,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/pause/mapScopes/filtering.js": 1960,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/pause/mapScopes/mappingContains.js": 1961,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/actions/sources/blackbox.js": 1962,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/actions/pause/mapFrames.js": 1963,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/components/SecondaryPanes/Breakpoints/ExceptionOption.js": 1964,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/components/SecondaryPanes/Frames/FrameIndent.js": 1965,
+      "../../@babel/types/lib/validators/buildMatchMemberExpression.js": 1966,
+      "../../@babel/types/lib/validators/matchesPattern.js": 1967,
+      "../../@babel/types/lib/validators/validate.js": 1968,
+      "../../@babel/types/lib/validators/isNode.js": 1969,
+      "../../@babel/types/lib/modifications/flow/removeTypeDuplicates.js": 1970,
+      "../../@babel/types/lib/clone/clone.js": 1971,
+      "../../@babel/types/lib/comments/addComments.js": 1972,
+      "../../@babel/types/lib/comments/inheritInnerComments.js": 1973,
+      "../../@babel/types/lib/comments/inheritLeadingComments.js": 1974,
+      "../../@babel/types/lib/comments/inheritsComments.js": 1975,
+      "../../@babel/types/lib/comments/inheritTrailingComments.js": 1976,
+      "../../@babel/types/lib/converters/toBlock.js": 1977,
+      "../../@babel/types/lib/converters/toIdentifier.js": 1978,
+      "../../@babel/types/lib/modifications/removePropertiesDeep.js": 1979,
+      "../../@babel/types/lib/traverse/traverseFast.js": 1980,
+      "../../@babel/types/lib/modifications/removeProperties.js": 1981,
+      "../../@babel/types/lib/validators/isLet.js": 1982,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/workers/parser/utils/simple-path.js": 1983,
+      "../../@babel/generator/lib/node/index.js": 1984,
+      "../../@babel/generator/lib/generators/modules.js": 1985,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/workers/parser/getScopes/index.js": 1986,
+      "../../../packages/devtools-source-map/node_modules/source-map/lib/source-map-generator.js": 1987,
+      "../../../packages/devtools-source-map/node_modules/source-map/lib/base64-vlq.js": 1988,
+      "../../webidl-conversions/lib/index.js": 1989,
+      "../../../packages/devtools-source-map/node_modules/whatwg-url/lib/utils.js": 1990,
+      "../../../packages/devtools-source-map/node_modules/whatwg-url/lib/infra.js": 1991,
+      "../../../packages/devtools-source-map/node_modules/whatwg-url/lib/URLSearchParams.js": 1992,
+      "../../../packages/devtools-source-map/node_modules/source-map/lib/array-set.js": 1993,
+      "../../../packages/devtools-source-map/node_modules/source-map/lib/read-wasm-browser.js": 1994,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-source-map/src/utils/createConsumer.js": 1995,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-source-map/src/utils/wasmAssetBrowser.js": 1996,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-source-map/src/utils/wasmXScopes.js": 1997,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/asyncStoreHelper.js": 1998,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/isMinified.js": 1999,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/editor/get-token-location.js": 2000,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/editor/token-events.js": 2001,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/editor/create-editor.js": 2002,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/sources-tree/updateTree.js": 2003,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/memoize.js": 2004,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/selectors/inComponent.js": 2005,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/selectors/getCallStackFrames.js": 2006,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/pause/frames/annotateFrames.js": 2007,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/pause/frames/collapseFrames.js": 2008,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/pause/frames/displayName.js": 2009,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/selectors/visibleSelectedFrame.js": 2010,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/selectors/breakpointSources.js": 2011,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/selectors/breakpoints.js": 2012,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/selectors/visibleColumnBreakpoints.js": 2013,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/client/firefox/workers.js": 2014,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/dbg.js": 2015,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/defer.js": 2016,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/pause/mapScopes/index.js": 2017,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/pause/mapScopes/rangeMetadata.js": 2018,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/pause/mapScopes/findGeneratedBindingFromPosition.js": 2019,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/pause/mapScopes/buildGeneratedBindingList.js": 2020,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/pause/mapScopes/getApplicableBindingsForOriginalPosition.js": 2021,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/actions/sources/newSources.js": 2022,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/actions/ast/setInScopeLines.js": 2023,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/actions/ast/setPausePoints.js": 2024,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/location.js": 2025,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/pause/why.js": 2026,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/pause/stepping.js": 2027,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/actions/pause/setPopupObjectProperties.js": 2028,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/actions/pause/skipPausing.js": 2029,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/actions/preview.js": 2030,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/preview.js": 2031,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/editor/get-expression.js": 2032,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/components/A11yIntention.js": 2033,
+      "../../extract-text-webpack-plugin/dist/loader.js??ref--3-0!../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/A11yIntention.css": 2034,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/components/ProjectSearch.js": 2035,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/project-search.js": 2036,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/components/shared/Button/CloseButton.js": 2037,
+      "../../extract-text-webpack-plugin/dist/loader.js??ref--3-0!../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/shared/AccessibleImage.css": 2038,
+      "../../extract-text-webpack-plugin/dist/loader.js??ref--3-0!../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/shared/Button/styles/CloseButton.css": 2039,
+      "../../extract-text-webpack-plugin/dist/loader.js??ref--3-0!../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/shared/Button/styles/CommandBarButton.css": 2040,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/components/shared/Button/PaneToggleButton.js": 2041,
+      "../../extract-text-webpack-plugin/dist/loader.js??ref--3-0!../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/shared/Button/styles/PaneToggleButton.css": 2042,
+      "../../extract-text-webpack-plugin/dist/loader.js??ref--3-0!../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/ProjectSearch.css": 2043,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/components/PrimaryPanes/OutlineFilter.js": 2044,
+      "../../extract-text-webpack-plugin/dist/loader.js??ref--3-0!../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/PrimaryPanes/OutlineFilter.css": 2045,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/components/PrimaryPanes/SourcesTreeItem.js": 2046,
+      "../../extract-text-webpack-plugin/dist/loader.js??ref--3-0!../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/shared/SourceIcon.css": 2047,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/components/Editor/ColumnBreakpoints.js": 2048,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/components/Editor/ColumnBreakpoint.js": 2049,
+      "../../extract-text-webpack-plugin/dist/loader.js??ref--3-0!../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/Editor/ColumnBreakpoints.css": 2050,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/components/Editor/HighlightLine.js": 2051,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/components/SecondaryPanes/Breakpoints/index.js": 2052,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/components/SecondaryPanes/Breakpoints/Breakpoint.js": 2053,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/components/SecondaryPanes/Breakpoints/BreakpointsContextMenu.js": 2054,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/components/SecondaryPanes/Breakpoints/BreakpointHeading.js": 2055,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/components/SecondaryPanes/Breakpoints/BreakpointHeadingsContextMenu.js": 2056,
+      "../../extract-text-webpack-plugin/dist/loader.js??ref--3-0!../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/SecondaryPanes/Breakpoints/Breakpoints.css": 2057,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/components/SecondaryPanes/Worker.js": 2058,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/components/SecondaryPanes/XHRBreakpoints.js": 2059,
+      "../../extract-text-webpack-plugin/dist/loader.js??ref--3-0!../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/SecondaryPanes/XHRBreakpoints.css": 2060,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/pause/scopes/index.js": 2061,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/pause/scopes/getScope.js": 2062,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/pause/scopes/getVariables.js": 2063,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/pause/scopes/utils.js": 2064,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/components/Editor/Tab.js": 2065,
+      "../../extract-text-webpack-plugin/dist/loader.js??ref--3-0!../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/QuickOpenModal.css": 2066,
+      "../../@babel/types/lib/validators/react/isReactComponent.js": 2067,
+      "../../@babel/types/lib/validators/react/isCompatTag.js": 2068,
+      "../../@babel/types/lib/builders/react/buildChildren.js": 2069,
+      "../../@babel/types/lib/utils/react/cleanJSXElementLiteralChild.js": 2070,
+      "../../@babel/types/lib/builders/builder.js": 2071,
+      "../../lodash/isMap.js": 2072,
+      "../../lodash/_baseIsMap.js": 2073,
+      "../../lodash/isSet.js": 2074,
+      "../../lodash/_baseIsSet.js": 2075,
+      "../../@babel/types/lib/definitions/flow.js": 2076,
+      "../../@babel/types/lib/definitions/jsx.js": 2077,
+      "../../@babel/types/lib/definitions/misc.js": 2078,
+      "../../@babel/types/lib/definitions/experimental.js": 2079,
+      "../../@babel/types/lib/definitions/typescript.js": 2080,
+      "../../@babel/types/lib/asserts/assertNode.js": 2081,
+      "../../@babel/types/lib/asserts/generated/index.js": 2082,
+      "../../@babel/types/lib/builders/flow/createTypeAnnotationBasedOnTypeof.js": 2083,
+      "../../@babel/types/lib/builders/flow/createUnionTypeAnnotation.js": 2084,
+      "../../@babel/types/lib/clone/cloneDeep.js": 2085,
+      "../../@babel/types/lib/clone/cloneWithoutLoc.js": 2086,
+      "../../@babel/types/lib/comments/addComment.js": 2087,
+      "../../@babel/types/lib/comments/removeComments.js": 2088,
+      "../../@babel/types/lib/constants/generated/index.js": 2089,
+      "../../@babel/types/lib/converters/ensureBlock.js": 2090,
+      "../../@babel/types/lib/converters/toBindingIdentifierName.js": 2091,
+      "../../@babel/types/lib/converters/toComputedKey.js": 2092,
+      "../../@babel/types/lib/converters/toExpression.js": 2093,
+      "../../@babel/types/lib/converters/toKeyAlias.js": 2094,
+      "../../@babel/types/lib/converters/toSequenceExpression.js": 2095,
+      "../../@babel/types/lib/converters/gatherSequenceExpressions.js": 2096,
+      "../../@babel/types/lib/converters/toStatement.js": 2097,
+      "../../@babel/types/lib/converters/valueToNode.js": 2098,
+      "../../@babel/types/lib/modifications/appendToMemberExpression.js": 2099,
+      "../../@babel/types/lib/modifications/inherits.js": 2100,
+      "../../@babel/types/lib/modifications/prependToMemberExpression.js": 2101,
+      "../../@babel/types/lib/retrievers/getOuterBindingIdentifiers.js": 2102,
+      "../../@babel/types/lib/traverse/traverse.js": 2103,
+      "../../@babel/types/lib/validators/isBinding.js": 2104,
+      "../../@babel/types/lib/validators/isBlockScoped.js": 2105,
+      "../../@babel/types/lib/validators/isImmutable.js": 2106,
+      "../../@babel/types/lib/validators/isNodesEquivalent.js": 2107,
+      "../../@babel/types/lib/validators/isReferenced.js": 2108,
+      "../../@babel/types/lib/validators/isScope.js": 2109,
+      "../../@babel/types/lib/validators/isSpecifierDefault.js": 2110,
+      "../../@babel/types/lib/validators/isValidES3Identifier.js": 2111,
+      "../../@babel/types/lib/validators/isVar.js": 2112,
+      "../../parse-script-tags/node_modules/babylon/lib/index.js": 2113,
+      "../../parse-script-tags/customParse.js": 2114,
+      "../../parse-script-tags/parseScriptFragment.js": 2115,
+      "../../@babel/parser/lib/index.js": 2116,
+      "../../@babel/generator/lib/source-map.js": 2117,
+      "../../@babel/generator/lib/printer.js": 2118,
+      "../../@babel/generator/lib/buffer.js": 2119,
+      "../../@babel/generator/lib/node/whitespace.js": 2120,
+      "../../@babel/generator/lib/node/parentheses.js": 2121,
+      "../../@babel/generator/lib/generators/index.js": 2122,
+      "../../@babel/generator/lib/generators/template-literals.js": 2123,
+      "../../@babel/generator/lib/generators/expressions.js": 2124,
+      "../../@babel/generator/lib/generators/statements.js": 2125,
+      "../../@babel/generator/lib/generators/classes.js": 2126,
+      "../../@babel/generator/lib/generators/methods.js": 2127,
+      "../../jsesc/jsesc.js": 2128,
+      "../../@babel/generator/lib/generators/flow.js": 2129,
+      "../../@babel/generator/lib/generators/base.js": 2130,
+      "../../@babel/generator/lib/generators/jsx.js": 2131,
+      "../../@babel/generator/lib/generators/typescript.js": 2132,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/workers/parser/getScopes/visitor.js": 2133,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/workers/parser/pausePoints.js": 2134,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/workers/parser/mapExpression.js": 2135,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/workers/parser/mapOriginalExpression.js": 2136,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/workers/parser/mapBindings.js": 2137,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/workers/parser/mapAwaitExpression.js": 2138,
+      "multi ../../../packages/devtools-source-map/src/worker.js": 2139,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-source-map/src/worker.js": 2140,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-source-map/src/source-map.js": 2141,
+      "../../../packages/devtools-source-map/node_modules/source-map/lib/base64.js": 2142,
+      "../../../packages/devtools-source-map/node_modules/source-map/lib/url-browser.js": 2143,
+      "../../../packages/devtools-source-map/node_modules/whatwg-url/lib/public-api.js": 2144,
+      "../../../packages/devtools-source-map/node_modules/whatwg-url/lib/URL.js": 2145,
+      "../../../packages/devtools-source-map/node_modules/whatwg-url/lib/URL-impl.js": 2146,
+      "../../tr46/index.js": 2147,
+      "../../tr46/lib/regexes.js": 2148,
+      "../../json-loader/index.js!../../tr46/lib/mappingTable.json": 2149,
+      "../../../packages/devtools-source-map/node_modules/whatwg-url/lib/URLSearchParams-impl.js": 2150,
+      "../../lodash.sortby/index.js": 2151,
+      "../../../packages/devtools-source-map/node_modules/source-map/lib/mapping-list.js": 2152,
+      "../../../packages/devtools-source-map/node_modules/source-map/lib/source-map-consumer.js": 2153,
+      "../../../packages/devtools-source-map/node_modules/source-map/lib/binary-search.js": 2154,
+      "../../../packages/devtools-source-map/node_modules/source-map/lib/wasm.js": 2155,
+      "../../../packages/devtools-source-map/node_modules/source-map/lib/source-node.js": 2156,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-source-map/src/utils/assert.js": 2157,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-source-map/src/utils/fetchSourceMap.js": 2158,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-source-map/src/utils/wasmRemap.js": 2159,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-source-map/src/utils/convertToJSON.js": 2160,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-source-map/src/utils/getOriginalStackFrames.js": 2161,
+      "multi ../../../packages/devtools-source-map/src/index.js": 2162,
+      "multi ../../../src/vendors.js": 2163,
+      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/vendors.js": 2164,
+      "multi ../../../packages/devtools-reps/src/index.js": 2165
     },
     "usedIds": {
       "0": 0,
@@ -22334,7 +22742,415 @@
       "1754": 1754,
       "1755": 1755,
       "1756": 1756,
-      "1757": 1757
+      "1757": 1757,
+      "1758": 1758,
+      "1759": 1759,
+      "1760": 1760,
+      "1761": 1761,
+      "1762": 1762,
+      "1763": 1763,
+      "1764": 1764,
+      "1765": 1765,
+      "1766": 1766,
+      "1767": 1767,
+      "1768": 1768,
+      "1769": 1769,
+      "1770": 1770,
+      "1771": 1771,
+      "1772": 1772,
+      "1773": 1773,
+      "1774": 1774,
+      "1775": 1775,
+      "1776": 1776,
+      "1777": 1777,
+      "1778": 1778,
+      "1779": 1779,
+      "1780": 1780,
+      "1781": 1781,
+      "1782": 1782,
+      "1783": 1783,
+      "1784": 1784,
+      "1785": 1785,
+      "1786": 1786,
+      "1787": 1787,
+      "1788": 1788,
+      "1789": 1789,
+      "1790": 1790,
+      "1791": 1791,
+      "1792": 1792,
+      "1793": 1793,
+      "1794": 1794,
+      "1795": 1795,
+      "1796": 1796,
+      "1797": 1797,
+      "1798": 1798,
+      "1799": 1799,
+      "1800": 1800,
+      "1801": 1801,
+      "1802": 1802,
+      "1803": 1803,
+      "1804": 1804,
+      "1805": 1805,
+      "1806": 1806,
+      "1807": 1807,
+      "1808": 1808,
+      "1809": 1809,
+      "1810": 1810,
+      "1811": 1811,
+      "1812": 1812,
+      "1813": 1813,
+      "1814": 1814,
+      "1815": 1815,
+      "1816": 1816,
+      "1817": 1817,
+      "1818": 1818,
+      "1819": 1819,
+      "1820": 1820,
+      "1821": 1821,
+      "1822": 1822,
+      "1823": 1823,
+      "1824": 1824,
+      "1825": 1825,
+      "1826": 1826,
+      "1827": 1827,
+      "1828": 1828,
+      "1829": 1829,
+      "1830": 1830,
+      "1831": 1831,
+      "1832": 1832,
+      "1833": 1833,
+      "1834": 1834,
+      "1835": 1835,
+      "1836": 1836,
+      "1837": 1837,
+      "1838": 1838,
+      "1839": 1839,
+      "1840": 1840,
+      "1841": 1841,
+      "1842": 1842,
+      "1843": 1843,
+      "1844": 1844,
+      "1845": 1845,
+      "1846": 1846,
+      "1847": 1847,
+      "1848": 1848,
+      "1849": 1849,
+      "1850": 1850,
+      "1851": 1851,
+      "1852": 1852,
+      "1853": 1853,
+      "1854": 1854,
+      "1855": 1855,
+      "1856": 1856,
+      "1857": 1857,
+      "1858": 1858,
+      "1859": 1859,
+      "1860": 1860,
+      "1861": 1861,
+      "1862": 1862,
+      "1863": 1863,
+      "1864": 1864,
+      "1865": 1865,
+      "1866": 1866,
+      "1867": 1867,
+      "1868": 1868,
+      "1869": 1869,
+      "1870": 1870,
+      "1871": 1871,
+      "1872": 1872,
+      "1873": 1873,
+      "1874": 1874,
+      "1875": 1875,
+      "1876": 1876,
+      "1877": 1877,
+      "1878": 1878,
+      "1879": 1879,
+      "1880": 1880,
+      "1881": 1881,
+      "1882": 1882,
+      "1883": 1883,
+      "1884": 1884,
+      "1885": 1885,
+      "1886": 1886,
+      "1887": 1887,
+      "1888": 1888,
+      "1889": 1889,
+      "1890": 1890,
+      "1891": 1891,
+      "1892": 1892,
+      "1893": 1893,
+      "1894": 1894,
+      "1895": 1895,
+      "1896": 1896,
+      "1897": 1897,
+      "1898": 1898,
+      "1899": 1899,
+      "1900": 1900,
+      "1901": 1901,
+      "1902": 1902,
+      "1903": 1903,
+      "1904": 1904,
+      "1905": 1905,
+      "1906": 1906,
+      "1907": 1907,
+      "1908": 1908,
+      "1909": 1909,
+      "1910": 1910,
+      "1911": 1911,
+      "1912": 1912,
+      "1913": 1913,
+      "1914": 1914,
+      "1915": 1915,
+      "1916": 1916,
+      "1917": 1917,
+      "1918": 1918,
+      "1919": 1919,
+      "1920": 1920,
+      "1921": 1921,
+      "1922": 1922,
+      "1923": 1923,
+      "1924": 1924,
+      "1925": 1925,
+      "1926": 1926,
+      "1927": 1927,
+      "1928": 1928,
+      "1929": 1929,
+      "1930": 1930,
+      "1931": 1931,
+      "1932": 1932,
+      "1933": 1933,
+      "1934": 1934,
+      "1935": 1935,
+      "1936": 1936,
+      "1937": 1937,
+      "1938": 1938,
+      "1939": 1939,
+      "1940": 1940,
+      "1941": 1941,
+      "1942": 1942,
+      "1943": 1943,
+      "1944": 1944,
+      "1945": 1945,
+      "1946": 1946,
+      "1947": 1947,
+      "1948": 1948,
+      "1949": 1949,
+      "1950": 1950,
+      "1951": 1951,
+      "1952": 1952,
+      "1953": 1953,
+      "1954": 1954,
+      "1955": 1955,
+      "1956": 1956,
+      "1957": 1957,
+      "1958": 1958,
+      "1959": 1959,
+      "1960": 1960,
+      "1961": 1961,
+      "1962": 1962,
+      "1963": 1963,
+      "1964": 1964,
+      "1965": 1965,
+      "1966": 1966,
+      "1967": 1967,
+      "1968": 1968,
+      "1969": 1969,
+      "1970": 1970,
+      "1971": 1971,
+      "1972": 1972,
+      "1973": 1973,
+      "1974": 1974,
+      "1975": 1975,
+      "1976": 1976,
+      "1977": 1977,
+      "1978": 1978,
+      "1979": 1979,
+      "1980": 1980,
+      "1981": 1981,
+      "1982": 1982,
+      "1983": 1983,
+      "1984": 1984,
+      "1985": 1985,
+      "1986": 1986,
+      "1987": 1987,
+      "1988": 1988,
+      "1989": 1989,
+      "1990": 1990,
+      "1991": 1991,
+      "1992": 1992,
+      "1993": 1993,
+      "1994": 1994,
+      "1995": 1995,
+      "1996": 1996,
+      "1997": 1997,
+      "1998": 1998,
+      "1999": 1999,
+      "2000": 2000,
+      "2001": 2001,
+      "2002": 2002,
+      "2003": 2003,
+      "2004": 2004,
+      "2005": 2005,
+      "2006": 2006,
+      "2007": 2007,
+      "2008": 2008,
+      "2009": 2009,
+      "2010": 2010,
+      "2011": 2011,
+      "2012": 2012,
+      "2013": 2013,
+      "2014": 2014,
+      "2015": 2015,
+      "2016": 2016,
+      "2017": 2017,
+      "2018": 2018,
+      "2019": 2019,
+      "2020": 2020,
+      "2021": 2021,
+      "2022": 2022,
+      "2023": 2023,
+      "2024": 2024,
+      "2025": 2025,
+      "2026": 2026,
+      "2027": 2027,
+      "2028": 2028,
+      "2029": 2029,
+      "2030": 2030,
+      "2031": 2031,
+      "2032": 2032,
+      "2033": 2033,
+      "2034": 2034,
+      "2035": 2035,
+      "2036": 2036,
+      "2037": 2037,
+      "2038": 2038,
+      "2039": 2039,
+      "2040": 2040,
+      "2041": 2041,
+      "2042": 2042,
+      "2043": 2043,
+      "2044": 2044,
+      "2045": 2045,
+      "2046": 2046,
+      "2047": 2047,
+      "2048": 2048,
+      "2049": 2049,
+      "2050": 2050,
+      "2051": 2051,
+      "2052": 2052,
+      "2053": 2053,
+      "2054": 2054,
+      "2055": 2055,
+      "2056": 2056,
+      "2057": 2057,
+      "2058": 2058,
+      "2059": 2059,
+      "2060": 2060,
+      "2061": 2061,
+      "2062": 2062,
+      "2063": 2063,
+      "2064": 2064,
+      "2065": 2065,
+      "2066": 2066,
+      "2067": 2067,
+      "2068": 2068,
+      "2069": 2069,
+      "2070": 2070,
+      "2071": 2071,
+      "2072": 2072,
+      "2073": 2073,
+      "2074": 2074,
+      "2075": 2075,
+      "2076": 2076,
+      "2077": 2077,
+      "2078": 2078,
+      "2079": 2079,
+      "2080": 2080,
+      "2081": 2081,
+      "2082": 2082,
+      "2083": 2083,
+      "2084": 2084,
+      "2085": 2085,
+      "2086": 2086,
+      "2087": 2087,
+      "2088": 2088,
+      "2089": 2089,
+      "2090": 2090,
+      "2091": 2091,
+      "2092": 2092,
+      "2093": 2093,
+      "2094": 2094,
+      "2095": 2095,
+      "2096": 2096,
+      "2097": 2097,
+      "2098": 2098,
+      "2099": 2099,
+      "2100": 2100,
+      "2101": 2101,
+      "2102": 2102,
+      "2103": 2103,
+      "2104": 2104,
+      "2105": 2105,
+      "2106": 2106,
+      "2107": 2107,
+      "2108": 2108,
+      "2109": 2109,
+      "2110": 2110,
+      "2111": 2111,
+      "2112": 2112,
+      "2113": 2113,
+      "2114": 2114,
+      "2115": 2115,
+      "2116": 2116,
+      "2117": 2117,
+      "2118": 2118,
+      "2119": 2119,
+      "2120": 2120,
+      "2121": 2121,
+      "2122": 2122,
+      "2123": 2123,
+      "2124": 2124,
+      "2125": 2125,
+      "2126": 2126,
+      "2127": 2127,
+      "2128": 2128,
+      "2129": 2129,
+      "2130": 2130,
+      "2131": 2131,
+      "2132": 2132,
+      "2133": 2133,
+      "2134": 2134,
+      "2135": 2135,
+      "2136": 2136,
+      "2137": 2137,
+      "2138": 2138,
+      "2139": 2139,
+      "2140": 2140,
+      "2141": 2141,
+      "2142": 2142,
+      "2143": 2143,
+      "2144": 2144,
+      "2145": 2145,
+      "2146": 2146,
+      "2147": 2147,
+      "2148": 2148,
+      "2149": 2149,
+      "2150": 2150,
+      "2151": 2151,
+      "2152": 2152,
+      "2153": 2153,
+      "2154": 2154,
+      "2155": 2155,
+      "2156": 2156,
+      "2157": 2157,
+      "2158": 2158,
+      "2159": 2159,
+      "2160": 2160,
+      "2161": 2161,
+      "2162": 2162,
+      "2163": 2163,
+      "2164": 2164,
+      "2165": 2165
     }
   },
   "chunks": {
@@ -22344,14 +23160,20 @@
       "pretty-print-worker": 2,
       "source-map-worker": 3,
       "parser-worker": 4,
-      "search-worker": 5
+      "search-worker": 5,
+      "vendors": 1,
+      "reps": 3,
+      "source-map-index": 6
     },
     "byBlocks": {},
     "usedIds": {
       "0": 0,
+      "1": 1,
       "2": 2,
+      "3": 3,
       "4": 4,
-      "5": 5
+      "5": 5,
+      "6": 6
     }
   },
   "extract-text-webpack-plugin ../../extract-text-webpack-plugin/dist ../../css-loader/index.js??ref--4-2!../../postcss-loader/lib/index.js??ref--4-3!../../../src/components/variables.css": [
@@ -25530,18 +26352,20 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/variables.css": 0,
-          "../../css-loader/lib/css-base.js": 1
+          "../../css-loader/lib/css-base.js": 1,
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/variables.css": 2
         },
         "usedIds": {
           "0": 0,
-          "1": 1
+          "1": 1,
+          "2": 2
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "1": 1
+          "0": 0
         }
       }
     }
@@ -25551,18 +26375,20 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/App.css": 0,
-          "../../css-loader/lib/css-base.js": 1
+          "../../css-loader/lib/css-base.js": 1,
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/App.css": 2
         },
         "usedIds": {
           "0": 0,
-          "1": 1
+          "1": 1,
+          "2": 2
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "1": 1
+          "0": 0
         }
       }
     }
@@ -25572,18 +26398,20 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/shared/menu.css": 0,
-          "../../css-loader/lib/css-base.js": 1
+          "../../css-loader/lib/css-base.js": 1,
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/shared/menu.css": 2
         },
         "usedIds": {
           "0": 0,
-          "1": 1
+          "1": 1,
+          "2": 2
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "1": 1
+          "0": 0
         }
       }
     }
@@ -25593,18 +26421,20 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/shared/reps.css": 0,
-          "../../css-loader/lib/css-base.js": 1
+          "../../css-loader/lib/css-base.js": 1,
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/shared/reps.css": 2
         },
         "usedIds": {
           "0": 0,
-          "1": 1
+          "1": 1,
+          "2": 2
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "1": 1
+          "0": 0
         }
       }
     }
@@ -25635,18 +26465,20 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/shared/SearchInput.css": 0,
-          "../../css-loader/lib/css-base.js": 1
+          "../../css-loader/lib/css-base.js": 1,
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/shared/SearchInput.css": 2
         },
         "usedIds": {
           "0": 0,
-          "1": 1
+          "1": 1,
+          "2": 2
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "1": 1
+          "0": 0
         }
       }
     }
@@ -25677,18 +26509,20 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/shared/Svg.css": 0,
-          "../../css-loader/lib/css-base.js": 1
+          "../../css-loader/lib/css-base.js": 1,
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/shared/Svg.css": 2
         },
         "usedIds": {
           "0": 0,
-          "1": 1
+          "1": 1,
+          "2": 2
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "1": 1
+          "0": 0
         }
       }
     }
@@ -25698,18 +26532,20 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/shared/Modal.css": 0,
-          "../../css-loader/lib/css-base.js": 1
+          "../../css-loader/lib/css-base.js": 1,
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/shared/Modal.css": 2
         },
         "usedIds": {
           "0": 0,
-          "1": 1
+          "1": 1,
+          "2": 2
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "1": 1
+          "0": 0
         }
       }
     }
@@ -25719,18 +26555,20 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/shared/ResultList.css": 0,
-          "../../css-loader/lib/css-base.js": 1
+          "../../css-loader/lib/css-base.js": 1,
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/shared/ResultList.css": 2
         },
         "usedIds": {
           "0": 0,
-          "1": 1
+          "1": 1,
+          "2": 2
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "1": 1
+          "0": 0
         }
       }
     }
@@ -25740,18 +26578,20 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/Editor/Tabs.css": 0,
-          "../../css-loader/lib/css-base.js": 1
+          "../../css-loader/lib/css-base.js": 1,
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/Editor/Tabs.css": 2
         },
         "usedIds": {
           "0": 0,
-          "1": 1
+          "1": 1,
+          "2": 2
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "1": 1
+          "0": 0
         }
       }
     }
@@ -25761,18 +26601,20 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/shared/Dropdown.css": 0,
-          "../../css-loader/lib/css-base.js": 1
+          "../../css-loader/lib/css-base.js": 1,
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/shared/Dropdown.css": 2
         },
         "usedIds": {
           "0": 0,
-          "1": 1
+          "1": 1,
+          "2": 2
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "1": 1
+          "0": 0
         }
       }
     }
@@ -25803,18 +26645,20 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/WelcomeBox.css": 0,
-          "../../css-loader/lib/css-base.js": 1
+          "../../css-loader/lib/css-base.js": 1,
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/WelcomeBox.css": 2
         },
         "usedIds": {
           "0": 0,
-          "1": 1
+          "1": 1,
+          "2": 2
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "1": 1
+          "0": 0
         }
       }
     }
@@ -25824,18 +26668,20 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/SecondaryPanes/SecondaryPanes.css": 0,
-          "../../css-loader/lib/css-base.js": 1
+          "../../css-loader/lib/css-base.js": 1,
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/SecondaryPanes/SecondaryPanes.css": 2
         },
         "usedIds": {
           "0": 0,
-          "1": 1
+          "1": 1,
+          "2": 2
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "1": 1
+          "0": 0
         }
       }
     }
@@ -25845,18 +26691,20 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/SecondaryPanes/Scopes.css": 0,
-          "../../css-loader/lib/css-base.js": 1
+          "../../css-loader/lib/css-base.js": 1,
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/SecondaryPanes/Scopes.css": 2
         },
         "usedIds": {
           "0": 0,
-          "1": 1
+          "1": 1,
+          "2": 2
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "1": 1
+          "0": 0
         }
       }
     }
@@ -25908,18 +26756,20 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/shared/ManagedTree.css": 0,
-          "../../css-loader/lib/css-base.js": 1
+          "../../css-loader/lib/css-base.js": 1,
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/shared/ManagedTree.css": 2
         },
         "usedIds": {
           "0": 0,
-          "1": 1
+          "1": 1,
+          "2": 2
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "1": 1
+          "0": 0
         }
       }
     }
@@ -25929,18 +26779,20 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/SecondaryPanes/CommandBar.css": 0,
-          "../../css-loader/lib/css-base.js": 1
+          "../../css-loader/lib/css-base.js": 1,
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/SecondaryPanes/CommandBar.css": 2
         },
         "usedIds": {
           "0": 0,
-          "1": 1
+          "1": 1,
+          "2": 2
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "1": 1
+          "0": 0
         }
       }
     }
@@ -25950,18 +26802,20 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/shared/Accordion.css": 0,
-          "../../css-loader/lib/css-base.js": 1
+          "../../css-loader/lib/css-base.js": 1,
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/shared/Accordion.css": 2
         },
         "usedIds": {
           "0": 0,
-          "1": 1
+          "1": 1,
+          "2": 2
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "1": 1
+          "0": 0
         }
       }
     }
@@ -25971,18 +26825,20 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/SecondaryPanes/Workers.css": 0,
-          "../../css-loader/lib/css-base.js": 1
+          "../../css-loader/lib/css-base.js": 1,
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/SecondaryPanes/Workers.css": 2
         },
         "usedIds": {
           "0": 0,
-          "1": 1
+          "1": 1,
+          "2": 2
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "1": 1
+          "0": 0
         }
       }
     }
@@ -26013,18 +26869,20 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/SecondaryPanes/Frames/Frames.css": 0,
-          "../../css-loader/lib/css-base.js": 1
+          "../../css-loader/lib/css-base.js": 1,
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/SecondaryPanes/Frames/Frames.css": 2
         },
         "usedIds": {
           "0": 0,
-          "1": 1
+          "1": 1,
+          "2": 2
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "1": 1
+          "0": 0
         }
       }
     }
@@ -26034,18 +26892,20 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/SecondaryPanes/Frames/WhyPaused.css": 0,
-          "../../css-loader/lib/css-base.js": 1
+          "../../css-loader/lib/css-base.js": 1,
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/SecondaryPanes/Frames/WhyPaused.css": 2
         },
         "usedIds": {
           "0": 0,
-          "1": 1
+          "1": 1,
+          "2": 2
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "1": 1
+          "0": 0
         }
       }
     }
@@ -26055,18 +26915,20 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/SecondaryPanes/Frames/Group.css": 0,
-          "../../css-loader/lib/css-base.js": 1
+          "../../css-loader/lib/css-base.js": 1,
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/SecondaryPanes/Frames/Group.css": 2
         },
         "usedIds": {
           "0": 0,
-          "1": 1
+          "1": 1,
+          "2": 2
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "1": 1
+          "0": 0
         }
       }
     }
@@ -26076,18 +26938,20 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/SecondaryPanes/Expressions.css": 0,
-          "../../css-loader/lib/css-base.js": 1
+          "../../css-loader/lib/css-base.js": 1,
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/SecondaryPanes/Expressions.css": 2
         },
         "usedIds": {
           "0": 0,
-          "1": 1
+          "1": 1,
+          "2": 2
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "1": 1
+          "0": 0
         }
       }
     }
@@ -26118,18 +26982,20 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/Editor/Editor.css": 0,
-          "../../css-loader/lib/css-base.js": 1
+          "../../css-loader/lib/css-base.js": 1,
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/Editor/Editor.css": 2
         },
         "usedIds": {
           "0": 0,
-          "1": 1
+          "1": 1,
+          "2": 2
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "1": 1
+          "0": 0
         }
       }
     }
@@ -26139,18 +27005,20 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/Editor/Highlight.css": 0,
-          "../../css-loader/lib/css-base.js": 1
+          "../../css-loader/lib/css-base.js": 1,
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/Editor/Highlight.css": 2
         },
         "usedIds": {
           "0": 0,
-          "1": 1
+          "1": 1,
+          "2": 2
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "1": 1
+          "0": 0
         }
       }
     }
@@ -26160,18 +27028,20 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/Editor/ConditionalPanel.css": 0,
-          "../../css-loader/lib/css-base.js": 1
+          "../../css-loader/lib/css-base.js": 1,
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/Editor/ConditionalPanel.css": 2
         },
         "usedIds": {
           "0": 0,
-          "1": 1
+          "1": 1,
+          "2": 2
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "1": 1
+          "0": 0
         }
       }
     }
@@ -26223,18 +27093,20 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/Editor/Preview/Popup.css": 0,
-          "../../css-loader/lib/css-base.js": 1
+          "../../css-loader/lib/css-base.js": 1,
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/Editor/Preview/Popup.css": 2
         },
         "usedIds": {
           "0": 0,
-          "1": 1
+          "1": 1,
+          "2": 2
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "1": 1
+          "0": 0
         }
       }
     }
@@ -26244,18 +27116,20 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/shared/PreviewFunction.css": 0,
-          "../../css-loader/lib/css-base.js": 1
+          "../../css-loader/lib/css-base.js": 1,
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/shared/PreviewFunction.css": 2
         },
         "usedIds": {
           "0": 0,
-          "1": 1
+          "1": 1,
+          "2": 2
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "1": 1
+          "0": 0
         }
       }
     }
@@ -26265,18 +27139,20 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/shared/Popover.css": 0,
-          "../../css-loader/lib/css-base.js": 1
+          "../../css-loader/lib/css-base.js": 1,
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/shared/Popover.css": 2
         },
         "usedIds": {
           "0": 0,
-          "1": 1
+          "1": 1,
+          "2": 2
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "1": 1
+          "0": 0
         }
       }
     }
@@ -26286,18 +27162,20 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/shared/BracketArrow.css": 0,
-          "../../css-loader/lib/css-base.js": 1
+          "../../css-loader/lib/css-base.js": 1,
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/shared/BracketArrow.css": 2
         },
         "usedIds": {
           "0": 0,
-          "1": 1
+          "1": 1,
+          "2": 2
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "1": 1
+          "0": 0
         }
       }
     }
@@ -26307,18 +27185,20 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/Editor/SearchBar.css": 0,
-          "../../css-loader/lib/css-base.js": 1
+          "../../css-loader/lib/css-base.js": 1,
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/Editor/SearchBar.css": 2
         },
         "usedIds": {
           "0": 0,
-          "1": 1
+          "1": 1,
+          "2": 2
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "1": 1
+          "0": 0
         }
       }
     }
@@ -26328,18 +27208,20 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/Editor/Footer.css": 0,
-          "../../css-loader/lib/css-base.js": 1
+          "../../css-loader/lib/css-base.js": 1,
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/Editor/Footer.css": 2
         },
         "usedIds": {
           "0": 0,
-          "1": 1
+          "1": 1,
+          "2": 2
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "1": 1
+          "0": 0
         }
       }
     }
@@ -26349,18 +27231,20 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/PrimaryPanes/Sources.css": 0,
-          "../../css-loader/lib/css-base.js": 1
+          "../../css-loader/lib/css-base.js": 1,
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/PrimaryPanes/Sources.css": 2
         },
         "usedIds": {
           "0": 0,
-          "1": 1
+          "1": 1,
+          "2": 2
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "1": 1
+          "0": 0
         }
       }
     }
@@ -26370,18 +27254,20 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/PrimaryPanes/Outline.css": 0,
-          "../../css-loader/lib/css-base.js": 1
+          "../../css-loader/lib/css-base.js": 1,
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/PrimaryPanes/Outline.css": 2
         },
         "usedIds": {
           "0": 0,
-          "1": 1
+          "1": 1,
+          "2": 2
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "1": 1
+          "0": 0
         }
       }
     }
@@ -26475,18 +27361,20 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/ShortcutsModal.css": 0,
-          "../../css-loader/lib/css-base.js": 1
+          "../../css-loader/lib/css-base.js": 1,
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/ShortcutsModal.css": 2
         },
         "usedIds": {
           "0": 0,
-          "1": 1
+          "1": 1,
+          "2": 2
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "1": 1
+          "0": 0
         }
       }
     }
@@ -26496,18 +27384,20 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!components/Root.css": 0,
-          "../../css-loader/lib/css-base.js": 1
+          "../../css-loader/lib/css-base.js": 1,
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!components/Root.css": 2
         },
         "usedIds": {
           "0": 0,
-          "1": 1
+          "1": 1,
+          "2": 2
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "1": 1
+          "0": 0
         }
       }
     }
@@ -26517,18 +27407,20 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../devtools-contextmenu/menu.css": 0,
-          "../../css-loader/lib/css-base.js": 1
+          "../../css-loader/lib/css-base.js": 1,
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../devtools-contextmenu/menu.css": 2
         },
         "usedIds": {
           "0": 0,
-          "1": 1
+          "1": 1,
+          "2": 2
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "1": 1
+          "0": 0
         }
       }
     }
@@ -26601,6 +27493,29 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/shared/Badge.css": 0,
+          "../../css-loader/lib/css-base.js": 1,
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/shared/Badge.css": 2
+        },
+        "usedIds": {
+          "0": 0,
+          "1": 1,
+          "2": 2
+        }
+      },
+      "chunks": {
+        "byName": {},
+        "byBlocks": {},
+        "usedIds": {
+          "0": 0
+        }
+      }
+    }
+  ],
+  "extract-text-webpack-plugin ../../extract-text-webpack-plugin/dist ../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/QuickOpenModal.css": [
+    {
+      "modules": {
+        "byIdentifier": {
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/QuickOpenModal.css": 0,
           "../../css-loader/lib/css-base.js": 1
         },
         "usedIds": {
@@ -26612,7 +27527,364 @@
         "byName": {},
         "byBlocks": {},
         "usedIds": {
+          "0": 0
+        }
+      }
+    }
+  ],
+  "extract-text-webpack-plugin ../../extract-text-webpack-plugin/dist ../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/shared/AccessibleImage.css": [
+    {
+      "modules": {
+        "byIdentifier": {
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/shared/AccessibleImage.css": 0,
+          "../../css-loader/lib/css-base.js": 1
+        },
+        "usedIds": {
+          "0": 0,
           "1": 1
+        }
+      },
+      "chunks": {
+        "byName": {},
+        "byBlocks": {},
+        "usedIds": {
+          "0": 0
+        }
+      }
+    }
+  ],
+  "extract-text-webpack-plugin ../../extract-text-webpack-plugin/dist ../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/shared/Button/styles/PaneToggleButton.css": [
+    {
+      "modules": {
+        "byIdentifier": {
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/shared/Button/styles/PaneToggleButton.css": 0,
+          "../../css-loader/lib/css-base.js": 1
+        },
+        "usedIds": {
+          "0": 0,
+          "1": 1
+        }
+      },
+      "chunks": {
+        "byName": {},
+        "byBlocks": {},
+        "usedIds": {
+          "0": 0
+        }
+      }
+    }
+  ],
+  "extract-text-webpack-plugin ../../extract-text-webpack-plugin/dist ../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/shared/Button/styles/CommandBarButton.css": [
+    {
+      "modules": {
+        "byIdentifier": {
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/shared/Button/styles/CommandBarButton.css": 0,
+          "../../css-loader/lib/css-base.js": 1
+        },
+        "usedIds": {
+          "0": 0,
+          "1": 1
+        }
+      },
+      "chunks": {
+        "byName": {},
+        "byBlocks": {},
+        "usedIds": {
+          "0": 0
+        }
+      }
+    }
+  ],
+  "extract-text-webpack-plugin ../../extract-text-webpack-plugin/dist ../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/shared/Button/styles/CloseButton.css": [
+    {
+      "modules": {
+        "byIdentifier": {
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/shared/Button/styles/CloseButton.css": 0,
+          "../../css-loader/lib/css-base.js": 1
+        },
+        "usedIds": {
+          "0": 0,
+          "1": 1
+        }
+      },
+      "chunks": {
+        "byName": {},
+        "byBlocks": {},
+        "usedIds": {
+          "0": 0
+        }
+      }
+    }
+  ],
+  "extract-text-webpack-plugin ../../extract-text-webpack-plugin/dist ../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/shared/SourceIcon.css": [
+    {
+      "modules": {
+        "byIdentifier": {
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/shared/SourceIcon.css": 0,
+          "../../css-loader/lib/css-base.js": 1
+        },
+        "usedIds": {
+          "0": 0,
+          "1": 1
+        }
+      },
+      "chunks": {
+        "byName": {},
+        "byBlocks": {},
+        "usedIds": {
+          "0": 0
+        }
+      }
+    }
+  ],
+  "extract-text-webpack-plugin ../../extract-text-webpack-plugin/dist ../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../packages/devtools-reps/src/object-inspector/components/ObjectInspector.css": [
+    {
+      "modules": {
+        "byIdentifier": {
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../packages/devtools-reps/src/object-inspector/components/ObjectInspector.css": 0,
+          "../../css-loader/lib/css-base.js": 1
+        },
+        "usedIds": {
+          "0": 0,
+          "1": 1
+        }
+      },
+      "chunks": {
+        "byName": {},
+        "byBlocks": {},
+        "usedIds": {
+          "0": 0
+        }
+      }
+    }
+  ],
+  "extract-text-webpack-plugin ../../extract-text-webpack-plugin/dist ../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../packages/devtools-components/src/tree.css": [
+    {
+      "modules": {
+        "byIdentifier": {
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../packages/devtools-components/src/tree.css": 0,
+          "../../css-loader/lib/css-base.js": 1
+        },
+        "usedIds": {
+          "0": 0,
+          "1": 1
+        }
+      },
+      "chunks": {
+        "byName": {},
+        "byBlocks": {},
+        "usedIds": {
+          "0": 0
+        }
+      }
+    }
+  ],
+  "extract-text-webpack-plugin ../../extract-text-webpack-plugin/dist ../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../packages/devtools-reps/src/reps/reps.css": [
+    {
+      "modules": {
+        "byIdentifier": {
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../packages/devtools-reps/src/reps/reps.css": 0,
+          "../../css-loader/lib/css-base.js": 1
+        },
+        "usedIds": {
+          "0": 0,
+          "1": 1
+        }
+      },
+      "chunks": {
+        "byName": {},
+        "byBlocks": {},
+        "usedIds": {
+          "0": 0
+        }
+      }
+    }
+  ],
+  "extract-text-webpack-plugin ../../extract-text-webpack-plugin/dist ../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/SecondaryPanes/XHRBreakpoints.css": [
+    {
+      "modules": {
+        "byIdentifier": {
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/SecondaryPanes/XHRBreakpoints.css": 0,
+          "../../css-loader/lib/css-base.js": 1
+        },
+        "usedIds": {
+          "0": 0,
+          "1": 1
+        }
+      },
+      "chunks": {
+        "byName": {},
+        "byBlocks": {},
+        "usedIds": {
+          "0": 0
+        }
+      }
+    }
+  ],
+  "extract-text-webpack-plugin ../../extract-text-webpack-plugin/dist ../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/SecondaryPanes/Breakpoints/Breakpoints.css": [
+    {
+      "modules": {
+        "byIdentifier": {
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/SecondaryPanes/Breakpoints/Breakpoints.css": 0,
+          "../../css-loader/lib/css-base.js": 1
+        },
+        "usedIds": {
+          "0": 0,
+          "1": 1
+        }
+      },
+      "chunks": {
+        "byName": {},
+        "byBlocks": {},
+        "usedIds": {
+          "0": 0
+        }
+      }
+    }
+  ],
+  "extract-text-webpack-plugin ../../extract-text-webpack-plugin/dist ../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/Editor/ColumnBreakpoints.css": [
+    {
+      "modules": {
+        "byIdentifier": {
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/Editor/ColumnBreakpoints.css": 0,
+          "../../css-loader/lib/css-base.js": 1
+        },
+        "usedIds": {
+          "0": 0,
+          "1": 1
+        }
+      },
+      "chunks": {
+        "byName": {},
+        "byBlocks": {},
+        "usedIds": {
+          "0": 0
+        }
+      }
+    }
+  ],
+  "extract-text-webpack-plugin ../../extract-text-webpack-plugin/dist ../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/PrimaryPanes/OutlineFilter.css": [
+    {
+      "modules": {
+        "byIdentifier": {
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/PrimaryPanes/OutlineFilter.css": 0,
+          "../../css-loader/lib/css-base.js": 1
+        },
+        "usedIds": {
+          "0": 0,
+          "1": 1
+        }
+      },
+      "chunks": {
+        "byName": {},
+        "byBlocks": {},
+        "usedIds": {
+          "0": 0
+        }
+      }
+    }
+  ],
+  "extract-text-webpack-plugin ../../extract-text-webpack-plugin/dist ../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../react-aria-components/src/tabs/tab.css": [
+    {
+      "modules": {
+        "byIdentifier": {
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../react-aria-components/src/tabs/tab.css": 0,
+          "../../css-loader/lib/css-base.js": 1
+        },
+        "usedIds": {
+          "0": 0,
+          "1": 1
+        }
+      },
+      "chunks": {
+        "byName": {},
+        "byBlocks": {},
+        "usedIds": {
+          "0": 0
+        }
+      }
+    }
+  ],
+  "extract-text-webpack-plugin ../../extract-text-webpack-plugin/dist ../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../react-aria-components/src/tabs/tab-list.css": [
+    {
+      "modules": {
+        "byIdentifier": {
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../react-aria-components/src/tabs/tab-list.css": 0,
+          "../../css-loader/lib/css-base.js": 1
+        },
+        "usedIds": {
+          "0": 0,
+          "1": 1
+        }
+      },
+      "chunks": {
+        "byName": {},
+        "byBlocks": {},
+        "usedIds": {
+          "0": 0
+        }
+      }
+    }
+  ],
+  "extract-text-webpack-plugin ../../extract-text-webpack-plugin/dist ../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/ProjectSearch.css": [
+    {
+      "modules": {
+        "byIdentifier": {
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/ProjectSearch.css": 0,
+          "../../css-loader/lib/css-base.js": 1
+        },
+        "usedIds": {
+          "0": 0,
+          "1": 1
+        }
+      },
+      "chunks": {
+        "byName": {},
+        "byBlocks": {},
+        "usedIds": {
+          "0": 0
+        }
+      }
+    }
+  ],
+  "extract-text-webpack-plugin ../../extract-text-webpack-plugin/dist ../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../packages/devtools-splitter/src/SplitBox.css": [
+    {
+      "modules": {
+        "byIdentifier": {
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../packages/devtools-splitter/src/SplitBox.css": 0,
+          "../../css-loader/lib/css-base.js": 1
+        },
+        "usedIds": {
+          "0": 0,
+          "1": 1
+        }
+      },
+      "chunks": {
+        "byName": {},
+        "byBlocks": {},
+        "usedIds": {
+          "0": 0
+        }
+      }
+    }
+  ],
+  "extract-text-webpack-plugin ../../extract-text-webpack-plugin/dist ../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/A11yIntention.css": [
+    {
+      "modules": {
+        "byIdentifier": {
+          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/A11yIntention.css": 0,
+          "../../css-loader/lib/css-base.js": 1
+        },
+        "usedIds": {
+          "0": 0,
+          "1": 1
+        }
+      },
+      "chunks": {
+        "byName": {},
+        "byBlocks": {},
+        "usedIds": {
+          "0": 0
         }
       }
     }

--- a/assets/module-manifest.json
+++ b/assets/module-manifest.json
@@ -20574,415 +20574,7 @@
       "../../parse5/lib/serializer/serializer_stream.js": 1752,
       "../../parse5/lib/sax/index.js": 1753,
       "../../parse5/lib/sax/dev_null_stream.js": 1754,
-      "../../parse5/lib/sax/parser_feedback_simulator.js": 1755,
-      "external \"devtools/client/shared/vendor/react-prop-types\"": 1758,
-      "external \"devtools/client/shared/vendor/react-dom-factories\"": 1759,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/selectors/index.js": 1760,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/rep-utils.js": 1761,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/constants.js": 1762,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/connect.js": 1763,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-source-map/src/index.js": 1764,
-      "../../@babel/types/lib/index.js": 1765,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-utils/index.js": 1766,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/rep.js": 1767,
-      "../../@babel/types/lib/validators/generated/index.js": 1768,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../devtools-environment/index.js": 1769,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/string.js": 1770,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-utils/src/privileged-network-request.js": 1771,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-utils/src/worker-utils.js": 1772,
-      "../../reselect/es/index.js": 1773,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/components/shared/AccessibleImage.js": 1774,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/array.js": 1775,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/prop-rep.js": 1776,
-      "../../@babel/types/lib/builders/generated/index.js": 1777,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/components/shared/Button/index.js": 1778,
-      "../../@babel/types/lib/definitions/index.js": 1779,
-      "../../../packages/devtools-source-map/node_modules/whatwg-url/lib/url-state-machine.js": 1780,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-source-map/src/utils/index.js": 1781,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/index.js": 1782,
-      "../../@babel/types/lib/definitions/utils.js": 1783,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/grip.js": 1784,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/object-inspector/utils/node.js": 1785,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/object-inspector/reducer.js": 1786,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/object-inspector/utils/index.js": 1787,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/actions/sources/index.js": 1788,
-      "../../@babel/types/lib/constants/index.js": 1789,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/pause/frames/index.js": 1790,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-components/index.js": 1791,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/actions/breakpoints/index.js": 1792,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/telemetry.js": 1793,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/function.js": 1794,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/shared/dom-node-constants.js": 1795,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/error.js": 1796,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/grip-array.js": 1797,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/shared/grip-length-bubble.js": 1798,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/grip-map.js": 1799,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/grip-map-entry.js": 1800,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-components/src/tree.js": 1801,
-      "../../extract-text-webpack-plugin/dist/loader.js??ref--3-0!../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../packages/devtools-components/src/tree.css": 1802,
-      "external \"devtools/client/shared/vendor/react-redux\"": 1803,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/object-inspector/utils/load-properties.js": 1804,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/object-inspector/utils/client.js": 1805,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/source-queue.js": 1806,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/pause/mapScopes/locColumn.js": 1807,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../react-aria-components/src/tabs/tab-list.js": 1808,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../react-aria-components/src/tabs/tab.js": 1809,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../react-aria-components/src/tabs/tab-panels.js": 1810,
-      "../../@babel/types/lib/validators/isValidIdentifier.js": 1811,
-      "../../@babel/types/lib/clone/cloneNode.js": 1812,
-      "external \"devtools/client/shared/vendor/immutable\"": 1813,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/url.js": 1814,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/workers.js": 1815,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/pause/frames/getFrameUrl.js": 1816,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/actions/tabs.js": 1817,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/pause/index.js": 1818,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-splitter/index.js": 1819,
-      "../../@babel/types/lib/retrievers/getBindingIdentifiers.js": 1820,
-      "../../@babel/generator/lib/index.js": 1821,
-      "../../../packages/devtools-source-map/node_modules/source-map/source-map.js": 1822,
-      "../../../packages/devtools-source-map/node_modules/source-map/lib/util.js": 1823,
-      "../../../packages/devtools-source-map/node_modules/whatwg-url/lib/urlencoded.js": 1824,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../devtools-modules/src/utils/text.js": 1825,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../devtools-modules/src/async-storage.js": 1826,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../devtools-modules/src/source-utils.js": 1827,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../devtools-modules/src/utils/telemetry.js": 1828,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../devtools-modules/src/unicode-url.js": 1829,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/build-query.js": 1830,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/reducers/tabs.js": 1831,
-      "../../lodash-move/lib/index.js": 1832,
-      "../../extract-text-webpack-plugin/dist/loader.js??ref--3-0!../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../packages/devtools-reps/src/reps/reps.css": 1833,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/undefined.js": 1834,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/null.js": 1835,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/number.js": 1836,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/object.js": 1837,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/symbol.js": 1838,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/infinity.js": 1839,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/nan.js": 1840,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/accessor.js": 1841,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/accessible.js": 1842,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/attribute.js": 1843,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/date-time.js": 1844,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/document.js": 1845,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/document-type.js": 1846,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/event.js": 1847,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/promise.js": 1848,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/regexp.js": 1849,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/stylesheet.js": 1850,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/comment-node.js": 1851,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/element-node.js": 1852,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/text-node.js": 1853,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/window.js": 1854,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/object-with-text.js": 1855,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/reps/object-with-url.js": 1856,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/object-inspector/index.js": 1857,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/object-inspector/components/ObjectInspector.js": 1858,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/object-inspector/actions.js": 1859,
-      "../../extract-text-webpack-plugin/dist/loader.js??ref--3-0!../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../packages/devtools-reps/src/object-inspector/components/ObjectInspector.css": 1860,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/object-inspector/components/ObjectInspectorItem.js": 1861,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-reps/src/object-inspector/utils/selection.js": 1862,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/pause/mapScopes/positionCmp.js": 1863,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/actions/sources/prettyPrint.js": 1864,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/actions/sources/select.js": 1865,
-      "../../react-lifecycles-compat/react-lifecycles-compat.es.js": 1866,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-splitter/src/SplitBox.js": 1867,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-splitter/src/Draggable.js": 1868,
-      "../../extract-text-webpack-plugin/dist/loader.js??ref--3-0!../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../packages/devtools-splitter/src/SplitBox.css": 1869,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../images/Svg.js": 1870,
-      "../../svg-inline-react/lib/index.js": 1871,
-      "../../svg-inline-react/lib/util.js": 1872,
-      "../../svg-inline-loader/index.js!../../../images/angle-brackets.svg": 1873,
-      "../../svg-inline-loader/index.js!../../../images/angular.svg": 1874,
-      "../../svg-inline-loader/index.js!../../../images/arrow.svg": 1875,
-      "../../svg-inline-loader/index.js!../../../images/babel.svg": 1876,
-      "../../svg-inline-loader/index.js!../../../images/backbone.svg": 1877,
-      "../../svg-inline-loader/index.js!../../../images/blackBox.svg": 1878,
-      "../../svg-inline-loader/index.js!../../../images/breadcrumbs-divider.svg": 1879,
-      "../../svg-inline-loader/index.js!../../../images/breakpoint.svg": 1880,
-      "../../svg-inline-loader/index.js!../../../images/column-breakpoint.svg": 1881,
-      "../../svg-inline-loader/index.js!../../../images/column-marker.svg": 1882,
-      "../../svg-inline-loader/index.js!../../../images/case-match.svg": 1883,
-      "../../svg-inline-loader/index.js!../../../images/choo.svg": 1884,
-      "../../svg-inline-loader/index.js!../../../images/close.svg": 1885,
-      "../../svg-inline-loader/index.js!../../../images/coffeescript.svg": 1886,
-      "../../svg-inline-loader/index.js!../../../images/dojo.svg": 1887,
-      "../../svg-inline-loader/index.js!../../../images/domain.svg": 1888,
-      "../../svg-inline-loader/index.js!../../../images/extension.svg": 1889,
-      "../../svg-inline-loader/index.js!../../../images/file.svg": 1890,
-      "../../svg-inline-loader/index.js!../../../images/folder.svg": 1891,
-      "../../svg-inline-loader/index.js!../../../images/globe.svg": 1892,
-      "../../svg-inline-loader/index.js!../../../images/home.svg": 1893,
-      "../../svg-inline-loader/index.js!../../../images/javascript.svg": 1894,
-      "../../svg-inline-loader/index.js!../../../images/jquery.svg": 1895,
-      "../../svg-inline-loader/index.js!../../../images/underscore.svg": 1896,
-      "../../svg-inline-loader/index.js!../../../images/lodash.svg": 1897,
-      "../../svg-inline-loader/index.js!../../../images/ember.svg": 1898,
-      "../../svg-inline-loader/index.js!../../../images/vuejs.svg": 1899,
-      "../../svg-inline-loader/index.js!../../../images/magnifying-glass.svg": 1900,
-      "../../svg-inline-loader/index.js!../../../images/arrow-up.svg": 1901,
-      "../../svg-inline-loader/index.js!../../../images/arrow-down.svg": 1902,
-      "../../svg-inline-loader/index.js!../../../images/pause.svg": 1903,
-      "../../svg-inline-loader/index.js!../../../images/pause-exceptions.svg": 1904,
-      "../../svg-inline-loader/index.js!../../../images/plus.svg": 1905,
-      "../../svg-inline-loader/index.js!../../../images/preact.svg": 1906,
-      "../../svg-inline-loader/index.js!../../../images/aframe.svg": 1907,
-      "../../svg-inline-loader/index.js!../../../images/prettyPrint.svg": 1908,
-      "../../svg-inline-loader/index.js!../../../images/react.svg": 1909,
-      "../../svg-inline-loader/index.js!../../../images/regex-match.svg": 1910,
-      "../../svg-inline-loader/index.js!../../../images/redux.svg": 1911,
-      "../../svg-inline-loader/index.js!../../../images/immutable.svg": 1912,
-      "../../svg-inline-loader/index.js!../../../images/resume.svg": 1913,
-      "../../svg-inline-loader/index.js!../../../images/settings.svg": 1914,
-      "../../svg-inline-loader/index.js!../../../images/stepIn.svg": 1915,
-      "../../svg-inline-loader/index.js!../../../images/stepOut.svg": 1916,
-      "../../svg-inline-loader/index.js!../../../images/stepOver.svg": 1917,
-      "../../svg-inline-loader/index.js!../../../images/subSettings.svg": 1918,
-      "../../svg-inline-loader/index.js!../../../images/tab.svg": 1919,
-      "../../svg-inline-loader/index.js!../../../images/toggle-breakpoints.svg": 1920,
-      "../../svg-inline-loader/index.js!../../../images/toggle-panes.svg": 1921,
-      "../../svg-inline-loader/index.js!../../../images/typescript.svg": 1922,
-      "../../svg-inline-loader/index.js!../../../images/whole-word-match.svg": 1923,
-      "../../svg-inline-loader/index.js!../../../images/worker.svg": 1924,
-      "../../svg-inline-loader/index.js!../../../images/webpack.svg": 1925,
-      "../../svg-inline-loader/index.js!../../../images/node.svg": 1926,
-      "../../svg-inline-loader/index.js!../../../images/express.svg": 1927,
-      "../../svg-inline-loader/index.js!../../../images/pug.svg": 1928,
-      "../../svg-inline-loader/index.js!../../../images/sencha-extjs.svg": 1929,
-      "../../svg-inline-loader/index.js!../../../images/mobx.svg": 1930,
-      "../../svg-inline-loader/index.js!../../../images/marko.svg": 1931,
-      "../../svg-inline-loader/index.js!../../../images/nextjs.svg": 1932,
-      "../../svg-inline-loader/index.js!../../../images/showSources.svg": 1933,
-      "../../svg-inline-loader/index.js!../../../images/showOutline.svg": 1934,
-      "../../svg-inline-loader/index.js!../../../images/nuxtjs.svg": 1935,
-      "../../svg-inline-loader/index.js!../../../images/rxjs.svg": 1936,
-      "../../svg-inline-loader/index.js!../../../images/loader.svg": 1937,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/components/shared/Button/CommandBarButton.js": 1938,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../react-aria-components/src/tabs/index.js": 1939,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../react-aria-components/src/prop-types/ref.js": 1940,
-      "../../extract-text-webpack-plugin/dist/loader.js??ref--3-0!../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../react-aria-components/src/tabs/tab.css": 1941,
-      "../../extract-text-webpack-plugin/dist/loader.js??ref--3-0!../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../react-aria-components/src/tabs/tab-list.css": 1942,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../react-aria-components/src/tabs/tabs.js": 1943,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../react-aria-components/src/utils/unique-id.js": 1944,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/components/shared/SourceIcon.js": 1945,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/tabs.js": 1946,
-      "../../@babel/types/lib/utils/shallowEqual.js": 1947,
-      "../../@babel/types/lib/definitions/core.js": 1948,
-      "../../@babel/types/lib/validators/is.js": 1949,
-      "../../@babel/types/lib/validators/isType.js": 1950,
-      "../../@babel/types/lib/definitions/es2015.js": 1951,
-      "../../@babel/types/lib/utils/inherit.js": 1952,
-      "../../@babel/generator/lib/generators/types.js": 1953,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-source-map/src/utils/sourceMapRequests.js": 1954,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/pause/frames/getLibraryFromUrl.js": 1955,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/selectors/visiblePausePoints.js": 1956,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/pause/pausePoints.js": 1957,
-      "external \"devtools/client/shared/vendor/redux\"": 1958,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/log.js": 1959,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/pause/mapScopes/filtering.js": 1960,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/pause/mapScopes/mappingContains.js": 1961,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/actions/sources/blackbox.js": 1962,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/actions/pause/mapFrames.js": 1963,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/components/SecondaryPanes/Breakpoints/ExceptionOption.js": 1964,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/components/SecondaryPanes/Frames/FrameIndent.js": 1965,
-      "../../@babel/types/lib/validators/buildMatchMemberExpression.js": 1966,
-      "../../@babel/types/lib/validators/matchesPattern.js": 1967,
-      "../../@babel/types/lib/validators/validate.js": 1968,
-      "../../@babel/types/lib/validators/isNode.js": 1969,
-      "../../@babel/types/lib/modifications/flow/removeTypeDuplicates.js": 1970,
-      "../../@babel/types/lib/clone/clone.js": 1971,
-      "../../@babel/types/lib/comments/addComments.js": 1972,
-      "../../@babel/types/lib/comments/inheritInnerComments.js": 1973,
-      "../../@babel/types/lib/comments/inheritLeadingComments.js": 1974,
-      "../../@babel/types/lib/comments/inheritsComments.js": 1975,
-      "../../@babel/types/lib/comments/inheritTrailingComments.js": 1976,
-      "../../@babel/types/lib/converters/toBlock.js": 1977,
-      "../../@babel/types/lib/converters/toIdentifier.js": 1978,
-      "../../@babel/types/lib/modifications/removePropertiesDeep.js": 1979,
-      "../../@babel/types/lib/traverse/traverseFast.js": 1980,
-      "../../@babel/types/lib/modifications/removeProperties.js": 1981,
-      "../../@babel/types/lib/validators/isLet.js": 1982,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/workers/parser/utils/simple-path.js": 1983,
-      "../../@babel/generator/lib/node/index.js": 1984,
-      "../../@babel/generator/lib/generators/modules.js": 1985,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/workers/parser/getScopes/index.js": 1986,
-      "../../../packages/devtools-source-map/node_modules/source-map/lib/source-map-generator.js": 1987,
-      "../../../packages/devtools-source-map/node_modules/source-map/lib/base64-vlq.js": 1988,
-      "../../webidl-conversions/lib/index.js": 1989,
-      "../../../packages/devtools-source-map/node_modules/whatwg-url/lib/utils.js": 1990,
-      "../../../packages/devtools-source-map/node_modules/whatwg-url/lib/infra.js": 1991,
-      "../../../packages/devtools-source-map/node_modules/whatwg-url/lib/URLSearchParams.js": 1992,
-      "../../../packages/devtools-source-map/node_modules/source-map/lib/array-set.js": 1993,
-      "../../../packages/devtools-source-map/node_modules/source-map/lib/read-wasm-browser.js": 1994,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-source-map/src/utils/createConsumer.js": 1995,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-source-map/src/utils/wasmAssetBrowser.js": 1996,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-source-map/src/utils/wasmXScopes.js": 1997,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/asyncStoreHelper.js": 1998,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/isMinified.js": 1999,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/editor/get-token-location.js": 2000,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/editor/token-events.js": 2001,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/editor/create-editor.js": 2002,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/sources-tree/updateTree.js": 2003,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/memoize.js": 2004,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/selectors/inComponent.js": 2005,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/selectors/getCallStackFrames.js": 2006,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/pause/frames/annotateFrames.js": 2007,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/pause/frames/collapseFrames.js": 2008,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/pause/frames/displayName.js": 2009,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/selectors/visibleSelectedFrame.js": 2010,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/selectors/breakpointSources.js": 2011,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/selectors/breakpoints.js": 2012,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/selectors/visibleColumnBreakpoints.js": 2013,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/client/firefox/workers.js": 2014,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/dbg.js": 2015,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/defer.js": 2016,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/pause/mapScopes/index.js": 2017,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/pause/mapScopes/rangeMetadata.js": 2018,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/pause/mapScopes/findGeneratedBindingFromPosition.js": 2019,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/pause/mapScopes/buildGeneratedBindingList.js": 2020,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/pause/mapScopes/getApplicableBindingsForOriginalPosition.js": 2021,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/actions/sources/newSources.js": 2022,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/actions/ast/setInScopeLines.js": 2023,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/actions/ast/setPausePoints.js": 2024,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/location.js": 2025,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/pause/why.js": 2026,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/pause/stepping.js": 2027,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/actions/pause/setPopupObjectProperties.js": 2028,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/actions/pause/skipPausing.js": 2029,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/actions/preview.js": 2030,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/preview.js": 2031,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/editor/get-expression.js": 2032,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/components/A11yIntention.js": 2033,
-      "../../extract-text-webpack-plugin/dist/loader.js??ref--3-0!../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/A11yIntention.css": 2034,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/components/ProjectSearch.js": 2035,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/project-search.js": 2036,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/components/shared/Button/CloseButton.js": 2037,
-      "../../extract-text-webpack-plugin/dist/loader.js??ref--3-0!../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/shared/AccessibleImage.css": 2038,
-      "../../extract-text-webpack-plugin/dist/loader.js??ref--3-0!../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/shared/Button/styles/CloseButton.css": 2039,
-      "../../extract-text-webpack-plugin/dist/loader.js??ref--3-0!../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/shared/Button/styles/CommandBarButton.css": 2040,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/components/shared/Button/PaneToggleButton.js": 2041,
-      "../../extract-text-webpack-plugin/dist/loader.js??ref--3-0!../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/shared/Button/styles/PaneToggleButton.css": 2042,
-      "../../extract-text-webpack-plugin/dist/loader.js??ref--3-0!../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/ProjectSearch.css": 2043,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/components/PrimaryPanes/OutlineFilter.js": 2044,
-      "../../extract-text-webpack-plugin/dist/loader.js??ref--3-0!../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/PrimaryPanes/OutlineFilter.css": 2045,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/components/PrimaryPanes/SourcesTreeItem.js": 2046,
-      "../../extract-text-webpack-plugin/dist/loader.js??ref--3-0!../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/shared/SourceIcon.css": 2047,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/components/Editor/ColumnBreakpoints.js": 2048,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/components/Editor/ColumnBreakpoint.js": 2049,
-      "../../extract-text-webpack-plugin/dist/loader.js??ref--3-0!../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/Editor/ColumnBreakpoints.css": 2050,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/components/Editor/HighlightLine.js": 2051,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/components/SecondaryPanes/Breakpoints/index.js": 2052,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/components/SecondaryPanes/Breakpoints/Breakpoint.js": 2053,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/components/SecondaryPanes/Breakpoints/BreakpointsContextMenu.js": 2054,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/components/SecondaryPanes/Breakpoints/BreakpointHeading.js": 2055,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/components/SecondaryPanes/Breakpoints/BreakpointHeadingsContextMenu.js": 2056,
-      "../../extract-text-webpack-plugin/dist/loader.js??ref--3-0!../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/SecondaryPanes/Breakpoints/Breakpoints.css": 2057,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/components/SecondaryPanes/Worker.js": 2058,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/components/SecondaryPanes/XHRBreakpoints.js": 2059,
-      "../../extract-text-webpack-plugin/dist/loader.js??ref--3-0!../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/SecondaryPanes/XHRBreakpoints.css": 2060,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/pause/scopes/index.js": 2061,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/pause/scopes/getScope.js": 2062,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/pause/scopes/getVariables.js": 2063,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/utils/pause/scopes/utils.js": 2064,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/components/Editor/Tab.js": 2065,
-      "../../extract-text-webpack-plugin/dist/loader.js??ref--3-0!../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/QuickOpenModal.css": 2066,
-      "../../@babel/types/lib/validators/react/isReactComponent.js": 2067,
-      "../../@babel/types/lib/validators/react/isCompatTag.js": 2068,
-      "../../@babel/types/lib/builders/react/buildChildren.js": 2069,
-      "../../@babel/types/lib/utils/react/cleanJSXElementLiteralChild.js": 2070,
-      "../../@babel/types/lib/builders/builder.js": 2071,
-      "../../lodash/isMap.js": 2072,
-      "../../lodash/_baseIsMap.js": 2073,
-      "../../lodash/isSet.js": 2074,
-      "../../lodash/_baseIsSet.js": 2075,
-      "../../@babel/types/lib/definitions/flow.js": 2076,
-      "../../@babel/types/lib/definitions/jsx.js": 2077,
-      "../../@babel/types/lib/definitions/misc.js": 2078,
-      "../../@babel/types/lib/definitions/experimental.js": 2079,
-      "../../@babel/types/lib/definitions/typescript.js": 2080,
-      "../../@babel/types/lib/asserts/assertNode.js": 2081,
-      "../../@babel/types/lib/asserts/generated/index.js": 2082,
-      "../../@babel/types/lib/builders/flow/createTypeAnnotationBasedOnTypeof.js": 2083,
-      "../../@babel/types/lib/builders/flow/createUnionTypeAnnotation.js": 2084,
-      "../../@babel/types/lib/clone/cloneDeep.js": 2085,
-      "../../@babel/types/lib/clone/cloneWithoutLoc.js": 2086,
-      "../../@babel/types/lib/comments/addComment.js": 2087,
-      "../../@babel/types/lib/comments/removeComments.js": 2088,
-      "../../@babel/types/lib/constants/generated/index.js": 2089,
-      "../../@babel/types/lib/converters/ensureBlock.js": 2090,
-      "../../@babel/types/lib/converters/toBindingIdentifierName.js": 2091,
-      "../../@babel/types/lib/converters/toComputedKey.js": 2092,
-      "../../@babel/types/lib/converters/toExpression.js": 2093,
-      "../../@babel/types/lib/converters/toKeyAlias.js": 2094,
-      "../../@babel/types/lib/converters/toSequenceExpression.js": 2095,
-      "../../@babel/types/lib/converters/gatherSequenceExpressions.js": 2096,
-      "../../@babel/types/lib/converters/toStatement.js": 2097,
-      "../../@babel/types/lib/converters/valueToNode.js": 2098,
-      "../../@babel/types/lib/modifications/appendToMemberExpression.js": 2099,
-      "../../@babel/types/lib/modifications/inherits.js": 2100,
-      "../../@babel/types/lib/modifications/prependToMemberExpression.js": 2101,
-      "../../@babel/types/lib/retrievers/getOuterBindingIdentifiers.js": 2102,
-      "../../@babel/types/lib/traverse/traverse.js": 2103,
-      "../../@babel/types/lib/validators/isBinding.js": 2104,
-      "../../@babel/types/lib/validators/isBlockScoped.js": 2105,
-      "../../@babel/types/lib/validators/isImmutable.js": 2106,
-      "../../@babel/types/lib/validators/isNodesEquivalent.js": 2107,
-      "../../@babel/types/lib/validators/isReferenced.js": 2108,
-      "../../@babel/types/lib/validators/isScope.js": 2109,
-      "../../@babel/types/lib/validators/isSpecifierDefault.js": 2110,
-      "../../@babel/types/lib/validators/isValidES3Identifier.js": 2111,
-      "../../@babel/types/lib/validators/isVar.js": 2112,
-      "../../parse-script-tags/node_modules/babylon/lib/index.js": 2113,
-      "../../parse-script-tags/customParse.js": 2114,
-      "../../parse-script-tags/parseScriptFragment.js": 2115,
-      "../../@babel/parser/lib/index.js": 2116,
-      "../../@babel/generator/lib/source-map.js": 2117,
-      "../../@babel/generator/lib/printer.js": 2118,
-      "../../@babel/generator/lib/buffer.js": 2119,
-      "../../@babel/generator/lib/node/whitespace.js": 2120,
-      "../../@babel/generator/lib/node/parentheses.js": 2121,
-      "../../@babel/generator/lib/generators/index.js": 2122,
-      "../../@babel/generator/lib/generators/template-literals.js": 2123,
-      "../../@babel/generator/lib/generators/expressions.js": 2124,
-      "../../@babel/generator/lib/generators/statements.js": 2125,
-      "../../@babel/generator/lib/generators/classes.js": 2126,
-      "../../@babel/generator/lib/generators/methods.js": 2127,
-      "../../jsesc/jsesc.js": 2128,
-      "../../@babel/generator/lib/generators/flow.js": 2129,
-      "../../@babel/generator/lib/generators/base.js": 2130,
-      "../../@babel/generator/lib/generators/jsx.js": 2131,
-      "../../@babel/generator/lib/generators/typescript.js": 2132,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/workers/parser/getScopes/visitor.js": 2133,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/workers/parser/pausePoints.js": 2134,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/workers/parser/mapExpression.js": 2135,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/workers/parser/mapOriginalExpression.js": 2136,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/workers/parser/mapBindings.js": 2137,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/workers/parser/mapAwaitExpression.js": 2138,
-      "multi ../../../packages/devtools-source-map/src/worker.js": 2139,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-source-map/src/worker.js": 2140,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-source-map/src/source-map.js": 2141,
-      "../../../packages/devtools-source-map/node_modules/source-map/lib/base64.js": 2142,
-      "../../../packages/devtools-source-map/node_modules/source-map/lib/url-browser.js": 2143,
-      "../../../packages/devtools-source-map/node_modules/whatwg-url/lib/public-api.js": 2144,
-      "../../../packages/devtools-source-map/node_modules/whatwg-url/lib/URL.js": 2145,
-      "../../../packages/devtools-source-map/node_modules/whatwg-url/lib/URL-impl.js": 2146,
-      "../../tr46/index.js": 2147,
-      "../../tr46/lib/regexes.js": 2148,
-      "../../json-loader/index.js!../../tr46/lib/mappingTable.json": 2149,
-      "../../../packages/devtools-source-map/node_modules/whatwg-url/lib/URLSearchParams-impl.js": 2150,
-      "../../lodash.sortby/index.js": 2151,
-      "../../../packages/devtools-source-map/node_modules/source-map/lib/mapping-list.js": 2152,
-      "../../../packages/devtools-source-map/node_modules/source-map/lib/source-map-consumer.js": 2153,
-      "../../../packages/devtools-source-map/node_modules/source-map/lib/binary-search.js": 2154,
-      "../../../packages/devtools-source-map/node_modules/source-map/lib/wasm.js": 2155,
-      "../../../packages/devtools-source-map/node_modules/source-map/lib/source-node.js": 2156,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-source-map/src/utils/assert.js": 2157,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-source-map/src/utils/fetchSourceMap.js": 2158,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-source-map/src/utils/wasmRemap.js": 2159,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-source-map/src/utils/convertToJSON.js": 2160,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../packages/devtools-source-map/src/utils/getOriginalStackFrames.js": 2161,
-      "multi ../../../packages/devtools-source-map/src/index.js": 2162,
-      "multi ../../../src/vendors.js": 2163,
-      "../../babel-loader/lib/index.js?ignore=src/lib!../../../src/vendors.js": 2164,
-      "multi ../../../packages/devtools-reps/src/index.js": 2165
+      "../../parse5/lib/sax/parser_feedback_simulator.js": 1755
     },
     "usedIds": {
       "0": 0,
@@ -22742,415 +22334,7 @@
       "1754": 1754,
       "1755": 1755,
       "1756": 1756,
-      "1757": 1757,
-      "1758": 1758,
-      "1759": 1759,
-      "1760": 1760,
-      "1761": 1761,
-      "1762": 1762,
-      "1763": 1763,
-      "1764": 1764,
-      "1765": 1765,
-      "1766": 1766,
-      "1767": 1767,
-      "1768": 1768,
-      "1769": 1769,
-      "1770": 1770,
-      "1771": 1771,
-      "1772": 1772,
-      "1773": 1773,
-      "1774": 1774,
-      "1775": 1775,
-      "1776": 1776,
-      "1777": 1777,
-      "1778": 1778,
-      "1779": 1779,
-      "1780": 1780,
-      "1781": 1781,
-      "1782": 1782,
-      "1783": 1783,
-      "1784": 1784,
-      "1785": 1785,
-      "1786": 1786,
-      "1787": 1787,
-      "1788": 1788,
-      "1789": 1789,
-      "1790": 1790,
-      "1791": 1791,
-      "1792": 1792,
-      "1793": 1793,
-      "1794": 1794,
-      "1795": 1795,
-      "1796": 1796,
-      "1797": 1797,
-      "1798": 1798,
-      "1799": 1799,
-      "1800": 1800,
-      "1801": 1801,
-      "1802": 1802,
-      "1803": 1803,
-      "1804": 1804,
-      "1805": 1805,
-      "1806": 1806,
-      "1807": 1807,
-      "1808": 1808,
-      "1809": 1809,
-      "1810": 1810,
-      "1811": 1811,
-      "1812": 1812,
-      "1813": 1813,
-      "1814": 1814,
-      "1815": 1815,
-      "1816": 1816,
-      "1817": 1817,
-      "1818": 1818,
-      "1819": 1819,
-      "1820": 1820,
-      "1821": 1821,
-      "1822": 1822,
-      "1823": 1823,
-      "1824": 1824,
-      "1825": 1825,
-      "1826": 1826,
-      "1827": 1827,
-      "1828": 1828,
-      "1829": 1829,
-      "1830": 1830,
-      "1831": 1831,
-      "1832": 1832,
-      "1833": 1833,
-      "1834": 1834,
-      "1835": 1835,
-      "1836": 1836,
-      "1837": 1837,
-      "1838": 1838,
-      "1839": 1839,
-      "1840": 1840,
-      "1841": 1841,
-      "1842": 1842,
-      "1843": 1843,
-      "1844": 1844,
-      "1845": 1845,
-      "1846": 1846,
-      "1847": 1847,
-      "1848": 1848,
-      "1849": 1849,
-      "1850": 1850,
-      "1851": 1851,
-      "1852": 1852,
-      "1853": 1853,
-      "1854": 1854,
-      "1855": 1855,
-      "1856": 1856,
-      "1857": 1857,
-      "1858": 1858,
-      "1859": 1859,
-      "1860": 1860,
-      "1861": 1861,
-      "1862": 1862,
-      "1863": 1863,
-      "1864": 1864,
-      "1865": 1865,
-      "1866": 1866,
-      "1867": 1867,
-      "1868": 1868,
-      "1869": 1869,
-      "1870": 1870,
-      "1871": 1871,
-      "1872": 1872,
-      "1873": 1873,
-      "1874": 1874,
-      "1875": 1875,
-      "1876": 1876,
-      "1877": 1877,
-      "1878": 1878,
-      "1879": 1879,
-      "1880": 1880,
-      "1881": 1881,
-      "1882": 1882,
-      "1883": 1883,
-      "1884": 1884,
-      "1885": 1885,
-      "1886": 1886,
-      "1887": 1887,
-      "1888": 1888,
-      "1889": 1889,
-      "1890": 1890,
-      "1891": 1891,
-      "1892": 1892,
-      "1893": 1893,
-      "1894": 1894,
-      "1895": 1895,
-      "1896": 1896,
-      "1897": 1897,
-      "1898": 1898,
-      "1899": 1899,
-      "1900": 1900,
-      "1901": 1901,
-      "1902": 1902,
-      "1903": 1903,
-      "1904": 1904,
-      "1905": 1905,
-      "1906": 1906,
-      "1907": 1907,
-      "1908": 1908,
-      "1909": 1909,
-      "1910": 1910,
-      "1911": 1911,
-      "1912": 1912,
-      "1913": 1913,
-      "1914": 1914,
-      "1915": 1915,
-      "1916": 1916,
-      "1917": 1917,
-      "1918": 1918,
-      "1919": 1919,
-      "1920": 1920,
-      "1921": 1921,
-      "1922": 1922,
-      "1923": 1923,
-      "1924": 1924,
-      "1925": 1925,
-      "1926": 1926,
-      "1927": 1927,
-      "1928": 1928,
-      "1929": 1929,
-      "1930": 1930,
-      "1931": 1931,
-      "1932": 1932,
-      "1933": 1933,
-      "1934": 1934,
-      "1935": 1935,
-      "1936": 1936,
-      "1937": 1937,
-      "1938": 1938,
-      "1939": 1939,
-      "1940": 1940,
-      "1941": 1941,
-      "1942": 1942,
-      "1943": 1943,
-      "1944": 1944,
-      "1945": 1945,
-      "1946": 1946,
-      "1947": 1947,
-      "1948": 1948,
-      "1949": 1949,
-      "1950": 1950,
-      "1951": 1951,
-      "1952": 1952,
-      "1953": 1953,
-      "1954": 1954,
-      "1955": 1955,
-      "1956": 1956,
-      "1957": 1957,
-      "1958": 1958,
-      "1959": 1959,
-      "1960": 1960,
-      "1961": 1961,
-      "1962": 1962,
-      "1963": 1963,
-      "1964": 1964,
-      "1965": 1965,
-      "1966": 1966,
-      "1967": 1967,
-      "1968": 1968,
-      "1969": 1969,
-      "1970": 1970,
-      "1971": 1971,
-      "1972": 1972,
-      "1973": 1973,
-      "1974": 1974,
-      "1975": 1975,
-      "1976": 1976,
-      "1977": 1977,
-      "1978": 1978,
-      "1979": 1979,
-      "1980": 1980,
-      "1981": 1981,
-      "1982": 1982,
-      "1983": 1983,
-      "1984": 1984,
-      "1985": 1985,
-      "1986": 1986,
-      "1987": 1987,
-      "1988": 1988,
-      "1989": 1989,
-      "1990": 1990,
-      "1991": 1991,
-      "1992": 1992,
-      "1993": 1993,
-      "1994": 1994,
-      "1995": 1995,
-      "1996": 1996,
-      "1997": 1997,
-      "1998": 1998,
-      "1999": 1999,
-      "2000": 2000,
-      "2001": 2001,
-      "2002": 2002,
-      "2003": 2003,
-      "2004": 2004,
-      "2005": 2005,
-      "2006": 2006,
-      "2007": 2007,
-      "2008": 2008,
-      "2009": 2009,
-      "2010": 2010,
-      "2011": 2011,
-      "2012": 2012,
-      "2013": 2013,
-      "2014": 2014,
-      "2015": 2015,
-      "2016": 2016,
-      "2017": 2017,
-      "2018": 2018,
-      "2019": 2019,
-      "2020": 2020,
-      "2021": 2021,
-      "2022": 2022,
-      "2023": 2023,
-      "2024": 2024,
-      "2025": 2025,
-      "2026": 2026,
-      "2027": 2027,
-      "2028": 2028,
-      "2029": 2029,
-      "2030": 2030,
-      "2031": 2031,
-      "2032": 2032,
-      "2033": 2033,
-      "2034": 2034,
-      "2035": 2035,
-      "2036": 2036,
-      "2037": 2037,
-      "2038": 2038,
-      "2039": 2039,
-      "2040": 2040,
-      "2041": 2041,
-      "2042": 2042,
-      "2043": 2043,
-      "2044": 2044,
-      "2045": 2045,
-      "2046": 2046,
-      "2047": 2047,
-      "2048": 2048,
-      "2049": 2049,
-      "2050": 2050,
-      "2051": 2051,
-      "2052": 2052,
-      "2053": 2053,
-      "2054": 2054,
-      "2055": 2055,
-      "2056": 2056,
-      "2057": 2057,
-      "2058": 2058,
-      "2059": 2059,
-      "2060": 2060,
-      "2061": 2061,
-      "2062": 2062,
-      "2063": 2063,
-      "2064": 2064,
-      "2065": 2065,
-      "2066": 2066,
-      "2067": 2067,
-      "2068": 2068,
-      "2069": 2069,
-      "2070": 2070,
-      "2071": 2071,
-      "2072": 2072,
-      "2073": 2073,
-      "2074": 2074,
-      "2075": 2075,
-      "2076": 2076,
-      "2077": 2077,
-      "2078": 2078,
-      "2079": 2079,
-      "2080": 2080,
-      "2081": 2081,
-      "2082": 2082,
-      "2083": 2083,
-      "2084": 2084,
-      "2085": 2085,
-      "2086": 2086,
-      "2087": 2087,
-      "2088": 2088,
-      "2089": 2089,
-      "2090": 2090,
-      "2091": 2091,
-      "2092": 2092,
-      "2093": 2093,
-      "2094": 2094,
-      "2095": 2095,
-      "2096": 2096,
-      "2097": 2097,
-      "2098": 2098,
-      "2099": 2099,
-      "2100": 2100,
-      "2101": 2101,
-      "2102": 2102,
-      "2103": 2103,
-      "2104": 2104,
-      "2105": 2105,
-      "2106": 2106,
-      "2107": 2107,
-      "2108": 2108,
-      "2109": 2109,
-      "2110": 2110,
-      "2111": 2111,
-      "2112": 2112,
-      "2113": 2113,
-      "2114": 2114,
-      "2115": 2115,
-      "2116": 2116,
-      "2117": 2117,
-      "2118": 2118,
-      "2119": 2119,
-      "2120": 2120,
-      "2121": 2121,
-      "2122": 2122,
-      "2123": 2123,
-      "2124": 2124,
-      "2125": 2125,
-      "2126": 2126,
-      "2127": 2127,
-      "2128": 2128,
-      "2129": 2129,
-      "2130": 2130,
-      "2131": 2131,
-      "2132": 2132,
-      "2133": 2133,
-      "2134": 2134,
-      "2135": 2135,
-      "2136": 2136,
-      "2137": 2137,
-      "2138": 2138,
-      "2139": 2139,
-      "2140": 2140,
-      "2141": 2141,
-      "2142": 2142,
-      "2143": 2143,
-      "2144": 2144,
-      "2145": 2145,
-      "2146": 2146,
-      "2147": 2147,
-      "2148": 2148,
-      "2149": 2149,
-      "2150": 2150,
-      "2151": 2151,
-      "2152": 2152,
-      "2153": 2153,
-      "2154": 2154,
-      "2155": 2155,
-      "2156": 2156,
-      "2157": 2157,
-      "2158": 2158,
-      "2159": 2159,
-      "2160": 2160,
-      "2161": 2161,
-      "2162": 2162,
-      "2163": 2163,
-      "2164": 2164,
-      "2165": 2165
+      "1757": 1757
     }
   },
   "chunks": {
@@ -23160,20 +22344,14 @@
       "pretty-print-worker": 2,
       "source-map-worker": 3,
       "parser-worker": 4,
-      "search-worker": 5,
-      "vendors": 1,
-      "reps": 3,
-      "source-map-index": 6
+      "search-worker": 5
     },
     "byBlocks": {},
     "usedIds": {
       "0": 0,
-      "1": 1,
       "2": 2,
-      "3": 3,
       "4": 4,
-      "5": 5,
-      "6": 6
+      "5": 5
     }
   },
   "extract-text-webpack-plugin ../../extract-text-webpack-plugin/dist ../../css-loader/index.js??ref--4-2!../../postcss-loader/lib/index.js??ref--4-3!../../../src/components/variables.css": [
@@ -26352,20 +25530,18 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/variables.css": 0,
-          "../../css-loader/lib/css-base.js": 1,
-          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/variables.css": 2
+          "../../css-loader/lib/css-base.js": 1
         },
         "usedIds": {
           "0": 0,
-          "1": 1,
-          "2": 2
+          "1": 1
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "0": 0
+          "1": 1
         }
       }
     }
@@ -26375,20 +25551,18 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/App.css": 0,
-          "../../css-loader/lib/css-base.js": 1,
-          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/App.css": 2
+          "../../css-loader/lib/css-base.js": 1
         },
         "usedIds": {
           "0": 0,
-          "1": 1,
-          "2": 2
+          "1": 1
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "0": 0
+          "1": 1
         }
       }
     }
@@ -26398,20 +25572,18 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/shared/menu.css": 0,
-          "../../css-loader/lib/css-base.js": 1,
-          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/shared/menu.css": 2
+          "../../css-loader/lib/css-base.js": 1
         },
         "usedIds": {
           "0": 0,
-          "1": 1,
-          "2": 2
+          "1": 1
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "0": 0
+          "1": 1
         }
       }
     }
@@ -26421,20 +25593,18 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/shared/reps.css": 0,
-          "../../css-loader/lib/css-base.js": 1,
-          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/shared/reps.css": 2
+          "../../css-loader/lib/css-base.js": 1
         },
         "usedIds": {
           "0": 0,
-          "1": 1,
-          "2": 2
+          "1": 1
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "0": 0
+          "1": 1
         }
       }
     }
@@ -26465,20 +25635,18 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/shared/SearchInput.css": 0,
-          "../../css-loader/lib/css-base.js": 1,
-          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/shared/SearchInput.css": 2
+          "../../css-loader/lib/css-base.js": 1
         },
         "usedIds": {
           "0": 0,
-          "1": 1,
-          "2": 2
+          "1": 1
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "0": 0
+          "1": 1
         }
       }
     }
@@ -26509,20 +25677,18 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/shared/Svg.css": 0,
-          "../../css-loader/lib/css-base.js": 1,
-          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/shared/Svg.css": 2
+          "../../css-loader/lib/css-base.js": 1
         },
         "usedIds": {
           "0": 0,
-          "1": 1,
-          "2": 2
+          "1": 1
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "0": 0
+          "1": 1
         }
       }
     }
@@ -26532,20 +25698,18 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/shared/Modal.css": 0,
-          "../../css-loader/lib/css-base.js": 1,
-          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/shared/Modal.css": 2
+          "../../css-loader/lib/css-base.js": 1
         },
         "usedIds": {
           "0": 0,
-          "1": 1,
-          "2": 2
+          "1": 1
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "0": 0
+          "1": 1
         }
       }
     }
@@ -26555,20 +25719,18 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/shared/ResultList.css": 0,
-          "../../css-loader/lib/css-base.js": 1,
-          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/shared/ResultList.css": 2
+          "../../css-loader/lib/css-base.js": 1
         },
         "usedIds": {
           "0": 0,
-          "1": 1,
-          "2": 2
+          "1": 1
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "0": 0
+          "1": 1
         }
       }
     }
@@ -26578,20 +25740,18 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/Editor/Tabs.css": 0,
-          "../../css-loader/lib/css-base.js": 1,
-          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/Editor/Tabs.css": 2
+          "../../css-loader/lib/css-base.js": 1
         },
         "usedIds": {
           "0": 0,
-          "1": 1,
-          "2": 2
+          "1": 1
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "0": 0
+          "1": 1
         }
       }
     }
@@ -26601,20 +25761,18 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/shared/Dropdown.css": 0,
-          "../../css-loader/lib/css-base.js": 1,
-          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/shared/Dropdown.css": 2
+          "../../css-loader/lib/css-base.js": 1
         },
         "usedIds": {
           "0": 0,
-          "1": 1,
-          "2": 2
+          "1": 1
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "0": 0
+          "1": 1
         }
       }
     }
@@ -26645,20 +25803,18 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/WelcomeBox.css": 0,
-          "../../css-loader/lib/css-base.js": 1,
-          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/WelcomeBox.css": 2
+          "../../css-loader/lib/css-base.js": 1
         },
         "usedIds": {
           "0": 0,
-          "1": 1,
-          "2": 2
+          "1": 1
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "0": 0
+          "1": 1
         }
       }
     }
@@ -26668,20 +25824,18 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/SecondaryPanes/SecondaryPanes.css": 0,
-          "../../css-loader/lib/css-base.js": 1,
-          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/SecondaryPanes/SecondaryPanes.css": 2
+          "../../css-loader/lib/css-base.js": 1
         },
         "usedIds": {
           "0": 0,
-          "1": 1,
-          "2": 2
+          "1": 1
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "0": 0
+          "1": 1
         }
       }
     }
@@ -26691,20 +25845,18 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/SecondaryPanes/Scopes.css": 0,
-          "../../css-loader/lib/css-base.js": 1,
-          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/SecondaryPanes/Scopes.css": 2
+          "../../css-loader/lib/css-base.js": 1
         },
         "usedIds": {
           "0": 0,
-          "1": 1,
-          "2": 2
+          "1": 1
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "0": 0
+          "1": 1
         }
       }
     }
@@ -26756,20 +25908,18 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/shared/ManagedTree.css": 0,
-          "../../css-loader/lib/css-base.js": 1,
-          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/shared/ManagedTree.css": 2
+          "../../css-loader/lib/css-base.js": 1
         },
         "usedIds": {
           "0": 0,
-          "1": 1,
-          "2": 2
+          "1": 1
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "0": 0
+          "1": 1
         }
       }
     }
@@ -26779,20 +25929,18 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/SecondaryPanes/CommandBar.css": 0,
-          "../../css-loader/lib/css-base.js": 1,
-          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/SecondaryPanes/CommandBar.css": 2
+          "../../css-loader/lib/css-base.js": 1
         },
         "usedIds": {
           "0": 0,
-          "1": 1,
-          "2": 2
+          "1": 1
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "0": 0
+          "1": 1
         }
       }
     }
@@ -26802,20 +25950,18 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/shared/Accordion.css": 0,
-          "../../css-loader/lib/css-base.js": 1,
-          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/shared/Accordion.css": 2
+          "../../css-loader/lib/css-base.js": 1
         },
         "usedIds": {
           "0": 0,
-          "1": 1,
-          "2": 2
+          "1": 1
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "0": 0
+          "1": 1
         }
       }
     }
@@ -26825,20 +25971,18 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/SecondaryPanes/Workers.css": 0,
-          "../../css-loader/lib/css-base.js": 1,
-          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/SecondaryPanes/Workers.css": 2
+          "../../css-loader/lib/css-base.js": 1
         },
         "usedIds": {
           "0": 0,
-          "1": 1,
-          "2": 2
+          "1": 1
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "0": 0
+          "1": 1
         }
       }
     }
@@ -26869,20 +26013,18 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/SecondaryPanes/Frames/Frames.css": 0,
-          "../../css-loader/lib/css-base.js": 1,
-          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/SecondaryPanes/Frames/Frames.css": 2
+          "../../css-loader/lib/css-base.js": 1
         },
         "usedIds": {
           "0": 0,
-          "1": 1,
-          "2": 2
+          "1": 1
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "0": 0
+          "1": 1
         }
       }
     }
@@ -26892,20 +26034,18 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/SecondaryPanes/Frames/WhyPaused.css": 0,
-          "../../css-loader/lib/css-base.js": 1,
-          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/SecondaryPanes/Frames/WhyPaused.css": 2
+          "../../css-loader/lib/css-base.js": 1
         },
         "usedIds": {
           "0": 0,
-          "1": 1,
-          "2": 2
+          "1": 1
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "0": 0
+          "1": 1
         }
       }
     }
@@ -26915,20 +26055,18 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/SecondaryPanes/Frames/Group.css": 0,
-          "../../css-loader/lib/css-base.js": 1,
-          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/SecondaryPanes/Frames/Group.css": 2
+          "../../css-loader/lib/css-base.js": 1
         },
         "usedIds": {
           "0": 0,
-          "1": 1,
-          "2": 2
+          "1": 1
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "0": 0
+          "1": 1
         }
       }
     }
@@ -26938,20 +26076,18 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/SecondaryPanes/Expressions.css": 0,
-          "../../css-loader/lib/css-base.js": 1,
-          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/SecondaryPanes/Expressions.css": 2
+          "../../css-loader/lib/css-base.js": 1
         },
         "usedIds": {
           "0": 0,
-          "1": 1,
-          "2": 2
+          "1": 1
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "0": 0
+          "1": 1
         }
       }
     }
@@ -26982,20 +26118,18 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/Editor/Editor.css": 0,
-          "../../css-loader/lib/css-base.js": 1,
-          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/Editor/Editor.css": 2
+          "../../css-loader/lib/css-base.js": 1
         },
         "usedIds": {
           "0": 0,
-          "1": 1,
-          "2": 2
+          "1": 1
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "0": 0
+          "1": 1
         }
       }
     }
@@ -27005,20 +26139,18 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/Editor/Highlight.css": 0,
-          "../../css-loader/lib/css-base.js": 1,
-          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/Editor/Highlight.css": 2
+          "../../css-loader/lib/css-base.js": 1
         },
         "usedIds": {
           "0": 0,
-          "1": 1,
-          "2": 2
+          "1": 1
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "0": 0
+          "1": 1
         }
       }
     }
@@ -27028,20 +26160,18 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/Editor/ConditionalPanel.css": 0,
-          "../../css-loader/lib/css-base.js": 1,
-          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/Editor/ConditionalPanel.css": 2
+          "../../css-loader/lib/css-base.js": 1
         },
         "usedIds": {
           "0": 0,
-          "1": 1,
-          "2": 2
+          "1": 1
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "0": 0
+          "1": 1
         }
       }
     }
@@ -27093,20 +26223,18 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/Editor/Preview/Popup.css": 0,
-          "../../css-loader/lib/css-base.js": 1,
-          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/Editor/Preview/Popup.css": 2
+          "../../css-loader/lib/css-base.js": 1
         },
         "usedIds": {
           "0": 0,
-          "1": 1,
-          "2": 2
+          "1": 1
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "0": 0
+          "1": 1
         }
       }
     }
@@ -27116,20 +26244,18 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/shared/PreviewFunction.css": 0,
-          "../../css-loader/lib/css-base.js": 1,
-          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/shared/PreviewFunction.css": 2
+          "../../css-loader/lib/css-base.js": 1
         },
         "usedIds": {
           "0": 0,
-          "1": 1,
-          "2": 2
+          "1": 1
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "0": 0
+          "1": 1
         }
       }
     }
@@ -27139,20 +26265,18 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/shared/Popover.css": 0,
-          "../../css-loader/lib/css-base.js": 1,
-          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/shared/Popover.css": 2
+          "../../css-loader/lib/css-base.js": 1
         },
         "usedIds": {
           "0": 0,
-          "1": 1,
-          "2": 2
+          "1": 1
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "0": 0
+          "1": 1
         }
       }
     }
@@ -27162,20 +26286,18 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/shared/BracketArrow.css": 0,
-          "../../css-loader/lib/css-base.js": 1,
-          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/shared/BracketArrow.css": 2
+          "../../css-loader/lib/css-base.js": 1
         },
         "usedIds": {
           "0": 0,
-          "1": 1,
-          "2": 2
+          "1": 1
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "0": 0
+          "1": 1
         }
       }
     }
@@ -27185,20 +26307,18 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/Editor/SearchBar.css": 0,
-          "../../css-loader/lib/css-base.js": 1,
-          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/Editor/SearchBar.css": 2
+          "../../css-loader/lib/css-base.js": 1
         },
         "usedIds": {
           "0": 0,
-          "1": 1,
-          "2": 2
+          "1": 1
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "0": 0
+          "1": 1
         }
       }
     }
@@ -27208,20 +26328,18 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/Editor/Footer.css": 0,
-          "../../css-loader/lib/css-base.js": 1,
-          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/Editor/Footer.css": 2
+          "../../css-loader/lib/css-base.js": 1
         },
         "usedIds": {
           "0": 0,
-          "1": 1,
-          "2": 2
+          "1": 1
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "0": 0
+          "1": 1
         }
       }
     }
@@ -27231,20 +26349,18 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/PrimaryPanes/Sources.css": 0,
-          "../../css-loader/lib/css-base.js": 1,
-          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/PrimaryPanes/Sources.css": 2
+          "../../css-loader/lib/css-base.js": 1
         },
         "usedIds": {
           "0": 0,
-          "1": 1,
-          "2": 2
+          "1": 1
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "0": 0
+          "1": 1
         }
       }
     }
@@ -27254,20 +26370,18 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/PrimaryPanes/Outline.css": 0,
-          "../../css-loader/lib/css-base.js": 1,
-          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/PrimaryPanes/Outline.css": 2
+          "../../css-loader/lib/css-base.js": 1
         },
         "usedIds": {
           "0": 0,
-          "1": 1,
-          "2": 2
+          "1": 1
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "0": 0
+          "1": 1
         }
       }
     }
@@ -27361,20 +26475,18 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/ShortcutsModal.css": 0,
-          "../../css-loader/lib/css-base.js": 1,
-          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/ShortcutsModal.css": 2
+          "../../css-loader/lib/css-base.js": 1
         },
         "usedIds": {
           "0": 0,
-          "1": 1,
-          "2": 2
+          "1": 1
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "0": 0
+          "1": 1
         }
       }
     }
@@ -27384,20 +26496,18 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!components/Root.css": 0,
-          "../../css-loader/lib/css-base.js": 1,
-          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!components/Root.css": 2
+          "../../css-loader/lib/css-base.js": 1
         },
         "usedIds": {
           "0": 0,
-          "1": 1,
-          "2": 2
+          "1": 1
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "0": 0
+          "1": 1
         }
       }
     }
@@ -27407,20 +26517,18 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../devtools-contextmenu/menu.css": 0,
-          "../../css-loader/lib/css-base.js": 1,
-          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../devtools-contextmenu/menu.css": 2
+          "../../css-loader/lib/css-base.js": 1
         },
         "usedIds": {
           "0": 0,
-          "1": 1,
-          "2": 2
+          "1": 1
         }
       },
       "chunks": {
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "0": 0
+          "1": 1
         }
       }
     }
@@ -27493,29 +26601,6 @@
       "modules": {
         "byIdentifier": {
           "../../css-loader/index.js?{\"importLoaders\":1,\"url\":false}!../../postcss-loader/lib/index.js!../../../src/components/shared/Badge.css": 0,
-          "../../css-loader/lib/css-base.js": 1,
-          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/shared/Badge.css": 2
-        },
-        "usedIds": {
-          "0": 0,
-          "1": 1,
-          "2": 2
-        }
-      },
-      "chunks": {
-        "byName": {},
-        "byBlocks": {},
-        "usedIds": {
-          "0": 0
-        }
-      }
-    }
-  ],
-  "extract-text-webpack-plugin ../../extract-text-webpack-plugin/dist ../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/QuickOpenModal.css": [
-    {
-      "modules": {
-        "byIdentifier": {
-          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/QuickOpenModal.css": 0,
           "../../css-loader/lib/css-base.js": 1
         },
         "usedIds": {
@@ -27527,364 +26612,7 @@
         "byName": {},
         "byBlocks": {},
         "usedIds": {
-          "0": 0
-        }
-      }
-    }
-  ],
-  "extract-text-webpack-plugin ../../extract-text-webpack-plugin/dist ../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/shared/AccessibleImage.css": [
-    {
-      "modules": {
-        "byIdentifier": {
-          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/shared/AccessibleImage.css": 0,
-          "../../css-loader/lib/css-base.js": 1
-        },
-        "usedIds": {
-          "0": 0,
           "1": 1
-        }
-      },
-      "chunks": {
-        "byName": {},
-        "byBlocks": {},
-        "usedIds": {
-          "0": 0
-        }
-      }
-    }
-  ],
-  "extract-text-webpack-plugin ../../extract-text-webpack-plugin/dist ../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/shared/Button/styles/PaneToggleButton.css": [
-    {
-      "modules": {
-        "byIdentifier": {
-          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/shared/Button/styles/PaneToggleButton.css": 0,
-          "../../css-loader/lib/css-base.js": 1
-        },
-        "usedIds": {
-          "0": 0,
-          "1": 1
-        }
-      },
-      "chunks": {
-        "byName": {},
-        "byBlocks": {},
-        "usedIds": {
-          "0": 0
-        }
-      }
-    }
-  ],
-  "extract-text-webpack-plugin ../../extract-text-webpack-plugin/dist ../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/shared/Button/styles/CommandBarButton.css": [
-    {
-      "modules": {
-        "byIdentifier": {
-          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/shared/Button/styles/CommandBarButton.css": 0,
-          "../../css-loader/lib/css-base.js": 1
-        },
-        "usedIds": {
-          "0": 0,
-          "1": 1
-        }
-      },
-      "chunks": {
-        "byName": {},
-        "byBlocks": {},
-        "usedIds": {
-          "0": 0
-        }
-      }
-    }
-  ],
-  "extract-text-webpack-plugin ../../extract-text-webpack-plugin/dist ../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/shared/Button/styles/CloseButton.css": [
-    {
-      "modules": {
-        "byIdentifier": {
-          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/shared/Button/styles/CloseButton.css": 0,
-          "../../css-loader/lib/css-base.js": 1
-        },
-        "usedIds": {
-          "0": 0,
-          "1": 1
-        }
-      },
-      "chunks": {
-        "byName": {},
-        "byBlocks": {},
-        "usedIds": {
-          "0": 0
-        }
-      }
-    }
-  ],
-  "extract-text-webpack-plugin ../../extract-text-webpack-plugin/dist ../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/shared/SourceIcon.css": [
-    {
-      "modules": {
-        "byIdentifier": {
-          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/shared/SourceIcon.css": 0,
-          "../../css-loader/lib/css-base.js": 1
-        },
-        "usedIds": {
-          "0": 0,
-          "1": 1
-        }
-      },
-      "chunks": {
-        "byName": {},
-        "byBlocks": {},
-        "usedIds": {
-          "0": 0
-        }
-      }
-    }
-  ],
-  "extract-text-webpack-plugin ../../extract-text-webpack-plugin/dist ../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../packages/devtools-reps/src/object-inspector/components/ObjectInspector.css": [
-    {
-      "modules": {
-        "byIdentifier": {
-          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../packages/devtools-reps/src/object-inspector/components/ObjectInspector.css": 0,
-          "../../css-loader/lib/css-base.js": 1
-        },
-        "usedIds": {
-          "0": 0,
-          "1": 1
-        }
-      },
-      "chunks": {
-        "byName": {},
-        "byBlocks": {},
-        "usedIds": {
-          "0": 0
-        }
-      }
-    }
-  ],
-  "extract-text-webpack-plugin ../../extract-text-webpack-plugin/dist ../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../packages/devtools-components/src/tree.css": [
-    {
-      "modules": {
-        "byIdentifier": {
-          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../packages/devtools-components/src/tree.css": 0,
-          "../../css-loader/lib/css-base.js": 1
-        },
-        "usedIds": {
-          "0": 0,
-          "1": 1
-        }
-      },
-      "chunks": {
-        "byName": {},
-        "byBlocks": {},
-        "usedIds": {
-          "0": 0
-        }
-      }
-    }
-  ],
-  "extract-text-webpack-plugin ../../extract-text-webpack-plugin/dist ../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../packages/devtools-reps/src/reps/reps.css": [
-    {
-      "modules": {
-        "byIdentifier": {
-          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../packages/devtools-reps/src/reps/reps.css": 0,
-          "../../css-loader/lib/css-base.js": 1
-        },
-        "usedIds": {
-          "0": 0,
-          "1": 1
-        }
-      },
-      "chunks": {
-        "byName": {},
-        "byBlocks": {},
-        "usedIds": {
-          "0": 0
-        }
-      }
-    }
-  ],
-  "extract-text-webpack-plugin ../../extract-text-webpack-plugin/dist ../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/SecondaryPanes/XHRBreakpoints.css": [
-    {
-      "modules": {
-        "byIdentifier": {
-          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/SecondaryPanes/XHRBreakpoints.css": 0,
-          "../../css-loader/lib/css-base.js": 1
-        },
-        "usedIds": {
-          "0": 0,
-          "1": 1
-        }
-      },
-      "chunks": {
-        "byName": {},
-        "byBlocks": {},
-        "usedIds": {
-          "0": 0
-        }
-      }
-    }
-  ],
-  "extract-text-webpack-plugin ../../extract-text-webpack-plugin/dist ../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/SecondaryPanes/Breakpoints/Breakpoints.css": [
-    {
-      "modules": {
-        "byIdentifier": {
-          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/SecondaryPanes/Breakpoints/Breakpoints.css": 0,
-          "../../css-loader/lib/css-base.js": 1
-        },
-        "usedIds": {
-          "0": 0,
-          "1": 1
-        }
-      },
-      "chunks": {
-        "byName": {},
-        "byBlocks": {},
-        "usedIds": {
-          "0": 0
-        }
-      }
-    }
-  ],
-  "extract-text-webpack-plugin ../../extract-text-webpack-plugin/dist ../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/Editor/ColumnBreakpoints.css": [
-    {
-      "modules": {
-        "byIdentifier": {
-          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/Editor/ColumnBreakpoints.css": 0,
-          "../../css-loader/lib/css-base.js": 1
-        },
-        "usedIds": {
-          "0": 0,
-          "1": 1
-        }
-      },
-      "chunks": {
-        "byName": {},
-        "byBlocks": {},
-        "usedIds": {
-          "0": 0
-        }
-      }
-    }
-  ],
-  "extract-text-webpack-plugin ../../extract-text-webpack-plugin/dist ../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/PrimaryPanes/OutlineFilter.css": [
-    {
-      "modules": {
-        "byIdentifier": {
-          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/PrimaryPanes/OutlineFilter.css": 0,
-          "../../css-loader/lib/css-base.js": 1
-        },
-        "usedIds": {
-          "0": 0,
-          "1": 1
-        }
-      },
-      "chunks": {
-        "byName": {},
-        "byBlocks": {},
-        "usedIds": {
-          "0": 0
-        }
-      }
-    }
-  ],
-  "extract-text-webpack-plugin ../../extract-text-webpack-plugin/dist ../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../react-aria-components/src/tabs/tab.css": [
-    {
-      "modules": {
-        "byIdentifier": {
-          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../react-aria-components/src/tabs/tab.css": 0,
-          "../../css-loader/lib/css-base.js": 1
-        },
-        "usedIds": {
-          "0": 0,
-          "1": 1
-        }
-      },
-      "chunks": {
-        "byName": {},
-        "byBlocks": {},
-        "usedIds": {
-          "0": 0
-        }
-      }
-    }
-  ],
-  "extract-text-webpack-plugin ../../extract-text-webpack-plugin/dist ../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../react-aria-components/src/tabs/tab-list.css": [
-    {
-      "modules": {
-        "byIdentifier": {
-          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../react-aria-components/src/tabs/tab-list.css": 0,
-          "../../css-loader/lib/css-base.js": 1
-        },
-        "usedIds": {
-          "0": 0,
-          "1": 1
-        }
-      },
-      "chunks": {
-        "byName": {},
-        "byBlocks": {},
-        "usedIds": {
-          "0": 0
-        }
-      }
-    }
-  ],
-  "extract-text-webpack-plugin ../../extract-text-webpack-plugin/dist ../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/ProjectSearch.css": [
-    {
-      "modules": {
-        "byIdentifier": {
-          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/ProjectSearch.css": 0,
-          "../../css-loader/lib/css-base.js": 1
-        },
-        "usedIds": {
-          "0": 0,
-          "1": 1
-        }
-      },
-      "chunks": {
-        "byName": {},
-        "byBlocks": {},
-        "usedIds": {
-          "0": 0
-        }
-      }
-    }
-  ],
-  "extract-text-webpack-plugin ../../extract-text-webpack-plugin/dist ../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../packages/devtools-splitter/src/SplitBox.css": [
-    {
-      "modules": {
-        "byIdentifier": {
-          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../packages/devtools-splitter/src/SplitBox.css": 0,
-          "../../css-loader/lib/css-base.js": 1
-        },
-        "usedIds": {
-          "0": 0,
-          "1": 1
-        }
-      },
-      "chunks": {
-        "byName": {},
-        "byBlocks": {},
-        "usedIds": {
-          "0": 0
-        }
-      }
-    }
-  ],
-  "extract-text-webpack-plugin ../../extract-text-webpack-plugin/dist ../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/A11yIntention.css": [
-    {
-      "modules": {
-        "byIdentifier": {
-          "../../css-loader/index.js??ref--3-1!../../postcss-loader/lib/index.js!../../../src/components/A11yIntention.css": 0,
-          "../../css-loader/lib/css-base.js": 1
-        },
-        "usedIds": {
-          "0": 0,
-          "1": 1
-        }
-      },
-      "chunks": {
-        "byName": {},
-        "byBlocks": {},
-        "usedIds": {
-          "0": 0
         }
       }
     }

--- a/packages/devtools-reps/src/reps/error.js
+++ b/packages/devtools-reps/src/reps/error.js
@@ -57,7 +57,7 @@ function ErrorRep(props) {
     const stacktrace = props.renderStacktrace
       ? props.renderStacktrace(parseStackString(preview.stack))
       : getStacktraceElements(props, preview);
-    content.push("\n", stacktrace);
+    content.push(stacktrace);
   }
 
   return span(

--- a/packages/devtools-reps/src/reps/tests/__snapshots__/error.js.snap
+++ b/packages/devtools-reps/src/reps/tests/__snapshots__/error.js.snap
@@ -6,8 +6,6 @@ exports[`Error - Eval error renders with expected text for an EvalError 1`] = `
   data-link-actor-id="server1.conn1.child1/obj1022"
 >
   EvalError: "EvalError message"
-  
-
   <span
     className="objectBox-stackTrace-grid"
     key="stack"
@@ -38,8 +36,6 @@ exports[`Error - Internal error renders with expected text for an InternalError 
   data-link-actor-id="server1.conn1.child1/obj1023"
 >
   InternalError: "InternalError message"
-  
-
   <span
     className="objectBox-stackTrace-grid"
     key="stack"
@@ -70,8 +66,6 @@ exports[`Error - Multi line stack error renders with expected text for Error obj
   data-link-actor-id="server1.conn1.child1/obj1021"
 >
   Error: "bar"
-  
-
   <span
     className="objectBox-stackTrace-grid"
     key="stack"
@@ -134,8 +128,6 @@ exports[`Error - Range error renders with expected text for RangeError 1`] = `
   data-link-actor-id="server1.conn1.child1/obj1024"
 >
   RangeError: "RangeError message"
-  
-
   <span
     className="objectBox-stackTrace-grid"
     key="stack"
@@ -166,8 +158,6 @@ exports[`Error - Reference error renders with expected text for ReferenceError 1
   data-link-actor-id="server1.conn1.child1/obj1025"
 >
   ReferenceError: "ReferenceError message"
-  
-
   <span
     className="objectBox-stackTrace-grid"
     key="stack"
@@ -198,8 +188,6 @@ exports[`Error - Simple error renders with expected text for simple error 1`] = 
   data-link-actor-id="server1.conn1.child1/obj1020"
 >
   Error: "Error message"
-  
-
   <span
     className="objectBox-stackTrace-grid"
     key="stack"
@@ -230,8 +218,6 @@ exports[`Error - Syntax error renders with expected text for SyntaxError 1`] = `
   data-link-actor-id="server1.conn1.child1/obj1026"
 >
   SyntaxError: "SyntaxError message"
-  
-
   <span
     className="objectBox-stackTrace-grid"
     key="stack"
@@ -262,8 +248,6 @@ exports[`Error - Type error renders with expected text for TypeError 1`] = `
   data-link-actor-id="server1.conn1.child1/obj1027"
 >
   TypeError: "TypeError message"
-  
-
   <span
     className="objectBox-stackTrace-grid"
     key="stack"
@@ -294,8 +278,6 @@ exports[`Error - URI error renders with expected text for URIError 1`] = `
   data-link-actor-id="server1.conn1.child1/obj1028"
 >
   URIError: "URIError message"
-  
-
   <span
     className="objectBox-stackTrace-grid"
     key="stack"
@@ -335,8 +317,6 @@ exports[`Error - base-loader.js renders as expected without mode 1`] = `
   data-link-actor-id="server1.conn1.child1/obj1020"
 >
   Error: "Error message"
-  
-
   <span
     className="objectBox-stackTrace-grid"
     key="stack"
@@ -415,8 +395,6 @@ exports[`Error - longString stacktrace - cut-off location renders as expected 1`
   data-link-actor-id="server1.conn1.child1/obj33"
 >
   InternalError: "too much recursion"
-  
-
   <span
     className="objectBox-stackTrace-grid"
     key="stack"
@@ -543,8 +521,6 @@ exports[`Error - longString stacktrace renders as expected 1`] = `
   data-link-actor-id="server1.conn2.child1/obj33"
 >
   Error: ""
-  
-
   <span
     className="objectBox-stackTrace-grid"
     key="stack"
@@ -719,8 +695,6 @@ exports[`Error - renderStacktrace prop uses renderStacktrace prop when provided 
   data-link-actor-id="server1.conn1.child1/obj1021"
 >
   Error: "bar"
-  
-
   <li
     className="frame"
   >
@@ -748,8 +722,6 @@ exports[`Error - renderStacktrace prop uses renderStacktrace with longString err
   data-link-actor-id="server1.conn1.child1/obj33"
 >
   InternalError: "too much recursion"
-  
-
   <li
     className="frame"
   >

--- a/src/components/SecondaryPanes/Frames/Frame.js
+++ b/src/components/SecondaryPanes/Frames/Frame.js
@@ -12,6 +12,7 @@ import Svg from "../../shared/Svg";
 import { formatDisplayName } from "../../../utils/pause/frames";
 import { getFilename, getFileURL } from "../../../utils/source";
 import FrameMenu from "./FrameMenu";
+import FrameIndent from "./FrameIndent";
 
 import type { Frame } from "../../../types";
 import type { LocalFrame } from "./types";
@@ -70,7 +71,8 @@ type FrameComponentProps = {
   toggleBlackBox: Function,
   displayFullUrl: boolean,
   getFrameTitle?: string => string,
-  disableContextMenu: boolean
+  disableContextMenu: boolean,
+  selectable: boolean
 };
 
 export default class FrameComponent extends Component<FrameComponentProps> {
@@ -126,7 +128,8 @@ export default class FrameComponent extends Component<FrameComponentProps> {
       shouldMapDisplayName,
       displayFullUrl,
       getFrameTitle,
-      disableContextMenu
+      disableContextMenu,
+      selectable
     } = this.props;
     const { l10n } = this.context;
 
@@ -140,11 +143,9 @@ export default class FrameComponent extends Component<FrameComponentProps> {
         )
       : undefined;
 
-    const tabChar = "\t";
-    const newLineChar = "\n";
-
     return (
-      <li
+      <div
+        role="listitem"
         key={frame.id}
         className={className}
         onMouseDown={e => this.onMouseDown(e, frame, selectedFrame)}
@@ -153,18 +154,18 @@ export default class FrameComponent extends Component<FrameComponentProps> {
         tabIndex={0}
         title={title}
       >
-        {tabChar}
+        {selectable && <FrameIndent />}
         <FrameTitle
           frame={frame}
           options={{ shouldMapDisplayName }}
           l10n={l10n}
         />
-        {!hideLocation && " "}
+        {!hideLocation && <span className="clipboard-only"> </span>}
         {!hideLocation && (
           <FrameLocation frame={frame} displayFullUrl={displayFullUrl} />
         )}
-        {newLineChar}
-      </li>
+        {selectable && <br className="clipboard-only" />}
+      </div>
     );
   }
 }

--- a/src/components/SecondaryPanes/Frames/FrameIndent.js
+++ b/src/components/SecondaryPanes/Frames/FrameIndent.js
@@ -1,0 +1,13 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
+import React from "react";
+
+export default function FrameIndent() {
+  return (
+    <span className="frame-indent clipboard-only">
+      &nbsp;&nbsp;&nbsp;&nbsp;
+    </span>
+  );
+}

--- a/src/components/SecondaryPanes/Frames/Frames.css
+++ b/src/components/SecondaryPanes/Frames/Frames.css
@@ -2,13 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
-.frames ul {
+.frames [role="list"] {
   list-style: none;
   margin-top: 4px;
   padding: 0;
 }
 
-.frames ul li {
+.frames [role="list"] [role="listitem"] {
   padding: 2px 10px 2px 20px;
   overflow: hidden;
   display: flex;
@@ -21,7 +21,7 @@
   flex-wrap: wrap;
 }
 
-.frames ul li * {
+.frames [role="list"] [role="listitem"] * {
   -moz-user-select: none;
   user-select: none;
 }
@@ -58,26 +58,26 @@
   overflow: hidden;
 }
 
-.frames ul li:hover,
-.frames ul li:focus {
+.frames [role="list"] [role="listitem"]hover,
+.frames [role="list"] [role="listitem"]focus {
   background-color: var(--theme-toolbar-background-alt);
 }
 
-.theme-dark .frames ul li:focus {
+.theme-dark .frames [role="list"] [role="listitem"]focus {
   background-color: var(--theme-tab-toolbar-background);
 }
 
-.frames ul li.selected {
+.frames [role="list"] [role="listitem"].selected {
   background-color: var(--theme-selection-background);
   color: white;
 }
 
-.frames ul li.selected i.annotation-logo svg path {
+.frames [role="list"] [role="listitem"].selected i.annotation-logo svg path {
   fill: white;
 }
 
-:root.theme-light .frames ul li.selected .location,
-:root.theme-dark .frames ul li.selected .location {
+:root.theme-light .frames [role="list"] [role="listitem"].selected .location,
+:root.theme-dark .frames [role="list"] [role="listitem"].selected .location {
   color: white;
 }
 
@@ -109,4 +109,13 @@
 
 :root.theme-dark .annotation-logo:not(.angular) svg path {
   fill: var(--theme-highlight-blue);
+}
+
+/* Some elements are added to the DOM only to be printed into the clipboard
+   when the user copy some elements. We don't want those elements to mess with
+   the layout so we put them outside of the screen
+*/
+.clipboard-only {
+  position: absolute;
+  left: -9999px;
 }

--- a/src/components/SecondaryPanes/Frames/Group.css
+++ b/src/components/SecondaryPanes/Frames/Group.css
@@ -2,8 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
-.frames ul .frames-group .group,
-.frames ul .frames-group .group .location {
+.frames [role="list"] .frames-group .group,
+.frames [role="list"] .frames-group .group .location {
   font-weight: 500;
   cursor: default;
   /*
@@ -14,25 +14,30 @@
   direction: ltr;
 }
 
-.frames ul .frames-group.expanded .group,
-.frames ul .frames-group.expanded .group .location {
+.frames [role="list"] .frames-group.expanded .group,
+.frames [role="list"] .frames-group.expanded .group .location {
   color: var(--theme-highlight-blue);
 }
 
-.frames ul .frames-group.expanded .react path {
+.frames [role="list"] .frames-group.expanded .react path {
   fill: var(--theme-highlight-blue);
 }
 
-.frames ul .frames-group .frames-list li {
+.frames [role="list"] .frames-group .frames-list [role="listitem"] {
   padding-left: 30px;
 }
 
-.frames ul .frames-group .frames-list {
+.frames [role="list"] .frames-group .frames-list {
   border-top: 1px solid var(--theme-splitter-color);
   border-bottom: 1px solid var(--theme-splitter-color);
 }
 
-.frames ul .frames-group.expanded .badge {
+/* We don't want to display those as flex since only the name is displayed */
+.frames [role="list"] .frames-group .frames-list [role="listitem"] {
+  display: block;
+}
+
+.frames [role="list"] .frames-group.expanded .badge {
   color: var(--theme-highlight-blue);
 }
 

--- a/src/components/SecondaryPanes/Frames/Group.js
+++ b/src/components/SecondaryPanes/Frames/Group.js
@@ -10,13 +10,13 @@ import Svg from "../../shared/Svg";
 import { getLibraryFromUrl } from "../../../utils/pause/frames";
 import FrameMenu from "./FrameMenu";
 import AccessibleImage from "../../shared/AccessibleImage";
+import FrameComponent from "./Frame";
 
 import "./Group.css";
 
-import FrameComponent from "./Frame";
-
 import type { LocalFrame } from "./types";
 import Badge from "../../shared/Badge";
+import FrameIndent from "./FrameIndent";
 
 type FrameLocationProps = { frame: LocalFrame, expanded: boolean };
 function FrameLocation({ frame, expanded }: FrameLocationProps) {
@@ -47,7 +47,8 @@ type Props = {
   frameworkGroupingOn: boolean,
   displayFullUrl: boolean,
   getFrameTitle?: string => string,
-  disableContextMenu: boolean
+  disableContextMenu: boolean,
+  selectable: boolean
 };
 
 type State = {
@@ -95,7 +96,8 @@ export default class Group extends Component<Props, State> {
       copyStackTrace,
       displayFullUrl,
       getFrameTitle,
-      disableContextMenu
+      disableContextMenu,
+      selectable
     } = this.props;
 
     const { expanded } = this.state;
@@ -105,31 +107,38 @@ export default class Group extends Component<Props, State> {
 
     return (
       <div className="frames-list">
-        {group.map(frame => (
-          <FrameComponent
-            copyStackTrace={copyStackTrace}
-            frame={frame}
-            frameworkGroupingOn={frameworkGroupingOn}
-            hideLocation={true}
-            key={frame.id}
-            selectedFrame={selectedFrame}
-            selectFrame={selectFrame}
-            shouldMapDisplayName={false}
-            toggleBlackBox={toggleBlackBox}
-            toggleFrameworkGrouping={toggleFrameworkGrouping}
-            displayFullUrl={displayFullUrl}
-            getFrameTitle={getFrameTitle}
-            disableContextMenu={disableContextMenu}
-          />
-        ))}
+        {group.reduce((acc, frame) => {
+          if (selectable) {
+            acc.push(<FrameIndent />);
+          }
+          return acc.concat(
+            <FrameComponent
+              copyStackTrace={copyStackTrace}
+              frame={frame}
+              frameworkGroupingOn={frameworkGroupingOn}
+              hideLocation={true}
+              key={frame.id}
+              selectedFrame={selectedFrame}
+              selectFrame={selectFrame}
+              shouldMapDisplayName={false}
+              toggleBlackBox={toggleBlackBox}
+              toggleFrameworkGrouping={toggleFrameworkGrouping}
+              displayFullUrl={displayFullUrl}
+              getFrameTitle={getFrameTitle}
+              disableContextMenu={disableContextMenu}
+              selectable={selectable}
+            />
+          );
+        }, [])}
       </div>
     );
   }
 
   renderDescription() {
     const { l10n } = this.context;
+    const { selectable, group } = this.props;
 
-    const frame = this.props.group[0];
+    const frame = group[0];
     const expanded = this.state.expanded;
     const l10NEntry = this.state.expanded
       ? "callStack.group.collapseTooltip"
@@ -137,16 +146,19 @@ export default class Group extends Component<Props, State> {
     const title = l10n.getFormatStr(l10NEntry, frame.library);
 
     return (
-      <li
+      <div
+        role="listitem"
         key={frame.id}
         className={classNames("group")}
         onClick={this.toggleFrames}
         tabIndex={0}
         title={title}
       >
+        {selectable && <FrameIndent />}
         <FrameLocation frame={frame} expanded={expanded} />
+        {selectable && <span className="clipboard-only"> </span>}
         <Badge>{this.props.group.length}</Badge>
-      </li>
+      </div>
     );
   }
 

--- a/src/components/SecondaryPanes/Frames/index.js
+++ b/src/components/SecondaryPanes/Frames/index.js
@@ -43,7 +43,8 @@ type Props = {
   disableFrameTruncate: boolean,
   disableContextMenu: boolean,
   displayFullUrl: boolean,
-  getFrameTitle?: string => string
+  getFrameTitle?: string => string,
+  selectable?: boolean
 };
 
 type State = {
@@ -120,14 +121,18 @@ class Frames extends Component<Props, State> {
       frameworkGroupingOn,
       displayFullUrl,
       getFrameTitle,
-      disableContextMenu
+      disableContextMenu,
+      selectable = false
     } = this.props;
 
     const framesOrGroups = this.truncateFrames(this.collapseFrames(frames));
     type FrameOrGroup = LocalFrame | LocalFrame[];
 
+    // We're not using a <ul> because it adds new lines before and after when
+    // the user copies the trace. Needed for the console which has several
+    // places where we don't want to have those new lines.
     return (
-      <ul>
+      <div role="list">
         {framesOrGroups.map(
           (frameOrGroup: FrameOrGroup) =>
             frameOrGroup.id ? (
@@ -143,6 +148,7 @@ class Frames extends Component<Props, State> {
                 displayFullUrl={displayFullUrl}
                 getFrameTitle={getFrameTitle}
                 disableContextMenu={disableContextMenu}
+                selectable={selectable}
               />
             ) : (
               <Group
@@ -157,10 +163,11 @@ class Frames extends Component<Props, State> {
                 displayFullUrl={displayFullUrl}
                 getFrameTitle={getFrameTitle}
                 disableContextMenu={disableContextMenu}
+                selectable={selectable}
               />
             )
         )}
-      </ul>
+      </div>
     );
   }
 

--- a/src/components/SecondaryPanes/Frames/tests/Frame.spec.js
+++ b/src/components/SecondaryPanes/Frames/tests/Frame.spec.js
@@ -81,7 +81,7 @@ describe("Frame", () => {
     };
 
     const component = mount(<Frame frame={frame} />);
-    expect(component.text()).toBe("\trenderFoo foo-view.js:10\n");
+    expect(component.text()).toBe("renderFoo foo-view.js:10");
   });
 
   it("full URL", () => {
@@ -98,7 +98,7 @@ describe("Frame", () => {
     };
 
     const component = mount(<Frame frame={frame} displayFullUrl={true} />);
-    expect(component.text()).toBe(`\trenderFoo ${url}:10\n`);
+    expect(component.text()).toBe(`renderFoo ${url}:10`);
   });
 
   it("getFrameTitle", () => {

--- a/src/components/SecondaryPanes/Frames/tests/Frames.spec.js
+++ b/src/components/SecondaryPanes/Frames/tests/Frames.spec.js
@@ -115,7 +115,7 @@ describe("Frames", () => {
         />
       );
       expect(component.text()).toBe(
-        "\trenderFoo http://myfile.com/mahscripts.js:55\n"
+        "renderFoo http://myfile.com/mahscripts.js:55"
       );
     });
 
@@ -263,6 +263,28 @@ describe("Frames", () => {
       const frameworkGroupingOn = true;
       const component = render({ frames, frameworkGroupingOn, selectedFrame });
 
+      expect(component).toMatchSnapshot();
+    });
+
+    it("selectable framework frames", () => {
+      const frames = [
+        { id: 1 },
+        { id: 2, library: "back" },
+        { id: 3, library: "back" },
+        { id: 8 }
+      ];
+
+      const selectedFrame = frames[0];
+
+      const component = render({
+        frames,
+        frameworkGroupingOn: false,
+        selectedFrame,
+        selectable: true
+      });
+      expect(component).toMatchSnapshot();
+
+      component.setProps({ frameworkGroupingOn: true });
       expect(component).toMatchSnapshot();
     });
   });

--- a/src/components/SecondaryPanes/Frames/tests/__snapshots__/Frame.spec.js.snap
+++ b/src/components/SecondaryPanes/Frames/tests/__snapshots__/Frame.spec.js.snap
@@ -1,16 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Frame getFrameTitle 1`] = `
-<li
+<div
   className="frame"
   key="1"
   onContextMenu={[Function]}
   onKeyUp={[Function]}
   onMouseDown={[Function]}
+  role="listitem"
   tabIndex={0}
   title="Jump to https://aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.com/assets/src/js/foo-view.js:10"
 >
-  	
   <FrameTitle
     frame={
       Object {
@@ -30,7 +30,11 @@ exports[`Frame getFrameTitle 1`] = `
       }
     }
   />
-   
+  <span
+    className="clipboard-only"
+  >
+     
+  </span>
   <FrameLocation
     frame={
       Object {
@@ -45,21 +49,19 @@ exports[`Frame getFrameTitle 1`] = `
       }
     }
   />
-  
-
-</li>
+</div>
 `;
 
 exports[`Frame library frame 1`] = `
-<li
+<div
   className="frame selected"
   key="3"
   onContextMenu={[Function]}
   onKeyUp={[Function]}
   onMouseDown={[Function]}
+  role="listitem"
   tabIndex={0}
 >
-  	
   <FrameTitle
     frame={
       Object {
@@ -82,7 +84,11 @@ exports[`Frame library frame 1`] = `
       }
     }
   />
-   
+  <span
+    className="clipboard-only"
+  >
+     
+  </span>
   <FrameLocation
     frame={
       Object {
@@ -100,21 +106,19 @@ exports[`Frame library frame 1`] = `
       }
     }
   />
-  
-
-</li>
+</div>
 `;
 
 exports[`Frame user frame (not selected) 1`] = `
-<li
+<div
   className="frame"
   key="1"
   onContextMenu={[Function]}
   onKeyUp={[Function]}
   onMouseDown={[Function]}
+  role="listitem"
   tabIndex={0}
 >
-  	
   <FrameTitle
     frame={
       Object {
@@ -138,7 +142,11 @@ exports[`Frame user frame (not selected) 1`] = `
       }
     }
   />
-   
+  <span
+    className="clipboard-only"
+  >
+     
+  </span>
   <FrameLocation
     frame={
       Object {
@@ -157,21 +165,19 @@ exports[`Frame user frame (not selected) 1`] = `
       }
     }
   />
-  
-
-</li>
+</div>
 `;
 
 exports[`Frame user frame 1`] = `
-<li
+<div
   className="frame selected"
   key="1"
   onContextMenu={[Function]}
   onKeyUp={[Function]}
   onMouseDown={[Function]}
+  role="listitem"
   tabIndex={0}
 >
-  	
   <FrameTitle
     frame={
       Object {
@@ -195,7 +201,11 @@ exports[`Frame user frame 1`] = `
       }
     }
   />
-   
+  <span
+    className="clipboard-only"
+  >
+     
+  </span>
   <FrameLocation
     frame={
       Object {
@@ -214,7 +224,5 @@ exports[`Frame user frame 1`] = `
       }
     }
   />
-  
-
-</li>
+</div>
 `;

--- a/src/components/SecondaryPanes/Frames/tests/__snapshots__/Frames.spec.js.snap
+++ b/src/components/SecondaryPanes/Frames/tests/__snapshots__/Frames.spec.js.snap
@@ -4,7 +4,9 @@ exports[`Frames Blackboxed Frames filters blackboxed frames 1`] = `
 <div
   className="pane frames"
 >
-  <ul>
+  <div
+    role="list"
+  >
     <Frame
       copyStackTrace={[Function]}
       disableContextMenu={false}
@@ -23,6 +25,7 @@ exports[`Frames Blackboxed Frames filters blackboxed frames 1`] = `
       hideLocation={false}
       key="1"
       selectFrame={[MockFunction]}
+      selectable={false}
       selectedFrame={
         Object {
           "id": 1,
@@ -53,6 +56,7 @@ exports[`Frames Blackboxed Frames filters blackboxed frames 1`] = `
       hideLocation={false}
       key="3"
       selectFrame={[MockFunction]}
+      selectable={false}
       selectedFrame={
         Object {
           "id": 1,
@@ -65,7 +69,7 @@ exports[`Frames Blackboxed Frames filters blackboxed frames 1`] = `
       toggleBlackBox={[MockFunction]}
       toggleFrameworkGrouping={[Function]}
     />
-  </ul>
+  </div>
 </div>
 `;
 
@@ -73,7 +77,9 @@ exports[`Frames Library Frames groups all the Webpack-related frames 1`] = `
 <div
   className="pane frames"
 >
-  <ul>
+  <div
+    role="list"
+  >
     <Frame
       copyStackTrace={[Function]}
       disableContextMenu={false}
@@ -86,6 +92,7 @@ exports[`Frames Library Frames groups all the Webpack-related frames 1`] = `
       hideLocation={false}
       key="1-appFrame"
       selectFrame={[MockFunction]}
+      selectable={false}
       selectedFrame={
         Object {
           "id": "1-appFrame",
@@ -128,6 +135,7 @@ exports[`Frames Library Frames groups all the Webpack-related frames 1`] = `
       }
       key="2-webpackBootstrapFrame"
       selectFrame={[MockFunction]}
+      selectable={false}
       selectedFrame={
         Object {
           "id": "1-appFrame",
@@ -136,15 +144,17 @@ exports[`Frames Library Frames groups all the Webpack-related frames 1`] = `
       toggleBlackBox={[MockFunction]}
       toggleFrameworkGrouping={[Function]}
     />
-  </ul>
+  </div>
 </div>
 `;
 
-exports[`Frames Library Frames toggling framework frames 1`] = `
+exports[`Frames Library Frames selectable framework frames 1`] = `
 <div
   className="pane frames"
 >
-  <ul>
+  <div
+    role="list"
+  >
     <Frame
       copyStackTrace={[Function]}
       disableContextMenu={false}
@@ -157,6 +167,7 @@ exports[`Frames Library Frames toggling framework frames 1`] = `
       hideLocation={false}
       key="1"
       selectFrame={[MockFunction]}
+      selectable={true}
       selectedFrame={
         Object {
           "id": 1,
@@ -179,6 +190,7 @@ exports[`Frames Library Frames toggling framework frames 1`] = `
       hideLocation={false}
       key="2"
       selectFrame={[MockFunction]}
+      selectable={true}
       selectedFrame={
         Object {
           "id": 1,
@@ -201,6 +213,7 @@ exports[`Frames Library Frames toggling framework frames 1`] = `
       hideLocation={false}
       key="3"
       selectFrame={[MockFunction]}
+      selectable={true}
       selectedFrame={
         Object {
           "id": 1,
@@ -222,6 +235,7 @@ exports[`Frames Library Frames toggling framework frames 1`] = `
       hideLocation={false}
       key="8"
       selectFrame={[MockFunction]}
+      selectable={true}
       selectedFrame={
         Object {
           "id": 1,
@@ -231,15 +245,17 @@ exports[`Frames Library Frames toggling framework frames 1`] = `
       toggleBlackBox={[MockFunction]}
       toggleFrameworkGrouping={[Function]}
     />
-  </ul>
+  </div>
 </div>
 `;
 
-exports[`Frames Library Frames toggling framework frames 2`] = `
+exports[`Frames Library Frames selectable framework frames 2`] = `
 <div
   className="pane frames"
 >
-  <ul>
+  <div
+    role="list"
+  >
     <Frame
       copyStackTrace={[Function]}
       disableContextMenu={false}
@@ -252,6 +268,7 @@ exports[`Frames Library Frames toggling framework frames 2`] = `
       hideLocation={false}
       key="1"
       selectFrame={[MockFunction]}
+      selectable={true}
       selectedFrame={
         Object {
           "id": 1,
@@ -278,6 +295,7 @@ exports[`Frames Library Frames toggling framework frames 2`] = `
       }
       key="2"
       selectFrame={[MockFunction]}
+      selectable={true}
       selectedFrame={
         Object {
           "id": 1,
@@ -298,6 +316,7 @@ exports[`Frames Library Frames toggling framework frames 2`] = `
       hideLocation={false}
       key="8"
       selectFrame={[MockFunction]}
+      selectable={true}
       selectedFrame={
         Object {
           "id": 1,
@@ -307,15 +326,17 @@ exports[`Frames Library Frames toggling framework frames 2`] = `
       toggleBlackBox={[MockFunction]}
       toggleFrameworkGrouping={[Function]}
     />
-  </ul>
+  </div>
 </div>
 `;
 
-exports[`Frames Supports different number of frames disable frame truncation 1`] = `
+exports[`Frames Library Frames toggling framework frames 1`] = `
 <div
   className="pane frames"
 >
-  <ul>
+  <div
+    role="list"
+  >
     <Frame
       copyStackTrace={[Function]}
       disableContextMenu={false}
@@ -328,6 +349,189 @@ exports[`Frames Supports different number of frames disable frame truncation 1`]
       hideLocation={false}
       key="1"
       selectFrame={[MockFunction]}
+      selectable={false}
+      selectedFrame={
+        Object {
+          "id": 1,
+        }
+      }
+      shouldMapDisplayName={true}
+      toggleBlackBox={[MockFunction]}
+      toggleFrameworkGrouping={[Function]}
+    />
+    <Frame
+      copyStackTrace={[Function]}
+      disableContextMenu={false}
+      frame={
+        Object {
+          "id": 2,
+          "library": "back",
+        }
+      }
+      frameworkGroupingOn={false}
+      hideLocation={false}
+      key="2"
+      selectFrame={[MockFunction]}
+      selectable={false}
+      selectedFrame={
+        Object {
+          "id": 1,
+        }
+      }
+      shouldMapDisplayName={true}
+      toggleBlackBox={[MockFunction]}
+      toggleFrameworkGrouping={[Function]}
+    />
+    <Frame
+      copyStackTrace={[Function]}
+      disableContextMenu={false}
+      frame={
+        Object {
+          "id": 3,
+          "library": "back",
+        }
+      }
+      frameworkGroupingOn={false}
+      hideLocation={false}
+      key="3"
+      selectFrame={[MockFunction]}
+      selectable={false}
+      selectedFrame={
+        Object {
+          "id": 1,
+        }
+      }
+      shouldMapDisplayName={true}
+      toggleBlackBox={[MockFunction]}
+      toggleFrameworkGrouping={[Function]}
+    />
+    <Frame
+      copyStackTrace={[Function]}
+      disableContextMenu={false}
+      frame={
+        Object {
+          "id": 8,
+        }
+      }
+      frameworkGroupingOn={false}
+      hideLocation={false}
+      key="8"
+      selectFrame={[MockFunction]}
+      selectable={false}
+      selectedFrame={
+        Object {
+          "id": 1,
+        }
+      }
+      shouldMapDisplayName={true}
+      toggleBlackBox={[MockFunction]}
+      toggleFrameworkGrouping={[Function]}
+    />
+  </div>
+</div>
+`;
+
+exports[`Frames Library Frames toggling framework frames 2`] = `
+<div
+  className="pane frames"
+>
+  <div
+    role="list"
+  >
+    <Frame
+      copyStackTrace={[Function]}
+      disableContextMenu={false}
+      frame={
+        Object {
+          "id": 1,
+        }
+      }
+      frameworkGroupingOn={true}
+      hideLocation={false}
+      key="1"
+      selectFrame={[MockFunction]}
+      selectable={false}
+      selectedFrame={
+        Object {
+          "id": 1,
+        }
+      }
+      shouldMapDisplayName={true}
+      toggleBlackBox={[MockFunction]}
+      toggleFrameworkGrouping={[Function]}
+    />
+    <Group
+      copyStackTrace={[Function]}
+      frameworkGroupingOn={true}
+      group={
+        Array [
+          Object {
+            "id": 2,
+            "library": "back",
+          },
+          Object {
+            "id": 3,
+            "library": "back",
+          },
+        ]
+      }
+      key="2"
+      selectFrame={[MockFunction]}
+      selectable={false}
+      selectedFrame={
+        Object {
+          "id": 1,
+        }
+      }
+      toggleBlackBox={[MockFunction]}
+      toggleFrameworkGrouping={[Function]}
+    />
+    <Frame
+      copyStackTrace={[Function]}
+      disableContextMenu={false}
+      frame={
+        Object {
+          "id": 8,
+        }
+      }
+      frameworkGroupingOn={true}
+      hideLocation={false}
+      key="8"
+      selectFrame={[MockFunction]}
+      selectable={false}
+      selectedFrame={
+        Object {
+          "id": 1,
+        }
+      }
+      shouldMapDisplayName={true}
+      toggleBlackBox={[MockFunction]}
+      toggleFrameworkGrouping={[Function]}
+    />
+  </div>
+</div>
+`;
+
+exports[`Frames Supports different number of frames disable frame truncation 1`] = `
+<div
+  className="pane frames"
+>
+  <div
+    role="list"
+  >
+    <Frame
+      copyStackTrace={[Function]}
+      disableContextMenu={false}
+      frame={
+        Object {
+          "id": 1,
+        }
+      }
+      frameworkGroupingOn={false}
+      hideLocation={false}
+      key="1"
+      selectFrame={[MockFunction]}
+      selectable={false}
       selectedFrame={null}
       shouldMapDisplayName={true}
       toggleBlackBox={[MockFunction]}
@@ -345,6 +549,7 @@ exports[`Frames Supports different number of frames disable frame truncation 1`]
       hideLocation={false}
       key="2"
       selectFrame={[MockFunction]}
+      selectable={false}
       selectedFrame={null}
       shouldMapDisplayName={true}
       toggleBlackBox={[MockFunction]}
@@ -362,6 +567,7 @@ exports[`Frames Supports different number of frames disable frame truncation 1`]
       hideLocation={false}
       key="3"
       selectFrame={[MockFunction]}
+      selectable={false}
       selectedFrame={null}
       shouldMapDisplayName={true}
       toggleBlackBox={[MockFunction]}
@@ -379,6 +585,7 @@ exports[`Frames Supports different number of frames disable frame truncation 1`]
       hideLocation={false}
       key="4"
       selectFrame={[MockFunction]}
+      selectable={false}
       selectedFrame={null}
       shouldMapDisplayName={true}
       toggleBlackBox={[MockFunction]}
@@ -396,6 +603,7 @@ exports[`Frames Supports different number of frames disable frame truncation 1`]
       hideLocation={false}
       key="5"
       selectFrame={[MockFunction]}
+      selectable={false}
       selectedFrame={null}
       shouldMapDisplayName={true}
       toggleBlackBox={[MockFunction]}
@@ -413,6 +621,7 @@ exports[`Frames Supports different number of frames disable frame truncation 1`]
       hideLocation={false}
       key="6"
       selectFrame={[MockFunction]}
+      selectable={false}
       selectedFrame={null}
       shouldMapDisplayName={true}
       toggleBlackBox={[MockFunction]}
@@ -430,6 +639,7 @@ exports[`Frames Supports different number of frames disable frame truncation 1`]
       hideLocation={false}
       key="7"
       selectFrame={[MockFunction]}
+      selectable={false}
       selectedFrame={null}
       shouldMapDisplayName={true}
       toggleBlackBox={[MockFunction]}
@@ -447,6 +657,7 @@ exports[`Frames Supports different number of frames disable frame truncation 1`]
       hideLocation={false}
       key="8"
       selectFrame={[MockFunction]}
+      selectable={false}
       selectedFrame={null}
       shouldMapDisplayName={true}
       toggleBlackBox={[MockFunction]}
@@ -464,6 +675,7 @@ exports[`Frames Supports different number of frames disable frame truncation 1`]
       hideLocation={false}
       key="9"
       selectFrame={[MockFunction]}
+      selectable={false}
       selectedFrame={null}
       shouldMapDisplayName={true}
       toggleBlackBox={[MockFunction]}
@@ -481,6 +693,7 @@ exports[`Frames Supports different number of frames disable frame truncation 1`]
       hideLocation={false}
       key="10"
       selectFrame={[MockFunction]}
+      selectable={false}
       selectedFrame={null}
       shouldMapDisplayName={true}
       toggleBlackBox={[MockFunction]}
@@ -498,6 +711,7 @@ exports[`Frames Supports different number of frames disable frame truncation 1`]
       hideLocation={false}
       key="11"
       selectFrame={[MockFunction]}
+      selectable={false}
       selectedFrame={null}
       shouldMapDisplayName={true}
       toggleBlackBox={[MockFunction]}
@@ -515,6 +729,7 @@ exports[`Frames Supports different number of frames disable frame truncation 1`]
       hideLocation={false}
       key="12"
       selectFrame={[MockFunction]}
+      selectable={false}
       selectedFrame={null}
       shouldMapDisplayName={true}
       toggleBlackBox={[MockFunction]}
@@ -532,6 +747,7 @@ exports[`Frames Supports different number of frames disable frame truncation 1`]
       hideLocation={false}
       key="13"
       selectFrame={[MockFunction]}
+      selectable={false}
       selectedFrame={null}
       shouldMapDisplayName={true}
       toggleBlackBox={[MockFunction]}
@@ -549,6 +765,7 @@ exports[`Frames Supports different number of frames disable frame truncation 1`]
       hideLocation={false}
       key="14"
       selectFrame={[MockFunction]}
+      selectable={false}
       selectedFrame={null}
       shouldMapDisplayName={true}
       toggleBlackBox={[MockFunction]}
@@ -566,6 +783,7 @@ exports[`Frames Supports different number of frames disable frame truncation 1`]
       hideLocation={false}
       key="15"
       selectFrame={[MockFunction]}
+      selectable={false}
       selectedFrame={null}
       shouldMapDisplayName={true}
       toggleBlackBox={[MockFunction]}
@@ -583,6 +801,7 @@ exports[`Frames Supports different number of frames disable frame truncation 1`]
       hideLocation={false}
       key="16"
       selectFrame={[MockFunction]}
+      selectable={false}
       selectedFrame={null}
       shouldMapDisplayName={true}
       toggleBlackBox={[MockFunction]}
@@ -600,6 +819,7 @@ exports[`Frames Supports different number of frames disable frame truncation 1`]
       hideLocation={false}
       key="17"
       selectFrame={[MockFunction]}
+      selectable={false}
       selectedFrame={null}
       shouldMapDisplayName={true}
       toggleBlackBox={[MockFunction]}
@@ -617,6 +837,7 @@ exports[`Frames Supports different number of frames disable frame truncation 1`]
       hideLocation={false}
       key="18"
       selectFrame={[MockFunction]}
+      selectable={false}
       selectedFrame={null}
       shouldMapDisplayName={true}
       toggleBlackBox={[MockFunction]}
@@ -634,6 +855,7 @@ exports[`Frames Supports different number of frames disable frame truncation 1`]
       hideLocation={false}
       key="19"
       selectFrame={[MockFunction]}
+      selectable={false}
       selectedFrame={null}
       shouldMapDisplayName={true}
       toggleBlackBox={[MockFunction]}
@@ -651,12 +873,13 @@ exports[`Frames Supports different number of frames disable frame truncation 1`]
       hideLocation={false}
       key="20"
       selectFrame={[MockFunction]}
+      selectable={false}
       selectedFrame={null}
       shouldMapDisplayName={true}
       toggleBlackBox={[MockFunction]}
       toggleFrameworkGrouping={[Function]}
     />
-  </ul>
+  </div>
 </div>
 `;
 
@@ -676,7 +899,9 @@ exports[`Frames Supports different number of frames one frame 1`] = `
 <div
   className="pane frames"
 >
-  <ul>
+  <div
+    role="list"
+  >
     <Frame
       copyStackTrace={[Function]}
       disableContextMenu={false}
@@ -689,6 +914,7 @@ exports[`Frames Supports different number of frames one frame 1`] = `
       hideLocation={false}
       key="1"
       selectFrame={[MockFunction]}
+      selectable={false}
       selectedFrame={
         Object {
           "id": 1,
@@ -698,7 +924,7 @@ exports[`Frames Supports different number of frames one frame 1`] = `
       toggleBlackBox={[MockFunction]}
       toggleFrameworkGrouping={[Function]}
     />
-  </ul>
+  </div>
 </div>
 `;
 
@@ -706,7 +932,9 @@ exports[`Frames Supports different number of frames passes the getFrameTitle pro
 <div
   className="pane frames"
 >
-  <ul>
+  <div
+    role="list"
+  >
     <Frame
       copyStackTrace={[Function]}
       disableContextMenu={false}
@@ -727,12 +955,13 @@ exports[`Frames Supports different number of frames passes the getFrameTitle pro
       hideLocation={false}
       key="1"
       selectFrame={[MockFunction]}
+      selectable={false}
       selectedFrame={null}
       shouldMapDisplayName={true}
       toggleBlackBox={[MockFunction]}
       toggleFrameworkGrouping={[Function]}
     />
-  </ul>
+  </div>
 </div>
 `;
 
@@ -740,7 +969,9 @@ exports[`Frames Supports different number of frames toggling the show more butto
 <div
   className="pane frames"
 >
-  <ul>
+  <div
+    role="list"
+  >
     <Frame
       copyStackTrace={[Function]}
       disableContextMenu={false}
@@ -753,6 +984,7 @@ exports[`Frames Supports different number of frames toggling the show more butto
       hideLocation={false}
       key="1"
       selectFrame={[MockFunction]}
+      selectable={false}
       selectedFrame={
         Object {
           "id": 1,
@@ -774,6 +1006,7 @@ exports[`Frames Supports different number of frames toggling the show more butto
       hideLocation={false}
       key="2"
       selectFrame={[MockFunction]}
+      selectable={false}
       selectedFrame={
         Object {
           "id": 1,
@@ -795,6 +1028,7 @@ exports[`Frames Supports different number of frames toggling the show more butto
       hideLocation={false}
       key="3"
       selectFrame={[MockFunction]}
+      selectable={false}
       selectedFrame={
         Object {
           "id": 1,
@@ -816,6 +1050,7 @@ exports[`Frames Supports different number of frames toggling the show more butto
       hideLocation={false}
       key="4"
       selectFrame={[MockFunction]}
+      selectable={false}
       selectedFrame={
         Object {
           "id": 1,
@@ -837,6 +1072,7 @@ exports[`Frames Supports different number of frames toggling the show more butto
       hideLocation={false}
       key="5"
       selectFrame={[MockFunction]}
+      selectable={false}
       selectedFrame={
         Object {
           "id": 1,
@@ -858,6 +1094,7 @@ exports[`Frames Supports different number of frames toggling the show more butto
       hideLocation={false}
       key="6"
       selectFrame={[MockFunction]}
+      selectable={false}
       selectedFrame={
         Object {
           "id": 1,
@@ -879,6 +1116,7 @@ exports[`Frames Supports different number of frames toggling the show more butto
       hideLocation={false}
       key="7"
       selectFrame={[MockFunction]}
+      selectable={false}
       selectedFrame={
         Object {
           "id": 1,
@@ -900,6 +1138,7 @@ exports[`Frames Supports different number of frames toggling the show more butto
       hideLocation={false}
       key="8"
       selectFrame={[MockFunction]}
+      selectable={false}
       selectedFrame={
         Object {
           "id": 1,
@@ -921,6 +1160,7 @@ exports[`Frames Supports different number of frames toggling the show more butto
       hideLocation={false}
       key="9"
       selectFrame={[MockFunction]}
+      selectable={false}
       selectedFrame={
         Object {
           "id": 1,
@@ -942,6 +1182,7 @@ exports[`Frames Supports different number of frames toggling the show more butto
       hideLocation={false}
       key="10"
       selectFrame={[MockFunction]}
+      selectable={false}
       selectedFrame={
         Object {
           "id": 1,
@@ -951,7 +1192,7 @@ exports[`Frames Supports different number of frames toggling the show more butto
       toggleBlackBox={[MockFunction]}
       toggleFrameworkGrouping={[Function]}
     />
-  </ul>
+  </div>
   <div
     className="show-more-container"
   >

--- a/src/components/SecondaryPanes/Frames/tests/__snapshots__/Group.spec.js.snap
+++ b/src/components/SecondaryPanes/Frames/tests/__snapshots__/Group.spec.js.snap
@@ -5,9 +5,10 @@ exports[`Group displays a group 1`] = `
   className="frames-group"
   onContextMenu={[Function]}
 >
-  <li
+  <div
     className="group"
     onClick={[Function]}
+    role="listitem"
     tabIndex={0}
     title="Show Back frames"
   >
@@ -23,7 +24,7 @@ exports[`Group displays a group 1`] = `
     <Badge>
       1
     </Badge>
-  </li>
+  </div>
 </div>
 `;
 
@@ -32,10 +33,11 @@ exports[`Group passes the getFrameTitle prop to the Frame components 1`] = `
   className="frames-group expanded"
   onContextMenu={[Function]}
 >
-  <li
+  <div
     className="group"
     key="1"
     onClick={[Function]}
+    role="listitem"
     tabIndex={0}
     title="Collapse Back frames"
   >
@@ -58,7 +60,7 @@ exports[`Group passes the getFrameTitle prop to the Frame components 1`] = `
     <Badge>
       3
     </Badge>
-  </li>
+  </div>
   <div
     className="frames-list"
   >
@@ -149,10 +151,11 @@ exports[`Group renders group with anonymous functions 1`] = `
   className="frames-group"
   onContextMenu={[Function]}
 >
-  <li
+  <div
     className="group"
     key="1"
     onClick={[Function]}
+    role="listitem"
     tabIndex={0}
     title="Show Back frames"
   >
@@ -175,7 +178,7 @@ exports[`Group renders group with anonymous functions 1`] = `
     <Badge>
       3
     </Badge>
-  </li>
+  </div>
 </div>
 `;
 
@@ -184,10 +187,11 @@ exports[`Group renders group with anonymous functions 2`] = `
   className="frames-group expanded"
   onContextMenu={[Function]}
 >
-  <li
+  <div
     className="group"
     key="1"
     onClick={[Function]}
+    role="listitem"
     tabIndex={0}
     title="Collapse Back frames"
   >
@@ -210,7 +214,7 @@ exports[`Group renders group with anonymous functions 2`] = `
     <Badge>
       3
     </Badge>
-  </li>
+  </div>
   <div
     className="frames-list"
   >

--- a/test/mochitest/helpers.js
+++ b/test/mochitest/helpers.js
@@ -1095,8 +1095,8 @@ const selectors = {
   scopeNode: i => `.scopes-list .tree-node:nth-child(${i}) .object-label`,
   scopeValue: i =>
     `.scopes-list .tree-node:nth-child(${i}) .object-delimiter + *`,
-  frame: i => `.frames ul li:nth-child(${i})`,
-  frames: ".frames ul li",
+  frame: i => `.frames [role="list"] [role="listitem"]:nth-child(${i})`,
+  frames: `.frames [role="list"] [role="listitem"]`,
   gutter: i => `.CodeMirror-code *:nth-child(${i}) .CodeMirror-linenumber`,
   // These work for bobth the breakpoint listing and gutter marker
   gutterContextMenu: {


### PR DESCRIPTION
This PR adds a `selectable` props to the Frames component,
which, when true, will cause some white-space only nodes to
be added into the DOM.

We also switch list from `<ul>`s to `<div>`s with proper aria roles. This is unfortunate but this is the only way of not having the engine adding empty lines around the copied text (See [nsXHTMLContentSerializer.cpp#560,567](https://searchfox.org/mozilla-central/rev/c3ebaf6de2d481c262c04bb9657eaf76bf47e2ac/dom/base/nsXHTMLContentSerializer.cpp#560,567))

This is mainly aimed for the console where stacktraces can be
copied and where we want the clipboard output to be as helpful
as what is shown in the console output.

---

The testing is pretty light here because none of the component in the debugger should make use of the `selectable` prop.
It will be used in the console as part of [Bug 1486870](https://bugzilla.mozilla.org/show_bug.cgi?id=1486870), with some mochitests.

At some point that could be used to implement the `Copy stacktrace` context menu entry that we have in the debugger (at the moment the process feels very manual).