### PR TITLE
Fix a couple bugs with windowless worker debugging.

### DIFF
--- a/src/actions/pause/resumed.js
+++ b/src/actions/pause/resumed.js
@@ -4,11 +4,12 @@
 
 // @flow
 
-import { getCurrentThread, isStepping, getPauseReason } from "../../selectors";
+import { isStepping, getPauseReason } from "../../selectors";
 import { evaluateExpressions } from "../expressions";
 import { inDebuggerEval } from "../../utils/pause";
 
 import type { ThunkArgs } from "../types";
+import type { ResumedPacket } from "../../client/firefox/types";
 
 /**
  * Debugger has just resumed
@@ -16,14 +17,13 @@ import type { ThunkArgs } from "../types";
  * @memberof actions/pause
  * @static
  */
-export function resumed() {
+export function resumed(packet: ResumedPacket) {
   return async ({ dispatch, client, getState }: ThunkArgs) => {
     const why = getPauseReason(getState());
     const wasPausedInEval = inDebuggerEval(why);
     const wasStepping = isStepping(getState());
-    const thread = getCurrentThread(getState());
 
-    dispatch({ type: "RESUME", thread });
+    dispatch({ type: "RESUME", thread: packet.from });
 
     if (!wasStepping && !wasPausedInEval) {
       await dispatch(evaluateExpressions());

--- a/src/actions/pause/tests/pause.spec.js
+++ b/src/actions/pause/tests/pause.spec.js
@@ -349,7 +349,7 @@ describe("pause", () => {
       const { dispatch } = createStore(client);
 
       dispatch(actions.stepIn());
-      await dispatch(actions.resumed());
+      await dispatch(actions.resumed({ from: "FakeThread" }));
       expect(client.evaluateExpressions.mock.calls).toHaveLength(1);
     });
 
@@ -366,7 +366,7 @@ describe("pause", () => {
       mockThreadClient.evaluateExpressions = () => new Promise(r => r(["YAY"]));
       await dispatch(actions.paused(mockPauseInfo));
 
-      await dispatch(actions.resumed());
+      await dispatch(actions.resumed({ from: "FakeThread" }));
       const expression = selectors.getExpression(getState(), "foo");
       expect(expression.value).toEqual("YAY");
     });

--- a/src/actions/tabs.js
+++ b/src/actions/tabs.js
@@ -106,6 +106,7 @@ export function closeTabsForMissingThreads(workers: Worker[]) {
       if (sourceId) {
         const source = getSourceFromId(getState(), sourceId);
         if (
+          source &&
           source.thread != mainThread.actor &&
           !workers.some(({ actor }) => actor == source.thread)
         ) {

--- a/src/actions/tabs.js
+++ b/src/actions/tabs.js
@@ -17,7 +17,7 @@ import { selectSource } from "./sources";
 import {
   getSourcesByURLs,
   getSourceTabs,
-  getSourceFromId,
+  getSource,
   getNewSelectedSourceId,
   removeSourceFromTabList,
   removeSourcesFromTabList
@@ -104,7 +104,7 @@ export function closeTabsForMissingThreads(workers: Worker[]) {
     const removed = [];
     for (const { sourceId } of oldTabs) {
       if (sourceId) {
-        const source = getSourceFromId(getState(), sourceId);
+        const source = getSource(getState(), sourceId);
         if (
           source &&
           source.thread != mainThread.actor &&


### PR DESCRIPTION
Addresses #7710 part 2

### Summary of Changes

* Fixes bug where refreshing a page that pauses at startup and has workers ends up in a messed up state where pause information is shown incorrectly.  The problem is that updating the redux state after a thread resumes updated the state of the current thread, instead of the thread that actually resumed.

* Fixes bug where loading devtools where persistent state referred to a worker source could access an undefined source object and throw an exception that prevents the debugger from loading.

### Test Plan

Manually verified issues were fixed.  These are hard to write tests for unfortunately :/