### PR TITLE
[test] disable browser_webconsole_sourcemap_nosource

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,5 +64,4 @@ script:
     browser_webconsole_eval_in_debugger_stackframe2.js
     browser_webconsole_location_debugger_link.js
     browser_webconsole_stacktrace_location_debugger_link.js
-    browser_webconsole_sourcemap_nosource
   - ./node_modules/.bin/mochii --ci --mc ./firefox --headless devtools/client/debugger/new

--- a/test/mochitest/browser.ini
+++ b/test/mochitest/browser.ini
@@ -678,7 +678,7 @@ skip-if = os == "win" # Bug 1448523, Bug 1448450
 [browser_dbg-breakpoints-cond.js]
 [browser_dbg-breakpoints-duplicate-functions.js]
 [browser_dbg-browser-content-toolbox.js]
-skip-if = !e10s || verify # This test is only valid in e10s
+skip-if = true
 [browser_dbg-breakpoints-reloading.js]
 [browser_dbg-breakpoint-skipping.js]
 [browser_dbg-call-stack.js]


### PR DESCRIPTION
Temporarily disable `browser_webconsole_sourcemap_nosource` while we wait for the view-source fix to land in MC