### PR TITLE
[breakpoints] Add possible breakpoints positions

### DIFF
--- a/src/actions/breakpoints/addBreakpoint.js
+++ b/src/actions/breakpoints/addBreakpoint.js
@@ -20,12 +20,13 @@ import {
   getSource,
   getSourceActors,
   getSymbols,
-  getFirstPausePointLocation
+  getFirstVisibleBreakpointPosition
 } from "../../selectors";
 import { getGeneratedLocation } from "../../utils/source-maps";
 import { getTextAtPosition } from "../../utils/source";
 import { recordEvent } from "../../utils/telemetry";
 import { features } from "../../utils/prefs";
+import { setBreakpointPositions } from "./breakpointPositions";
 
 import type {
   BreakpointOptions,
@@ -146,26 +147,26 @@ export function enableBreakpoint(breakpoint: Breakpoint) {
   };
 }
 
-/**
- * Add a new breakpoint
- *
- * @memberof actions/breakpoints
- * @static
- * @param {BreakpointOptions} options Any options for the new breakpoint.
- */
-
 export function addBreakpoint(
   location: SourceLocation,
   options: BreakpointOptions = {}
 ) {
   return async ({ dispatch, getState, sourceMaps, client }: ThunkArgs) => {
     recordEvent("add_breakpoint");
-
+    let breakpointPosition = location;
     if (features.columnBreakpoints && location.column === undefined) {
-      location = getFirstPausePointLocation(getState(), location);
+      await dispatch(setBreakpointPositions(location));
+      breakpointPosition = getFirstVisibleBreakpointPosition(
+        getState(),
+        location
+      );
     }
 
-    const breakpoint = createBreakpoint(location, options);
+    if (!breakpointPosition) {
+      return;
+    }
+
+    const breakpoint = createBreakpoint(breakpointPosition, options);
 
     return dispatch({
       type: "ADD_BREAKPOINT",

--- a/src/actions/breakpoints/breakpointPositions.js
+++ b/src/actions/breakpoints/breakpointPositions.js
@@ -1,0 +1,32 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
+import {
+  getSourceActors,
+  getBreakpointPositionsForLine
+} from "../../selectors";
+
+import { makeSourceActorLocation } from "../../utils/breakpoint";
+
+export function setBreakpointPositions(location) {
+  return async ({ getState, dispatch, client }: ThunkArgs) => {
+    if (
+      getBreakpointPositionsForLine(
+        getState(),
+        location.sourceId,
+        location.line
+      )
+    ) {
+      return;
+    }
+
+    const sourceActors = getSourceActors(getState(), location.sourceId);
+    const sourceActor = sourceActors[0];
+
+    const sourceActorLocation = makeSourceActorLocation(sourceActor, location);
+    const positions = await client.getBreakpointPositions(sourceActorLocation);
+
+    return dispatch({ type: "ADD_BREAKPOINT_POSITIONS", positions, location });
+  };
+}

--- a/src/actions/breakpoints/syncBreakpoint.js
+++ b/src/actions/breakpoints/syncBreakpoint.js
@@ -3,6 +3,8 @@
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
 // @flow
+
+import { setBreakpointPositions } from "./breakpointPositions";
 import {
   locationMoved,
   createBreakpoint,
@@ -16,6 +18,8 @@ import { getGeneratedLocation } from "../../utils/source-maps";
 import { getTextAtPosition } from "../../utils/source";
 import { originalToGeneratedId, isOriginalId } from "devtools-source-map";
 import { getSource, getSourceActors } from "../../selectors";
+import { features } from "../../utils/prefs";
+
 import type { ThunkArgs, Action } from "../types";
 
 import type {
@@ -75,6 +79,7 @@ export async function syncBreakpointPromise(
   getState: Function,
   client: Object,
   sourceMaps: Object,
+  dispatch: Function,
   sourceId: SourceId,
   pendingBreakpoint: PendingBreakpoint
 ): Promise<BreakpointSyncData | null> {
@@ -121,10 +126,19 @@ export async function syncBreakpointPromise(
   );
 
   const sourceActors = getSourceActors(getState(), sourceId);
+  let possiblePosition = true;
+  if (features.columnBreakpoints && generatedLocation.column != undefined) {
+    const { positions } = await dispatch(
+      setBreakpointPositions(generatedLocation)
+    );
+    if (!positions.includes(generatedLocation.column)) {
+      possiblePosition = false;
+    }
+  }
 
   /** ******* CASE 1: No server change ***********/
   // early return if breakpoint is disabled or we are in the sameLocation
-  if (pendingBreakpoint.disabled || isSameLocation) {
+  if (possiblePosition && (pendingBreakpoint.disabled || isSameLocation)) {
     // Make sure the breakpoint is installed on all source actors.
     if (!pendingBreakpoint.disabled) {
       for (const sourceActor of sourceActors) {
@@ -166,13 +180,13 @@ export async function syncBreakpointPromise(
     }
   }
 
+  if (!possiblePosition || !scopedGeneratedLocation.line) {
+    return { previousLocation, breakpoint: null };
+  }
+
   /** ******* Case 2: Add New Breakpoint ***********/
   // If we are not disabled, set the breakpoint on the server and get
   // that info so we can set it on our breakpoints.
-
-  if (!scopedGeneratedLocation.line) {
-    return { previousLocation, breakpoint: null };
-  }
 
   const newGeneratedLocation = { ...scopedGeneratedLocation };
   for (const sourceActor of sourceActors) {
@@ -226,6 +240,7 @@ export function syncBreakpoint(
       getState,
       client,
       sourceMaps,
+      dispatch,
       sourceId,
       pendingBreakpoint
     );

--- a/src/actions/breakpoints/tests/syncing.spec.js
+++ b/src/actions/breakpoints/tests/syncing.spec.js
@@ -135,6 +135,7 @@ describe("loading the debugger", () => {
       getState,
       threadClient,
       sourceMaps,
+      dispatch,
       reloadedSource.source.id,
       pendingBreakpoint()
     );
@@ -165,6 +166,7 @@ describe("loading the debugger", () => {
       getState,
       threadClient,
       sourceMaps,
+      dispatch,
       reloadedSource.source.id,
       pendingBreakpoint()
     );
@@ -209,6 +211,7 @@ describe("reloading debuggee", () => {
       getState,
       threadClient,
       sourceMaps,
+      dispatch,
       reloadedSource.source.id,
       pendingBreakpoint({ location: loc1 })
     );
@@ -252,6 +255,7 @@ describe("reloading debuggee", () => {
       getState,
       threadClient,
       sourceMaps,
+      dispatch,
       reloadedSource.source.id,
       pendingBreakpoint()
     );

--- a/src/actions/types/BreakpointAction.js
+++ b/src/actions/types/BreakpointAction.js
@@ -4,7 +4,12 @@
 
 // @flow
 
-import type { Breakpoint, SourceLocation, XHRBreakpoint } from "../../types";
+import type {
+  Breakpoint,
+  SourceLocation,
+  XHRBreakpoint,
+  BreakpointLinePositions
+} from "../../types";
 
 import type { PromiseAction } from "../utils/middleware/promise";
 
@@ -91,4 +96,9 @@ export type BreakpointAction =
   | {|
       +type: "REMAP_BREAKPOINTS",
       +breakpoints: Breakpoint[]
+    |}
+  | {|
+      type: "ADD_BREAKPOINT_POSITIONS",
+      positions: BreakpointLinePositions,
+      location: SourceLocation
     |};

--- a/src/client/firefox/commands.js
+++ b/src/client/firefox/commands.js
@@ -461,6 +461,23 @@ function getMainThread() {
   return threadClient.actor;
 }
 
+async function getBreakpointPositions(
+  location: SourceActorLocation
+): Promise<Array<Number>> {
+  const {
+    sourceActor: { thread, actor },
+    line
+  } = location;
+  const sourceThreadClient = lookupThreadClient(thread);
+  const sourceClient = sourceThreadClient.source({ actor });
+  const { positions } = await sourceClient.getBreakpointPositionsCompressed({
+    start: { line },
+    end: { line }
+  });
+
+  return positions ? positions[line] : [];
+}
+
 const clientCommands = {
   autocomplete,
   blackBox,
@@ -481,6 +498,7 @@ const clientCommands = {
   sourceContents,
   getSourceForActor,
   getBreakpointByLocation,
+  getBreakpointPositions,
   setBreakpoint,
   setXHRBreakpoint,
   removeXHRBreakpoint,

--- a/src/client/firefox/types.js
+++ b/src/client/firefox/types.js
@@ -333,6 +333,10 @@ export type SourceClient = {
     condition: ?string,
     noSliding: boolean
   }) => Promise<BreakpointResponse>,
+  getBreakpointPositionsCompressed: (range: {
+    start: { line: number },
+    end: { line: number }
+  }) => Promise<any>,
   prettyPrint: number => Promise<*>,
   disablePrettyPrint: () => Promise<*>,
   blackBox: (range?: Range) => Promise<*>,

--- a/src/components/SecondaryPanes/Frames/Group.js
+++ b/src/components/SecondaryPanes/Frames/Group.js
@@ -159,7 +159,7 @@ export default class Group extends Component<Props, State> {
         <FrameLocation frame={frame} expanded={expanded} />
         {selectable && <span className="clipboard-only"> </span>}
         <Badge>{this.props.group.length}</Badge>
-        {selectable && <br className="clipboard-only"/>}
+        {selectable && <br className="clipboard-only" />}
       </div>
     );
   }

--- a/src/reducers/ast.js
+++ b/src/reducers/ast.js
@@ -232,30 +232,6 @@ export function getPausePoint(
   }
 }
 
-export function getFirstPausePointLocation(
-  state: OuterState,
-  location: SourceLocation
-): SourceLocation {
-  const { sourceId } = location;
-  const pausePoints = getPausePoints(state, location.sourceId);
-  if (!pausePoints) {
-    return location;
-  }
-
-  const pausesAtLine = pausePoints.filter(
-    point => point.location.line == location.line
-  );
-
-  if (pausesAtLine) {
-    const values: PausePoint[] = (Object.values(pausesAtLine): any);
-    const firstPausePoint = values.find(pausePoint => pausePoint.types.break);
-    if (firstPausePoint) {
-      return { ...firstPausePoint.location, sourceId };
-    }
-  }
-  return location;
-}
-
 export function hasPausePoints(state: OuterState, sourceId: string): boolean {
   const pausePoints = getPausePoints(state, sourceId);
   return !!pausePoints;

--- a/src/reducers/breakpoints.js
+++ b/src/reducers/breakpoints.js
@@ -18,7 +18,10 @@ import type {
   XHRBreakpoint,
   Breakpoint,
   BreakpointId,
-  SourceLocation
+  SourceLocation,
+  BreakpointPositions,
+  BreakpointLinePositions,
+  BreakpointSourcePositions
 } from "../types";
 import type { Action, DonePromiseAction } from "../actions/types";
 
@@ -27,7 +30,9 @@ export type XHRBreakpointsList = $ReadOnlyArray<XHRBreakpoint>;
 
 export type BreakpointsState = {
   breakpoints: BreakpointsMap,
-  xhrBreakpoints: XHRBreakpointsList
+  breakpointPositions: BreakpointPositions,
+  xhrBreakpoints: XHRBreakpointsList,
+  breakpointsDisabled: boolean
 };
 
 export function initialBreakpointsState(
@@ -36,6 +41,7 @@ export function initialBreakpointsState(
   return {
     breakpoints: {},
     xhrBreakpoints: xhrBreakpoints,
+    breakpointPositions: {},
     breakpointsDisabled: false
   };
 }
@@ -103,6 +109,21 @@ function update(
 
     case "DISABLE_XHR_BREAKPOINT": {
       return updateXHRBreakpoint(state, action);
+    }
+
+    case "ADD_BREAKPOINT_POSITIONS": {
+      const {
+        location: { sourceId, line },
+        positions
+      } = action;
+      const sourcePositions = state.breakpointPositions[sourceId] || {};
+      return {
+        ...state,
+        breakpointPositions: {
+          ...state.breakpointPositions,
+          [sourceId]: { ...sourcePositions, [line]: positions }
+        }
+      };
     }
   }
 
@@ -329,6 +350,29 @@ export function getBreakpointForLocation(
 export function getHiddenBreakpoint(state: OuterState): ?Breakpoint {
   const breakpoints = getBreakpointsList(state);
   return breakpoints.find(bp => bp.options.hidden);
+}
+
+export function getBreakpointPositions(
+  state: OuterState
+): ?BreakpointPositions {
+  return state.breakpoints.breakpointPositions;
+}
+
+export function getBreakpointPositionsForSource(
+  state: OuterState,
+  sourceId: string
+): ?BreakpointSourcePositions {
+  const positions = getBreakpointPositions(state);
+  return positions && positions[sourceId];
+}
+
+export function getBreakpointPositionsForLine(
+  state: OuterState,
+  sourceId: string,
+  line: number
+): ?BreakpointLinePositions {
+  const positions = getBreakpointPositionsForSource(state, sourceId);
+  return positions ? positions[line] : null;
 }
 
 export default update;

--- a/src/selectors/index.js
+++ b/src/selectors/index.js
@@ -30,7 +30,8 @@ export {
 } from "./breakpointAtLocation";
 export {
   getVisibleBreakpoints,
-  getFirstVisibleBreakpoints
+  getFirstVisibleBreakpoints,
+  getFirstVisibleBreakpointPosition
 } from "./visibleBreakpoints";
 export { inComponent } from "./inComponent";
 export { isSelectedFrameVisible } from "./isSelectedFrameVisible";

--- a/src/selectors/visibleBreakpoints.js
+++ b/src/selectors/visibleBreakpoints.js
@@ -7,14 +7,24 @@
 import { createSelector } from "reselect";
 import { uniqBy } from "lodash";
 
-import { getBreakpointsList } from "../reducers/breakpoints";
+import {
+  getBreakpointsList,
+  getBreakpointPositionsForLine,
+  getBreakpointPositions
+} from "../reducers/breakpoints";
+import { getPausePoints } from "../reducers/ast";
 import { getSelectedSource } from "../reducers/sources";
 
 import { sortBreakpoints } from "../utils/breakpoint";
 import { getSelectedLocation } from "../utils/source-maps";
 
-import type { Breakpoint, Source } from "../types";
-import type { Selector } from "../reducers/types";
+import type {
+  Breakpoint,
+  Source,
+  SourceLocation,
+  BreakpointPositions
+} from "../types";
+import type { Selector, State } from "../reducers/types";
 
 function isVisible(breakpoint: Breakpoint, selectedSource: Source) {
   const location = getSelectedLocation(breakpoint, selectedSource);
@@ -27,7 +37,12 @@ function isVisible(breakpoint: Breakpoint, selectedSource: Source) {
 export const getVisibleBreakpoints: Selector<?(Breakpoint[])> = createSelector(
   getSelectedSource,
   getBreakpointsList,
-  (selectedSource: ?Source, breakpoints: Breakpoint[]) => {
+  getBreakpointPositions,
+  (
+    selectedSource: ?Source,
+    breakpoints: Breakpoint[],
+    positions: ?BreakpointPositions
+  ) => {
     if (selectedSource == null) {
       return null;
     }
@@ -38,6 +53,33 @@ export const getVisibleBreakpoints: Selector<?(Breakpoint[])> = createSelector(
     return breakpoints.filter(bp => isVisible(bp, source));
   }
 );
+
+export function getFirstVisibleBreakpointPosition(
+  state: State,
+  location: SourceLocation
+): ?SourceLocation {
+  const { sourceId, line } = location;
+  const pausePoints = getPausePoints(state, location.sourceId);
+  const positions = getBreakpointPositionsForLine(state, sourceId, line);
+
+  if (!pausePoints || !positions) {
+    return null;
+  }
+
+  const pausesAtLine = pausePoints.filter(
+    p => p.location.line == line && positions.includes(p.location.column)
+  );
+
+  if (pausesAtLine.length > 0) {
+    const firstPausePoint = pausesAtLine.find(
+      pausePoint => pausePoint.types.break
+    );
+    if (firstPausePoint) {
+      return { ...firstPausePoint.location, sourceId };
+    }
+  }
+  return location;
+}
 
 /*
  * Finds the first breakpoint per line, which appear in the selected source.

--- a/src/types.js
+++ b/src/types.js
@@ -440,3 +440,8 @@ export type Cancellable = {
 export type EventListenerBreakpoints = string[];
 
 export type SourceDocuments = { [string]: Object };
+
+export type BreakpointPosition = { line: number, string: number };
+export type BreakpointLinePositions = Array<BreakpointPosition>;
+export type BreakpointSourcePositions = { [number]: BreakpointLinePositions };
+export type BreakpointPositions = { [string]: BreakpointSourcePositions };

--- a/test/mochitest/helpers.js
+++ b/test/mochitest/helpers.js
@@ -767,10 +767,13 @@ function findBreakpoint(dbg, url, line) {
   if (
     Services.prefs.getBoolPref("devtools.debugger.features.column-breakpoints")
   ) {
-    column = dbg.selectors.getFirstPausePointLocation(dbg.store.getState(), {
-      sourceId: source.id,
-      line
-    }).column;
+    ({ column } = dbg.selectors.getFirstVisibleBreakpointPosition(
+      dbg.store.getState(), 
+      {
+        sourceId: source.id, 
+        line
+      }
+    ));
   }
   return getBreakpoint(getState(), { sourceId: source.id, line, column });
 }


### PR DESCRIPTION

### Summary of Changes

Adds "possible breakpoints" which are positions that the server says would be good places to place breakpoints. This is something we want for a couple of reasons:

1. when we place a breakpoint we want to know it'll be good
2. we want to know what lines the engine considers empty

