### PR TITLE
Fix #7566 Use the same expand arrow icon as Inspector, Console etc.

### DIFF
--- a/images/arrow.svg
+++ b/images/arrow.svg
@@ -1,6 +1,6 @@
 <!-- This Source Code Form is subject to the terms of the Mozilla Public
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 16 16" fill="context-fill #9B9B9B">
-  <path d="M8 13.4c-.5 0-.9-.2-1.2-.6L.4 5.2C0 4.7-.1 4.3.2 3.7S1 3 1.6 3h12.8c.6 0 1.2.1 1.4.7.3.6.2 1.1-.2 1.6l-6.4 7.6c-.3.4-.7.5-1.2.5z"/>
+<svg viewBox="0 0 10 10" xmlns="http://www.w3.org/2000/svg">
+  <path d="M5 8c-.25 0-.35-.1-.65-.4l-3.1-3.35C.75 3.7 1.1 3 1.75 3h6.5c.65 0 1 .7.5 1.25L5.65 7.6c-.3.3-.4.4-.65.4z"/>
 </svg>

--- a/packages/devtools-components/src/images/arrow.svg
+++ b/packages/devtools-components/src/images/arrow.svg
@@ -1,6 +1,6 @@
 <!-- This Source Code Form is subject to the terms of the Mozilla Public
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
-<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="context-fill #9B9B9B">
-  <path d="M8 13.4c-.5 0-.9-.2-1.2-.6L.4 5.2C0 4.7-.1 4.3.2 3.7S1 3 1.6 3h12.8c.6 0 1.2.1 1.4.7.3.6.2 1.1-.2 1.6l-6.4 7.6c-.3.4-.7.5-1.2.5z"/>
+<svg viewBox="0 0 10 10" xmlns="http://www.w3.org/2000/svg">
+  <path d="M5 8c-.25 0-.35-.1-.65-.4l-3.1-3.35C.75 3.7 1.1 3 1.75 3h6.5c.65 0 1 .7.5 1.25L5.65 7.6c-.3.3-.4.4-.65.4z"/>
 </svg>

--- a/packages/devtools-components/src/tree.css
+++ b/packages/devtools-components/src/tree.css
@@ -58,8 +58,8 @@
   background:url(/images/arrow.svg) no-repeat;
   background-size:contain;
   background-position:center center;
-  width: 9px;
-  height: 9px;
+  width: 10px;
+  height: 10px;
   border:0;
   padding:0;
   margin-inline-start: 1px;

--- a/src/components/PrimaryPanes/Sources.css
+++ b/src/components/PrimaryPanes/Sources.css
@@ -112,6 +112,10 @@
   display: inline-block;
 }
 
+.sources-list .tree .arrow {
+  vertical-align: 1px;
+}
+
 .sources-list .tree .node .no-arrow {
   width: 10px;
   display: inline-block;

--- a/src/components/shared/Svg.css
+++ b/src/components/shared/Svg.css
@@ -316,17 +316,16 @@ span.img.marko {
 
 .img.arrow {
   mask: url(/images/arrow.svg);
-  margin-inline-end: 5px;
-  margin-top: 3px;
-  width: 9px;
-  height: 9px;
+  margin-inline-end: 4px;
+  width: 10px;
+  height: 10px;
   padding-top: 9px;
   background: var(--disclosure-arrow);
   mask-size: 100%;
   display: inline-block;
-  margin-bottom: 1px;
   transform: rotate(-90deg);
   transition: transform 0.18s ease;
+  vertical-align: -1px;
 }
 
 html[dir="rtl"] .img.arrow {
@@ -335,8 +334,10 @@ html[dir="rtl"] .img.arrow {
 
 .arrow {
   transition: transform 0.125s ease;
+  height: 10px;
   width: 10px;
   transform: rotate(-90deg);
+  vertical-align: -1px;
 }
 
 html[dir="rtl"] .arrow,

--- a/src/components/shared/Svg.css
+++ b/src/components/shared/Svg.css
@@ -325,7 +325,6 @@ span.img.marko {
   display: inline-block;
   transform: rotate(-90deg);
   transition: transform 0.18s ease;
-  vertical-align: -1px;
 }
 
 html[dir="rtl"] .img.arrow {


### PR DESCRIPTION
Fixes #7566 


### Summary of Changes

* Implemented new `arrow.svg` icon found in mozilla-central
* Edited stylesheets to ensure proper sizing of new arrow icon in debugger.

### Test Plan

Examined arrow icons with Firefox's DevTools' Inspector, in the Layout panel, and ran `yarn run test:all`.


