### PR TITLE
Change max-width boundaries for verticalLayoutBreakpoint

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -35,7 +35,7 @@ const isMacOS = appinfo.OS === "Darwin";
 
 const horizontalLayoutBreakpoint = window.matchMedia("(min-width: 800px)");
 const verticalLayoutBreakpoint = window.matchMedia(
-  "(min-width: 10px) and (max-width: 800px)"
+  "(min-width: 10px) and (max-width: 799px)"
 );
 
 import "./variables.css";


### PR DESCRIPTION
Fixes #7765 

### Summary of Changes

* Changing the max-width boundaries for horizontalLayoutBreakpoint and verticalLayoutBreakpoint so that they do not clash.

