### PR TITLE
Fix #7647 - Update empty line color

### DIFF
--- a/src/components/Editor/Editor.css
+++ b/src/components/Editor/Editor.css
@@ -71,7 +71,7 @@ html[dir="rtl"] .editor-mount {
 }
 
 .theme-dark .cm-s-mozilla .empty-line .CodeMirror-linenumber {
-  color: var(--grey-60);
+  color: var(--grey-50);
 }
 
 :not(.empty-line):not(.new-breakpoint)


### PR DESCRIPTION
Fixes #7647

This is the empty lines portion; the regular line number color needs to be changed in MC.