### PR TITLE
spread the options object inside the pendingBreakpoint

### DIFF
--- a/src/actions/breakpoints/addBreakpoint.js
+++ b/src/actions/breakpoints/addBreakpoint.js
@@ -146,7 +146,7 @@ export function addBreakpoint(
       return;
     }
 
-    const breakpoint = createBreakpoint(breakpointPosition, options);
+    const breakpoint = createBreakpoint(breakpointPosition, { options });
 
     return dispatch({
       type: "ADD_BREAKPOINT",

--- a/src/actions/breakpoints/tests/syncing.spec.js
+++ b/src/actions/breakpoints/tests/syncing.spec.js
@@ -98,11 +98,12 @@ function pendingBreakpoint(overrides) {
       },
       index: 0
     },
-    condition: null,
+    options: {
+      logValue: "",
+      hidden: false
+    },
     disabled: false,
-    hidden: false,
     loading: false,
-    options: {},
     text: "",
     ...overrides
   };

--- a/src/actions/tests/__snapshots__/pending-breakpoints.spec.js.snap
+++ b/src/actions/tests/__snapshots__/pending-breakpoints.spec.js.snap
@@ -10,19 +10,21 @@ Object {
         "line": 5,
       },
     },
-    "condition": null,
     "disabled": false,
     "generatedLocation": Object {
       "column": undefined,
       "line": 5,
       "sourceUrl": "http://localhost:8000/examples/bar.js",
     },
-    "hidden": false,
     "location": Object {
       "column": undefined,
       "line": 5,
       "sourceId": "",
       "sourceUrl": "http://localhost:8000/examples/bar.js",
+    },
+    "options": Object {
+      "condition": null,
+      "hidden": false,
     },
   },
 }

--- a/src/actions/tests/helpers/breakpoints.js
+++ b/src/actions/tests/helpers/breakpoints.js
@@ -25,9 +25,11 @@ export function mockPendingBreakpoint(overrides: Object = {}) {
       },
       index: 0
     },
-    condition: condition || null,
-    disabled: disabled || false,
-    hidden: hidden || false
+    options: {
+      condition: condition || null,
+      hidden: hidden || false
+    },
+    disabled: disabled || false
   };
 }
 

--- a/src/components/SecondaryPanes/Breakpoints/tests/BreakpointsContextMenu.spec.js
+++ b/src/components/SecondaryPanes/Breakpoints/tests/BreakpointsContextMenu.spec.js
@@ -30,7 +30,15 @@ function generateDefaults(disabled) {
         sourceId: "source-https://example.com/main.js",
         sourceUrl: "https://example.com/main.js"
       },
-      { id: "source-https://example.com/main.js:1:", disabled: disabled }
+      {
+        id: "https://example.com/main.js:1:",
+        disabled: disabled,
+        options: {
+          condition: "",
+          logValue: "",
+          hidden: false
+        }
+      }
     ),
     createBreakpoint(
       {
@@ -39,7 +47,13 @@ function generateDefaults(disabled) {
         sourceId: "source-https://example.com/main.js",
         sourceUrl: "https://example.com/main.js"
       },
-      { id: "source-https://example.com/main.js:2:", disabled: disabled }
+      {
+        id: "https://example.com/main.js:2:",
+        disabled: disabled,
+        options: {
+          hidden: false
+        }
+      }
     ),
     createBreakpoint(
       {
@@ -48,7 +62,11 @@ function generateDefaults(disabled) {
         sourceId: "source-https://example.com/main.js",
         sourceUrl: "https://example.com/main.js"
       },
-      { id: "source-https://example.com/main.js:3:", disabled: disabled }
+      {
+        id: "https://example.com/main.js:3:",
+        disabled: disabled,
+        options: {}
+      }
     )
   ];
 

--- a/src/reducers/tests/breakpoints.spec.js
+++ b/src/reducers/tests/breakpoints.spec.js
@@ -24,11 +24,14 @@ describe("Breakpoints Selectors", () => {
   it("it gets a breakpoint for an original source", () => {
     const sourceId = "server1.conn1.child1/source1/originalSource";
     const matchingBreakpoints = {
-      id1: createBreakpoint({ line: 1, sourceId: sourceId })
+      id1: createBreakpoint({ line: 1, sourceId: sourceId }, { options: {} })
     };
 
     const otherBreakpoints = {
-      id2: createBreakpoint({ line: 1, sourceId: "not-this-source" })
+      id2: createBreakpoint(
+        { line: 1, sourceId: "not-this-source" },
+        { options: {} }
+      )
     };
 
     const data = {
@@ -55,7 +58,10 @@ describe("Breakpoints Selectors", () => {
           line: 1,
           sourceId: "original-source-id-1"
         },
-        { generatedLocation: { line: 1, sourceId: generatedSourceId } }
+        {
+          generatedLocation: { line: 1, sourceId: generatedSourceId },
+          options: {}
+        }
       )
     };
 
@@ -65,7 +71,10 @@ describe("Breakpoints Selectors", () => {
           line: 1,
           sourceId: "original-source-id-2"
         },
-        { generatedLocation: { line: 1, sourceId: "not-this-source" } }
+        {
+          generatedLocation: { line: 1, sourceId: "not-this-source" },
+          options: {}
+        }
       )
     };
 

--- a/src/utils/breakpoint/index.js
+++ b/src/utils/breakpoint/index.js
@@ -147,14 +147,12 @@ export function createBreakpoint(
   overrides: Object = {}
 ): Breakpoint {
   const {
-    condition,
     disabled,
-    hidden,
     generatedLocation,
     astLocation,
     text,
     originalText,
-    logValue
+    options
   } = overrides;
 
   const defaultASTLocation = {
@@ -165,9 +163,9 @@ export function createBreakpoint(
   const properties = {
     id: makeBreakpointId(location),
     options: {
-      condition: condition || null,
-      logValue: logValue || null,
-      hidden: hidden || false
+      condition: options.condition || null,
+      logValue: options.logValue || null,
+      hidden: options.hidden || false
     },
     disabled: disabled || false,
     loading: false,


### PR DESCRIPTION
Fixes #7817
we now have an `options` object on the `pendingBreakpoint` which needs to be flattened into `overrrides `

### Screenshots/Videos 
![fix-bp-reload](https://user-images.githubusercontent.com/792924/51794642-fe017a00-21ce-11e9-8c58-2231f7008fe5.gif)



