### PR TITLE
Don't wait to load already-loaded source maps

### DIFF
--- a/packages/devtools-source-map/src/index.js
+++ b/packages/devtools-source-map/src/index.js
@@ -37,6 +37,7 @@ const applySourceMap = dispatcher.task("applySourceMap");
 const clearSourceMaps = dispatcher.task("clearSourceMaps");
 const hasMappedSource = dispatcher.task("hasMappedSource");
 const getOriginalStackFrames = dispatcher.task("getOriginalStackFrames");
+const hasLoadedSourceMap = dispatcher.task("hasLoadedSourceMap");
 
 module.exports = {
   originalToGeneratedId,
@@ -56,6 +57,7 @@ module.exports = {
   applySourceMap,
   clearSourceMaps,
   getOriginalStackFrames,
+  hasLoadedSourceMap,
   startSourceMapWorker(url: string, assetRoot: string) {
     dispatcher.start(url);
     setAssetRootURL(assetRoot);

--- a/packages/devtools-source-map/src/source-map.js
+++ b/packages/devtools-source-map/src/source-map.js
@@ -14,7 +14,10 @@ const { SourceMapConsumer, SourceMapGenerator } = require("source-map");
 
 const { createConsumer } = require("./utils/createConsumer");
 const assert = require("./utils/assert");
-const { fetchSourceMap } = require("./utils/fetchSourceMap");
+const {
+  fetchSourceMap,
+  hasLoadedSourceMap
+} = require("./utils/fetchSourceMap");
 const {
   getSourceMap,
   setSourceMap,
@@ -373,5 +376,6 @@ module.exports = {
   getFileGeneratedRange,
   applySourceMap,
   clearSourceMaps,
-  hasMappedSource
+  hasMappedSource,
+  hasLoadedSourceMap
 };

--- a/packages/devtools-source-map/src/utils/fetchSourceMap.js
+++ b/packages/devtools-source-map/src/utils/fetchSourceMap.js
@@ -5,7 +5,12 @@
 // @flow
 
 const { networkRequest } = require("devtools-utils");
-const { getSourceMap, setSourceMap } = require("./sourceMapRequests");
+const {
+  getSourceMap,
+  setSourceMap,
+  addLoadedSourceMapURL,
+  hasLoadedSourceMapURL
+} = require("./sourceMapRequests");
 const { WasmRemap } = require("./wasmRemap");
 const { SourceMapConsumer } = require("source-map");
 const { convertToJSON } = require("./convertToJSON");
@@ -55,6 +60,7 @@ async function _resolveAndFetch(generatedSource: Source): SourceMapConsumer {
     }
   }
 
+  addLoadedSourceMapURL(sourceMapURL);
   return map;
 }
 
@@ -84,4 +90,9 @@ function fetchSourceMap(generatedSource: Source) {
   return req;
 }
 
-module.exports = { fetchSourceMap };
+function hasLoadedSourceMap(generatedSource: Source) {
+  const { sourceMapURL } = _resolveSourceMapURL(generatedSource);
+  return hasLoadedSourceMapURL(sourceMapURL);
+}
+
+module.exports = { fetchSourceMap, hasLoadedSourceMap };

--- a/packages/devtools-source-map/src/utils/sourceMapRequests.js
+++ b/packages/devtools-source-map/src/utils/sourceMapRequests.js
@@ -3,9 +3,11 @@
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
 const sourceMapRequests = new Map();
+const loadedSourceMapURLs = new Set();
 
 function clearSourceMaps() {
   sourceMapRequests.clear();
+  loadedSourceMapURLs.clear();
 }
 
 function getSourceMap(generatedSourceId: string): ?Promise<SourceMapConsumer> {
@@ -16,8 +18,18 @@ function setSourceMap(generatedId, request) {
   sourceMapRequests.set(generatedId, request);
 }
 
+function addLoadedSourceMapURL(url: string) {
+  loadedSourceMapURLs.add(url);
+}
+
+function hasLoadedSourceMapURL(url: string) {
+  return loadedSourceMapURLs.has(url);
+}
+
 module.exports = {
   clearSourceMaps,
   getSourceMap,
-  setSourceMap
+  setSourceMap,
+  addLoadedSourceMapURL,
+  hasLoadedSourceMapURL
 };

--- a/packages/devtools-source-map/src/worker.js
+++ b/packages/devtools-source-map/src/worker.js
@@ -13,6 +13,7 @@ const {
   getOriginalSourceText,
   getFileGeneratedRange,
   hasMappedSource,
+  hasLoadedSourceMap,
   clearSourceMaps,
   applySourceMap
 } = require("./source-map");
@@ -38,6 +39,7 @@ self.onmessage = workerHandler({
   getOriginalStackFrames,
   getFileGeneratedRange,
   hasMappedSource,
+  hasLoadedSourceMap,
   applySourceMap,
   clearSourceMaps
 });

--- a/src/actions/tests/project-text-search.spec.js
+++ b/src/actions/tests/project-text-search.spec.js
@@ -85,7 +85,8 @@ describe("project text search", () => {
         source: "function bla(x, y) {\n const bar = 4; return 2;\n}",
         contentType: "text/javascript"
       }),
-      getOriginalURLs: async () => [source2.url]
+      getOriginalURLs: async () => [source2.url],
+      hasLoadedSourceMap: async () => true
     };
 
     const { dispatch, getState } = createStore(threadClient, {}, mockMaps);


### PR DESCRIPTION
This addresses an issue that was exposed by testing PR #7796.  When sources are added to the debugger, source maps for those sources are loaded asynchronously --- the newSources() redux action will finish before the loads have finished.  This is good, because the loads could take an extremely long time if they 404, but causes problems when another devtool (i.e. the console) is trying to open up an original source that has already been mapped by the source map worker.  After loading the debugger the original sources might not be loaded yet.  This patch deals with this by having the worker keep track of source map requests it has finished loading.  The newSources() redux action does not finish until all sources with one of these maps have had that map loaded.  Note that due to how this is implemented a source can go through loadSourceMaps twice --- things are a little cleaner this way.

### Summary of Changes

* Keep track of loaded source maps in the source map worker.
* Don't finish newSources() redux action until existing source maps have been loaded.