### PR TITLE
Refactor src/utils/pause unit tests.

### DIFF
--- a/src/utils/pause/frames/tests/annotateFrames.spec.js
+++ b/src/utils/pause/frames/tests/annotateFrames.spec.js
@@ -2,31 +2,23 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
+// @flow
+
 import { annotateFrames } from "../annotateFrames";
+import { makeMockFrameWithURL } from "../../../test-mockup";
 
 describe("annotateFrames", () => {
   it("should return Angular", () => {
     const callstack = [
-      {
-        source: {
-          url: "https://cdnjs.cloudflare.com/ajax/libs/angular/angular.js"
-        }
-      },
-      {
-        source: {
-          url: "/node_modules/zone/zone.js"
-        }
-      },
-      {
-        source: {
-          url: "https://cdnjs.cloudflare.com/ajax/libs/angular/angular.js"
-        }
-      }
+      makeMockFrameWithURL(
+        "https://cdnjs.cloudflare.com/ajax/libs/angular/angular.js"
+      ),
+      makeMockFrameWithURL("/node_modules/zone/zone.js"),
+      makeMockFrameWithURL(
+        "https://cdnjs.cloudflare.com/ajax/libs/angular/angular.js"
+      )
     ];
     const frames = annotateFrames(callstack);
-    expect(frames).toEqual(
-      callstack.map(f => ({ ...f, library: "Angular" })),
-      "Angular (and zone.js) callstack is annotated as expected"
-    );
+    expect(frames).toEqual(callstack.map(f => ({ ...f, library: "Angular" })));
   });
 });

--- a/src/utils/pause/frames/tests/displayName.spec.js
+++ b/src/utils/pause/frames/tests/displayName.spec.js
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
+// @flow
+
 import {
   formatCopyName,
   formatDisplayName,
@@ -20,7 +22,7 @@ describe("formatCopyName", () => {
       }
     };
 
-    expect(formatCopyName(frame)).toEqual("child (todo-view.js#12)");
+    expect(formatCopyName(frame, L10N)).toEqual("child (todo-view.js#12)");
   });
 });
 
@@ -34,7 +36,7 @@ describe("formatting display names", () => {
       }
     };
 
-    expect(formatDisplayName(frame)).toEqual("Create Class");
+    expect(formatDisplayName(frame, undefined, L10N)).toEqual("Create Class");
   });
 
   it("shortens an anonymous function", () => {
@@ -45,7 +47,7 @@ describe("formatting display names", () => {
       }
     };
 
-    expect(formatDisplayName(frame)).toEqual("baz");
+    expect(formatDisplayName(frame, undefined, L10N)).toEqual("baz");
   });
 
   it("does not truncates long function names", () => {
@@ -56,7 +58,7 @@ describe("formatting display names", () => {
       }
     };
 
-    expect(formatDisplayName(frame)).toEqual(
+    expect(formatDisplayName(frame, undefined, L10N)).toEqual(
       "bazbazbazbazbazbazbazbazbazbazbazbazbaz"
     );
   });
@@ -70,7 +72,7 @@ describe("formatting display names", () => {
       }
     };
 
-    expect(formatDisplayName(frame)).toEqual("originalFn");
+    expect(formatDisplayName(frame, undefined, L10N)).toEqual("originalFn");
   });
 
   it("returns anonymous when displayName is undefined", () => {

--- a/src/utils/pause/frames/tests/getLibraryFromUrl.spec.js
+++ b/src/utils/pause/frames/tests/getLibraryFromUrl.spec.js
@@ -2,21 +2,17 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
+// @flow
+
 import { getLibraryFromUrl } from "../getLibraryFromUrl";
+import { makeMockFrameWithURL } from "../../../test-mockup";
 
 describe("getLibraryFromUrl", () => {
   describe("When Preact is on the frame", () => {
     it("should return Preact and not React", () => {
-      const frame = {
-        displayName: "name",
-        location: {
-          line: 12
-        },
-        source: {
-          url: "https://cdnjs.cloudflare.com/ajax/libs/preact/8.2.5/preact.js"
-        }
-      };
-
+      const frame = makeMockFrameWithURL(
+        "https://cdnjs.cloudflare.com/ajax/libs/preact/8.2.5/preact.js"
+      );
       expect(getLibraryFromUrl(frame)).toEqual("Preact");
     });
   });
@@ -35,16 +31,9 @@ describe("getLibraryFromUrl", () => {
       ];
 
       buildTypeList.forEach(buildType => {
-        const frame = {
-          displayName: "name",
-          location: {
-            line: 42
-          },
-          source: {
-            url: `https://cdnjs.cloudflare.com/ajax/libs/vue/2.5.17/${buildType}`
-          }
-        };
-
+        const frame = makeMockFrameWithURL(
+          `https://cdnjs.cloudflare.com/ajax/libs/vue/2.5.17/${buildType}`
+        );
         expect(getLibraryFromUrl(frame)).toEqual("VueJS");
       });
     });
@@ -59,15 +48,7 @@ describe("getLibraryFromUrl", () => {
         "https://debugger-react-example.com/react/test.js"
       ];
       notReactUrlList.forEach(notReactUrl => {
-        const frame = {
-          displayName: "name",
-          location: {
-            line: 12
-          },
-          source: {
-            url: notReactUrl
-          }
-        };
+        const frame = makeMockFrameWithURL(notReactUrl);
         expect(getLibraryFromUrl(frame)).toBeNull();
       });
     });
@@ -82,15 +63,7 @@ describe("getLibraryFromUrl", () => {
         "/node_modules/react-dom/test.js"
       ];
       reactUrlList.forEach(reactUrl => {
-        const frame = {
-          displayName: "name",
-          location: {
-            line: 12
-          },
-          source: {
-            url: reactUrl
-          }
-        };
+        const frame = makeMockFrameWithURL(reactUrl);
         expect(getLibraryFromUrl(frame)).toEqual("React");
       });
     });
@@ -98,51 +71,24 @@ describe("getLibraryFromUrl", () => {
 
   describe("When zone.js is on the frame", () => {
     it("should not return Angular when no callstack", () => {
-      const frame = {
-        displayName: "name",
-        location: {
-          line: 12
-        },
-        source: {
-          url: "/node_modules/zone/zone.js"
-        }
-      };
-
+      const frame = makeMockFrameWithURL("/node_modules/zone/zone.js");
       expect(getLibraryFromUrl(frame)).toEqual(null);
     });
 
     it("should not return Angular when stack without Angular frames", () => {
-      const frame = {
-        displayName: "name",
-        location: {
-          line: 12
-        },
-        source: {
-          url: "/node_modules/zone/zone.js"
-        }
-      };
+      const frame = makeMockFrameWithURL("/node_modules/zone/zone.js");
       const callstack = [frame];
 
       expect(getLibraryFromUrl(frame, callstack)).toEqual(null);
     });
 
     it("should return Angular when stack with Angular frames", () => {
-      const frame = {
-        displayName: "name",
-        location: {
-          line: 12
-        },
-        source: {
-          url: "/node_modules/zone/zone.js"
-        }
-      };
+      const frame = makeMockFrameWithURL("/node_modules/zone/zone.js");
       const callstack = [
         frame,
-        {
-          source: {
-            url: "https://cdnjs.cloudflare.com/ajax/libs/angular/angular.js"
-          }
-        }
+        makeMockFrameWithURL(
+          "https://cdnjs.cloudflare.com/ajax/libs/angular/angular.js"
+        )
       ];
 
       expect(getLibraryFromUrl(frame, callstack)).toEqual("Angular");

--- a/src/utils/pause/scopes/tests/getFramePopVariables.spec.js
+++ b/src/utils/pause/scopes/tests/getFramePopVariables.spec.js
@@ -3,7 +3,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
+// @flow
+
 import { getFramePopVariables } from "../utils";
+import type { NamedValue } from "../types";
 
 const errorGrip = {
   type: "object",
@@ -42,6 +45,16 @@ function throwWhy(grip) {
     }
   };
 }
+
+function getContentsValue(v: NamedValue) {
+  return (v.contents: any).value;
+}
+
+function getContentsClass(v: NamedValue) {
+  const value = getContentsValue(v);
+  return value ? value.class || undefined : "";
+}
+
 describe("pause - scopes", () => {
   describe("getFramePopVariables", () => {
     describe("falsey values", () => {
@@ -54,7 +67,7 @@ describe("pause - scopes", () => {
           const vars = getFramePopVariables(why, "");
           expect(vars[0].name).toEqual("<return>");
           expect(vars[0].name).toEqual("<return>");
-          expect(vars[0].contents.value).toEqual(value);
+          expect(getContentsValue(vars[0])).toEqual(value);
         });
 
         it(`shows ${test} throws`, () => {
@@ -62,7 +75,7 @@ describe("pause - scopes", () => {
           const vars = getFramePopVariables(why, "");
           expect(vars[0].name).toEqual("<exception>");
           expect(vars[0].name).toEqual("<exception>");
-          expect(vars[0].contents.value).toEqual(value);
+          expect(getContentsValue(vars[0])).toEqual(value);
         });
       }
     });
@@ -73,7 +86,7 @@ describe("pause - scopes", () => {
         const vars = getFramePopVariables(why, "");
         expect(vars[0].name).toEqual("<return>");
         expect(vars[0].name).toEqual("<return>");
-        expect(vars[0].contents.value.class).toEqual("Error");
+        expect(getContentsClass(vars[0])).toEqual("Error");
       });
 
       it("shows error throws", () => {
@@ -81,7 +94,7 @@ describe("pause - scopes", () => {
         const vars = getFramePopVariables(why, "");
         expect(vars[0].name).toEqual("<exception>");
         expect(vars[0].name).toEqual("<exception>");
-        expect(vars[0].contents.value.class).toEqual("Error");
+        expect(getContentsClass(vars[0])).toEqual("Error");
       });
     });
 
@@ -97,7 +110,7 @@ describe("pause - scopes", () => {
         const vars = getFramePopVariables(why, "");
         expect(vars[0].name).toEqual("<exception>");
         expect(vars[0].name).toEqual("<exception>");
-        expect(vars[0].contents.value).toEqual({ type: "undefined" });
+        expect(getContentsValue(vars[0])).toEqual({ type: "undefined" });
       });
     });
   });

--- a/src/utils/pause/scopes/tests/scopes.spec.js
+++ b/src/utils/pause/scopes/tests/scopes.spec.js
@@ -2,32 +2,36 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
+// @flow
+
 import { getScopes } from "..";
+import {
+  makeMockFrame,
+  makeMockScope,
+  makeWhyNormal,
+  makeWhyThrow,
+  mockScopeAddVariable
+} from "../../../test-mockup";
+
+import type { Scope } from "../../../../types";
+import type { RenderableScope } from "../getScope";
+
+function convertScope(scope: Scope): RenderableScope {
+  return (scope: any);
+}
 
 describe("scopes", () => {
   describe("getScopes", () => {
     it("single scope", () => {
-      const pauseData = {
-        frame: {
-          this: {}
-        }
-      };
+      const pauseData = makeWhyNormal();
+      const scope = makeMockScope("actor1");
+      const selectedFrame = makeMockFrame(undefined, undefined, scope);
 
-      const selectedFrame = {
-        scope: {
-          actor: "actor1",
-          type: "block",
-          bindings: {
-            arguments: [],
-            variables: {}
-          },
-          parent: null
-        },
-        this: {}
-      };
-
-      const frameScopes = selectedFrame.scope;
+      const frameScopes = convertScope(selectedFrame.scope);
       const scopes = getScopes(pauseData, selectedFrame, frameScopes);
+      if (!scopes) {
+        throw new Error("missing scopes");
+      }
       expect(scopes[0].path).toEqual("actor1-1");
       expect(scopes[0].contents[0]).toEqual({
         name: "<this>",
@@ -37,65 +41,31 @@ describe("scopes", () => {
     });
 
     it("second scope", () => {
-      const pauseData = {
-        frame: {
-          this: {}
-        }
-      };
+      const pauseData = makeWhyNormal();
+      const scope0 = makeMockScope("actor2");
+      const scope1 = makeMockScope("actor1", undefined, scope0);
+      const selectedFrame = makeMockFrame(undefined, undefined, scope1);
+      mockScopeAddVariable(scope0, "foo");
 
-      const selectedFrame = {
-        scope: {
-          actor: "actor1",
-          type: "block",
-          bindings: {
-            arguments: [],
-            variables: {}
-          },
-          parent: {
-            actor: "actor2",
-            type: "block",
-            bindings: {
-              arguments: [],
-              variables: {
-                foo: {}
-              }
-            }
-          }
-        },
-        this: {}
-      };
-
-      const frameScopes = selectedFrame.scope;
+      const frameScopes = convertScope(selectedFrame.scope);
       const scopes = getScopes(pauseData, selectedFrame, frameScopes);
+      if (!scopes) {
+        throw new Error("missing scopes");
+      }
       expect(scopes[1].path).toEqual("actor2-2");
       expect(scopes[1].contents[0]).toEqual({
         name: "foo",
         path: "actor2-2/foo",
-        contents: {}
+        contents: { value: null }
       });
     });
 
     it("returning scope", () => {
-      const why = {
-        frameFinished: {
-          return: "to sender"
-        }
-      };
+      const why = makeWhyNormal("to sender");
+      const scope = makeMockScope("actor1");
+      const selectedFrame = makeMockFrame(undefined, undefined, scope);
 
-      const selectedFrame = {
-        scope: {
-          actor: "actor1",
-          type: "block",
-          bindings: {
-            arguments: [],
-            variables: {}
-          },
-          parent: null
-        },
-        this: {}
-      };
-
-      const frameScopes = selectedFrame.scope;
+      const frameScopes = convertScope(selectedFrame.scope);
       const scopes = getScopes(why, selectedFrame, frameScopes);
       expect(scopes).toMatchObject([
         {
@@ -121,26 +91,11 @@ describe("scopes", () => {
     });
 
     it("throwing scope", () => {
-      const why = {
-        frameFinished: {
-          throw: "a party"
-        }
-      };
+      const why = makeWhyThrow("a party");
+      const scope = makeMockScope("actor1");
+      const selectedFrame = makeMockFrame(undefined, undefined, scope);
 
-      const selectedFrame = {
-        scope: {
-          actor: "actor1",
-          type: "block",
-          bindings: {
-            arguments: [],
-            variables: {}
-          },
-          parent: null
-        },
-        this: {}
-      };
-
-      const frameScopes = selectedFrame.scope;
+      const frameScopes = convertScope(selectedFrame.scope);
       const scopes = getScopes(why, selectedFrame, frameScopes);
       expect(scopes).toMatchObject([
         {

--- a/src/utils/test-head.js
+++ b/src/utils/test-head.js
@@ -19,6 +19,11 @@ import configureStore from "../actions/utils/create-store";
 import sourceQueue from "../utils/source-queue";
 
 /**
+ * This file contains older interfaces used by tests that have not been
+ * converted to use test-mockup.js
+ */
+
+/**
  * @memberof utils/test-head
  * @static
  */

--- a/src/utils/test-mockup.js
+++ b/src/utils/test-mockup.js
@@ -1,0 +1,104 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
+// @flow
+
+/**
+ * This file is for use by unit tests for isolated debugger components that do
+ * not need to interact with the redux store. When these tests need to construct
+ * debugger objects, these interfaces should be used instead of plain object
+ * literals.
+ */
+
+import type {
+  ActorId,
+  Frame,
+  FrameId,
+  Scope,
+  Source,
+  SourceId,
+  Why
+} from "../types";
+
+function makeMockSource(id: SourceId = "source", url: string): Source {
+  return {
+    id,
+    url,
+    thread: "FakeThread",
+    isBlackBoxed: false,
+    isPrettyPrinted: false,
+    loadedState: "unloaded",
+    relativeUrl: url,
+    introductionUrl: null,
+    isWasm: false
+  };
+}
+
+function makeMockScope(
+  actor: ActorId = "scope-actor",
+  type: string = "block",
+  parent: ?Scope = null
+): Scope {
+  return {
+    actor,
+    parent,
+    bindings: {
+      arguments: [],
+      variables: {}
+    },
+    object: null,
+    function: null,
+    type
+  };
+}
+
+function mockScopeAddVariable(scope: Scope, name: string) {
+  if (!scope.bindings) {
+    throw new Error("no scope bindings");
+  }
+  scope.bindings.variables[name] = { value: null };
+}
+
+function makeMockFrame(
+  id: FrameId = "frame",
+  source: Source = makeMockSource(undefined, "url"),
+  scope: Scope = makeMockScope()
+): Frame {
+  const location = { sourceId: source.id, line: 4 };
+  return {
+    id,
+    thread: "FakeThread",
+    displayName: `display-${id}`,
+    location,
+    generatedLocation: location,
+    source,
+    scope,
+    this: {}
+  };
+}
+
+function makeMockFrameWithURL(url: string): Frame {
+  return makeMockFrame(undefined, makeMockSource(undefined, url));
+}
+
+function makeWhyNormal(frameReturnValue: any = undefined): Why {
+  if (frameReturnValue) {
+    return { type: "why-normal", frameFinished: { return: frameReturnValue } };
+  }
+  return { type: "why-normal" };
+}
+
+function makeWhyThrow(frameThrowValue: any): Why {
+  return { type: "why-throw", frameFinished: { throw: frameThrowValue } };
+}
+
+export {
+  makeMockSource,
+  makeMockScope,
+  mockScopeAddVariable,
+  makeMockFrame,
+  makeMockFrameWithURL,
+  makeWhyNormal,
+  makeWhyThrow
+};


### PR DESCRIPTION
Partial fix for #7797

### Summary of Changes

* Flow-ize and eliminate object literals for core structures in src/utils/pause unit tests.
* Add a test-mockup.js shared test file for use by unit tests in #7797 test refactoring.
