### PR TITLE
Don't map bindings when not paused

### DIFF
--- a/src/actions/expressions.js
+++ b/src/actions/expressions.js
@@ -13,7 +13,8 @@ import {
   getSourceFromId,
   getSelectedSource,
   getSelectedScopeMappings,
-  getSelectedFrameBindings
+  getSelectedFrameBindings,
+  isPaused
 } from "../selectors";
 import { PROMISE } from "./utils/middleware/promise";
 import { wrapExpression } from "../utils/expressions";
@@ -172,8 +173,9 @@ function evaluateExpression(expression: Expression) {
  */
 export function getMappedExpression(expression: string) {
   return async function({ dispatch, getState, client, sourceMaps }: ThunkArgs) {
-    const mappings = getSelectedScopeMappings(getState());
-    const bindings = getSelectedFrameBindings(getState());
+    const state = getState();
+    const mappings = getSelectedScopeMappings(state);
+    const bindings = getSelectedFrameBindings(state);
 
     // We bail early if we do not need to map the expression. This is important
     // because mapping an expression can be slow if the parser worker is
@@ -190,7 +192,7 @@ export function getMappedExpression(expression: string) {
       expression,
       mappings,
       bindings || [],
-      features.mapExpressionBindings,
+      features.mapExpressionBindings && isPaused(state),
       features.mapAwaitExpression
     );
   };

--- a/src/workers/parser/mapAwaitExpression.js
+++ b/src/workers/parser/mapAwaitExpression.js
@@ -7,7 +7,7 @@
 import generate from "@babel/generator";
 import * as t from "@babel/types";
 
-import { hasNode } from "./utils/ast";
+import { hasNode, replaceNode } from "./utils/ast";
 import { isTopLevel } from "./utils/helpers";
 
 function hasTopLevelAwait(ast: Object): boolean {
@@ -19,19 +19,157 @@ function hasTopLevelAwait(ast: Object): boolean {
   return hasAwait;
 }
 
-function wrapExpressionFromAst(ast): string {
+// translates new bindings `var a = 3` into `a = 3`.
+function translateDeclarationIntoAssignment(node: Object): Object[] {
+  return node.declarations.reduce((acc, declaration) => {
+    // Don't translate declaration without initial assignment (e.g. `var a;`)
+    if (!declaration.init) {
+      return acc;
+    }
+    acc.push(
+      t.expressionStatement(
+        t.assignmentExpression("=", declaration.id, declaration.init)
+      )
+    );
+    return acc;
+  }, []);
+}
+
+/**
+ * Given an AST, compute its last statement and replace it with a
+ * return statement.
+ */
+function addReturnNode(ast: Object): Object {
   const statements = ast.program.body;
   const lastStatement = statements[statements.length - 1];
-  const body = statements
+  return statements
     .slice(0, -1)
     .concat(t.returnStatement(lastStatement.expression));
+}
 
-  const newAst = t.expressionStatement(
+function getDeclarations(node: Object) {
+  const { kind, declarations } = node;
+  const declaratorNodes = declarations.reduce((acc, d) => {
+    const declarators = getVariableDeclarators(d.id);
+    return acc.concat(declarators);
+  }, []);
+
+  // We can't declare const variables outside of the async iife because we
+  // wouldn't be able to re-assign them. As a workaround, we transform them
+  // to `let` which should be good enough for those case.
+  return t.variableDeclaration(
+    kind === "const" ? "let" : kind,
+    declaratorNodes
+  );
+}
+
+function getVariableDeclarators(node: Object): Object[] | Object {
+  if (t.isIdentifier(node)) {
+    return t.variableDeclarator(t.identifier(node.name));
+  }
+
+  if (t.isObjectProperty(node)) {
+    return getVariableDeclarators(node.value);
+  }
+  if (t.isRestElement(node)) {
+    return getVariableDeclarators(node.argument);
+  }
+
+  if (t.isAssignmentPattern(node)) {
+    return getVariableDeclarators(node.left);
+  }
+
+  if (t.isArrayPattern(node)) {
+    return node.elements.reduce(
+      (acc, element) => acc.concat(getVariableDeclarators(element)),
+      []
+    );
+  }
+  if (t.isObjectPattern(node)) {
+    return node.properties.reduce(
+      (acc, property) => acc.concat(getVariableDeclarators(property)),
+      []
+    );
+  }
+  return [];
+}
+
+/**
+ * Given an AST and an array of variableDeclaration nodes, return a new AST with
+ * all the declarations at the top of the AST.
+ */
+function addTopDeclarationNodes(ast: Object, declarationNodes: Object[]) {
+  const statements = [];
+  declarationNodes.forEach(declarationNode => {
+    statements.push(getDeclarations(declarationNode));
+  });
+  statements.push(ast);
+  return t.program(statements);
+}
+
+/**
+ * Given an AST, return an object of the following shape:
+ *   - newAst: {AST} the AST where variable declarations were transformed into
+ *             variable assignments
+ *   - declarations: {Array<Node>} An array of all the declaration nodes needed
+ *                   outside of the async iife.
+ */
+function translateDeclarationsIntoAssignment(
+  ast: Object
+): { newAst: Object, declarations: Node[] } {
+  const declarations = [];
+  t.traverse(ast, (node, ancestors) => {
+    const parent = ancestors[ancestors.length - 1];
+
+    if (
+      t.isWithStatement(node) ||
+      !isTopLevel(ancestors) ||
+      t.isAssignmentExpression(node) ||
+      !t.isVariableDeclaration(node) ||
+      t.isForStatement(parent.node) ||
+      !Array.isArray(node.declarations) ||
+      node.declarations.length === 0
+    ) {
+      return;
+    }
+
+    const newNodes = translateDeclarationIntoAssignment(node);
+    replaceNode(ancestors, newNodes);
+    declarations.push(node);
+  });
+
+  return {
+    newAst: ast,
+    declarations
+  };
+}
+
+/**
+ * Given an AST, wrap its body in an async iife, transform variable declarations
+ * in assignments and move the variable declarations outside of the async iife.
+ * Example: With the AST for the following expression: `let a = await 123`, the
+ * function will return:
+ * let a;
+ * (async => {
+ *   return a = await 123;
+ * })();
+ */
+function wrapExpressionFromAst(ast: Object): string {
+  // Transform let and var declarations into assignments, and get back an array
+  // of variable declarations.
+  let { newAst, declarations } = translateDeclarationsIntoAssignment(ast);
+  const body = addReturnNode(newAst);
+
+  // Create the async iife.
+  newAst = t.expressionStatement(
     t.callExpression(
       t.arrowFunctionExpression([], t.blockStatement(body), true),
       []
     )
   );
+
+  // Now let's put all the variable declarations at the top of the async iife.
+  newAst = addTopDeclarationNodes(newAst, declarations);
 
   return generate(newAst).code;
 }

--- a/src/workers/parser/mapBindings.js
+++ b/src/workers/parser/mapBindings.js
@@ -4,6 +4,7 @@
 
 // @flow
 
+import { replaceNode } from "./utils/ast";
 import { isTopLevel } from "./utils/helpers";
 
 import generate from "@babel/generator";
@@ -73,20 +74,6 @@ function globalizeAssignment(node, bindings) {
     getAssignmentTarget(node.left, bindings),
     node.right
   );
-}
-
-function replaceNode(ancestors, node) {
-  const parent = ancestors[ancestors.length - 1];
-
-  if (typeof parent.index === "number") {
-    if (Array.isArray(node)) {
-      parent.node[parent.key].splice(parent.index, 1, ...node);
-    } else {
-      parent.node[parent.key][parent.index] = node;
-    }
-  } else {
-    parent.node[parent.key] = node;
-  }
 }
 
 export default function mapExpressionBindings(

--- a/src/workers/parser/tests/mapExpression.spec.js
+++ b/src/workers/parser/tests/mapExpression.spec.js
@@ -13,16 +13,11 @@ function test({
   newExpression,
   bindings,
   mappings,
-  shouldMapExpression,
+  shouldMapBindings,
   expectedMapped,
   parseExpression = true
 }) {
-  const res = mapExpression(
-    expression,
-    mappings,
-    bindings,
-    shouldMapExpression
-  );
+  const res = mapExpression(expression, mappings, bindings, shouldMapBindings);
 
   if (parseExpression) {
     expect(
@@ -49,7 +44,7 @@ describe("mapExpression", () => {
       newExpression: formatAwait("return await a()"),
       bindings: [],
       mappings: {},
-      shouldMapExpression: true,
+      shouldMapBindings: true,
       expectedMapped: {
         await: true,
         bindings: false,
@@ -62,7 +57,7 @@ describe("mapExpression", () => {
       newExpression: formatAwait("self.x = await a(); return x + x;"),
       bindings: [],
       mappings: {},
-      shouldMapExpression: true,
+      shouldMapBindings: true,
       expectedMapped: {
         await: true,
         bindings: true,
@@ -75,7 +70,7 @@ describe("mapExpression", () => {
       newExpression: "async () => await a();",
       bindings: [],
       mappings: {},
-      shouldMapExpression: true,
+      shouldMapBindings: true,
       expectedMapped: {
         await: false,
         bindings: false,
@@ -88,7 +83,7 @@ describe("mapExpression", () => {
       newExpression: formatAwait("self.x = await a(); return await b(x);"),
       bindings: [],
       mappings: {},
-      shouldMapExpression: true,
+      shouldMapBindings: true,
       expectedMapped: {
         await: true,
         bindings: true,
@@ -101,7 +96,7 @@ describe("mapExpression", () => {
       newExpression: formatAwait("return (self.x = await sleep(100, 2))"),
       bindings: [],
       mappings: {},
-      shouldMapExpression: true,
+      shouldMapBindings: true,
       expectedMapped: {
         await: true,
         bindings: true,
@@ -116,7 +111,7 @@ describe("mapExpression", () => {
       ),
       bindings: [],
       mappings: {},
-      shouldMapExpression: true,
+      shouldMapBindings: true,
       expectedMapped: {
         await: true,
         bindings: true,
@@ -129,7 +124,7 @@ describe("mapExpression", () => {
       newExpression: formatAwait("return ([self.a, self.y] = await b())"),
       bindings: [],
       mappings: {},
-      shouldMapExpression: true,
+      shouldMapBindings: true,
       expectedMapped: {
         await: true,
         bindings: true,
@@ -142,7 +137,7 @@ describe("mapExpression", () => {
       newExpression: formatAwait("return ([{ a: self.a }] = await b())"),
       bindings: [],
       mappings: {},
-      shouldMapExpression: true,
+      shouldMapBindings: true,
       expectedMapped: {
         await: true,
         bindings: true,
@@ -158,7 +153,7 @@ describe("mapExpression", () => {
       `),
       bindings: [],
       mappings: {},
-      shouldMapExpression: true,
+      shouldMapBindings: true,
       expectedMapped: {
         await: true,
         bindings: true,
@@ -171,7 +166,7 @@ describe("mapExpression", () => {
       newExpression: formatAwait("return ({ a, c: y } = await b())"),
       bindings: ["a", "y"],
       mappings: {},
-      shouldMapExpression: true,
+      shouldMapBindings: true,
       expectedMapped: {
         await: true,
         bindings: true,
@@ -184,7 +179,7 @@ describe("mapExpression", () => {
       newExpression: formatAwait("return ([a, y] = await b())"),
       bindings: ["a", "y"],
       mappings: {},
-      shouldMapExpression: true,
+      shouldMapBindings: true,
       expectedMapped: {
         await: true,
         bindings: true,
@@ -197,7 +192,7 @@ describe("mapExpression", () => {
       newExpression: formatAwait("return ([{ a }] = await b())"),
       bindings: ["a"],
       mappings: {},
-      shouldMapExpression: true,
+      shouldMapBindings: true,
       expectedMapped: {
         await: true,
         bindings: true,
@@ -210,7 +205,7 @@ describe("mapExpression", () => {
       newExpression: formatAwait("return ({ c: self.c, a = 5 } = await b())"),
       bindings: ["a", "y"],
       mappings: {},
-      shouldMapExpression: true,
+      shouldMapBindings: true,
       expectedMapped: {
         await: true,
         bindings: true,
@@ -223,7 +218,7 @@ describe("mapExpression", () => {
       newExpression: formatAwait("return ([a, y = 10] = await b())"),
       bindings: ["a", "y"],
       mappings: {},
-      shouldMapExpression: true,
+      shouldMapBindings: true,
       expectedMapped: {
         await: true,
         bindings: true,
@@ -238,7 +233,7 @@ describe("mapExpression", () => {
       ),
       bindings: ["a"],
       mappings: {},
-      shouldMapExpression: true,
+      shouldMapBindings: true,
       expectedMapped: {
         await: true,
         bindings: true,
@@ -256,7 +251,7 @@ describe("mapExpression", () => {
     `),
       bindings: ["a", "y"],
       mappings: {},
-      shouldMapExpression: true,
+      shouldMapBindings: true,
       expectedMapped: {
         await: true,
         bindings: true,
@@ -273,7 +268,7 @@ describe("mapExpression", () => {
     `),
       bindings: [],
       mappings: {},
-      shouldMapExpression: true,
+      shouldMapBindings: true,
       expectedMapped: {
         await: true,
         bindings: true,
@@ -296,7 +291,7 @@ describe("mapExpression", () => {
     `),
       bindings: [],
       mappings: {},
-      shouldMapExpression: true,
+      shouldMapBindings: true,
       expectedMapped: {
         await: true,
         bindings: true,
@@ -310,7 +305,199 @@ describe("mapExpression", () => {
       parseExpression: false,
       bindings: [],
       mappings: {},
-      shouldMapExpression: true,
+      shouldMapBindings: true,
+      expectedMapped: {
+        await: true,
+        bindings: false,
+        originalExpression: false
+      }
+    },
+    {
+      name: "await (no bindings, let assignment)",
+      expression: "let a = await 123;",
+      newExpression: `let a;
+
+        (async () => {
+          return a = await 123;
+        })()`,
+      shouldMapBindings: false,
+      expectedMapped: {
+        await: true,
+        bindings: false,
+        originalExpression: false
+      }
+    },
+    {
+      name: "await (no bindings, var assignment)",
+      expression: "var a = await 123;",
+      newExpression: `var a;
+
+        (async () => {
+          return a = await 123;
+        })()`,
+      shouldMapBindings: false,
+      expectedMapped: {
+        await: true,
+        bindings: false,
+        originalExpression: false
+      }
+    },
+    {
+      name: "await (no bindings, const assignment)",
+      expression: "const a = await 123;",
+      newExpression: `let a;
+
+        (async () => {
+          return a = await 123;
+        })()`,
+      shouldMapBindings: false,
+      expectedMapped: {
+        await: true,
+        bindings: false,
+        originalExpression: false
+      }
+    },
+    {
+      name: "await (no bindings, multiple assignments)",
+      expression: "let a = 1, b, c = 3; b = await 123; a + b + c",
+      newExpression: `let a, b, c;
+
+        (async () => {
+          a = 1;
+          c = 3;
+          b = await 123;
+          return a + b + c;
+        })()`,
+      shouldMapBindings: false,
+      expectedMapped: {
+        await: true,
+        bindings: false,
+        originalExpression: false
+      }
+    },
+    {
+      name: "await (no bindings, object destructuring)",
+      expression: "let {a, b, c} = await x;",
+      newExpression: `let a, b, c;
+
+        (async () => {
+          return ({a, b, c} = await x);
+        })()`,
+      shouldMapBindings: false,
+      expectedMapped: {
+        await: true,
+        bindings: false,
+        originalExpression: false
+      }
+    },
+    {
+      name: "await (no bindings, object destructuring with rest)",
+      expression: "let {a, ...rest} = await x;",
+      newExpression: `let a, rest;
+
+        (async () => {
+          return ({a, ...rest} = await x);
+        })()`,
+      shouldMapBindings: false,
+      expectedMapped: {
+        await: true,
+        bindings: false,
+        originalExpression: false
+      }
+    },
+    {
+      name:
+        "await (no bindings, object destructuring with renaming and default)",
+      expression: "let {a: hello, b, c: world, d: $ = 4} = await x;",
+      newExpression: `let hello, b, world, $;
+
+        (async () => {
+          return ({a: hello, b, c: world, d: $ = 4} = await x);
+        })()`,
+      shouldMapBindings: false,
+      expectedMapped: {
+        await: true,
+        bindings: false,
+        originalExpression: false
+      }
+    },
+    {
+      name:
+        "await (no bindings, nested object destructuring + renaming + default)",
+      expression: `let {
+          a: hello, c: { y: { z = 10, b: bill, d: [e, f = 20] }}
+        } = await x; z;`,
+      newExpression: `let hello, z, bill, e, f;
+
+        (async () => {
+          ({ a: hello, c: { y: { z = 10, b: bill, d: [e, f = 20] }}} = await x);
+          return z;
+        })()`,
+      shouldMapBindings: false,
+      expectedMapped: {
+        await: true,
+        bindings: false,
+        originalExpression: false
+      }
+    },
+    {
+      name: "await (no bindings, array destructuring)",
+      expression: "let [a, b, c] = await x; c;",
+      newExpression: `let a, b, c;
+
+        (async () => {
+          [a, b, c] = await x;
+          return c;
+        })()`,
+      shouldMapBindings: false,
+      expectedMapped: {
+        await: true,
+        bindings: false,
+        originalExpression: false
+      }
+    },
+    {
+      name: "await (no bindings, array destructuring with default)",
+      expression: "let [a, b = 1, c = 2] = await x; c;",
+      newExpression: `let a, b, c;
+
+        (async () => {
+          [a, b = 1, c = 2] = await x;
+          return c;
+        })()`,
+      shouldMapBindings: false,
+      expectedMapped: {
+        await: true,
+        bindings: false,
+        originalExpression: false
+      }
+    },
+    {
+      name: "await (no bindings, array destructuring with default and rest)",
+      expression: "let [a, b = 1, c = 2, ...rest] = await x; rest;",
+      newExpression: `let a, b, c, rest;
+
+        (async () => {
+          [a, b = 1, c = 2, ...rest] = await x;
+          return rest;
+        })()`,
+      shouldMapBindings: false,
+      expectedMapped: {
+        await: true,
+        bindings: false,
+        originalExpression: false
+      }
+    },
+    {
+      name: "await (no bindings, nested array destructuring with default)",
+      expression: "let [a, b = 1, [c = 2, [d = 3, e = 4]]] = await x; c;",
+      newExpression: `let a, b, c, d, e;
+
+        (async () => {
+          [a, b = 1, [c = 2, [d = 3, e = 4]]] = await x;
+          return c;
+        })()`,
+      shouldMapBindings: false,
       expectedMapped: {
         await: true,
         bindings: false,
@@ -323,7 +510,7 @@ describe("mapExpression", () => {
       newExpression: "a",
       bindings: [],
       mappings: {},
-      shouldMapExpression: true,
+      shouldMapBindings: true,
       expectedMapped: {
         await: false,
         bindings: false,
@@ -338,7 +525,7 @@ describe("mapExpression", () => {
       mappings: {
         a: "_a"
       },
-      shouldMapExpression: true,
+      shouldMapBindings: true,
       expectedMapped: {
         await: false,
         bindings: false,
@@ -351,7 +538,7 @@ describe("mapExpression", () => {
       newExpression: "self.a = 3",
       bindings: [],
       mappings: {},
-      shouldMapExpression: true,
+      shouldMapBindings: true,
       expectedMapped: {
         await: false,
         bindings: true,
@@ -364,7 +551,7 @@ describe("mapExpression", () => {
       newExpression: "({ a: self.a } = {\n a: 3 \n})",
       bindings: [],
       mappings: {},
-      shouldMapExpression: true,
+      shouldMapBindings: true,
       expectedMapped: {
         await: false,
         bindings: true,
@@ -377,7 +564,7 @@ describe("mapExpression", () => {
       newExpression: "a = 3",
       bindings: ["a"],
       mappings: {},
-      shouldMapExpression: true,
+      shouldMapBindings: true,
       expectedMapped: {
         await: false,
         bindings: true,
@@ -390,7 +577,7 @@ describe("mapExpression", () => {
       newExpression: "({ a } = { \n a: 3 \n })",
       bindings: ["a"],
       mappings: {},
-      shouldMapExpression: true,
+      shouldMapBindings: true,
       expectedMapped: {
         await: false,
         bindings: true,
@@ -403,7 +590,7 @@ describe("mapExpression", () => {
       newExpression: "({ a, ...self.foo } = {})",
       bindings: ["a"],
       mappings: {},
-      shouldMapExpression: true,
+      shouldMapBindings: true,
       expectedMapped: {
         await: false,
         bindings: true,
@@ -416,7 +603,7 @@ describe("mapExpression", () => {
       newExpression: "([a, ...self.foo] = [])",
       bindings: ["a"],
       mappings: {},
-      shouldMapExpression: true,
+      shouldMapBindings: true,
       expectedMapped: {
         await: false,
         bindings: true,
@@ -429,7 +616,7 @@ describe("mapExpression", () => {
       newExpression: "self.a = 3",
       bindings: ["_a"],
       mappings: { a: "_a" },
-      shouldMapExpression: true,
+      shouldMapBindings: true,
       expectedMapped: {
         await: false,
         bindings: true,
@@ -442,7 +629,7 @@ describe("mapExpression", () => {
       newExpression: "({ a: self.a } = {\n a: 4 \n})",
       bindings: ["_a"],
       mappings: { a: "_a" },
-      shouldMapExpression: true,
+      shouldMapBindings: true,
       expectedMapped: {
         await: false,
         bindings: true,
@@ -455,7 +642,7 @@ describe("mapExpression", () => {
       newExpression: "a = 3",
       bindings: [],
       mappings: { a: "_a" },
-      shouldMapExpression: false,
+      shouldMapBindings: false,
       expectedMapped: {
         await: false,
         bindings: false,
@@ -468,7 +655,7 @@ describe("mapExpression", () => {
       newExpression: "({ a: _a } = {})",
       bindings: [],
       mappings: { a: "_a" },
-      shouldMapExpression: false,
+      shouldMapBindings: false,
       expectedMapped: {
         await: false,
         bindings: false,

--- a/src/workers/parser/utils/ast.js
+++ b/src/workers/parser/utils/ast.js
@@ -192,3 +192,17 @@ export function hasNode(rootNode: Node, predicate: Function) {
   }
   return false;
 }
+
+export function replaceNode(ancestors: Object[], node: Object) {
+  const parent = ancestors[ancestors.length - 1];
+
+  if (typeof parent.index === "number") {
+    if (Array.isArray(node)) {
+      parent.node[parent.key].splice(parent.index, 1, ...node);
+    } else {
+      parent.node[parent.key][parent.index] = node;
+    }
+  } else {
+    parent.node[parent.key] = node;
+  }
+}


### PR DESCRIPTION
`mapExpression` used to try to map bindings everytime, even when the debugger wasn't paused, which causes some issue ([See 1494318](https://bugzilla.mozilla.org/show_bug.cgi?id=1494318)).

With this PR, `mapExpression` will map the bindings only when paused, which brings other issue, in `mapAwait`.

In `mapAwait`, we wrap the expression into an async iife in order to get a Promise to listen for. This was working great when the bindings are mapped (because variables were put as `self` properties).
When we don't bind, we have an issue with assignments.

Say the user want to do `let a = await 123`, we can't simply return 
```js
(async () => {
  let a = await 123;
})()
```
because then the user won't have access to `a`.

What we want instead is: 
```js
let a;
(async () => {
  return a = await 123;
})()
```

So we traverse the AST to pull out variable declaration outside of the async iife.
This causes another issue with `const` variables, as we can't re-assign them.
For now, I decided to switch them to `let` to not block us. I don't know if there could be unwanted behavior (on top of being able to re-assign to what the user think is a `const`).