### PR TITLE
[Editor] add overflow-anchor:none as a temporary fix

### DIFF
--- a/src/components/Editor/Editor.css
+++ b/src/components/Editor/Editor.css
@@ -25,6 +25,10 @@
   min-width: 0 !important;
 }
 
+.CodeMirror.cm-s-mozilla, .CodeMirror-scroll, .CodeMirror-sizer {
+  overflow-anchor: none;
+}
+
 .theme-dark {
   --theme-conditional-breakpoint-color: #9fa4a9;
 }


### PR DESCRIPTION
This adds a short-term fix when the user scrolls in the editor in nightly
https://bugzilla.mozilla.org/show_bug.cgi?id=1519462#c8