### PR TITLE
Fix logpoints bug

### DIFF
--- a/assets/panel/debugger.properties
+++ b/assets/panel/debugger.properties
@@ -534,6 +534,12 @@ editor.addLogPoint.accesskey=l
 # LOCALIZATION NOTE (editor.editLogPoint): Editor gutter context menu item
 # for editing a log point already set on a line.
 editor.editLogPoint=Edit log
+editor.editLogPoint.accesskey=E
+
+# LOCALIZATION NOTE (editor.removeLogPoint): Context menu item for removing
+# a log point on a line.
+editor.removeLogPoint.label=Remove log
+editor.removeLogPoint.accesskey=V
 
 # LOCALIZATION NOTE (editor.conditionalPanel.placeholder): Placeholder text for
 # input element inside ConditionalPanel component

--- a/src/components/Editor/Breakpoint.js
+++ b/src/components/Editor/Breakpoint.js
@@ -57,6 +57,7 @@ class Breakpoint extends PureComponent<Props> {
     doc.setGutterMarker(line, "breakpoints", null);
     doc.removeLineClass(line, "line", "new-breakpoint");
     doc.removeLineClass(line, "line", "has-condition");
+    doc.removeLineClass(line, "line", "has-log");
   }
 
   get selectedLocation() {
@@ -133,12 +134,13 @@ class Breakpoint extends PureComponent<Props> {
     doc.setGutterMarker(line, "breakpoints", this.makeMarker());
 
     editor.codeMirror.addLineClass(line, "line", "new-breakpoint");
-    if (breakpoint.options.condition) {
+    editor.codeMirror.removeLineClass(line, "line", "has-condition");
+    editor.codeMirror.removeLineClass(line, "line", "has-log");
+
+    if (breakpoint.options.logValue) {
+      editor.codeMirror.addLineClass(line, "line", "has-log");
+    } else if (breakpoint.options.condition) {
       editor.codeMirror.addLineClass(line, "line", "has-condition");
-    } else if (breakpoint.options.logValue) {
-      editor.codeMirror.addLineClass(line, "line", "has-condition log");
-    } else {
-      editor.codeMirror.removeLineClass(line, "line", "has-condition");
     }
   };
 

--- a/src/components/Editor/ColumnBreakpoint.js
+++ b/src/components/Editor/ColumnBreakpoint.js
@@ -32,11 +32,15 @@ ReactDOM.render(<Svg name={"column-marker"} />, breakpointImg);
 
 function makeBookmark({ breakpoint }, { onClick, onContextMenu }) {
   const bp = breakpointImg.cloneNode(true);
-  const condition = breakpoint && breakpoint.options.condition;
+  if (!breakpoint) {
+    return;
+  }
+  const { condition, logValue } = breakpoint.options;
   const isActive = breakpoint && !breakpoint.disabled;
 
   bp.className = classnames("column-breakpoint", {
     "has-condition": condition,
+    "has-log": logValue,
     active: isActive,
     disabled: !isActive
   });

--- a/src/components/Editor/ColumnBreakpoints.css
+++ b/src/components/Editor/ColumnBreakpoints.css
@@ -36,9 +36,9 @@
   stroke: var(--theme-graphs-orange);
 }
 
-.column-breakpoint.has-condition.log svg {
-  fill: var(--theme-graphs-orange);
-  stroke: var(--theme-graphs-yellow);
+.column-breakpoint.has-log svg {
+  fill: var(--theme-graphs-purple);
+  stroke: var(--purple-60);
 }
 
 .theme-dark .column-breakpoint.active svg {

--- a/src/components/Editor/ConditionalPanel.js
+++ b/src/components/Editor/ConditionalPanel.js
@@ -62,12 +62,14 @@ export class ConditionalPanel extends PureComponent<Props> {
     }
   };
 
-  setBreakpoint(condition: string) {
-    const { location, log } = this.props;
-    return this.props.setBreakpointOptions(
-      location,
-      log ? { logValue: condition } : { condition }
-    );
+  setBreakpoint(value: string) {
+    const { location, log, breakpoint } = this.props;
+    const options = breakpoint ? breakpoint.options : {};
+    const type = log ? "logValue" : "condition";
+    return this.props.setBreakpointOptions(location, {
+      ...options,
+      [type]: value
+    });
   }
 
   clearConditionalPanel() {

--- a/src/components/Editor/Editor.css
+++ b/src/components/Editor/Editor.css
@@ -167,9 +167,9 @@ html[dir="rtl"] .editor-mount {
   stroke: var(--theme-graphs-orange);
 }
 
-.new-breakpoint.has-condition.log .CodeMirror-gutter-wrapper svg {
-  fill: var(--theme-highlight-purple);
-  stroke: var(--breakpoint-stroke);
+.new-breakpoint.has-log .CodeMirror-gutter-wrapper svg {
+  fill: var(--theme-graphs-purple);
+  stroke: var(--purple-60);
 }
 
 .editor.new-breakpoint.breakpoint-disabled svg {

--- a/src/components/Editor/Editor.css
+++ b/src/components/Editor/Editor.css
@@ -24,7 +24,9 @@
   min-width: 0 !important;
 }
 
-.CodeMirror.cm-s-mozilla, .CodeMirror-scroll, .CodeMirror-sizer {
+.CodeMirror.cm-s-mozilla,
+.CodeMirror-scroll,
+.CodeMirror-sizer {
   overflow-anchor: none;
 }
 
@@ -166,8 +168,8 @@ html[dir="rtl"] .editor-mount {
 }
 
 .new-breakpoint.has-condition.log .CodeMirror-gutter-wrapper svg {
-  fill: var(--theme-graphs-orange);
-  stroke: var(--theme-graphs-yellow);
+  fill: var(--theme-highlight-purple);
+  stroke: var(--breakpoint-stroke);
 }
 
 .editor.new-breakpoint.breakpoint-disabled svg {

--- a/src/components/Editor/menus/breakpoints.js
+++ b/src/components/Editor/menus/breakpoints.js
@@ -131,10 +131,6 @@ export function breakpointItems(
   breakpoint: Breakpoint,
   breakpointActions: BreakpointItemActions
 ) {
-  const {
-    options: { condition, logValue }
-  } = breakpoint;
-
   const items = [
     removeBreakpointItem(breakpoint, breakpointActions),
     toggleDisabledBreakpointItem(breakpoint, breakpointActions)
@@ -151,13 +147,12 @@ export function breakpointItems(
     );
   }
 
-  if (condition || (!condition && !logValue)) {
-    items.push(conditionalBreakpointItem(breakpoint, breakpointActions));
-  }
+  items.push(conditionalBreakpointItem(breakpoint, breakpointActions));
 
-  if ((features.logPoints && logValue) || (!condition && !logValue)) {
+  if (features.logPoints) {
     items.push(logPointItem(breakpoint, breakpointActions));
   }
+
   return items;
 }
 

--- a/src/components/Editor/menus/breakpoints.js
+++ b/src/components/Editor/menus/breakpoints.js
@@ -151,11 +151,11 @@ export function breakpointItems(
     );
   }
 
-  if (condition) {
+  if (condition || (!condition && !logValue)) {
     items.push(conditionalBreakpointItem(breakpoint, breakpointActions));
   }
 
-  if (features.logPoints && logValue) {
+  if ((features.logPoints && logValue) || (!condition && !logValue)) {
     items.push(logPointItem(breakpoint, breakpointActions));
   }
   return items;

--- a/src/components/Editor/menus/breakpoints.js
+++ b/src/components/Editor/menus/breakpoints.js
@@ -33,30 +33,6 @@ export const removeBreakpointItem = (
   accelerator: L10N.getStr("toggleBreakpoint.key")
 });
 
-export const createConditionalBreakpointItem = (
-  location: SourceLocation,
-  breakpointActions: BreakpointItemActions
-) => ({
-  id: "node-menu-add-conditional-breakpoint",
-  label: L10N.getStr("editor.addConditionalBreakpoint"),
-  accelerator: L10N.getStr("toggleCondPanel.key"),
-  accesskey: L10N.getStr("editor.addConditionBreakpoint.accesskey"),
-  disabled: false,
-  click: () => breakpointActions.openConditionalPanel(location)
-});
-
-export const createLogBreakpointItem = (
-  location: SourceLocation,
-  breakpointActions: BreakpointItemActions
-) => ({
-  id: "node-menu-add-log-breakpoint",
-  label: L10N.getStr("editor.addLogBreakpoint"),
-  accelerator: L10N.getStr("toggleCondPanel.key"),
-  accesskey: L10N.getStr("editor.addConditionBreakpoint.accesskey"),
-  disabled: false,
-  click: () => breakpointActions.openConditionalPanel(location)
-});
-
 export const addConditionalBreakpointItem = (
   location: SourceLocation,
   breakpointActions: BreakpointItemActions
@@ -123,10 +99,10 @@ export const logPointItem = (
   breakpointActions: BreakpointItemActions
 ) => {
   const {
-    options: { condition },
+    options: { logValue },
     location
   } = breakpoint;
-  return condition
+  return logValue
     ? editLogPointItem(location, breakpointActions)
     : addLogPointItem(location, breakpointActions);
 };
@@ -155,6 +131,10 @@ export function breakpointItems(
   breakpoint: Breakpoint,
   breakpointActions: BreakpointItemActions
 ) {
+  const {
+    options: { condition, logValue }
+  } = breakpoint;
+
   const items = [
     removeBreakpointItem(breakpoint, breakpointActions),
     toggleDisabledBreakpointItem(breakpoint, breakpointActions)
@@ -171,9 +151,11 @@ export function breakpointItems(
     );
   }
 
-  items.push(conditionalBreakpointItem(breakpoint, breakpointActions));
+  if (condition) {
+    items.push(conditionalBreakpointItem(breakpoint, breakpointActions));
+  }
 
-  if (features.logPoints) {
+  if (features.logPoints && logValue) {
     items.push(logPointItem(breakpoint, breakpointActions));
   }
   return items;
@@ -185,11 +167,11 @@ export function createBreakpointItems(
 ) {
   const items = [
     addBreakpointItem(location, breakpointActions),
-    createConditionalBreakpointItem(location, breakpointActions)
+    addConditionalBreakpointItem(location, breakpointActions)
   ];
 
   if (features.logPoints) {
-    items.push(createLogBreakpointItem(location, breakpointActions));
+    items.push(addLogPointItem(location, breakpointActions));
   }
   return items;
 }

--- a/src/components/SecondaryPanes/Breakpoints/Breakpoint.js
+++ b/src/components/SecondaryPanes/Breakpoints/Breakpoint.js
@@ -128,7 +128,7 @@ class Breakpoint extends PureComponent<Props> {
   getBreakpointText() {
     const { breakpoint, selectedSource } = this.props;
     const { condition, logValue } = breakpoint.options;
-    return condition || logValue || getSelectedText(breakpoint, selectedSource);
+    return logValue || condition || getSelectedText(breakpoint, selectedSource);
   }
 
   highlightText = memoize(
@@ -156,7 +156,7 @@ class Breakpoint extends PureComponent<Props> {
           paused: this.isCurrentlyPausedAtBreakpoint(),
           disabled: breakpoint.disabled,
           "is-conditional": !!breakpoint.options.condition,
-          log: !!breakpoint.options.logValue
+          "is-log": !!breakpoint.options.logValue
         })}
         onClick={this.selectBreakpoint}
         onDoubleClick={this.onDoubleClick}

--- a/src/components/SecondaryPanes/Breakpoints/Breakpoint.js
+++ b/src/components/SecondaryPanes/Breakpoints/Breakpoint.js
@@ -127,10 +127,8 @@ class Breakpoint extends PureComponent<Props> {
 
   getBreakpointText() {
     const { breakpoint, selectedSource } = this.props;
-    return (
-      breakpoint.options.condition ||
-      getSelectedText(breakpoint, selectedSource)
-    );
+    const { condition, logValue } = breakpoint.options;
+    return condition || logValue || getSelectedText(breakpoint, selectedSource);
   }
 
   highlightText = memoize(
@@ -151,7 +149,6 @@ class Breakpoint extends PureComponent<Props> {
     const { breakpoint } = this.props;
     const text = this.getBreakpointText();
     const editor = getEditor();
-
     return (
       <div
         className={classnames({

--- a/src/components/SecondaryPanes/Breakpoints/Breakpoints.css
+++ b/src/components/SecondaryPanes/Breakpoints/Breakpoints.css
@@ -110,20 +110,12 @@ html:not([dir="rtl"]) .breakpoints-exceptions {
   border-left: 4px solid transparent;
 }
 
-html:not([dir="rtl"]) .breakpoints-list .breakpoint.is-conditional {
-  border-left-color: var(--theme-graphs-yellow);
+html .breakpoints-list .breakpoint.is-conditional {
+  border-inline-start-color: var(--theme-graphs-yellow);
 }
 
-html[dir="rtl"] .breakpoints-list .breakpoint.is-conditional {
-  border-right-color: var(--theme-graphs-yellow);
-}
-
-html:not([dir="rtl"]) .breakpoints-list .breakpoint.log {
-  border-left-color: var(--theme-highlight-purple);
-}
-
-html[dir="rtl"] .breakpoints-list .breakpoint.log {
-  border-right-color: var(--theme-highlight-purple);
+html .breakpoints-list .breakpoint.is-log {
+  border-inline-start-color: var(--theme-graphs-purple);
 }
 
 html .breakpoints-list .breakpoint.paused {

--- a/src/components/SecondaryPanes/Breakpoints/Breakpoints.css
+++ b/src/components/SecondaryPanes/Breakpoints/Breakpoints.css
@@ -119,11 +119,11 @@ html[dir="rtl"] .breakpoints-list .breakpoint.is-conditional {
 }
 
 html:not([dir="rtl"]) .breakpoints-list .breakpoint.log {
-  border-left-color: var(--theme-graphs-orange);
+  border-left-color: var(--theme-highlight-purple);
 }
 
 html[dir="rtl"] .breakpoints-list .breakpoint.log {
-  border-right-color: var(--theme-graphs-orange);
+  border-right-color: var(--theme-highlight-purple);
 }
 
 html .breakpoints-list .breakpoint.paused {

--- a/src/components/SecondaryPanes/Breakpoints/Breakpoints.css
+++ b/src/components/SecondaryPanes/Breakpoints/Breakpoints.css
@@ -118,11 +118,11 @@ html[dir="rtl"] .breakpoints-list .breakpoint.is-conditional {
   border-right-color: var(--theme-graphs-yellow);
 }
 
-html:not([dir="rtl"]) .breakpoints-list .breakpoint.is-conditional.log {
+html:not([dir="rtl"]) .breakpoints-list .breakpoint.log {
   border-left-color: var(--theme-graphs-orange);
 }
 
-html[dir="rtl"] .breakpoints-list .breakpoint.is-conditional.log {
+html[dir="rtl"] .breakpoints-list .breakpoint.log {
   border-right-color: var(--theme-graphs-orange);
 }
 

--- a/src/components/SecondaryPanes/Breakpoints/BreakpointsContextMenu.js
+++ b/src/components/SecondaryPanes/Breakpoints/BreakpointsContextMenu.js
@@ -191,7 +191,11 @@ export default function showContextMenu(props: Props) {
     label: removeConditionLabel,
     accesskey: removeConditionKey,
     disabled: false,
-    click: () => setBreakpointOptions(selectedLocation, {})
+    click: () =>
+      setBreakpointOptions(selectedLocation, {
+        ...breakpoint.options,
+        condition: null
+      })
   };
 
   const addConditionItem = {
@@ -232,6 +236,18 @@ export default function showContextMenu(props: Props) {
     accelerator: L10N.getStr("toggleCondPanel.key")
   };
 
+  const removeLogPointItem = {
+    id: "node-menu-remove-log",
+    label: L10N.getStr("editor.removeLogPoint.label"),
+    accesskey: L10N.getStr("editor.removeLogPoint.accesskey"),
+    disabled: false,
+    click: () =>
+      setBreakpointOptions(selectedLocation, {
+        ...breakpoint.options,
+        logValue: null
+      })
+  };
+
   const logPointItem = breakpoint.options.logValue
     ? editLogPointItem
     : addLogPointItem;
@@ -269,23 +285,23 @@ export default function showContextMenu(props: Props) {
     },
     {
       item: addConditionItem,
-      hidden: () => breakpoint.options.logValue || breakpoint.options.condition
+      hidden: () => breakpoint.options.condition
     },
     {
       item: editConditionItem,
-      hidden: () => breakpoint.options.logValue || !breakpoint.options.condition
+      hidden: () => !breakpoint.options.condition
     },
     {
       item: removeConditionItem,
-      hidden: () => breakpoint.options.logValue || !breakpoint.options.condition
+      hidden: () => !breakpoint.options.condition
     },
     {
       item: logPointItem,
-      hidden: () =>
-        !(
-          (features.logPoints && breakpoint.options.logValue) ||
-          (!breakpoint.options.condition && !breakpoint.options.logValue)
-        )
+      hidden: () => !features.logPoints
+    },
+    {
+      item: removeLogPointItem,
+      hidden: () => !features.logPoints || !breakpoint.options.logValue
     }
   ];
 

--- a/src/components/SecondaryPanes/Breakpoints/BreakpointsContextMenu.js
+++ b/src/components/SecondaryPanes/Breakpoints/BreakpointsContextMenu.js
@@ -7,6 +7,8 @@
 import { buildMenu, showMenu } from "devtools-contextmenu";
 import { getSelectedLocation } from "../../../utils/source-maps";
 import actions from "../../../actions";
+import { features } from "../../../utils/prefs";
+
 import type { Breakpoint, Source } from "../../../types";
 
 type Props = {
@@ -212,6 +214,28 @@ export default function showContextMenu(props: Props) {
     }
   };
 
+  const addLogPointItem = {
+    id: "node-menu-add-log-point",
+    label: L10N.getStr("editor.addLogPoint"),
+    accesskey: L10N.getStr("editor.addLogPoint.accesskey"),
+    disabled: false,
+    click: () => openConditionalPanel(selectedLocation, true),
+    accelerator: L10N.getStr("toggleCondPanel.key")
+  };
+
+  const editLogPointItem = {
+    id: "node-menu-edit-log-point",
+    label: L10N.getStr("editor.editLogPoint"),
+    accesskey: L10N.getStr("editor.addLogPoint.accesskey"),
+    disabled: false,
+    click: () => openConditionalPanel(selectedLocation, true),
+    accelerator: L10N.getStr("toggleCondPanel.key")
+  };
+
+  const logPointItem = breakpoint.options.logValue
+    ? editLogPointItem
+    : addLogPointItem;
+
   const hideEnableSelfItem = !breakpoint.disabled;
   const hideEnableAllItem = disabledBreakpoints.length === 0;
   const hideEnableOthersItem = otherDisabledBreakpoints.length === 0;
@@ -245,15 +269,23 @@ export default function showContextMenu(props: Props) {
     },
     {
       item: addConditionItem,
-      hidden: () => breakpoint.options.condition
+      hidden: () => breakpoint.options.logValue || breakpoint.options.condition
     },
     {
       item: editConditionItem,
-      hidden: () => !breakpoint.options.condition
+      hidden: () => breakpoint.options.logValue || !breakpoint.options.condition
     },
     {
       item: removeConditionItem,
-      hidden: () => !breakpoint.options.condition
+      hidden: () => breakpoint.options.logValue || !breakpoint.options.condition
+    },
+    {
+      item: logPointItem,
+      hidden: () =>
+        !(
+          (features.logPoints && breakpoint.options.logValue) ||
+          (!breakpoint.options.condition && !breakpoint.options.logValue)
+        )
     }
   ];
 

--- a/src/types.js
+++ b/src/types.js
@@ -119,8 +119,8 @@ export type Breakpoint = {|
  */
 export type BreakpointOptions = {
   hidden?: boolean,
-  condition?: string,
-  logValue?: string
+  condition?: string | null,
+  logValue?: string | null
 };
 
 export type BreakpointActor = {|

--- a/test/mochitest/browser_dbg-breakpoints-cond.js
+++ b/test/mochitest/browser_dbg-breakpoints-cond.js
@@ -1,5 +1,6 @@
-/* Any copyright is dedicated to the Public Domain.
- * http://creativecommons.org/publicdomain/zero/1.0/ */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
 function findBreakpoint(dbg, url, line, column = 0) {
   const {
@@ -16,21 +17,58 @@ function getLineEl(dbg, line) {
   return lines[line - 1];
 }
 
-function assertEditorBreakpoint(dbg, line, shouldExist) {
-  const exists = getLineEl(dbg, line).classList.contains("has-condition");
+function assertEditorBreakpoint(
+  dbg,
+  line,
+  { hasCondition = false, hasLog = false } = {}
+) {
+  const hasConditionClass = getLineEl(dbg, line).classList.contains(
+    "has-condition"
+  );
 
   ok(
-    exists === shouldExist,
-    "Breakpoint " +
-      (shouldExist ? "exists" : "does not exist") +
-      " on line " +
-      line
+    hasConditionClass === hasCondition,
+    `Breakpoint condition ${
+      hasCondition ? "exists" : "does not exist"
+    } on line ${line}`
+  );
+
+  const hasLogClass = getLineEl(dbg, line).classList.contains("has-log");
+
+  ok(
+    hasLogClass === hasLog,
+    `Breakpoint log ${hasLog ? "exists" : "does not exist"} on line ${line}`
   );
 }
 
 function waitForElementFocus(dbg, el) {
   const doc = dbg.win.document;
   return waitFor(() => doc.activeElement == el && doc.hasFocus());
+}
+
+function waitForBreakpoint(dbg, url, line) {
+  return waitForState(dbg, () => findBreakpoint(dbg, url, line));
+}
+
+function waitForBreakpointWithCondition(dbg, url, line) {
+  return waitForState(dbg, () => {
+    const bp = findBreakpoint(dbg, url, line);
+    return bp && bp.options.condition;
+  });
+}
+
+function waitForBreakpointWithLog(dbg, url, line) {
+  return waitForState(dbg, () => {
+    const bp = findBreakpoint(dbg, url, line);
+    return bp && bp.options.logValue;
+  });
+}
+
+function waitForBreakpointWithoutCondition(dbg, url, line) {
+  return waitForState(dbg, () => {
+    const bp = findBreakpoint(dbg, url, line);
+    return bp && !bp.options.condition;
+  });
 }
 
 async function assertConditionalBreakpointIsFocused(dbg) {
@@ -57,51 +95,74 @@ async function setConditionalBreakpoint(dbg, index, condition) {
   pressKey(dbg, "Enter");
 }
 
+async function setLogPoint(dbg, index, value) {
+  const { addLogPoint, editLogPoint } = selectors.gutterContextMenu;
+
+  // Make this work with either add or edit menu items
+  const selector = `${addLogPoint},${editLogPoint}`;
+
+  rightClickElement(dbg, "gutter", index);
+  selectContextMenuItem(dbg, selector);
+  await waitForElement(dbg, "conditionalPanelInput");
+  await assertConditionalBreakpointIsFocused(dbg);
+
+  // Position cursor reliably at the end of the text.
+  pressKey(dbg, "End");
+  type(dbg, value);
+  pressKey(dbg, "Enter");
+}
+
 add_task(async function() {
   const dbg = await initDebugger("doc-scripts.html", "simple2");
   await pushPref("devtools.debugger.features.column-breakpoints", false);
+  await pushPref("devtools.debugger.features.log-points", true);
 
   await selectSource(dbg, "simple2");
   await waitForSelectedSource(dbg, "simple2");
 
   await setConditionalBreakpoint(dbg, 5, "1");
   await waitForDispatch(dbg, "ADD_BREAKPOINT");
+  await waitForBreakpointWithCondition(dbg, "simple2", 5);
 
   let bp = findBreakpoint(dbg, "simple2", 5);
   is(bp.options.condition, "1", "breakpoint is created with the condition");
-  assertEditorBreakpoint(dbg, 5, true);
+  assertEditorBreakpoint(dbg, 5, { hasCondition: true });
 
-  // Edit the conditional breakpoint set above
-  const bpCondition1 = waitForDispatch(dbg, "SET_BREAKPOINT_OPTIONS");
+  info("Edit the conditional breakpoint set above");
   await setConditionalBreakpoint(dbg, 5, "2");
-  await bpCondition1;
+  await waitForBreakpointWithCondition(dbg, "simple2", 5);
+
   bp = findBreakpoint(dbg, "simple2", 5);
   is(bp.options.condition, "12", "breakpoint is created with the condition");
-  assertEditorBreakpoint(dbg, 5, true);
+  assertEditorBreakpoint(dbg, 5, { hasCondition: true });
 
   clickElement(dbg, "gutter", 5);
   await waitForDispatch(dbg, "REMOVE_BREAKPOINT");
   bp = findBreakpoint(dbg, "simple2", 5);
   is(bp, null, "breakpoint was removed");
-  assertEditorBreakpoint(dbg, 5, false);
+  assertEditorBreakpoint(dbg, 5);
 
-  // Adding a condition to a breakpoint
+  info("Adding a condition to a breakpoint");
   clickElement(dbg, "gutter", 5);
   await waitForDispatch(dbg, "ADD_BREAKPOINT");
-  const bpCondition2 = waitForDispatch(dbg, "SET_BREAKPOINT_OPTIONS");
   await setConditionalBreakpoint(dbg, 5, "1");
-  await bpCondition2;
+  await waitForBreakpointWithCondition(dbg, "simple2", 5);
 
   bp = findBreakpoint(dbg, "simple2", 5);
   is(bp.options.condition, "1", "breakpoint is created with the condition");
-  assertEditorBreakpoint(dbg, 5, true);
+  assertEditorBreakpoint(dbg, 5, { hasCondition: true });
 
-  const bpCondition3 = waitForDispatch(dbg, "SET_BREAKPOINT_OPTIONS");
-  //right click breakpoint in breakpoints list
-  rightClickElement(dbg, "breakpointItem", 3)
-  // select "remove condition";
+  rightClickElement(dbg, "breakpointItem", 3);
+  info('select "remove condition"');
   selectContextMenuItem(dbg, selectors.breakpointContextMenu.removeCondition);
-  await bpCondition3;
+  await waitForBreakpointWithoutCondition(dbg, "simple2", 5);
   bp = findBreakpoint(dbg, "simple2", 5);
   is(bp.options.condition, undefined, "breakpoint condition removed");
+
+  info('Add "log point"');
+  await setLogPoint(dbg, 5, "44");
+  assertEditorBreakpoint(dbg, 5, { hasLog: true });
+  await waitForBreakpointWithLog(dbg, "simple2", 5);
+  bp = findBreakpoint(dbg, "simple2", 5);
+  is(bp.options.logValue, "44", "breakpoint condition removed");
 });

--- a/test/mochitest/helpers.js
+++ b/test/mochitest/helpers.js
@@ -1113,7 +1113,9 @@ const selectors = {
     addConditionalBreakpoint:
       "#node-menu-add-condition, #node-menu-add-conditional-breakpoint",
     editConditionalBreakpoint:
-      "#node-menu-edit-condition, #node-menu-edit-conditional-breakpoint"
+      "#node-menu-edit-condition, #node-menu-edit-conditional-breakpoint",
+    addLogPoint: "#node-menu-add-log-point",
+    editLogPoint: "#node-menu-edit-log-point"
   },
   menuitem: i => `menupopup menuitem:nth-child(${i})`,
   pauseOnExceptions: ".pause-exceptions",


### PR DESCRIPTION
#### Issues
* The log points are shown as conditional breakpoints
* On editing the log point nothing shows up in the conditional breakpoint panel

![logpoints1](https://user-images.githubusercontent.com/792924/51778881-0c329600-20fc-11e9-9f9f-ec67dc67242c.gif)

* The context menu for a log point should not show any item relating to conditional breakpoints and vice versa
<img width="237" alt="screenshot 2019-01-25 at 21 51 05" src="https://user-images.githubusercontent.com/792924/51779001-a85c9d00-20fc-11e9-92a9-35c8e7790f27.png">

### Summary of Changes

* change  log points color to purple
* cleanup unused menu items
* fix `logValue`

### Test Plan

Tell us a little a bit about how you tested your patch.

Example test plan:

- [x] about:config
- [x] set `devtools.debugger.features.log-points` to `true`
- [x] right click editor gutter menu

### Screenshots/Videos (OPTIONAL)

![logpoints3](https://user-images.githubusercontent.com/792924/51778859-ead1aa00-20fb-11e9-8a4b-5b4859af1634.gif)
