### PR TITLE
Specify top alignment for sources tree icons only

### DIFF
--- a/src/components/shared/Svg.css
+++ b/src/components/shared/Svg.css
@@ -286,6 +286,22 @@ span.img.marko {
   width: 15px;
   height: 15px;
   position: relative;
+}
+
+.sources-list .img.angular,
+.sources-list .img.webpack,
+.sources-list .img.vue,
+.sources-list .img.aframe,
+.sources-list .img.dojo,
+.sources-list .img.ember,
+.sources-list .img.marko,
+.sources-list .img.mobx,
+.sources-list .img.nextjs,
+.sources-list .img.nuxtjs,
+.sources-list .img.preact,
+.sources-list .img.pug,
+.sources-list .img.rxjs,
+.sources-list .img.sencha-extjs {
   top: 3px;
 }
 


### PR DESCRIPTION
The previous PR for SVG's was too broad; this PR styles the top margin for only icons appearing in the SourcesTree.