### PR TITLE
Show command bar if paused and secondary panel hidden

### DIFF
--- a/src/actions/pause/paused.js
+++ b/src/actions/pause/paused.js
@@ -8,7 +8,8 @@ import {
   isEvaluatingExpression,
   getSelectedFrame,
   getSources,
-  getLastCommand
+  getLastCommand,
+  isStepping
 } from "../../selectors";
 
 import { mapFrames } from ".";
@@ -41,6 +42,7 @@ export function paused(pauseInfo: Pause) {
   return async function({ dispatch, getState, client, sourceMaps }: ThunkArgs) {
     const { thread, frames, why, loadedObjects } = pauseInfo;
     const topFrame = frames.length > 0 ? frames[0] : null;
+    const didStep = isStepping(getState());
 
     // NOTE: do not step when leaving a frame or paused at a debugger statement
     if (topFrame && !why.frameFinished && why.type == "resumeLimit") {
@@ -81,7 +83,10 @@ export function paused(pauseInfo: Pause) {
       await dispatch(selectLocation(selectedFrame.location));
     }
 
-    dispatch(togglePaneCollapse("end", false));
+    if (!didStep) {
+      dispatch(togglePaneCollapse("end", false));
+    }
+
     await dispatch(fetchScopes());
 
     // Run after fetching scoping data so that it may make use of the sourcemap

--- a/src/actions/pause/paused.js
+++ b/src/actions/pause/paused.js
@@ -9,7 +9,7 @@ import {
   getSelectedFrame,
   getSources,
   getLastCommand,
-  isStepping
+  wasStepping
 } from "../../selectors";
 
 import { mapFrames } from ".";
@@ -42,7 +42,6 @@ export function paused(pauseInfo: Pause) {
   return async function({ dispatch, getState, client, sourceMaps }: ThunkArgs) {
     const { thread, frames, why, loadedObjects } = pauseInfo;
     const topFrame = frames.length > 0 ? frames[0] : null;
-    const didStep = isStepping(getState());
 
     // NOTE: do not step when leaving a frame or paused at a debugger statement
     if (topFrame && !why.frameFinished && why.type == "resumeLimit") {
@@ -83,7 +82,7 @@ export function paused(pauseInfo: Pause) {
       await dispatch(selectLocation(selectedFrame.location));
     }
 
-    if (!didStep) {
+    if (!wasStepping(getState())) {
       dispatch(togglePaneCollapse("end", false));
     }
 

--- a/src/actions/pause/resumed.js
+++ b/src/actions/pause/resumed.js
@@ -23,7 +23,7 @@ export function resumed(packet: ResumedPacket) {
     const wasPausedInEval = inDebuggerEval(why);
     const wasStepping = isStepping(getState());
 
-    dispatch({ type: "RESUME", thread: packet.from });
+    dispatch({ type: "RESUME", thread: packet.from, wasStepping });
 
     if (!wasStepping && !wasPausedInEval) {
       await dispatch(evaluateExpressions());

--- a/src/actions/pause/tests/pause.spec.js
+++ b/src/actions/pause/tests/pause.spec.js
@@ -20,12 +20,8 @@ import * as parser from "../../../workers/parser/index";
 
 const { isStepping } = selectors;
 
-let stepInResolve = null;
 const mockThreadClient = {
-  stepIn: () =>
-    new Promise(_resolve => {
-      stepInResolve = _resolve;
-    }),
+  stepIn: () => new Promise(_resolve => _resolve),
   stepOver: () => new Promise(_resolve => _resolve),
   evaluate: async () => {},
   evaluateInFrame: async () => {},
@@ -103,13 +99,13 @@ function resumedPacket() {
 
 describe("pause", () => {
   describe("stepping", () => {
-    it("should set and clear the command", async () => {
+    it("should set the command", async () => {
       const { dispatch, getState } = createStore(mockThreadClient);
       const mockPauseInfo = createPauseInfo();
 
       await dispatch(actions.newSource(makeSource("foo1")));
       await dispatch(actions.paused(mockPauseInfo));
-      const stepped = dispatch(actions.stepIn());
+      dispatch(actions.stepIn());
       expect(isStepping(getState())).toBeTruthy();
       if (!stepInResolve) {
         throw new Error("no stepInResolve");

--- a/src/actions/pause/tests/pause.spec.js
+++ b/src/actions/pause/tests/pause.spec.js
@@ -20,8 +20,12 @@ import * as parser from "../../../workers/parser/index";
 
 const { isStepping } = selectors;
 
+let stepInResolve = null;
 const mockThreadClient = {
-  stepIn: () => new Promise(_resolve => _resolve),
+  stepIn: () =>
+    new Promise(_resolve => {
+      stepInResolve = _resolve;
+    }),
   stepOver: () => new Promise(_resolve => _resolve),
   evaluate: async () => {},
   evaluateInFrame: async () => {},
@@ -99,13 +103,13 @@ function resumedPacket() {
 
 describe("pause", () => {
   describe("stepping", () => {
-    it("should set the command", async () => {
+    it("should set and clear the command", async () => {
       const { dispatch, getState } = createStore(mockThreadClient);
       const mockPauseInfo = createPauseInfo();
 
       await dispatch(actions.newSource(makeSource("foo1")));
       await dispatch(actions.paused(mockPauseInfo));
-      dispatch(actions.stepIn());
+      const stepped = dispatch(actions.stepIn());
       expect(isStepping(getState())).toBeTruthy();
       if (!stepInResolve) {
         throw new Error("no stepInResolve");

--- a/src/actions/types/PauseAction.js
+++ b/src/actions/types/PauseAction.js
@@ -18,7 +18,8 @@ export type PauseAction =
   | {|
       +type: "RESUME",
       +thread: string,
-      +value: void
+      +value: void,
+      +wasStepping: boolean
     |}
   | {|
       +type: "PAUSED",

--- a/src/components/Editor/Tabs.css
+++ b/src/components/Editor/Tabs.css
@@ -15,24 +15,6 @@
   user-select: none;
 }
 
-<<<<<<< head|||||||merged common ancestors .source-header .new-tab-btn {
-  padding: 4px;
-  margin-top: 4px;
-  margin-left: 2px;
-  fill: var(--theme-comment);
-  transition: 0.1s ease;
-  align-self: center;
-}
-
-.source-header .new-tab-btn:hover {
-  background-color: var(--theme-toolbar-background-hover);
-}
-
-.source-header .new-tab-btn svg {
-  width: 12px;
-  display: block;
-}
-
 .source-header .command-bar {
   flex: initial;
   flex-shrink: 0;

--- a/src/components/Editor/Tabs.css
+++ b/src/components/Editor/Tabs.css
@@ -15,6 +15,31 @@
   user-select: none;
 }
 
+<<<<<<< head|||||||merged common ancestors .source-header .new-tab-btn {
+  padding: 4px;
+  margin-top: 4px;
+  margin-left: 2px;
+  fill: var(--theme-comment);
+  transition: 0.1s ease;
+  align-self: center;
+}
+
+.source-header .new-tab-btn:hover {
+  background-color: var(--theme-toolbar-background-hover);
+}
+
+.source-header .new-tab-btn svg {
+  width: 12px;
+  display: block;
+}
+
+.source-header .command-bar {
+  flex: initial;
+  flex-shrink: 0;
+  border-bottom: 0;
+  border-inline-start: 1px solid var(--theme-splitter-color);
+}
+
 .source-tabs {
   max-width: calc(100% - 80px);
   align-self: flex-start;
@@ -43,7 +68,8 @@
   width: 100%;
   height: 2px;
   background-color: var(--tab-line-color, transparent);
-  transition: transform 250ms var(--animation-curve), opacity 250ms var(--animation-curve);
+  transition: transform 250ms var(--animation-curve),
+    opacity 250ms var(--animation-curve);
   opacity: 0;
   transform: scaleX(0);
 }

--- a/src/components/Editor/Tabs.js
+++ b/src/components/Editor/Tabs.js
@@ -7,7 +7,11 @@
 import React, { PureComponent } from "react";
 import { connect } from "../../utils/connect";
 
-import { getSelectedSource, getSourcesForTabs } from "../../selectors";
+import {
+  getSelectedSource,
+  getSourcesForTabs,
+  getIsPaused
+} from "../../selectors";
 import { isVisible } from "../../utils/ui";
 
 import { getHiddenTabs } from "../../utils/tabs";
@@ -21,6 +25,7 @@ import Tab from "./Tab";
 import { PaneToggleButton } from "../shared/Button";
 import Dropdown from "../shared/Dropdown";
 import AccessibleImage from "../shared/AccessibleImage";
+import CommandBar from "../SecondaryPanes/CommandBar";
 
 import type { Source } from "../../types";
 
@@ -36,7 +41,8 @@ type Props = {
   closeTab: typeof actions.closeTab,
   togglePaneCollapse: typeof actions.togglePaneCollapse,
   showSource: typeof actions.showSource,
-  selectSource: typeof actions.selectSource
+  selectSource: typeof actions.selectSource,
+  isPaused: boolean
 };
 
 type State = {
@@ -170,6 +176,15 @@ class Tabs extends PureComponent<Props, State> {
     return <Dropdown panel={Panel} icon={icon} />;
   }
 
+  renderCommandBar() {
+    const { horizontal, endPanelCollapsed, isPaused } = this.props;
+    if (!endPanelCollapsed || !isPaused) {
+      return;
+    }
+
+    return <CommandBar horizontal={horizontal} />;
+  }
+
   renderStartPanelToggleButton() {
     return (
       <PaneToggleButton
@@ -203,6 +218,7 @@ class Tabs extends PureComponent<Props, State> {
         {this.renderTabs()}
         {this.renderDropdown()}
         {this.renderEndPanelToggleButton()}
+        {this.renderCommandBar()}
       </div>
     );
   }
@@ -210,7 +226,8 @@ class Tabs extends PureComponent<Props, State> {
 
 const mapStateToProps = state => ({
   selectedSource: getSelectedSource(state),
-  tabSources: getSourcesForTabs(state)
+  tabSources: getSourcesForTabs(state),
+  isPaused: getIsPaused(state)
 });
 
 export default connect(

--- a/src/reducers/pause.js
+++ b/src/reducers/pause.js
@@ -270,7 +270,7 @@ function update(
           previousLocation: getPauseLocation(threadState(), action)
         });
       }
-      return updateThreadState({ command: null });
+      return updateThreadState({ command: action.command });
 
     case "RESUME":
       // Workaround for threads resuming before the initial connection.


### PR DESCRIPTION
## Summary

Display the command bar in the tab bar if the debugger is paused and the secondary panel is closed. This allows users to step while keeping the secondary panel closed.

Fixes #7667 

## Discussion Points

- Can the appearance be improved? Is the command bar is the wrong place here?
- The secondary panel will continue to open automatically if a breakpoint is hit and the user is not stepping.
- Should this be a opt-in via an option?

## Demo

![](http://g.recordit.co/s5G79g4gj9.gif)