### PR TITLE
Fixed selectors for pane toggle buttons

### DIFF
--- a/src/components/shared/Button/styles/PaneToggleButton.css
+++ b/src/components/shared/Button/styles/PaneToggleButton.css
@@ -9,12 +9,12 @@
   height: inherit;
 }
 
-.toggle-button svg {
+.toggle-button .img {
   fill: var(--theme-comment);
   vertical-align: 0;
 }
 
-:root.theme-dark .toggle-button svg {
+:root.theme-dark .toggle-button .img {
   fill: var(--theme-comment-alt);
 }
 
@@ -27,12 +27,12 @@
   margin-inline-start: 0px;
 }
 
-html:not([dir="rtl"]) .toggle-button.end svg,
-html[dir="rtl"] .toggle-button.start svg {
+html:not([dir="rtl"]) .toggle-button.end .img,
+html[dir="rtl"] .toggle-button.start .img {
   transform: rotate(180deg);
 }
 
-html .toggle-button.end.vertical svg {
+html .toggle-button.end.vertical .img {
   transform: rotate(-90deg);
 }
 


### PR DESCRIPTION
Pane toggle buttons regressed from the switch away from inline SVGs, as noted by @fvsch. The right collapse/expand toggle button was pointing left when it was supposed to be pointing right, and vice versa. It also wasn't switching from pointing left/right to up/down when in vertical mode. 
<details>
<summary>Click here for GIFs from before the fix</summary>
<img src="https://user-images.githubusercontent.com/15959269/51728769-573aa380-203f-11e9-995b-e58dd8c6e9df.gif">
<img src="https://user-images.githubusercontent.com/15959269/51728770-573aa380-203f-11e9-871c-c1e3ee824122.gif">
</details>
<br>

Updated the selectors from `svg` to `.img` and they're working fine now.

<details>
<summary>Click here for GIFs from after the fix</summary>
<img src="https://user-images.githubusercontent.com/15959269/51728833-9c5ed580-203f-11e9-9614-d34369453d6e.gif">
<img src="https://user-images.githubusercontent.com/15959269/51728834-9c5ed580-203f-11e9-8710-9ca4feb151c3.gif">
</details>