### PR TITLE
[Preview] Ensure correct event listening

### DIFF
--- a/src/components/Editor/Preview/index.js
+++ b/src/components/Editor/Preview/index.js
@@ -67,33 +67,29 @@ class Preview extends PureComponent<Props, State> {
     this.updateListeners();
   }
 
+  componentWillUnmount() {
+    const { codeMirror } = this.props.editor;
+    const codeMirrorWrapper = codeMirror.getWrapperElement();
+
+    codeMirror.off("scroll", this.onScroll);
+    codeMirror.off("tokenenter", this.onTokenEnter);
+    codeMirror.off("tokenleave", this.onTokenLeave);
+    codeMirrorWrapper.removeEventListener("mouseup", this.onMouseUp);
+    codeMirrorWrapper.removeEventListener("mousedown", this.onMouseDown);
+  }
+
   componentDidUpdate(prevProps) {
-    this.updateListeners(prevProps);
     this.updateHighlight(prevProps);
   }
 
   updateListeners(prevProps: ?Props) {
-    const { isPaused } = this.props;
-
     const { codeMirror } = this.props.editor;
     const codeMirrorWrapper = codeMirror.getWrapperElement();
-    const wasNotPaused = !prevProps || !prevProps.isPaused;
-    const wasPaused = prevProps && prevProps.isPaused;
-
-    if (isPaused && wasNotPaused) {
-      codeMirror.on("scroll", this.onScroll);
-      codeMirror.on("tokenenter", this.onTokenEnter);
-      codeMirror.on("tokenleave", this.onTokenLeave);
-      codeMirrorWrapper.addEventListener("mouseup", this.onMouseUp);
-      codeMirrorWrapper.addEventListener("mousedown", this.onMouseDown);
-    }
-
-    if (!isPaused && wasPaused) {
-      codeMirror.off("tokenenter", this.onTokenEnter);
-      codeMirror.off("tokenleave", this.onTokenLeave);
-      codeMirrorWrapper.removeEventListener("mouseup", this.onMouseUp);
-      codeMirrorWrapper.removeEventListener("mousedown", this.onMouseDown);
-    }
+    codeMirror.on("scroll", this.onScroll);
+    codeMirror.on("tokenenter", this.onTokenEnter);
+    codeMirror.on("tokenleave", this.onTokenLeave);
+    codeMirrorWrapper.addEventListener("mouseup", this.onMouseUp);
+    codeMirrorWrapper.addEventListener("mousedown", this.onMouseDown);
   }
 
   updateHighlight(prevProps) {
@@ -111,31 +107,41 @@ class Preview extends PureComponent<Props, State> {
   }
 
   onTokenEnter = ({ target, tokenPos }) => {
-    this.props.updatePreview(target, tokenPos, this.props.editor.codeMirror);
+    if (this.props.isPaused) {
+      this.props.updatePreview(target, tokenPos, this.props.editor.codeMirror);
+    }
   };
 
   onTokenLeave = e => {
-    if (!inPopup(e)) {
+    if (this.props.isPaused && !inPopup(e)) {
       this.props.clearPreview();
     }
   };
 
   onMouseUp = () => {
-    this.setState({ selecting: false });
-    return true;
+    if (this.props.isPaused) {
+      this.setState({ selecting: false });
+      return true;
+    }
   };
 
   onMouseDown = () => {
-    this.setState({ selecting: true });
-    return true;
+    if (this.props.isPaused) {
+      this.setState({ selecting: true });
+      return true;
+    }
   };
 
   onScroll = () => {
-    this.props.clearPreview();
+    if (this.props.isPaused) {
+      this.props.clearPreview();
+    }
   };
 
   onClose = e => {
-    this.props.clearPreview();
+    if (this.props.isPaused) {
+      this.props.clearPreview();
+    }
   };
 
   render() {


### PR DESCRIPTION
### Summary of Changes

It's possible to hover on a token when paused and see nothing. This currently happens when you have closed and re-opened devtools and pause. 

STR:
1. open devtools
2. pause
3. close devtools
4. open devtools
5. pause
6. hover

The underlying bug was that we would add a second tokenEvent handler, which meant that we would respond twice to every `tokenenter`, etc. The fix opts for a simpler solution where we handle every event, but bail out quickly if we're not paused.