### PR TITLE
Split Source into Source/SourceActor, and Breakpoint into Breakpoint/…

### DIFF
--- a/src/actions/ast/setPausePoints.js
+++ b/src/actions/ast/setPausePoints.js
@@ -4,7 +4,7 @@
 
 // @flow
 
-import { getSourceFromId } from "../../selectors";
+import { getSourceFromId, getSourceActors } from "../../selectors";
 import * as parser from "../../workers/parser";
 import { isGenerated } from "../../utils/source";
 import { convertToList } from "../../utils/pause/pausePoints";
@@ -62,7 +62,9 @@ export function setPausePoints(sourceId: SourceId) {
 
     if (isGenerated(source)) {
       const compressed = compressPausePoints(pausePoints);
-      await client.setPausePoints(sourceId, compressed);
+      for (const sourceActor of getSourceActors(getState(), sourceId)) {
+        await client.setPausePoints(sourceActor, compressed);
+      }
     }
 
     pausePoints = await mapLocations(

--- a/src/actions/breakpoints/addBreakpoint.js
+++ b/src/actions/breakpoints/addBreakpoint.js
@@ -11,11 +11,14 @@ import {
   assertBreakpoint,
   createBreakpoint,
   getASTLocation,
-  assertLocation
+  assertLocation,
+  makeLocationId,
+  makeSourceActorLocation
 } from "../../utils/breakpoint";
 import { PROMISE } from "../utils/middleware/promise";
 import {
   getSource,
+  getSourceActors,
   getSymbols,
   getFirstPausePointLocation
 } from "../../selectors";
@@ -54,6 +57,12 @@ async function addBreakpointPromise(getState, client, sourceMaps, breakpoint) {
 
   const generatedSource = getSource(state, generatedLocation.sourceId);
 
+  if (!generatedSource) {
+    throw new Error(
+      `Unable to find generated source: ${generatedLocation.sourceId}`
+    );
+  }
+
   assertLocation(location);
   assertLocation(generatedLocation);
 
@@ -63,13 +72,23 @@ async function addBreakpointPromise(getState, client, sourceMaps, breakpoint) {
     return { breakpoint: newBreakpoint };
   }
 
-  const { id, actualLocation } = await client.setBreakpoint(
-    generatedLocation,
-    breakpoint.options,
-    isOriginalId(location.sourceId)
-  );
+  const sourceActors = getSourceActors(state, generatedSource.id);
+  const newGeneratedLocation = { ...generatedLocation };
 
-  const newGeneratedLocation = actualLocation || generatedLocation;
+  for (const sourceActor of sourceActors) {
+    const sourceActorLocation = makeSourceActorLocation(
+      sourceActor,
+      generatedLocation
+    );
+    const { actualLocation } = await client.setBreakpoint(
+      sourceActorLocation,
+      breakpoint.options,
+      isOriginalId(location.sourceId)
+    );
+    newGeneratedLocation.line = actualLocation.line;
+    newGeneratedLocation.column = actualLocation.column;
+  }
+
   const newLocation = await sourceMaps.getOriginalLocation(
     newGeneratedLocation
   );
@@ -78,10 +97,10 @@ async function addBreakpointPromise(getState, client, sourceMaps, breakpoint) {
   const astLocation = await getASTLocation(source, symbols, newLocation);
 
   const originalText = getTextAtPosition(source, location);
-  const text = getTextAtPosition(generatedSource, actualLocation);
+  const text = getTextAtPosition(generatedSource, newGeneratedLocation);
 
   const newBreakpoint = {
-    id,
+    id: makeLocationId(generatedLocation),
     disabled: false,
     loading: false,
     options: breakpoint.options,

--- a/src/actions/breakpoints/tests/__snapshots__/breakpoints.spec.js.snap
+++ b/src/actions/breakpoints/tests/__snapshots__/breakpoints.spec.js.snap
@@ -13,6 +13,7 @@ Object {
   },
   "disabled": false,
   "generatedLocation": Object {
+    "column": undefined,
     "line": 7,
     "sourceId": "a",
     "sourceUrl": "http://localhost:8000/examples/a",
@@ -50,11 +51,12 @@ Array [
         },
         "disabled": false,
         "generatedLocation": Object {
+          "column": undefined,
           "line": 2,
           "sourceId": "a",
           "sourceUrl": "http://localhost:8000/examples/a",
         },
-        "id": "hi",
+        "id": "a:2:",
         "loading": false,
         "location": Object {
           "line": 2,
@@ -104,11 +106,12 @@ Object {
   },
   "disabled": false,
   "generatedLocation": Object {
+    "column": undefined,
     "line": 1,
     "sourceId": "a.js",
     "sourceUrl": "http://localhost:8000/examples/a.js",
   },
-  "id": "hi",
+  "id": "a.js:1:",
   "loading": false,
   "location": Object {
     "column": 0,
@@ -142,11 +145,12 @@ Array [
         },
         "disabled": true,
         "generatedLocation": Object {
+          "column": undefined,
           "line": 5,
           "sourceId": "a",
           "sourceUrl": "http://localhost:8000/examples/a",
         },
-        "id": "hi",
+        "id": "a:5:",
         "loading": false,
         "location": Object {
           "line": 5,

--- a/src/actions/breakpoints/tests/__snapshots__/syncing.spec.js.snap
+++ b/src/actions/breakpoints/tests/__snapshots__/syncing.spec.js.snap
@@ -16,7 +16,7 @@ Object {
       "sourceId": "gen.js",
       "sourceUrl": "http://localhost:8000/gen.js",
     },
-    "id": "foo",
+    "id": "magic.js:3:",
     "loading": false,
     "location": Object {
       "column": undefined,
@@ -57,7 +57,7 @@ Object {
       "sourceId": "gen.js",
       "sourceUrl": "http://localhost:8000/gen.js",
     },
-    "id": "foo",
+    "id": "magic.js:12:",
     "loading": false,
     "location": Object {
       "column": undefined,
@@ -127,7 +127,7 @@ Object {
       "sourceId": "gen.js",
       "sourceUrl": "http://localhost:8000/gen.js",
     },
-    "id": "foo",
+    "id": "magic.js:3:",
     "loading": false,
     "location": Object {
       "column": undefined,
@@ -168,7 +168,7 @@ Object {
       "sourceId": "gen.js",
       "sourceUrl": "http://localhost:8000/gen.js",
     },
-    "id": "gen.js:5:",
+    "id": "magic.js:3:",
     "loading": false,
     "location": Object {
       "column": undefined,

--- a/src/actions/breakpoints/tests/breakpoints.spec.js
+++ b/src/actions/breakpoints/tests/breakpoints.spec.js
@@ -24,8 +24,9 @@ describe("breakpoints", () => {
       sourceUrl: "http://localhost:8000/examples/a"
     };
 
-    await dispatch(actions.newSource(makeSource("a")));
-    await dispatch(actions.loadSourceText(makeSource("a")));
+    const source = makeSource("a");
+    await dispatch(actions.newSource(source));
+    await dispatch(actions.loadSourceText(source.source));
     await dispatch(actions.addBreakpoint(loc1));
 
     expect(selectors.getBreakpointCount(getState())).toEqual(1);
@@ -61,8 +62,9 @@ describe("breakpoints", () => {
       line: 5,
       sourceUrl: "http://localhost:8000/examples/a"
     };
-    await dispatch(actions.newSource(makeSource("a")));
-    await dispatch(actions.loadSourceText(makeSource("a")));
+    const source = makeSource("a");
+    await dispatch(actions.newSource(source));
+    await dispatch(actions.loadSourceText(source.source));
     const { breakpoint } = await dispatch(actions.addBreakpoint(loc1));
     await dispatch(actions.disableBreakpoint(breakpoint));
 
@@ -336,7 +338,7 @@ describe("breakpoints", () => {
 
     const source = makeSource("a.js");
     await dispatch(actions.newSource(source));
-    await dispatch(actions.loadSourceText(makeSource("a.js")));
+    await dispatch(actions.loadSourceText(source.source));
 
     await dispatch(actions.addBreakpoint(loc));
     await dispatch(actions.togglePrettyPrint("a.js"));

--- a/src/actions/breakpoints/tests/syncing.spec.js
+++ b/src/actions/breakpoints/tests/syncing.spec.js
@@ -127,7 +127,7 @@ describe("loading the debugger", () => {
       getState,
       threadClient,
       sourceMaps,
-      reloadedSource.id,
+      reloadedSource.source.id,
       pendingBreakpoint()
     );
 
@@ -157,7 +157,7 @@ describe("loading the debugger", () => {
       getState,
       threadClient,
       sourceMaps,
-      reloadedSource.id,
+      reloadedSource.source.id,
       pendingBreakpoint()
     );
 
@@ -187,7 +187,9 @@ describe("reloading debuggee", () => {
       line: 3,
       column: undefined
     };
+    const generatedSource = makeSource("gen.js");
     await dispatch(actions.newSource(reloadedSource));
+    await dispatch(actions.newSource(generatedSource));
     await dispatch(actions.addBreakpoint(loc1));
 
     // manually sync
@@ -195,7 +197,7 @@ describe("reloading debuggee", () => {
       getState,
       threadClient,
       sourceMaps,
-      reloadedSource.id,
+      reloadedSource.source.id,
       pendingBreakpoint({ location: loc1 })
     );
     expect(threadClient.removeBreakpoint.mock.calls).toHaveLength(0);
@@ -228,12 +230,15 @@ describe("reloading debuggee", () => {
     const reloadedSource = makeSource("magic.js");
     await dispatch(actions.newSource(reloadedSource));
 
+    const generatedSource = makeSource("gen.js");
+    await dispatch(actions.newSource(generatedSource));
+
     // manually sync
     const update = await syncBreakpointPromise(
       getState,
       threadClient,
       sourceMaps,
-      reloadedSource.id,
+      reloadedSource.source.id,
       pendingBreakpoint()
     );
     expect(threadClient.removeBreakpoint.mock.calls).toHaveLength(1);
@@ -248,8 +253,12 @@ describe("reloading debuggee", () => {
 
     const reloadedSource = makeSource("magic.js");
     await dispatch(actions.newSource(reloadedSource));
+
+    const generatedSource = makeSource("gen.js");
+    await dispatch(actions.newSource(generatedSource));
+
     const location = {
-      sourceId: reloadedSource.id,
+      sourceId: reloadedSource.source.id,
       line: 3,
       column: undefined
     };
@@ -261,7 +270,7 @@ describe("reloading debuggee", () => {
 
     await dispatch(
       actions.syncBreakpoint(
-        reloadedSource.id,
+        reloadedSource.source.id,
         pendingBreakpoint({ disabled: true })
       )
     );

--- a/src/actions/debuggee.js
+++ b/src/actions/debuggee.js
@@ -5,16 +5,11 @@
 // @flow
 
 import type { Action, ThunkArgs } from "./types";
-import { closeTabsForMissingThreads } from "./tabs";
-import { features } from "../utils/prefs";
 
 export function updateWorkers() {
   return async function({ dispatch, getState, client }: ThunkArgs) {
     const workers = await client.fetchWorkers();
-    dispatch(({ type: "SET_WORKERS", workers }: Action));
-
-    if (features.windowlessWorkers) {
-      dispatch(closeTabsForMissingThreads(workers));
-    }
+    const mainThread = client.getMainThread();
+    dispatch(({ type: "SET_WORKERS", workers, mainThread }: Action));
   };
 }

--- a/src/actions/pause/mapFrames.js
+++ b/src/actions/pause/mapFrames.js
@@ -136,6 +136,7 @@ async function expandFrames(
       const id = j == 0 ? frame.id : `${frame.id}-originalFrame${j}`;
       result.push({
         id,
+        thread: originalFrame.thread,
         displayName: originalFrame.displayName,
         location: originalFrame.location,
         scope: frame.scope,

--- a/src/actions/pause/tests/pause.spec.js
+++ b/src/actions/pause/tests/pause.spec.js
@@ -30,9 +30,9 @@ const mockThreadClient = {
   getFrameScopes: async frame => frame.scope,
   setPausePoints: async () => {},
   setBreakpoint: () => new Promise(_resolve => {}),
-  sourceContents: sourceId => {
+  sourceContents: ({ source }) => {
     return new Promise((resolve, reject) => {
-      switch (sourceId) {
+      switch (source) {
         case "foo1":
           return resolve({
             source: "function foo1() {\n  return 5;\n}",
@@ -252,7 +252,7 @@ describe("pause", () => {
       const mockPauseInfo = createPauseInfo(generatedLocation);
 
       await dispatch(actions.newSource(makeSource("foo")));
-      await dispatch(actions.newSource(makeOriginalSource("foo")));
+      await dispatch(actions.newSource(makeSource("foo-original")));
       await dispatch(actions.loadSourceText({ id: "foo" }));
       await dispatch(actions.loadSourceText({ id: "foo-original" }));
       await dispatch(actions.setSymbols("foo-original"));

--- a/src/actions/preview.js
+++ b/src/actions/preview.js
@@ -101,7 +101,7 @@ export function setPreview(
 
         const { result } = await client.evaluateInFrame(expression, {
           frameId: selectedFrame.id,
-          thread: source.thread
+          thread: selectedFrame.thread
         });
 
         if (!result) {

--- a/src/actions/sources/prettyPrint.js
+++ b/src/actions/sources/prettyPrint.js
@@ -20,7 +20,8 @@ import {
   getSource,
   getSourceFromId,
   getSourceByURL,
-  getSelectedLocation
+  getSelectedLocation,
+  getSourceActors
 } from "../../selectors";
 
 import type { Action, ThunkArgs } from "../types";
@@ -37,7 +38,6 @@ export function createPrettySource(sourceId: string) {
       url,
       relativeUrl: url,
       id,
-      thread: "",
       isBlackBoxed: false,
       isPrettyPrinted: true,
       isWasm: false,
@@ -51,6 +51,13 @@ export function createPrettySource(sourceId: string) {
 
     const { code, mappings } = await prettyPrint({ source, url });
     await sourceMaps.applySourceMap(source.id, url, code, mappings);
+
+    // The source map URL service used by other devtools listens to changes to
+    // sources based on their actor IDs, so apply the mapping there too.
+    const sourceActors = getSourceActors(getState(), sourceId);
+    for (const sourceActor of sourceActors) {
+      await sourceMaps.applySourceMap(sourceActor.actor, url, code, mappings);
+    }
 
     const loadedPrettySource: JsSource = {
       ...prettySource,

--- a/src/actions/sources/select.js
+++ b/src/actions/sources/select.js
@@ -42,7 +42,6 @@ export const setSelectedLocation = (
   location: SourceLocation
 ) => ({
   type: "SET_SELECTED_LOCATION",
-  thread: source.thread,
   source,
   location
 });

--- a/src/actions/sources/tests/__snapshots__/prettyPrint.spec.js.snap
+++ b/src/actions/sources/tests/__snapshots__/prettyPrint.spec.js.snap
@@ -15,7 +15,6 @@ Object {
   "sourceMapURL": undefined,
   "text": "undefined
 ",
-  "thread": "",
   "url": "http://localhost:8000/examples/base.js:formatted",
 }
 `;

--- a/src/actions/sources/tests/loadSource.spec.js
+++ b/src/actions/sources/tests/loadSource.spec.js
@@ -15,11 +15,13 @@ describe("loadSourceText", async () => {
     const store = createStore(sourceThreadClient);
     const { dispatch, getState } = store;
 
+    await dispatch(actions.newSource(makeSource("foo1")));
     await dispatch(actions.loadSourceText({ id: "foo1" }));
     const fooSource = selectors.getSource(getState(), "foo1");
 
     expect(fooSource.text.indexOf("return foo1")).not.toBe(-1);
 
+    await dispatch(actions.newSource(makeSource("foo2")));
     await dispatch(actions.loadSourceText({ id: "foo2" }));
     const foo2Source = selectors.getSource(getState(), "foo2");
 
@@ -102,6 +104,7 @@ describe("loadSourceText", async () => {
   it("should indicate an errored source text", async () => {
     const { dispatch, getState } = createStore(sourceThreadClient);
 
+    await dispatch(actions.newSource(makeSource("bad-id")));
     await dispatch(actions.loadSourceText({ id: "bad-id" }));
     const badSource = selectors.getSource(getState(), "bad-id");
     expect(badSource.error.indexOf("unknown source")).not.toBe(-1);

--- a/src/actions/sources/tests/newSources.spec.js
+++ b/src/actions/sources/tests/newSources.spec.js
@@ -45,11 +45,11 @@ describe("sources - new sources", () => {
   it("should automatically select a pending source", async () => {
     const { dispatch, getState } = createStore(threadClient);
     const baseSource = makeSource("base.js");
-    await dispatch(actions.selectSourceURL(baseSource.url));
+    await dispatch(actions.selectSourceURL(baseSource.source.url));
 
     expect(getSelectedSource(getState())).toBe(undefined);
     await dispatch(actions.newSource(baseSource));
-    expect(getSelectedSource(getState()).url).toBe(baseSource.url);
+    expect(getSelectedSource(getState()).url).toBe(baseSource.source.url);
   });
 
   it("should add original sources", async () => {

--- a/src/actions/sources/tests/prettyPrint.spec.js
+++ b/src/actions/sources/tests/prettyPrint.spec.js
@@ -18,9 +18,9 @@ describe("sources - pretty print", () => {
     const url = "base.js";
     const source = makeSource(url);
     await dispatch(actions.newSource(source));
-    await dispatch(createPrettySource(url));
+    await dispatch(createPrettySource(source.source.id));
 
-    const prettyURL = `${source.url}:formatted`;
+    const prettyURL = `${source.source.url}:formatted`;
     const pretty = selectors.getSourceByURL(getState(), prettyURL);
     expect(pretty.contentType).toEqual("text/javascript");
     expect(pretty.url.includes(prettyURL)).toEqual(true);

--- a/src/actions/sources/tests/select.spec.js
+++ b/src/actions/sources/tests/select.spec.js
@@ -83,7 +83,7 @@ describe("sources", () => {
     await dispatch(actions.selectLocation({ sourceId: "foo.js" }));
 
     // closes the 1st tab, which should have no previous tab
-    await dispatch(actions.closeTab(fooSource));
+    await dispatch(actions.closeTab(fooSource.source));
 
     expect(getSelectedSource(getState()).id).toBe("bar.js");
     expect(getSourceTabs(getState())).toHaveLength(2);
@@ -110,7 +110,7 @@ describe("sources", () => {
     await dispatch(actions.selectLocation({ sourceId: "foo.js" }));
     await dispatch(actions.selectLocation({ sourceId: "bar.js" }));
     await dispatch(actions.selectLocation({ sourceId: "baz.js" }));
-    await dispatch(actions.closeTab(bazSource));
+    await dispatch(actions.closeTab(bazSource.source));
     expect(getSelectedSource(getState()).id).toBe("bar.js");
     expect(getSourceTabs(getState())).toHaveLength(2);
   });
@@ -135,14 +135,14 @@ describe("sources", () => {
 
     // 3rd tab is reselected
     await dispatch(actions.selectLocation({ sourceId: "foo.js" }));
-    await dispatch(actions.closeTab(bazSource));
+    await dispatch(actions.closeTab(bazSource.source));
     expect(getSelectedSource(getState()).id).toBe("foo.js");
     expect(getSourceTabs(getState())).toHaveLength(2);
   });
 
   it("should not select new sources that lack a URL", async () => {
     const { dispatch, getState } = createStore(sourceThreadClient);
-    await dispatch(actions.newSource({ id: "foo" }));
+    await dispatch(actions.newSource({ source: { id: "foo" } }));
 
     expect(getSourceCount(getState())).toEqual(1);
     const selectedLocation = getSelectedLocation(getState());
@@ -192,11 +192,11 @@ describe("sources", () => {
     await dispatch(actions.newSource(baseSource));
 
     await dispatch(
-      actions.selectLocation({ sourceId: baseSource.id, line: 1 })
+      actions.selectLocation({ sourceId: baseSource.source.id, line: 1 })
     );
 
-    expect(getSelectedSource(getState()).id).toBe(baseSource.id);
-    await waitForState(store, state => getSymbols(state, baseSource));
+    expect(getSelectedSource(getState()).id).toBe(baseSource.source.id);
+    await waitForState(store, state => getSymbols(state, baseSource.source));
   });
 
   it("should keep the original the viewing context", async () => {
@@ -216,11 +216,13 @@ describe("sources", () => {
     const originalBaseSource = makeOriginalSource("base.js");
     await dispatch(actions.newSource(originalBaseSource));
 
-    await dispatch(actions.selectSource(originalBaseSource.id));
+    await dispatch(actions.selectSource(originalBaseSource.source.id));
 
     const fooSource = makeSource("foo.js");
     await dispatch(actions.newSource(fooSource));
-    await dispatch(actions.selectLocation({ sourceId: fooSource.id, line: 1 }));
+    await dispatch(
+      actions.selectLocation({ sourceId: fooSource.source.id, line: 1 })
+    );
 
     expect(getSelectedLocation(getState()).line).toBe(12);
   });
@@ -234,10 +236,13 @@ describe("sources", () => {
 
     const baseSource = makeOriginalSource("base.js");
     await dispatch(actions.newSource(baseSource));
-    await dispatch(actions.selectSource(baseSource.id));
+    await dispatch(actions.selectSource(baseSource.source.id));
 
     await dispatch(
-      actions.selectSpecificLocation({ sourceId: baseSource.id, line: 1 })
+      actions.selectSpecificLocation({
+        sourceId: baseSource.source.id,
+        line: 1
+      })
     );
     expect(getSelectedLocation(getState()).line).toBe(1);
   });
@@ -246,11 +251,11 @@ describe("sources", () => {
     it("should automatically select a pending source", async () => {
       const { dispatch, getState } = createStore(sourceThreadClient);
       const baseSource = makeSource("base.js");
-      await dispatch(actions.selectSourceURL(baseSource.url));
+      await dispatch(actions.selectSourceURL(baseSource.source.url));
 
       expect(getSelectedSource(getState())).toBe(undefined);
       await dispatch(actions.newSource(baseSource));
-      expect(getSelectedSource(getState()).url).toBe(baseSource.url);
+      expect(getSelectedSource(getState()).url).toBe(baseSource.source.url);
     });
   });
 });

--- a/src/actions/tabs.js
+++ b/src/actions/tabs.js
@@ -17,19 +17,16 @@ import { selectSource } from "./sources";
 import {
   getSourcesByURLs,
   getSourceTabs,
-  getSource,
   getNewSelectedSourceId,
   removeSourceFromTabList,
   removeSourcesFromTabList
 } from "../selectors";
 
-import { getMainThread } from "../reducers/debuggee";
-
 import type { Action, ThunkArgs } from "./types";
-import type { Source, Worker } from "../types";
+import type { Source } from "../types";
 
 export function updateTab(source: Source, framework: string): Action {
-  const { url, id: sourceId, thread } = source;
+  const { url, id: sourceId } = source;
   const isOriginal = isOriginalId(source.id);
 
   return {
@@ -37,21 +34,19 @@ export function updateTab(source: Source, framework: string): Action {
     url,
     framework,
     isOriginal,
-    sourceId,
-    thread
+    sourceId
   };
 }
 
 export function addTab(source: Source): Action {
-  const { url, id: sourceId, thread } = source;
+  const { url, id: sourceId } = source;
   const isOriginal = isOriginalId(source.id);
 
   return {
     type: "ADD_TAB",
     url,
     isOriginal,
-    sourceId,
-    thread
+    sourceId
   };
 }
 
@@ -91,31 +86,6 @@ export function closeTabs(urls: string[]) {
 
     const tabs = removeSourcesFromTabList(getSourceTabs(getState()), sources);
     dispatch(({ type: "CLOSE_TABS", sources, tabs }: Action));
-
-    const sourceId = getNewSelectedSourceId(getState(), tabs);
-    dispatch(selectSource(sourceId));
-  };
-}
-
-export function closeTabsForMissingThreads(workers: Worker[]) {
-  return ({ dispatch, getState }: ThunkArgs) => {
-    const oldTabs = getSourceTabs(getState());
-    const mainThread = getMainThread(getState());
-    const removed = [];
-    for (const { sourceId } of oldTabs) {
-      if (sourceId) {
-        const source = getSource(getState(), sourceId);
-        if (
-          source &&
-          source.thread != mainThread.actor &&
-          !workers.some(({ actor }) => actor == source.thread)
-        ) {
-          removed.push(source);
-        }
-      }
-    }
-    const tabs = removeSourcesFromTabList(oldTabs, removed);
-    dispatch({ type: "CLOSE_TABS", removed, tabs });
 
     const sourceId = getNewSelectedSourceId(getState(), tabs);
     dispatch(selectSource(sourceId));

--- a/src/actions/tests/__snapshots__/pending-breakpoints.spec.js.snap
+++ b/src/actions/tests/__snapshots__/pending-breakpoints.spec.js.snap
@@ -34,7 +34,7 @@ Object {
     "name": undefined,
     "offset": Object {
       "line": 7,
-      "sourceId": "foo.js/originalSource",
+      "sourceId": "foo.js",
       "sourceUrl": "http://localhost:8000/examples/foo.js",
     },
   },

--- a/src/actions/tests/ast.spec.js
+++ b/src/actions/tests/ast.spec.js
@@ -27,8 +27,8 @@ const {
 import { prefs } from "../../utils/prefs";
 
 const threadClient = {
-  sourceContents: async sourceId => ({
-    source: sourceTexts[sourceId],
+  sourceContents: async ({ source }) => ({
+    source: sourceTexts[source],
     contentType: "text/javascript"
   }),
   setPausePoints: async () => {},
@@ -69,11 +69,11 @@ describe("ast", () => {
       await dispatch(actions.loadSourceText({ id: "scopes.js" }));
       await dispatch(actions.setPausePoints("scopes.js"));
       await waitForState(store, state => {
-        const lines = getEmptyLines(state, source.id);
+        const lines = getEmptyLines(state, source.source.id);
         return lines && lines.length > 0;
       });
 
-      const emptyLines = getEmptyLines(getState(), source.id);
+      const emptyLines = getEmptyLines(getState(), source.source.id);
       expect(emptyLines).toMatchSnapshot();
     });
   });
@@ -88,15 +88,17 @@ describe("ast", () => {
 
       await dispatch(actions.newSource(source));
 
-      await dispatch(actions.loadSourceText(getSource(getState(), source.id)));
-      await dispatch(actions.setSourceMetaData(source.id));
+      await dispatch(
+        actions.loadSourceText(getSource(getState(), source.source.id))
+      );
+      await dispatch(actions.setSourceMetaData(source.source.id));
 
       await waitForState(store, state => {
-        const metaData = getSourceMetaData(state, source.id);
+        const metaData = getSourceMetaData(state, source.source.id);
         return metaData && metaData.framework;
       });
 
-      const sourceMetaData = getSourceMetaData(getState(), source.id);
+      const sourceMetaData = getSourceMetaData(getState(), source.source.id);
       expect(sourceMetaData.framework).toBe("React");
     });
 
@@ -122,9 +124,12 @@ describe("ast", () => {
         await dispatch(actions.newSource(base));
         await dispatch(actions.loadSourceText({ id: "base.js" }));
         await dispatch(actions.setSymbols("base.js"));
-        await waitForState(store, state => !isSymbolsLoading(state, base));
+        await waitForState(
+          store,
+          state => !isSymbolsLoading(state, base.source)
+        );
 
-        const baseSymbols = getSymbols(getState(), base);
+        const baseSymbols = getSymbols(getState(), base.source);
         expect(baseSymbols).toMatchSnapshot();
       });
     });

--- a/src/actions/tests/expressions.spec.js
+++ b/src/actions/tests/expressions.spec.js
@@ -2,7 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
-import { actions, selectors, createStore } from "../../utils/test-head";
+import {
+  actions,
+  selectors,
+  createStore,
+  makeSource
+} from "../../utils/test-head";
 
 const mockThreadClient = {
   evaluateInFrame: (script, { frameId }) =>
@@ -27,7 +32,7 @@ const mockThreadClient = {
       )
     ),
   getFrameScopes: async () => {},
-  sourceContents: () => ({}),
+  sourceContents: () => ({ source: "", contentType: "text/javascript" }),
   autocomplete: () => {
     return new Promise(resolve => {
       resolve({
@@ -147,7 +152,7 @@ async function createFrames(dispatch) {
     location: { sourceId, line: 3 }
   };
 
-  await dispatch(actions.newSource({ id: sourceId }));
+  await dispatch(actions.newSource(makeSource("example.js")));
 
   await dispatch(
     actions.paused({

--- a/src/actions/tests/helpers/threadClient.js
+++ b/src/actions/tests/helpers/threadClient.js
@@ -40,13 +40,13 @@ export const simpleMockThreadClient = {
   setBreakpointOptions: (_id, _location, _options, _noSliding) =>
     Promise.resolve({ sourceId: "a", line: 5 }),
   setPausePoints: () => Promise.resolve({}),
-  sourceContents: sourceId =>
+  sourceContents: ({ source }) =>
     new Promise((resolve, reject) => {
-      if (sources.includes(sourceId)) {
-        resolve(createSource(sourceId));
+      if (sources.includes(source)) {
+        resolve(createSource(source));
       }
 
-      reject(`unknown source: ${sourceId}`);
+      reject(`unknown source: ${source}`);
     })
 };
 
@@ -63,7 +63,7 @@ function generateCorrectingThreadClient(offset = 0) {
         condition
       });
     },
-    sourceContents: sourceId => Promise.resolve(createSource(sourceId))
+    sourceContents: ({ source }) => Promise.resolve(createSource(source))
   };
 }
 
@@ -81,13 +81,13 @@ export function simulateCorrectThreadClient(offset, location) {
 
 // sources and tabs
 export const sourceThreadClient = {
-  sourceContents: function(sourceId) {
+  sourceContents: function({ source }) {
     return new Promise((resolve, reject) => {
-      if (sources.includes(sourceId)) {
-        resolve(createSource(sourceId));
+      if (sources.includes(source)) {
+        resolve(createSource(source));
       }
 
-      reject(`unknown source: ${sourceId}`);
+      reject(`unknown source: ${source}`);
     });
   },
   threadClient: async () => {},

--- a/src/actions/tests/navigation.spec.js
+++ b/src/actions/tests/navigation.spec.js
@@ -31,7 +31,8 @@ const threadClient = {
 describe("navigation", () => {
   it("connect sets the debuggeeUrl", async () => {
     const { dispatch, getState } = createStore({
-      fetchWorkers: () => Promise.resolve([])
+      fetchWorkers: () => Promise.resolve([]),
+      getMainThread: () => "FakeThread"
     });
     await dispatch(actions.connect("http://test.com/foo"));
     expect(selectors.getDebuggeeUrl(getState())).toEqual("http://test.com/foo");

--- a/src/actions/tests/project-text-search.spec.js
+++ b/src/actions/tests/project-text-search.spec.js
@@ -17,9 +17,9 @@ const {
 } = selectors;
 
 const threadClient = {
-  sourceContents: function(sourceId) {
+  sourceContents: function({ source }) {
     return new Promise((resolve, reject) => {
-      switch (sourceId) {
+      switch (source) {
         case "foo1":
           resolve({
             source: "function foo1() {\n  const foo = 5; return foo;\n}",
@@ -46,7 +46,7 @@ const threadClient = {
           break;
       }
 
-      reject(`unknown source: ${sourceId}`);
+      reject(`unknown source: ${source}`);
     });
   }
 };
@@ -85,7 +85,7 @@ describe("project text search", () => {
         source: "function bla(x, y) {\n const bar = 4; return 2;\n}",
         contentType: "text/javascript"
       }),
-      getOriginalURLs: async () => [source2.url]
+      getOriginalURLs: async () => [source2.source.url]
     };
 
     const { dispatch, getState } = createStore(threadClient, {}, mockMaps);

--- a/src/actions/tests/tabs.spec.js
+++ b/src/actions/tests/tabs.spec.js
@@ -19,7 +19,7 @@ describe("closing tabs", () => {
     const fooSource = makeSource("foo.js");
     await dispatch(actions.newSource(fooSource));
     await dispatch(actions.selectLocation({ sourceId: "foo.js" }));
-    dispatch(actions.closeTab(fooSource));
+    dispatch(actions.closeTab(fooSource.source));
 
     expect(getSelectedSource(getState())).toBe(undefined);
     expect(getSourceTabs(getState())).toHaveLength(0);
@@ -33,7 +33,7 @@ describe("closing tabs", () => {
     await dispatch(actions.newSource(makeSource("bar.js")));
     await dispatch(actions.selectLocation({ sourceId: "foo.js" }));
     await dispatch(actions.selectLocation({ sourceId: "bar.js" }));
-    dispatch(actions.closeTab(fooSource));
+    dispatch(actions.closeTab(fooSource.source));
 
     expect(getSelectedSource(getState()).id).toBe("bar.js");
     expect(getSourceTabs(getState())).toHaveLength(1);
@@ -45,7 +45,7 @@ describe("closing tabs", () => {
     const fooSource = makeSource("foo.js");
     await dispatch(actions.newSource(fooSource));
     await dispatch(actions.selectLocation({ sourceId: "foo.js" }));
-    dispatch(actions.closeTab(fooSource));
+    dispatch(actions.closeTab(fooSource.source));
 
     expect(getSelectedSource(getState())).toBe(undefined);
     expect(getSourceTabs(getState())).toHaveLength(0);
@@ -59,7 +59,7 @@ describe("closing tabs", () => {
     await dispatch(actions.newSource(barSource));
     await dispatch(actions.selectLocation({ sourceId: "foo.js" }));
     await dispatch(actions.selectLocation({ sourceId: "bar.js" }));
-    await dispatch(actions.closeTab(barSource));
+    await dispatch(actions.closeTab(barSource.source));
 
     expect(getSelectedSource(getState()).id).toBe("foo.js");
     expect(getSourceTabs(getState())).toHaveLength(1);

--- a/src/actions/types/SourceAction.js
+++ b/src/actions/types/SourceAction.js
@@ -4,7 +4,7 @@
 
 // @flow
 
-import type { Source, SourceLocation } from "../../types";
+import type { Source, SourceActor, SourceLocation } from "../../types";
 import type { PromiseAction } from "../utils/middleware/promise";
 
 export type LoadSourceAction = PromiseAction<
@@ -22,7 +22,8 @@ export type SourceAction =
     |}
   | {|
       +type: "ADD_SOURCES",
-      +sources: Array<Source>
+      +sources: Array<Source>,
+      +sourceActors: SourceActor[]
     |}
   | {|
       +type: "UPDATE_SOURCE",

--- a/src/actions/types/index.js
+++ b/src/actions/types/index.js
@@ -53,8 +53,7 @@ type AddTabAction = {|
   +url: string,
   +framework?: string,
   +isOriginal?: boolean,
-  +sourceId?: string,
-  +thread: string
+  +sourceId?: string
 |};
 
 type UpdateTabAction = {|
@@ -62,8 +61,7 @@ type UpdateTabAction = {|
   +url: string,
   +framework?: string,
   +isOriginal?: boolean,
-  +sourceId?: string,
-  +thread: string
+  +sourceId?: string
 |};
 
 type ReplayAction =
@@ -141,7 +139,8 @@ export type QuickOpenAction =
 export type DebugeeAction =
   | {|
       +type: "SET_WORKERS",
-      +workers: WorkerList
+      +workers: WorkerList,
+      +mainThread: string
     |}
   | {|
       +type: "SELECT_THREAD",

--- a/src/client/firefox/create.js
+++ b/src/client/firefox/create.js
@@ -5,17 +5,18 @@
 // @flow
 // This module converts Firefox specific types to the generic types
 
-import type { Frame, Source, SourceLocation } from "../../types";
+import type { Frame, Source, SourceActorLocation, ThreadId } from "../../types";
 import type {
   PausedPacket,
   FramesResponse,
   FramePacket,
-  SourcePayload
+  SourcePayload,
+  CreateSourceResult
 } from "./types";
 
 import { clientCommands } from "./commands";
 
-export function createFrame(frame: FramePacket): ?Frame {
+export function createFrame(thread: ThreadId, frame: FramePacket): ?Frame {
   if (!frame) {
     return null;
   }
@@ -28,14 +29,17 @@ export function createFrame(frame: FramePacket): ?Frame {
   }
 
   // NOTE: Firefox 66 switched from where.source to where.actor
+  const actor = frame.where.source ? frame.where.source.actor : frame.where.actor;
+
   const location = {
-    sourceId: frame.where.source ? frame.where.source.actor : frame.where.actor,
+    sourceId: clientCommands.getSourceForActor(actor),
     line: frame.where.line,
     column: frame.where.column
   };
 
   return {
     id: frame.actor,
+    thread,
     displayName: title,
     location,
     generatedLocation: location,
@@ -44,27 +48,33 @@ export function createFrame(frame: FramePacket): ?Frame {
   };
 }
 
+function makeSourceId(source) {
+  return source.url ? `sourceURL-${source.url}` : `source-${source.actor}`;
+}
+
 export function createSource(
   thread: string,
   source: SourcePayload,
   { supportsWasm }: { supportsWasm: boolean }
-): Source {
-  const createdSource = {
-    id: source.actor,
-    thread,
+): CreateSourceResult {
+  const createdSource: any = {
+    id: makeSourceId(source),
     url: source.url,
     relativeUrl: source.url,
     isPrettyPrinted: false,
-    isWasm: false,
     sourceMapURL: source.sourceMapURL,
     introductionUrl: source.introductionUrl,
     isBlackBoxed: false,
-    loadedState: "unloaded"
-  };
-  clientCommands.registerSource(createdSource);
-  return Object.assign(createdSource, {
+    loadedState: "unloaded",
     isWasm: supportsWasm && source.introductionType === "wasm"
-  });
+  };
+  const sourceActor = {
+    actor: source.actor,
+    source: createdSource.id,
+    thread
+  };
+  clientCommands.registerSourceActor(sourceActor);
+  return { sourceActor, source: (createdSource: Source) };
 }
 
 export function createPause(
@@ -78,8 +88,8 @@ export function createPause(
   return {
     ...packet,
     thread,
-    frame: createFrame(frame),
-    frames: response.frames.map(createFrame)
+    frame: createFrame(thread, frame),
+    frames: response.frames.map(createFrame.bind(null, thread))
   };
 }
 
@@ -88,16 +98,15 @@ export function createPause(
 // exists, otherwise use `location`.
 
 export function createBreakpointLocation(
-  location: SourceLocation,
+  location: SourceActorLocation,
   actualLocation?: Object
-): SourceLocation {
+): SourceActorLocation {
   if (!actualLocation) {
     return location;
   }
 
   return {
-    sourceId: actualLocation.source.actor,
-    sourceUrl: actualLocation.source.url,
+    ...location,
     line: actualLocation.line,
     column: actualLocation.column
   };

--- a/src/client/firefox/types.js
+++ b/src/client/firefox/types.js
@@ -19,7 +19,8 @@ import type {
   Pause,
   Frame,
   SourceId,
-  Worker
+  Worker,
+  SourceActor
 } from "../../types";
 
 type URL = string;
@@ -117,6 +118,11 @@ export type SourcesPacket = {
   from: ActorId,
   sources: SourcePayload[]
 };
+
+export type CreateSourceResult = {|
+  +sourceActor: SourceActor,
+  +source: Source
+|};
 
 /**
  * Pause Packet sent when the server is in a "paused" state
@@ -318,7 +324,8 @@ export type FunctionGrip = {|
  * @static
  */
 export type SourceClient = {
-  source: () => Source,
+  source: () => { source: any, contentType?: string },
+  _activeThread: ThreadClient,
   actor: string,
   setBreakpoint: ({
     line: number,

--- a/src/components/Editor/tests/DebugLine.spec.js
+++ b/src/components/Editor/tests/DebugLine.spec.js
@@ -31,7 +31,7 @@ function generateDefaults(editor, overrides) {
       why: { type: "breakpoint" }
     },
     frame: null,
-    source: makeSource("foo"),
+    source: makeSource("foo").source,
     ...overrides
   };
 }
@@ -65,7 +65,7 @@ describe("DebugLine Component", () => {
   describe("pausing at the first location", () => {
     it("should show a new debug line", async () => {
       const { component, props, doc } = render({
-        source: makeSource("foo", { loadedState: "loaded" })
+        source: makeSource("foo", { loadedState: "loaded" }).source
       });
       const line = 2;
       const frame = createFrame(line);
@@ -81,7 +81,7 @@ describe("DebugLine Component", () => {
     describe("pausing at a new location", () => {
       it("should replace the first debug line", async () => {
         const { props, component, clear, doc } = render({
-          source: makeSource("foo", { loadedState: "loaded" })
+          source: makeSource("foo", { loadedState: "loaded" }).source
         });
 
         component.instance().debugExpression = { clear: jest.fn() };

--- a/src/components/Editor/tests/Footer.spec.js
+++ b/src/components/Editor/tests/Footer.spec.js
@@ -28,7 +28,7 @@ function generateDefaults(overrides) {
         on: jest.fn()
       }
     },
-    selectedSource: makeSource("foo"),
+    selectedSource: makeSource("foo").source,
     ...overrides
   };
 }

--- a/src/components/PrimaryPanes/SourcesTree.js
+++ b/src/components/PrimaryPanes/SourcesTree.js
@@ -17,7 +17,6 @@ import {
   getExpandedState,
   getProjectDirectoryRoot,
   getRelativeSourcesForThread,
-  getSourceCount,
   getFocusedSourceItem,
   getWorkerByThread,
   getWorkerCount
@@ -345,18 +344,20 @@ class SourcesTree extends Component<Props, State> {
 
 function getSourceForTree(
   state: AppState,
+  relativeSources: SourcesMap,
   source: ?Source,
-  thread: ?string
+  thread
 ): ?Source {
+  if (!source) {
+    return null;
+  }
+
+  source = relativeSources[source.id];
   if (!source || !source.isPrettyPrinted) {
     return source;
   }
 
-  const candidate = getGeneratedSourceByURL(state, getRawSourceURL(source.url));
-
-  if (!thread || !candidate || candidate.thread == thread) {
-    return candidate;
-  }
+  return getGeneratedSourceByURL(state, getRawSourceURL(source.url));
 }
 
 const mapStateToProps = (state, props) => {
@@ -364,16 +365,22 @@ const mapStateToProps = (state, props) => {
   const shownSource = getShownSource(state);
   const focused = getFocusedSourceItem(state);
   const thread = props.thread;
+  const relativeSources = getRelativeSourcesForThread(state, thread);
 
   return {
-    shownSource: getSourceForTree(state, shownSource, thread),
-    selectedSource: getSourceForTree(state, selectedSource, thread),
+    shownSource: getSourceForTree(state, relativeSources, shownSource, thread),
+    selectedSource: getSourceForTree(
+      state,
+      relativeSources,
+      selectedSource,
+      thread
+    ),
     debuggeeUrl: getDebuggeeUrl(state),
     expanded: getExpandedState(state, props.thread),
     focused: focused && focused.thread == props.thread ? focused.item : null,
     projectRoot: getProjectDirectoryRoot(state),
-    sources: getRelativeSourcesForThread(state, thread),
-    sourceCount: getSourceCount(state, props.thread),
+    sources: relativeSources,
+    sourceCount: Object.values(relativeSources).length,
     worker: getWorkerByThread(state, thread),
     workerCount: getWorkerCount(state)
   };

--- a/src/components/SecondaryPanes/Breakpoints/tests/Breakpoint.spec.js
+++ b/src/components/SecondaryPanes/Breakpoints/tests/Breakpoint.spec.js
@@ -31,7 +31,7 @@ describe("Breakpoint", () => {
   it("paused at an original location", () => {
     const { component } = render(
       {
-        selectedSource: makeOriginalSource("foo"),
+        selectedSource: makeOriginalSource("foo").source,
         frame: { selectedLocation: location }
       },
       { location, options: {} }
@@ -72,9 +72,9 @@ function makeBreakpoint(overrides = {}) {
 }
 
 function generateDefaults(overrides = {}, breakpointOverrides = {}) {
-  const source = makeSource("foo");
+  const source = makeSource("foo").source;
   const breakpoint = makeBreakpoint(breakpointOverrides);
-  const selectedSource = makeSource("foo");
+  const selectedSource = makeSource("foo").source;
   return {
     source,
     breakpoint,

--- a/src/components/SecondaryPanes/Breakpoints/tests/BreakpointsContextMenu.spec.js
+++ b/src/components/SecondaryPanes/Breakpoints/tests/BreakpointsContextMenu.spec.js
@@ -27,28 +27,28 @@ function generateDefaults(disabled) {
       {
         line: 1,
         column: undefined,
-        sourceId: "server1.conn26.child3/source26",
+        sourceId: "source-https://example.com/main.js",
         sourceUrl: "https://example.com/main.js"
       },
-      { id: "https://example.com/main.js:1:", disabled: disabled }
+      { id: "source-https://example.com/main.js:1:", disabled: disabled }
     ),
     createBreakpoint(
       {
         line: 2,
         column: undefined,
-        sourceId: "server1.conn26.child3/source26",
+        sourceId: "source-https://example.com/main.js",
         sourceUrl: "https://example.com/main.js"
       },
-      { id: "https://example.com/main.js:2:", disabled: disabled }
+      { id: "source-https://example.com/main.js:2:", disabled: disabled }
     ),
     createBreakpoint(
       {
         line: 3,
         column: undefined,
-        sourceId: "server1.conn26.child3/source26",
+        sourceId: "source-https://example.com/main.js",
         sourceUrl: "https://example.com/main.js"
       },
-      { id: "https://example.com/main.js:3:", disabled: disabled }
+      { id: "source-https://example.com/main.js:3:", disabled: disabled }
     )
   ];
 

--- a/src/reducers/breakpoints.js
+++ b/src/reducers/breakpoints.js
@@ -14,10 +14,15 @@ import { isEqual } from "lodash";
 
 import { makeLocationId } from "../utils/breakpoint";
 
-import type { XHRBreakpoint, Breakpoint, SourceLocation } from "../types";
+import type {
+  XHRBreakpoint,
+  Breakpoint,
+  BreakpointId,
+  SourceLocation
+} from "../types";
 import type { Action, DonePromiseAction } from "../actions/types";
 
-export type BreakpointsMap = { [string]: Breakpoint };
+export type BreakpointsMap = { [BreakpointId]: Breakpoint };
 export type XHRBreakpointsList = $ReadOnlyArray<XHRBreakpoint>;
 
 export type BreakpointsState = {

--- a/src/reducers/sources.js
+++ b/src/reducers/sources.js
@@ -22,22 +22,44 @@ import {
 import { originalToGeneratedId } from "devtools-source-map";
 import { prefs } from "../utils/prefs";
 
-import type { Source, SourceId, SourceLocation, Thread } from "../types";
+import type {
+  Source,
+  SourceActor,
+  SourceId,
+  SourceLocation,
+  ThreadId,
+  WorkerList
+} from "../types";
 import type { PendingSelectedLocation, Selector } from "./types";
 import type { Action, DonePromiseAction, FocusItem } from "../actions/types";
 import type { LoadSourceAction } from "../actions/types/SourceAction";
 import { omitBy, mapValues } from "lodash";
 
-export type SourcesMap = { [string]: Source };
-export type SourcesMapByThread = { [string]: SourcesMap };
+export type SourcesMap = { [SourceId]: Source };
+export type SourcesMapByThread = { [ThreadId]: SourcesMap };
 
+type SourceActorsMap = { [SourceId]: SourceActor[] };
 type UrlsMap = { [string]: SourceId[] };
 type GetRelativeSourcesSelector = OuterState => SourcesMapByThread;
 
 export type SourcesState = {
+  // All known sources.
   sources: SourcesMap,
+
+  // Actors associated with each source.
+  sourceActors: SourceActorsMap,
+
+  // All sources associated with a given URL. When using source maps, multiple
+  // sources can have the same URL.
   urls: UrlsMap,
+
+  // All original sources associated with a generated source.
+  originalSources: { [SourceId]: SourceId[] },
+
+  // For each thread, all sources in that thread that are under the project root
+  // and should be shown in the editor's sources pane.
   relativeSources: SourcesMapByThread,
+
   pendingSelectedLocation?: PendingSelectedLocation,
   selectedLocation: ?SourceLocation,
   projectDirectoryRoot: string,
@@ -48,7 +70,9 @@ export type SourcesState = {
 export function initialSourcesState(): SourcesState {
   return {
     sources: {},
+    sourceActors: {},
     urls: {},
+    originalSources: {},
     relativeSources: {},
     selectedLocation: undefined,
     pendingSelectedLocation: prefs.pendingSelectedLocation,
@@ -82,19 +106,17 @@ function update(
   let location = null;
 
   switch (action.type) {
-    case "UPDATE_SOURCE": {
-      const source = action.source;
-      return updateSources(state, [source]);
-    }
+    case "UPDATE_SOURCE":
+      return updateSources(state, [action.source]);
 
-    case "ADD_SOURCE": {
-      const source = action.source;
-      return updateSources(state, [source]);
-    }
+    case "ADD_SOURCE":
+      return updateSources(state, [action.source]);
 
-    case "ADD_SOURCES": {
-      return updateSources(state, action.sources);
-    }
+    case "ADD_SOURCES":
+      return updateSources(state, action.sources, action.sourceActors);
+
+    case "SET_WORKERS":
+      return updateWorkers(state, action.workers, action.mainThread);
 
     case "SET_SELECTED_LOCATION":
       location = {
@@ -149,15 +171,8 @@ function update(
     case "SET_PROJECT_DIRECTORY_ROOT":
       return updateProjectDirectoryRoot(state, action.url);
 
-    case "SET_WORKERS":
-      return addRelativeSourceThreads(state, action.workers);
-
     case "NAVIGATE":
-      const newState = initialSourcesState();
-      return addRelativeSourceThread(newState, action.mainThread);
-
-    case "CONNECT":
-      return addRelativeSourceThread(state, action.mainThread);
+      return initialSourcesState();
 
     case "SET_FOCUSED_SOURCE_ITEM":
       return { ...state, focusedItem: action.item };
@@ -199,7 +214,7 @@ function setSourceTextProps(state, action: LoadSourceAction): SourcesState {
   return updateSources(state, [source]);
 }
 
-function updateSources(state, sources) {
+function updateSources(state, sources, sourceActors) {
   const relativeSources = { ...state.relativeSources };
   for (const thread in relativeSources) {
     relativeSources[thread] = { ...relativeSources[thread] };
@@ -208,19 +223,50 @@ function updateSources(state, sources) {
   state = {
     ...state,
     sources: { ...state.sources },
-    relativeSources,
-    urls: { ...state.urls }
+    sourceActors: { ...state.sourceActors },
+    urls: { ...state.urls },
+    originalSources: { ...state.originalSources },
+    relativeSources
   };
 
-  return sources.reduce(
-    (newState, source) => updateSource(newState, source),
-    state
-  );
+  sources.forEach(source => updateSource(state, source));
+  if (sourceActors) {
+    sourceActors.forEach(sourceActor =>
+      updateForNewSourceActor(state, sourceActor)
+    );
+  }
+
+  return state;
+}
+
+function updateSourceUrl(state: SourcesState, source: Object) {
+  const existing = state.urls[source.url] || [];
+  if (!existing.includes(source.id)) {
+    state.urls[source.url] = [...existing, source.id];
+  }
+}
+
+function updateOriginalSources(state: SourcesState, source: Object) {
+  if (!isOriginalSource(source)) {
+    return;
+  }
+  const generatedId = originalToGeneratedId(source.id);
+  const existing = state.originalSources[generatedId] || [];
+  if (!existing.includes(source.id)) {
+    state.originalSources[generatedId] = [...existing, source.id];
+
+    // Update relative sources for any affected threads.
+    if (state.sourceActors[generatedId]) {
+      for (const sourceActor of state.sourceActors[generatedId]) {
+        updateRelativeSource(state, source, sourceActor);
+      }
+    }
+  }
 }
 
 function updateSource(state: SourcesState, source: Object) {
   if (!source.id) {
-    return state;
+    return;
   }
 
   const existingSource = state.sources[source.id];
@@ -230,27 +276,19 @@ function updateSource(state: SourcesState, source: Object) {
 
   state.sources[source.id] = updatedSource;
 
-  const existingUrls = state.urls[source.url];
-  state.urls[source.url] = existingUrls
-    ? [...existingUrls, source.id]
-    : [source.id];
-
-  updateRelativeSource(
-    state.relativeSources,
-    updatedSource,
-    state.projectDirectoryRoot
-  );
-
-  return state;
+  updateSourceUrl(state, source);
+  updateOriginalSources(state, source);
 }
 
 function updateRelativeSource(
-  relativeSources: SourcesMapByThread,
-  source: Source,
-  root: string
-): SourcesMapByThread {
+  state: SourcesState,
+  source: Object,
+  sourceActor: SourceActor
+) {
+  const root = state.projectDirectoryRoot;
+
   if (!underRoot(source, root)) {
-    return relativeSources;
+    return;
   }
 
   const relativeSource: Source = ({
@@ -258,47 +296,66 @@ function updateRelativeSource(
     relativeUrl: getRelativeUrl(source, root)
   }: any);
 
-  if (!relativeSources[source.thread]) {
-    relativeSources[source.thread] = {};
+  if (!state.relativeSources[sourceActor.thread]) {
+    state.relativeSources[sourceActor.thread] = {};
   }
-
-  relativeSources[source.thread][source.id] = relativeSource;
-
-  return relativeSources;
+  state.relativeSources[sourceActor.thread][source.id] = relativeSource;
 }
 
-function addRelativeSourceThread(state: SourcesState, thread: Thread) {
-  if (getRelativeSourcesForThread({ sources: state }, thread.actor)) {
-    return state;
-  }
-  return {
-    ...state,
-    relativeSources: { ...state.relativeSources, [thread.actor]: {} }
-  };
+function updateForNewSourceActor(
+  state: SourcesState,
+  sourceActor: SourceActor
+) {
+  const existing = state.sourceActors[sourceActor.source] || [];
+  state.sourceActors[sourceActor.source] = [...existing, sourceActor];
+
+  updateRelativeSource(state, state.sources[sourceActor.source], sourceActor);
 }
 
-function addRelativeSourceThreads(state: SourcesState, workers: Thread[]) {
-  let newState = state;
-  for (const worker of workers) {
-    newState = addRelativeSourceThread(newState, worker);
+function updateWorkers(
+  state: SourcesState,
+  workers: WorkerList,
+  mainThread: ThreadId
+) {
+  // Clear out actors for any removed workers by regenerating source actor
+  // state for all remaining workers.
+  const sourceActors = [];
+  for (const actors: any of Object.values(state.sourceActors)) {
+    for (const sourceActor of actors) {
+      if (
+        workers.some(worker => worker.actor == sourceActor.thread) ||
+        mainThread == sourceActor.thread
+      ) {
+        sourceActors.push(sourceActor);
+      }
+    }
   }
 
-  return newState;
+  return updateSources(
+    { ...state, sourceActors: {}, relativeSources: {} },
+    [],
+    sourceActors
+  );
 }
 
 function updateProjectDirectoryRoot(state: SourcesState, root: string) {
   prefs.projectDirectoryRoot = root;
 
-  const relativeSources = getSourceList({ sources: state }).reduce(
-    (sources, source: Source) => updateRelativeSource(sources, source, root),
-    {}
-  );
+  const sourceActors = [];
+  for (const actors: any of Object.values(state.sourceActors)) {
+    actors.forEach(sourceActor => sourceActors.push(sourceActor));
+  }
 
-  return {
-    ...state,
-    projectDirectoryRoot: root,
-    relativeSources
-  };
+  return updateSources(
+    {
+      ...state,
+      projectDirectoryRoot: root,
+      sourceActors: {},
+      relativeSources: {}
+    },
+    [],
+    sourceActors
+  );
 }
 
 function updateBlackBoxList(url, isBlackBoxed) {
@@ -331,12 +388,21 @@ type OuterState = { sources: SourcesState };
 
 const getSourcesState = (state: OuterState) => state.sources;
 
-export function getSource(state: OuterState, id: string) {
+export function getSource(state: OuterState, id: SourceId) {
   return getSourceInSources(getSources(state), id);
 }
 
 export function getSourceFromId(state: OuterState, id: string): Source {
   return getSourcesState(state).sources[id];
+}
+
+export function getSourceActors(state: OuterState, id: SourceId) {
+  return getSourcesState(state).sourceActors[id] || [];
+}
+
+export function hasSourceActor(state: OuterState, sourceActor: SourceActor) {
+  const existing = getSourceActors(state, sourceActor.source);
+  return existing.some(({ actor }) => actor == sourceActor.actor);
 }
 
 export function getOriginalSourceByURL(
@@ -346,8 +412,7 @@ export function getOriginalSourceByURL(
   return getOriginalSourceByUrlInSources(
     getSources(state),
     getUrls(state),
-    url,
-    ""
+    url
   );
 }
 
@@ -358,8 +423,7 @@ export function getGeneratedSourceByURL(
   return getGeneratedSourceByUrlInSources(
     getSources(state),
     getUrls(state),
-    url,
-    ""
+    url
   );
 }
 
@@ -425,19 +489,14 @@ function getSourceHelper(
   original: boolean,
   sources: SourcesMap,
   urls: UrlsMap,
-  url: string,
-  thread: string = ""
+  url: string
 ) {
   const foundSources = getSourcesByUrlInSources(sources, urls, url);
   if (!foundSources) {
     return null;
   }
 
-  return foundSources.find(
-    source =>
-      isOriginalSource(source) == original &&
-      (!thread || source.thread == thread)
-  );
+  return foundSources.find(source => isOriginalSource(source) == original);
 }
 
 export const getOriginalSourceByUrlInSources = getSourceHelper.bind(null, true);
@@ -451,12 +510,11 @@ export function getSpecificSourceByUrlInSources(
   sources: SourcesMap,
   urls: UrlsMap,
   url: string,
-  isOriginal: boolean,
-  thread: string
+  isOriginal: boolean
 ) {
   return isOriginal
-    ? getOriginalSourceByUrlInSources(sources, urls, url, thread)
-    : getGeneratedSourceByUrlInSources(sources, urls, url, thread);
+    ? getOriginalSourceByUrlInSources(sources, urls, url)
+    : getGeneratedSourceByUrlInSources(sources, urls, url);
 }
 
 export function getSourceByUrlInSources(
@@ -519,11 +577,8 @@ export function getUrls(state: OuterState) {
   return state.sources.urls;
 }
 
-export function getSourceList(state: OuterState, thread?: string): Source[] {
-  const sourceList = (Object.values(getSources(state)): any);
-  return !thread
-    ? sourceList
-    : sourceList.filter(source => source.thread == thread);
+export function getSourceList(state: OuterState): Source[] {
+  return (Object.values(getSources(state)): any);
 }
 
 export function getRelativeSourcesList(state: OuterState): Source[] {
@@ -532,8 +587,8 @@ export function getRelativeSourcesList(state: OuterState): Source[] {
   ): any);
 }
 
-export function getSourceCount(state: OuterState, thread?: string) {
-  return getSourceList(state, thread).length;
+export function getSourceCount(state: OuterState) {
+  return getSourceList(state).length;
 }
 
 export const getSelectedLocation: Selector<?SourceLocation> = createSelector(
@@ -582,7 +637,7 @@ export function getRelativeSourcesForThread(
   state: OuterState,
   thread: string
 ): SourcesMap {
-  return getRelativeSources(state)[thread];
+  return getRelativeSources(state)[thread] || {};
 }
 
 export function getFocusedSourceItem(state: OuterState): ?FocusItem {

--- a/src/reducers/tabs.js
+++ b/src/reducers/tabs.js
@@ -31,22 +31,12 @@ export type Tab = {
   url: string,
   framework?: string | null,
   isOriginal: boolean,
-  sourceId?: string,
-  thread: string
+  sourceId?: string
 };
 export type TabList = Tab[];
 
-function isSimilarTab(
-  tab: Tab,
-  url: string,
-  isOriginal: boolean,
-  thread: string
-) {
-  return (
-    tab.url === url &&
-    tab.isOriginal === isOriginal &&
-    (!thread || !tab.thread || thread == tab.thread)
-  );
+function isSimilarTab(tab: Tab, url: string, isOriginal: boolean) {
+  return tab.url === url && tab.isOriginal === isOriginal;
 }
 
 function update(state: TabList = [], action: Action): TabList {
@@ -73,10 +63,7 @@ export function removeSourceFromTabList(
   source: Source
 ): TabList {
   return tabs.filter(
-    tab =>
-      tab.url !== source.url ||
-      tab.isOriginal != isOriginalId(source.id) ||
-      (tab.thread && tab.thread !== source.thread)
+    tab => tab.url !== source.url || tab.isOriginal != isOriginalId(source.id)
   );
 }
 
@@ -94,16 +81,16 @@ export function removeSourcesFromTabList(tabs: TabList, sources: Source[]) {
  */
 function updateTabList(
   tabs: TabList,
-  { url, framework = null, sourceId, isOriginal = false, thread = "" }
+  { url, framework = null, sourceId, isOriginal = false }
 ) {
   // Set currentIndex to -1 for URL-less tabs so that they aren't
   // filtered by isSimilarTab
   const currentIndex = url
-    ? tabs.findIndex(tab => isSimilarTab(tab, url, isOriginal, thread))
+    ? tabs.findIndex(tab => isSimilarTab(tab, url, isOriginal))
     : -1;
 
   if (currentIndex === -1) {
-    tabs = [{ url, framework, sourceId, isOriginal, thread }, ...tabs];
+    tabs = [{ url, framework, sourceId, isOriginal }, ...tabs];
   } else if (framework) {
     tabs[currentIndex].framework = framework;
   }
@@ -151,12 +138,7 @@ export function getNewSelectedSourceId(
   }
 
   const matchingTab = availableTabs.find(tab =>
-    isSimilarTab(
-      tab,
-      selectedTab.url,
-      isOriginalId(selectedLocation.sourceId),
-      selectedTab.thread
-    )
+    isSimilarTab(tab, selectedTab.url, isOriginalId(selectedLocation.sourceId))
   );
 
   if (matchingTab) {
@@ -189,8 +171,7 @@ export function getNewSelectedSourceId(
       getSources(state),
       getUrls(state),
       availableTab.url,
-      availableTab.isOriginal,
-      availableTab.thread
+      availableTab.isOriginal
     );
 
     if (tabSource) {
@@ -236,8 +217,7 @@ function getTabWithOrWithoutUrl(tab, sources, urls) {
       sources,
       urls,
       tab.url,
-      tab.isOriginal,
-      tab.thread
+      tab.isOriginal
     );
   }
 

--- a/src/reducers/tests/sources.spec.js
+++ b/src/reducers/tests/sources.spec.js
@@ -16,26 +16,33 @@ const fakeSources = foobar.sources.sources;
 
 const extenstionSource = {
   id: "extenstionId",
-  url: "http://example.com/script.js",
-  thread: "foo"
+  url: "http://example.com/script.js"
 };
 
 const firefoxExtensionSource = {
   id: "firefoxExtension",
-  url: "moz-extension://id/js/content.js",
-  thread: "foo"
+  url: "moz-extension://id/js/content.js"
 };
 
 const chromeExtensionSource = {
   id: "chromeExtension",
-  url: "chrome-extension://id/js/content.js",
-  thread: "foo"
+  url: "chrome-extension://id/js/content.js"
 };
 
 const mockedSources = [
   extenstionSource,
   firefoxExtensionSource,
   chromeExtensionSource
+];
+
+const mockedSourceActors = [
+  { actor: "extensionId-actor", source: "extenstionId", thread: "foo" },
+  {
+    actor: "firefoxExtension-actor",
+    source: "firefoxExtension",
+    thread: "foo"
+  },
+  { actor: "chromeExtension-actor", source: "chromeExtension", thread: "foo" }
 ];
 
 describe("sources reducer", () => {
@@ -58,7 +65,8 @@ describe("sources selectors", () => {
       sources: update(state, {
         type: "ADD_SOURCES",
         // coercing to a Source for the purpose of this test
-        sources: ((mockedSources: any): Source[])
+        sources: ((mockedSources: any): Source[]),
+        sourceActors: mockedSourceActors
       })
     };
     const selectedRelativeSources = getRelativeSources(state);
@@ -73,7 +81,8 @@ describe("sources selectors", () => {
       sources: update(state, {
         type: "ADD_SOURCES",
         // coercing to a Source for the purpose of this test
-        sources: ((mockedSources: any): Source[])
+        sources: ((mockedSources: any): Source[]),
+        sourceActors: mockedSourceActors
       })
     };
     const selectedRelativeSources = getRelativeSources(state);

--- a/src/types.js
+++ b/src/types.js
@@ -21,6 +21,8 @@ export type Mode =
       }
     };
 
+export type ThreadId = string;
+
 /**
  * Breakpoint ID
  *
@@ -44,6 +46,12 @@ export type SourceId = string;
  * @static
  */
 export type ActorId = string;
+
+export type SourceActorLocation = {|
+  +sourceActor: SourceActor,
+  +line: number,
+  +column?: number
+|};
 
 /**
  * Source File Location
@@ -89,7 +97,7 @@ export type ASTLocation = {|
 |};
 
 /**
- * Breakpoint
+ * Breakpoint is associated with a Source.
  *
  * @memberof types
  * @static
@@ -106,11 +114,19 @@ export type Breakpoint = {|
   +options: BreakpointOptions
 |};
 
+/**
+ * Options for a breakpoint that can be modified by the user.
+ */
 export type BreakpointOptions = {
   hidden?: boolean,
   condition?: string,
   logValue?: string
 };
+
+export type BreakpointActor = {|
+  +actor: ActorId,
+  +source: SourceActor
+|};
 
 /**
  * XHR Breakpoint
@@ -133,7 +149,7 @@ export type XHRBreakpoint = {|
  */
 export type BreakpointResult = {
   id: ActorId,
-  actualLocation: SourceLocation
+  actualLocation: SourceActorLocation
 };
 
 /**
@@ -167,6 +183,7 @@ export type FrameId = string;
  */
 export type Frame = {
   id: FrameId,
+  thread: string,
   displayName: string,
   location: SourceLocation,
   generatedLocation: SourceLocation,
@@ -306,9 +323,8 @@ export type Grip = {
  */
 
 type BaseSource = {|
-  +id: string,
+  +id: SourceId,
   +url: string,
-  +thread: string,
   +sourceMapURL?: string,
   +isBlackBoxed: boolean,
   +isPrettyPrinted: boolean,
@@ -346,6 +362,12 @@ export type WasmSource = {|
 |};
 
 export type Source = JsSource | WasmSource;
+
+export type SourceActor = {|
+  +actor: ActorId,
+  +source: SourceId,
+  +thread: ThreadId
+|};
 
 /**
  * Script

--- a/src/utils/breakpoint/index.js
+++ b/src/utils/breakpoint/index.js
@@ -17,7 +17,9 @@ export { getASTLocation, findScopeByName } from "./astBreakpointLocation";
 
 import type {
   Source,
+  SourceActor,
   SourceLocation,
+  SourceActorLocation,
   PendingLocation,
   Breakpoint,
   PendingBreakpoint
@@ -45,6 +47,8 @@ export function locationMoved(
   );
 }
 
+// The ID for a Breakpoint is derived from its location in its Source.
+// FIXME rename this to makeBreakpointId.
 export function makeLocationId(location: SourceLocation) {
   const { sourceId, line, column } = location;
   const columnString = column || "";
@@ -63,6 +67,24 @@ export function makePendingLocationId(location: SourceLocation) {
   const columnString = column || "";
 
   return `${sourceUrlString}:${line}:${columnString}`;
+}
+
+export function makeSourceActorLocation(
+  sourceActor: SourceActor,
+  location: SourceLocation
+) {
+  return {
+    sourceActor,
+    line: location.line,
+    column: location.column
+  };
+}
+
+// The ID for a BreakpointActor is derived from its location in its SourceActor.
+export function makeBreakpointActorId(location: SourceActorLocation) {
+  const { sourceActor, line, column } = location;
+  const columnString = column || "";
+  return `${sourceActor.actor}:${line}:${columnString}`;
 }
 
 export function assertBreakpoint(breakpoint: Breakpoint) {
@@ -131,7 +153,6 @@ export function createBreakpoint(
     hidden,
     generatedLocation,
     astLocation,
-    id,
     text,
     originalText,
     logValue
@@ -143,7 +164,7 @@ export function createBreakpoint(
     index: 0
   };
   const properties = {
-    id,
+    id: makeLocationId(location),
     options: {
       condition: condition || null,
       logValue: logValue || null,

--- a/src/utils/source-queue.js
+++ b/src/utils/source-queue.js
@@ -5,7 +5,7 @@
 // @flow
 
 import { throttle } from "lodash";
-import type { Source } from "../types";
+import type { CreateSourceResult } from "../client/firefox/types";
 
 let newSources;
 let queuedSources;
@@ -24,11 +24,11 @@ export default {
     newSources = actions.newSources;
     queuedSources = [];
   },
-  queue: (source: Source) => {
+  queue: (source: CreateSourceResult) => {
     queuedSources.push(source);
     queue();
   },
-  queueSources: (sources: Source[]) => {
+  queueSources: (sources: CreateSourceResult[]) => {
     queuedSources = queuedSources.concat(sources);
     queue();
   },

--- a/src/utils/sources-tree/addToTree.js
+++ b/src/utils/sources-tree/addToTree.js
@@ -82,7 +82,6 @@ function findOrCreateNode(
  */
 function traverseTree(
   url: ParsedURL,
-  thread: string,
   tree: TreeDirectory,
   debuggeeHost: ?string
 ): TreeNode {
@@ -167,7 +166,7 @@ export function addToTree(
     return;
   }
 
-  const finalNode = traverseTree(url, source.thread, tree, debuggeeHost);
+  const finalNode = traverseTree(url, tree, debuggeeHost);
 
   // $FlowIgnore
   finalNode.contents = addSourceToNode(finalNode, url, source);

--- a/src/utils/test-head.js
+++ b/src/utils/test-head.js
@@ -64,11 +64,7 @@ function makeFrame({ id, sourceId }: Object, opts: Object = {}) {
   };
 }
 
-/**
- * @memberof utils/test-head
- * @static
- */
-function makeSource(name: string, props: any = {}) {
+function makeSourceRaw(name: string, props: any = {}) {
   return {
     id: name,
     loadedState: "unloaded",
@@ -77,9 +73,24 @@ function makeSource(name: string, props: any = {}) {
   };
 }
 
+/**
+ * @memberof utils/test-head
+ * @static
+ */
+function makeSource(name: string, props: any = {}) {
+  return {
+    source: makeSourceRaw(name, props),
+    sourceActor: {
+      actor: `${name}-actor`,
+      source: name,
+      thread: "FakeThread"
+    }
+  };
+}
+
 function makeOriginalSource(name: string, props?: Object) {
-  const source = makeSource(name, props);
-  return { ...source, id: `${name}/originalSource` };
+  const source = makeSourceRaw(name, props);
+  return { source: { ...source, id: `${name}/originalSource` } };
 }
 
 function makeFuncLocation(startLine, endLine) {

--- a/src/utils/test-mockup.js
+++ b/src/utils/test-mockup.js
@@ -34,7 +34,6 @@ function makeMockSource(
   return {
     id,
     url,
-    thread: "FakeThread",
     isBlackBoxed: false,
     isPrettyPrinted: false,
     loadedState: text ? "loaded" : "unloaded",
@@ -50,7 +49,6 @@ function makeMockWasmSource(text: {| binary: Object |}): WasmSource {
   return {
     id: "wasm-source-id",
     url: "url",
-    thread: "FakeThread",
     isBlackBoxed: false,
     isPrettyPrinted: false,
     loadedState: "unloaded",


### PR DESCRIPTION
### Summary of Changes

* Add a SourceActor object representing a SourceClient connected to a source in a thread.
* Change Source to be independent of threads, and provide a mapping Source -> SourceActor[] in redux state.
* Add a BreakpointActor object representing a BreakpointClient, and which is associated with a SourceActor instead of a Source (as Breakpoint is).

This has the general effect of making sources and breakpoints in the client thread-independent, as was the case before windowless worker debugging landed.  More background on this change can be found in bug 1518884.

### Test Plan

Passes unit tests.
Manually tested on TodoMVC.

There are still some holes in the implementation wrt threads.  Mainly, as sources from new threads appear, BreakpointActors will not be created if there are applicable sites for existing breakpoints in those sources.  I'd like to fix this in followup, as there are a fair number of cleanups to client breakpoint state that can be performed once this lands.