### PR TITLE
[XHR Breakpoints] Clicking text toggles breakpoint

### DIFF
--- a/src/components/SecondaryPanes/XHRBreakpoints.js
+++ b/src/components/SecondaryPanes/XHRBreakpoints.js
@@ -154,7 +154,8 @@ class XHRBreakpoints extends Component<Props, State> {
       </li>
     );
   }
-  handleCheckbox = index => {
+  handleCheckbox = (index, e) => {
+    e.stopPropagation();
     const {
       xhrBreakpoints,
       enableXHRBreakpoint,
@@ -193,13 +194,13 @@ class XHRBreakpoints extends Component<Props, State> {
         key={path}
         title={path}
         onDoubleClick={(items, options) => this.editExpression(index)}
+        onClick={e => this.handleCheckbox(index, e)}
       >
         <input
           type="checkbox"
           className="xhr-checkbox"
           checked={!disabled}
-          onChange={() => this.handleCheckbox(index)}
-          onClick={ev => ev.stopPropagation()}
+          onChange={e => this.handleCheckbox(index, e)}
         />
         <div className="xhr-label">{text}</div>
         <div className="xhr-container__close-btn">

--- a/src/components/SecondaryPanes/XHRBreakpoints.js
+++ b/src/components/SecondaryPanes/XHRBreakpoints.js
@@ -154,8 +154,7 @@ class XHRBreakpoints extends Component<Props, State> {
       </li>
     );
   }
-  handleCheckbox = (index, e) => {
-    e.stopPropagation();
+  handleCheckbox = index => {
     const {
       xhrBreakpoints,
       enableXHRBreakpoint,
@@ -194,15 +193,17 @@ class XHRBreakpoints extends Component<Props, State> {
         key={path}
         title={path}
         onDoubleClick={(items, options) => this.editExpression(index)}
-        onClick={e => this.handleCheckbox(index, e)}
       >
-        <input
-          type="checkbox"
-          className="xhr-checkbox"
-          checked={!disabled}
-          onChange={e => this.handleCheckbox(index, e)}
-        />
-        <div className="xhr-label">{text}</div>
+        <label>
+          <input
+            type="checkbox"
+            className="xhr-checkbox"
+            checked={!disabled}
+            onChange={() => this.handleCheckbox(index)}
+            onClick={ev => ev.stopPropagation()}
+          />
+          <div className="xhr-label">{text}</div>
+        </label>
         <div className="xhr-container__close-btn">
           <CloseButton handleClick={e => removeXHRBreakpoint(index)} />
         </div>

--- a/src/reducers/breakpoints.js
+++ b/src/reducers/breakpoints.js
@@ -140,35 +140,13 @@ function removeXHRBreakpoint(state, action) {
 
   return {
     ...state,
-    xhrBreakpoints: xhrBreakpoints.filter(bp => {
-      if (bp.method === breakpoint.method && bp.path === breakpoint.path) {
-        return false;
-      }
-      return true;
-    })
+    xhrBreakpoints: xhrBreakpoints.filter(bp => !isEqual(bp, breakpoint))
   };
 }
 
 function updateXHRBreakpoint(state, action) {
   const { breakpoint, index } = action;
   const { xhrBreakpoints } = state;
-  if (
-    action.type === "DISABLE_XHR_BREAKPOINT" ||
-    action.type === "ENABLE_XHR_BREAKPOINT"
-  ) {
-    let breakpointExists = false;
-    for (var i = 0; i < xhrBreakpoints.length; i++) {
-      if (
-        breakpoint.method === xhrBreakpoints[i].method &&
-        breakpoint.path === xhrBreakpoints[i].path
-      ) {
-        breakpointExists = true;
-      }
-    }
-    if (breakpointExists === false) {
-      return state;
-    }
-  }
   const newXhrBreakpoints = [...xhrBreakpoints];
   newXhrBreakpoints[index] = breakpoint;
   return {

--- a/src/reducers/breakpoints.js
+++ b/src/reducers/breakpoints.js
@@ -143,9 +143,8 @@ function removeXHRBreakpoint(state, action) {
     xhrBreakpoints: xhrBreakpoints.filter(bp => {
       if (bp.method === breakpoint.method && bp.path === breakpoint.path) {
         return false;
-      } else {
-        return true;
       }
+      return true;
     })
   };
 }
@@ -153,10 +152,16 @@ function removeXHRBreakpoint(state, action) {
 function updateXHRBreakpoint(state, action) {
   const { breakpoint, index } = action;
   const { xhrBreakpoints } = state;
-  if (action.type === "DISABLE_XHR_BREAKPOINT" || action.type === "ENABLE_XHR_BREAKPOINT") {
+  if (
+    action.type === "DISABLE_XHR_BREAKPOINT" ||
+    action.type === "ENABLE_XHR_BREAKPOINT"
+  ) {
     let breakpointExists = false;
     for (var i = 0; i < xhrBreakpoints.length; i++) {
-      if (breakpoint.method === xhrBreakpoints[i].method && breakpoint.path === xhrBreakpoints[i].path) {
+      if (
+        breakpoint.method === xhrBreakpoints[i].method &&
+        breakpoint.path === xhrBreakpoints[i].path
+      ) {
         breakpointExists = true;
       }
     }

--- a/src/reducers/breakpoints.js
+++ b/src/reducers/breakpoints.js
@@ -140,13 +140,30 @@ function removeXHRBreakpoint(state, action) {
 
   return {
     ...state,
-    xhrBreakpoints: xhrBreakpoints.filter(bp => !isEqual(bp, breakpoint))
+    xhrBreakpoints: xhrBreakpoints.filter(bp => {
+      if (bp.method === breakpoint.method && bp.path === breakpoint.path) {
+        return false;
+      } else {
+        return true;
+      }
+    })
   };
 }
 
 function updateXHRBreakpoint(state, action) {
   const { breakpoint, index } = action;
   const { xhrBreakpoints } = state;
+  if (action.type === "DISABLE_XHR_BREAKPOINT" || action.type === "ENABLE_XHR_BREAKPOINT") {
+    let breakpointExists = false;
+    for (var i = 0; i < xhrBreakpoints.length; i++) {
+      if (breakpoint.method === xhrBreakpoints[i].method && breakpoint.path === xhrBreakpoints[i].path) {
+        breakpointExists = true;
+      }
+    }
+    if (breakpointExists === false) {
+      return state;
+    }
+  }
   const newXhrBreakpoints = [...xhrBreakpoints];
   newXhrBreakpoints[index] = breakpoint;
   return {


### PR DESCRIPTION
Hi all!

This PR fixes #7700. 

I added an onClick function to each XHR breakpoint list item that toggles the respective breakpoint.

I had to change the callback for the filter in removeXHRBreakpoint since the new toggle feature was altering the state of the breakpoints (when using isEqual, the **_same_** breakpoint passed in through the `action` and `state` args would now have different toggle statuses, ie. disabled vs enabled, resulting in a falsey value being returned).

In addition to this issue, updateXHRBreakpoint was being called after the breakpoint was removed. This caused an error since updateXHRBreakpoint tried to update with a now non-existent breakpoint. I resolved this through checking if the breakpoint exists when a toggle action is called and returning the state accordingly.

I plan to add tests for this PR later, as I saw @notjaril already has a comprehensive testing spec in the process of being merged.

Please let me know if there are any questions or concerns. Thanks!

GIF:
https://gyazo.com/cdcc6d2f9a36330e030af1f700484ec1