### PR TITLE
replace formatted breakpoint

### DIFF
--- a/src/actions/breakpoints/tests/__snapshots__/breakpoints.spec.js.snap
+++ b/src/actions/breakpoints/tests/__snapshots__/breakpoints.spec.js.snap
@@ -37,15 +37,32 @@ Array [
   Object {
     "breakpoints": Array [
       Object {
+        "astLocation": Object {
+          "index": 0,
+          "name": undefined,
+          "offset": Object {
+            "line": 2,
+            "sourceId": "a",
+            "sourceUrl": "http://localhost:8000/examples/a",
+          },
+        },
         "condition": null,
         "disabled": false,
-        "id": "hi",
-        "log": false,
-        "selectedLocation": Object {
+        "generatedLocation": Object {
           "line": 2,
           "sourceId": "a",
           "sourceUrl": "http://localhost:8000/examples/a",
         },
+        "hidden": false,
+        "id": "hi",
+        "loading": false,
+        "location": Object {
+          "line": 2,
+          "sourceId": "a",
+          "sourceUrl": "http://localhost:8000/examples/a",
+        },
+        "log": false,
+        "originalText": "return a",
         "text": "return a",
       },
     ],
@@ -107,15 +124,32 @@ Array [
   Object {
     "breakpoints": Array [
       Object {
+        "astLocation": Object {
+          "index": 0,
+          "name": undefined,
+          "offset": Object {
+            "line": 5,
+            "sourceId": "a",
+            "sourceUrl": "http://localhost:8000/examples/a",
+          },
+        },
         "condition": null,
         "disabled": true,
-        "id": "hi",
-        "log": false,
-        "selectedLocation": Object {
+        "generatedLocation": Object {
           "line": 5,
           "sourceId": "a",
           "sourceUrl": "http://localhost:8000/examples/a",
         },
+        "hidden": false,
+        "id": "hi",
+        "loading": false,
+        "location": Object {
+          "line": 5,
+          "sourceId": "a",
+          "sourceUrl": "http://localhost:8000/examples/a",
+        },
+        "log": false,
+        "originalText": "",
         "text": "",
       },
     ],

--- a/src/components/SecondaryPanes/Breakpoints/Breakpoint.js
+++ b/src/components/SecondaryPanes/Breakpoints/Breakpoint.js
@@ -8,18 +8,18 @@ import React, { PureComponent } from "react";
 import { connect } from "../../../utils/connect";
 import { createSelector } from "reselect";
 import classnames from "classnames";
-
 import actions from "../../../actions";
 
 import showContextMenu from "./BreakpointsContextMenu";
 import { CloseButton } from "../../shared/Button";
 
-import { getLocationWithoutColumn } from "../../../utils/breakpoint";
+import {
+  getLocationWithoutColumn,
+  getSelectedText
+} from "../../../utils/breakpoint";
 import { getSelectedLocation } from "../../../utils/source-maps";
 import { features } from "../../../utils/prefs";
 import { getEditor } from "../../../utils/editor";
-
-import type { FormattedBreakpoint } from "../../../selectors/breakpointSources";
 
 import type {
   Breakpoint as BreakpointType,
@@ -39,8 +39,9 @@ import {
 } from "../../../selectors";
 
 type Props = {
-  breakpoint: FormattedBreakpoint,
+  breakpoint: BreakpointType,
   breakpoints: BreakpointType[],
+  selectedSource: Source,
   source: Source,
   frame: FormattedFrame,
   enableBreakpoint: typeof actions.enableBreakpoint,
@@ -61,51 +62,52 @@ class Breakpoint extends PureComponent<Props> {
     showContextMenu({ ...this.props, contextMenuEvent: e });
   };
 
+  get selectedLocation() {
+    const { breakpoint, selectedSource } = this.props;
+    return getSelectedLocation(breakpoint, selectedSource);
+  }
+
   onDoubleClick = () => {
     const { breakpoint, openConditionalPanel } = this.props;
     if (breakpoint.condition) {
-      openConditionalPanel(breakpoint.selectedLocation);
+      openConditionalPanel(this.selectedLocation);
     }
   };
 
-  selectBreakpoint = event => {
-    const { breakpoint, selectSpecificLocation } = this.props;
-
-    event.preventDefault();
-    selectSpecificLocation(breakpoint.selectedLocation);
+  selectBreakpoint = () => {
+    const { selectSpecificLocation } = this.props;
+    selectSpecificLocation(this.selectedLocation);
   };
 
   removeBreakpoint = event => {
-    const { breakpoint, removeBreakpoint } = this.props;
-
+    const { removeBreakpoint } = this.props;
     event.stopPropagation();
-    removeBreakpoint(breakpoint.selectedLocation);
+    removeBreakpoint(this.selectedLocation);
   };
 
   handleBreakpointCheckbox = () => {
     const { breakpoint, enableBreakpoint, disableBreakpoint } = this.props;
     if (breakpoint.disabled) {
-      enableBreakpoint(breakpoint.selectedLocation);
+      enableBreakpoint(this.selectedLocation);
     } else {
-      disableBreakpoint(breakpoint.selectedLocation);
+      disableBreakpoint(this.selectedLocation);
     }
   };
 
   isCurrentlyPausedAtBreakpoint() {
-    const { frame, breakpoint } = this.props;
+    const { frame } = this.props;
     if (!frame) {
       return false;
     }
 
-    const bpId = getLocationWithoutColumn(breakpoint.selectedLocation);
+    const bpId = getLocationWithoutColumn(this.selectedLocation);
     const frameId = getLocationWithoutColumn(frame.selectedLocation);
-
     return bpId == frameId;
   }
 
   getBreakpointLocation() {
-    const { breakpoint, source } = this.props;
-    const { column, line } = breakpoint.selectedLocation;
+    const { source } = this.props;
+    const { column, line } = this.selectedLocation;
 
     const isWasm = source && source.isWasm;
     const columnVal = features.columnBreakpoints && column ? `:${column}` : "";
@@ -117,8 +119,8 @@ class Breakpoint extends PureComponent<Props> {
   }
 
   getBreakpointText() {
-    const { breakpoint } = this.props;
-    return breakpoint.condition || breakpoint.text;
+    const { breakpoint, selectedSource } = this.props;
+    return breakpoint.condition || getSelectedText(breakpoint, selectedSource);
   }
 
   highlightText() {
@@ -161,7 +163,6 @@ class Breakpoint extends PureComponent<Props> {
         <label
           htmlFor={breakpoint.id}
           className="breakpoint-label cm-s-mozilla"
-          onClick={this.selectBreakpoint}
           title={this.getBreakpointText()}
         >
           <span dangerouslySetInnerHTML={this.highlightText()} />

--- a/src/components/SecondaryPanes/Breakpoints/BreakpointsContextMenu.js
+++ b/src/components/SecondaryPanes/Breakpoints/BreakpointsContextMenu.js
@@ -6,13 +6,14 @@
 
 import { buildMenu, showMenu } from "devtools-contextmenu";
 
+import { getSelectedLocation } from "../../../utils/source-maps";
 import actions from "../../../actions";
-import type { Breakpoint } from "../../../types";
-import type { FormattedBreakpoint } from "../../../selectors/breakpointSources";
+import type { Breakpoint, Source } from "../../../types";
 
 type Props = {
-  breakpoint: FormattedBreakpoint,
+  breakpoint: Breakpoint,
   breakpoints: Breakpoint[],
+  selectedSource: Source,
   removeBreakpoint: typeof actions.removeBreakpoint,
   removeBreakpoints: typeof actions.removeBreakpoints,
   removeAllBreakpoints: typeof actions.removeAllBreakpoints,
@@ -29,6 +30,7 @@ export default function showContextMenu(props: Props) {
   const {
     breakpoint,
     breakpoints,
+    selectedSource,
     removeBreakpoint,
     removeBreakpoints,
     removeAllBreakpoints,
@@ -95,6 +97,7 @@ export default function showContextMenu(props: Props) {
     "breakpointMenuItem.addCondition2.accesskey"
   );
 
+  const selectedLocation = getSelectedLocation(breakpoint, selectedSource);
   const otherBreakpoints = breakpoints.filter(b => b.id !== breakpoint.id);
   const enabledBreakpoints = breakpoints.filter(b => !b.disabled);
   const disabledBreakpoints = breakpoints.filter(b => b.disabled);
@@ -110,7 +113,7 @@ export default function showContextMenu(props: Props) {
     label: deleteSelfLabel,
     accesskey: deleteSelfKey,
     disabled: false,
-    click: () => removeBreakpoint(breakpoint.selectedLocation)
+    click: () => removeBreakpoint(selectedLocation)
   };
 
   const deleteAllItem = {
@@ -134,7 +137,7 @@ export default function showContextMenu(props: Props) {
     label: enableSelfLabel,
     accesskey: enableSelfKey,
     disabled: false,
-    click: () => toggleDisabledBreakpoint(breakpoint.selectedLocation.line)
+    click: () => toggleDisabledBreakpoint(selectedLocation.line)
   };
 
   const enableAllItem = {
@@ -158,7 +161,7 @@ export default function showContextMenu(props: Props) {
     label: disableSelfLabel,
     accesskey: disableSelfKey,
     disabled: false,
-    click: () => toggleDisabledBreakpoint(breakpoint.selectedLocation.line)
+    click: () => toggleDisabledBreakpoint(selectedLocation.line)
   };
 
   const disableAllItem = {
@@ -181,7 +184,7 @@ export default function showContextMenu(props: Props) {
     label: removeConditionLabel,
     accesskey: removeConditionKey,
     disabled: false,
-    click: () => setBreakpointCondition(breakpoint.selectedLocation)
+    click: () => setBreakpointCondition(selectedLocation)
   };
 
   const addConditionItem = {
@@ -189,8 +192,8 @@ export default function showContextMenu(props: Props) {
     label: addConditionLabel,
     accesskey: addConditionKey,
     click: () => {
-      selectSpecificLocation(breakpoint.selectedLocation);
-      openConditionalPanel(breakpoint.selectedLocation);
+      selectSpecificLocation(selectedLocation);
+      openConditionalPanel(selectedLocation);
     }
   };
 
@@ -199,8 +202,8 @@ export default function showContextMenu(props: Props) {
     label: editConditionLabel,
     accesskey: editConditionKey,
     click: () => {
-      selectSpecificLocation(breakpoint.selectedLocation);
-      openConditionalPanel(breakpoint.selectedLocation);
+      selectSpecificLocation(selectedLocation);
+      openConditionalPanel(selectedLocation);
     }
   };
 

--- a/src/components/SecondaryPanes/Breakpoints/index.js
+++ b/src/components/SecondaryPanes/Breakpoints/index.js
@@ -15,9 +15,11 @@ import BreakpointHeading from "./BreakpointHeading";
 
 import actions from "../../../actions";
 import { getDisplayPath } from "../../../utils/source";
+import { getSelectedLocation } from "../../../utils/source-maps";
+
 import {
   makeLocationId,
-  sortFormattedBreakpoints
+  sortSelectedBreakpoints
 } from "../../../utils/breakpoint";
 
 import { getSelectedSource, getBreakpointSources } from "../../../selectors";
@@ -74,7 +76,7 @@ class Breakpoints extends Component<Props> {
   }
 
   renderBreakpoints() {
-    const { breakpointSources } = this.props;
+    const { breakpointSources, selectedSource } = this.props;
     const sources = [
       ...breakpointSources.map(({ source, breakpoints }) => source)
     ];
@@ -82,7 +84,10 @@ class Breakpoints extends Component<Props> {
     return [
       ...breakpointSources.map(({ source, breakpoints, i }) => {
         const path = getDisplayPath(source, sources);
-        const sortedBreakpoints = sortFormattedBreakpoints(breakpoints);
+        const sortedBreakpoints = sortSelectedBreakpoints(
+          breakpoints,
+          selectedSource
+        );
 
         return [
           <BreakpointHeading
@@ -95,7 +100,10 @@ class Breakpoints extends Component<Props> {
             <Breakpoint
               breakpoint={breakpoint}
               source={source}
-              key={makeLocationId(breakpoint.selectedLocation)}
+              selectedSource={selectedSource}
+              key={makeLocationId(
+                getSelectedLocation(breakpoint, selectedSource)
+              )}
             />
           ))
         ];

--- a/src/components/SecondaryPanes/Breakpoints/tests/Breakpoint.spec.js
+++ b/src/components/SecondaryPanes/Breakpoints/tests/Breakpoint.spec.js
@@ -6,7 +6,7 @@ import React from "react";
 import { shallow } from "enzyme";
 
 import Breakpoint from "../Breakpoint";
-import { makeSource } from "../../../../utils/test-head";
+import { makeSource, makeOriginalSource } from "../../../../utils/test-head";
 
 describe("Breakpoint", () => {
   it("simple", () => {
@@ -31,7 +31,8 @@ describe("Breakpoint", () => {
   it("paused at an original location", () => {
     const { component } = render({
       frame: { selectedLocation: location },
-      breakpoint: { selectedLocation: location }
+      breakpoint: { location },
+      selectedSource: makeOriginalSource("foo")
     });
 
     expect(component).toMatchSnapshot();
@@ -47,7 +48,6 @@ describe("Breakpoint", () => {
 
 const generatedLocation = { sourceId: "foo", line: 53, column: 73 };
 const location = { sourceId: "foo/original", line: 5, column: 7 };
-const selectedLocation = generatedLocation;
 
 function render(overrides = {}) {
   const props = generateDefaults(overrides);
@@ -60,7 +60,8 @@ function render(overrides = {}) {
 
 function makeBreakpoint(overrides = {}) {
   return {
-    selectedLocation,
+    location,
+    generatedLocation,
     disabled: false,
     ...overrides
   };

--- a/src/components/SecondaryPanes/Breakpoints/tests/__snapshots__/Breakpoint.spec.js.snap
+++ b/src/components/SecondaryPanes/Breakpoints/tests/__snapshots__/Breakpoint.spec.js.snap
@@ -16,7 +16,6 @@ exports[`Breakpoint disabled 1`] = `
   />
   <label
     className="breakpoint-label cm-s-mozilla"
-    onClick={[Function]}
   >
     <span
       dangerouslySetInnerHTML={
@@ -58,7 +57,6 @@ exports[`Breakpoint paused at a different 1`] = `
   />
   <label
     className="breakpoint-label cm-s-mozilla"
-    onClick={[Function]}
   >
     <span
       dangerouslySetInnerHTML={
@@ -100,7 +98,6 @@ exports[`Breakpoint paused at a generatedLocation 1`] = `
   />
   <label
     className="breakpoint-label cm-s-mozilla"
-    onClick={[Function]}
   >
     <span
       dangerouslySetInnerHTML={
@@ -142,7 +139,6 @@ exports[`Breakpoint paused at an original location 1`] = `
   />
   <label
     className="breakpoint-label cm-s-mozilla"
-    onClick={[Function]}
   >
     <span
       dangerouslySetInnerHTML={
@@ -184,7 +180,6 @@ exports[`Breakpoint simple 1`] = `
   />
   <label
     className="breakpoint-label cm-s-mozilla"
-    onClick={[Function]}
   >
     <span
       dangerouslySetInnerHTML={

--- a/src/selectors/breakpointSources.js
+++ b/src/selectors/breakpointSources.js
@@ -11,49 +11,16 @@ import {
   getBreakpointsList,
   getSelectedSource
 } from "../selectors";
-import { isGenerated, getFilename } from "../utils/source";
+import { getFilename } from "../utils/source";
 import { getSelectedLocation } from "../utils/source-maps";
 
-import type {
-  Source,
-  Breakpoint,
-  BreakpointId,
-  SourceLocation
-} from "../types";
+import type { Source, Breakpoint } from "../types";
 import type { Selector, SourcesMap } from "../reducers/types";
 
 export type BreakpointSources = Array<{
   source: Source,
-  breakpoints: FormattedBreakpoint[]
+  breakpoints: Breakpoint[]
 }>;
-
-export type FormattedBreakpoint = {|
-  id: BreakpointId,
-  condition: ?string,
-  log: boolean,
-  disabled: boolean,
-  text: string,
-  selectedLocation: SourceLocation
-|};
-
-function formatBreakpoint(
-  breakpoint: Breakpoint,
-  selectedSource: ?Source
-): FormattedBreakpoint {
-  const { id, condition, disabled, log } = breakpoint;
-
-  return {
-    id,
-    condition,
-    disabled,
-    log,
-    text:
-      selectedSource && isGenerated(selectedSource)
-        ? breakpoint.text
-        : breakpoint.originalText,
-    selectedLocation: getSelectedLocation(breakpoint, selectedSource)
-  };
-}
 
 function getBreakpointsForSource(
   source: Source,
@@ -68,8 +35,9 @@ function getBreakpointsForSource(
         !bp.loading &&
         (bp.text || bp.originalText || bp.condition || bp.disabled)
     )
-    .map(bp => formatBreakpoint(bp, selectedSource))
-    .filter(bp => bp.selectedLocation.sourceId == source.id);
+    .filter(
+      bp => getSelectedLocation(bp, selectedSource).sourceId == source.id
+    );
 }
 
 function findBreakpointSources(

--- a/src/utils/breakpoint/index.js
+++ b/src/utils/breakpoint/index.js
@@ -9,11 +9,13 @@ import { sortBy } from "lodash";
 import { getBreakpoint } from "../../selectors";
 import assert from "../assert";
 import { features } from "../prefs";
+import { getSelectedLocation } from "../source-maps";
+import { isGenerated } from "../source";
 
 export { getASTLocation, findScopeByName } from "./astBreakpointLocation";
 
-import type { FormattedBreakpoint } from "../../selectors/breakpointSources";
 import type {
+  Source,
   SourceLocation,
   PendingLocation,
   Breakpoint,
@@ -193,8 +195,27 @@ export function createPendingBreakpoint(bp: Breakpoint) {
   };
 }
 
-export function sortFormattedBreakpoints(breakpoints: FormattedBreakpoint[]) {
-  return _sortBreakpoints(breakpoints, "selectedLocation");
+export function getSelectedText(
+  breakpoint: Breakpoint,
+  selectedSource: Source
+) {
+  return selectedSource && isGenerated(selectedSource)
+    ? breakpoint.text
+    : breakpoint.originalText;
+}
+
+export function sortSelectedBreakpoints(
+  breakpoints: Breakpoint[],
+  selectedSource: Source
+): Breakpoint[] {
+  return sortBy(breakpoints, [
+    // Priority: line number, undefined column, column number
+    bp => getSelectedLocation(bp, selectedSource).line,
+    bp => {
+      const location = getSelectedLocation(bp, selectedSource);
+      return location.column === undefined || location.column;
+    }
+  ]);
 }
 
 export function sortBreakpoints(breakpoints: Breakpoint[]) {

--- a/src/utils/breakpoint/tests/index.spec.js
+++ b/src/utils/breakpoint/tests/index.spec.js
@@ -2,23 +2,26 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
-import { sortBreakpoints, sortFormattedBreakpoints } from "../index";
+import { sortBreakpoints, sortSelectedBreakpoints } from "../index";
 
 describe("breakpoint sorting", () => {
-  it("sortFormattedBreakpoints should sort by line number and column ", () => {
-    const sorted = sortFormattedBreakpoints([
-      { selectedLocation: { line: 100, column: 2 } },
-      { selectedLocation: { line: 9, column: 2 } },
-      { selectedLocation: { line: 2, column: undefined } },
-      { selectedLocation: { line: 2, column: 7 } }
-    ]);
+  it("sortSelectedBreakpoints should sort by line number and column ", () => {
+    const sorted = sortSelectedBreakpoints(
+      [
+        { location: { line: 100, column: 2 } },
+        { location: { line: 9, column: 2 } },
+        { location: { line: 2, column: undefined } },
+        { location: { line: 2, column: 7 } }
+      ],
+      { id: "foo/originalSource-1" }
+    );
 
-    expect(sorted[0].selectedLocation.line).toBe(2);
-    expect(sorted[0].selectedLocation.column).toBe(undefined);
-    expect(sorted[1].selectedLocation.line).toBe(2);
-    expect(sorted[1].selectedLocation.column).toBe(7);
-    expect(sorted[2].selectedLocation.line).toBe(9);
-    expect(sorted[3].selectedLocation.line).toBe(100);
+    expect(sorted[0].location.line).toBe(2);
+    expect(sorted[0].location.column).toBe(undefined);
+    expect(sorted[1].location.line).toBe(2);
+    expect(sorted[1].location.column).toBe(7);
+    expect(sorted[2].location.line).toBe(9);
+    expect(sorted[3].location.line).toBe(100);
   });
 
   it("sortBreakpoints should sort by line number and column ", () => {


### PR DESCRIPTION
### Summary

This is a small opinionated refactor, which is necessitated by our increased use of flow. The lesson is that `FormattedBreakpoint` can't be passed into functions that expect a `Breakpoint`