### PR TITLE
Fix color of arrows in trees

### DIFF
--- a/src/components/shared/Svg.css
+++ b/src/components/shared/Svg.css
@@ -343,6 +343,14 @@ span.img.marko {
   transition: transform 0.18s ease;
 }
 
+/* overrides tree component */
+.tree-node button.arrow {
+  background: none;
+  mask: url(/images/arrow.svg);
+  background: var(--disclosure-arrow);
+  mask-size: 100%;
+}
+
 html[dir="rtl"] .img.arrow {
   transform: rotate(90deg);
 }


### PR DESCRIPTION
The arrows that display in our tree components (preview, scopes) are very dark, unlike our accordion items and sources tree.  This small patch fixes that issue while @jaril and I work on unifying our styles from the Svg.css change