### PR TITLE
Add context menus for handling breakpoints on a line

### DIFF
--- a/assets/panel/debugger.properties
+++ b/assets/panel/debugger.properties
@@ -406,9 +406,9 @@ breakpointMenuItem.removeCondition.accesskey=c
 breakpointMenuItem.editCondition.label=Edit breakpoint condition
 breakpointMenuItem.editCondition.accesskey=n
 breakpointMenuItem.disableAllAtLine.label=Disable breakpoints on line
-breakpointMenuItem.disableAllAtLine.accesskey=Z
+breakpointMenuItem.disableAllAtLine.accesskey=K
 breakpointMenuItem.enableAllAtLine.label=Enable breakpoints on line
-breakpointMenuItem.enableAllAtLine.accesskey=V
+breakpointMenuItem.enableAllAtLine.accesskey=L
 breakpointMenuItem.removeAllAtLine.label=Remove breakpoints on line
 breakpointMenuItem.removeAllAtLine.accesskey=X
 

--- a/assets/panel/debugger.properties
+++ b/assets/panel/debugger.properties
@@ -406,9 +406,10 @@ breakpointMenuItem.removeCondition.accesskey=c
 breakpointMenuItem.editCondition.label=Edit breakpoint condition
 breakpointMenuItem.editCondition.accesskey=n
 breakpointMenuItem.disableAllAtLine.label=Disable breakpoints on line
+breakpointMenuItem.disableAllAtLine.accesskey=d
 breakpointMenuItem.enableAllAtLine.label=Enable breakpoints on line
-breakpointMenuItem.removeAllAtLine.label=Remove breakpoints on line
 breakpointMenuItem.enableAllAtLine.accesskey=l
+breakpointMenuItem.removeAllAtLine.label=Remove breakpoints on line
 breakpointMenuItem.removeAllAtLine.accesskey=x
 
 # LOCALIZATION NOTE (breakpoints.header): Breakpoints right sidebar pane header.

--- a/assets/panel/debugger.properties
+++ b/assets/panel/debugger.properties
@@ -408,6 +408,8 @@ breakpointMenuItem.editCondition.accesskey=n
 breakpointMenuItem.disableAllAtLine.label=Disable breakpoints on line
 breakpointMenuItem.enableAllAtLine.label=Enable breakpoints on line
 breakpointMenuItem.removeAllAtLine.label=Remove breakpoints on line
+breakpointMenuItem.enableAllAtLine.accesskey=l
+breakpointMenuItem.removeAllAtLine.accesskey=x
 
 # LOCALIZATION NOTE (breakpoints.header): Breakpoints right sidebar pane header.
 breakpoints.header=Breakpoints

--- a/assets/panel/debugger.properties
+++ b/assets/panel/debugger.properties
@@ -405,6 +405,9 @@ breakpointMenuItem.removeCondition.label=Remove breakpoint condition
 breakpointMenuItem.removeCondition.accesskey=c
 breakpointMenuItem.editCondition.label=Edit breakpoint condition
 breakpointMenuItem.editCondition.accesskey=n
+breakpointMenuItem.disableAllAtLine.label=Disable breakpoints on line
+breakpointMenuItem.enableAllAtLine.label=Enable breakpoints on line
+breakpointMenuItem.removeAllAtLine.label=Remove breakpoints on line
 
 # LOCALIZATION NOTE (breakpoints.header): Breakpoints right sidebar pane header.
 breakpoints.header=Breakpoints

--- a/assets/panel/debugger.properties
+++ b/assets/panel/debugger.properties
@@ -406,11 +406,11 @@ breakpointMenuItem.removeCondition.accesskey=c
 breakpointMenuItem.editCondition.label=Edit breakpoint condition
 breakpointMenuItem.editCondition.accesskey=n
 breakpointMenuItem.disableAllAtLine.label=Disable breakpoints on line
-breakpointMenuItem.disableAllAtLine.accesskey=d
+breakpointMenuItem.disableAllAtLine.accesskey=Z
 breakpointMenuItem.enableAllAtLine.label=Enable breakpoints on line
-breakpointMenuItem.enableAllAtLine.accesskey=l
+breakpointMenuItem.enableAllAtLine.accesskey=V
 breakpointMenuItem.removeAllAtLine.label=Remove breakpoints on line
-breakpointMenuItem.removeAllAtLine.accesskey=x
+breakpointMenuItem.removeAllAtLine.accesskey=X
 
 # LOCALIZATION NOTE (breakpoints.header): Breakpoints right sidebar pane header.
 breakpoints.header=Breakpoints

--- a/src/actions/breakpoints/index.js
+++ b/src/actions/breakpoints/index.js
@@ -386,8 +386,34 @@ export function addBreakpointAtLine(line: number) {
 
 export function removeBreakpointsAtLine(sourceId: string, line: number) {
   return ({ dispatch, getState, client, sourceMaps }: ThunkArgs) => {
-    const breakpoints = getBreakpointsForSource(getState(), sourceId, line);
-    return dispatch(removeBreakpoints(breakpoints));
+    const breakpointsAtLine = getBreakpointsForSource(
+      getState(),
+      sourceId,
+      line
+    );
+    return dispatch(removeBreakpoints(breakpointsAtLine));
+  };
+}
+
+export function disableBreakpointsAtLine(sourceId: string, line: number) {
+  return ({ dispatch, getState, client, sourceMaps }: ThunkArgs) => {
+    const breakpointsAtLine = getBreakpointsForSource(
+      getState(),
+      sourceId,
+      line
+    );
+    return dispatch(toggleBreakpoints(true, breakpointsAtLine));
+  };
+}
+
+export function enableBreakpointsAtLine(sourceId: string, line: number) {
+  return ({ dispatch, getState, client, sourceMaps }: ThunkArgs) => {
+    const breakpointsAtLine = getBreakpointsForSource(
+      getState(),
+      sourceId,
+      line
+    );
+    return dispatch(toggleBreakpoints(false, breakpointsAtLine));
   };
 }
 

--- a/src/components/Editor/menus/breakpoints.js
+++ b/src/components/Editor/menus/breakpoints.js
@@ -225,7 +225,7 @@ export const disableBreakpointsOnLineItem = (
 ) => ({
   id: "node-menu-remove-breakpoints-on-line",
   label: L10N.getStr("breakpointMenuItem.disableAllAtLine.label"),
-  accesskey: L10N.getStr("breakpointMenuItem.enableAllAtLine.accesskey"),
+  accesskey: L10N.getStr("breakpointMenuItem.disableAllAtLine.accesskey"),
   disabled: false,
   click: () =>
     breakpointActions.disableBreakpointsAtLine(location.sourceId, location.line)

--- a/src/components/Editor/menus/breakpoints.js
+++ b/src/components/Editor/menus/breakpoints.js
@@ -8,7 +8,6 @@ import actions from "../../../actions";
 import { bindActionCreators } from "redux";
 import type { SourceLocation, Breakpoint } from "../../../types";
 import { features } from "../../../utils/prefs";
-import { enableBreakpointsAtLine } from "../../../actions/breakpoints";
 
 export const addBreakpointItem = (
   location: SourceLocation,
@@ -158,17 +157,18 @@ export function breakpointItems(
 ) {
   const items = [
     removeBreakpointItem(breakpoint, breakpointActions),
-
-    // TODO:  Make this item conditional
-    removeBreakpointsOnLineItem(breakpoint.location, breakpointActions),
-    // TODO:  Make this item conditional
-    enableBreakpointsOnLineItem(breakpoint.location, breakpointActions),
-    // TODO:  Make this item conditional
-    disableBreakpointsOnLineItem(breakpoint.location, breakpointActions),
-
-    toggleDisabledBreakpointItem(breakpoint, breakpointActions),
-    conditionalBreakpointItem(breakpoint, breakpointActions)
+    toggleDisabledBreakpointItem(breakpoint, breakpointActions)
   ];
+
+  if (features.columnBreakpoints) {
+    items.push(
+      removeBreakpointsOnLineItem(breakpoint.location, breakpointActions),
+      enableBreakpointsOnLineItem(breakpoint.location, breakpointActions),
+      disableBreakpointsOnLineItem(breakpoint.location, breakpointActions)
+    );
+  }
+
+  items.push(conditionalBreakpointItem(breakpoint, breakpointActions));
 
   if (features.logPoints) {
     items.push(logPointItem(breakpoint, breakpointActions));
@@ -197,7 +197,7 @@ export const removeBreakpointsOnLineItem = (
   breakpointActions: BreakpointItemActions
 ) => ({
   id: "node-menu-remove-breakpoints-on-line",
-  label: "Remove Breakpoints on Line",
+  label: L10N.getStr("breakpointMenuItem.removeAllAtLine.label"),
   accesskey: "", // TODO
   disabled: false, // TODO
   click: () =>
@@ -211,7 +211,7 @@ export const enableBreakpointsOnLineItem = (
   breakpointActions: BreakpointItemActions
 ) => ({
   id: "node-menu-remove-breakpoints-on-line",
-  label: "Enable Breakpoints on Line",
+  label: L10N.getStr("breakpointMenuItem.enableAllAtLine.label"),
   accesskey: "", // TODO
   disabled: false, // TODO
   click: () =>
@@ -225,7 +225,7 @@ export const disableBreakpointsOnLineItem = (
   breakpointActions: BreakpointItemActions
 ) => ({
   id: "node-menu-remove-breakpoints-on-line",
-  label: "Disable Breakpoints on Line",
+  label: L10N.getStr("breakpointMenuItem.disableAllAtLine.label"),
   accesskey: "", // TODO
   disabled: false, // TODO
   click: () =>

--- a/src/components/Editor/menus/breakpoints.js
+++ b/src/components/Editor/menus/breakpoints.js
@@ -162,9 +162,11 @@ export function breakpointItems(
 
   if (features.columnBreakpoints) {
     items.push(
+      { type: "separator" },
       removeBreakpointsOnLineItem(breakpoint.location, breakpointActions),
       enableBreakpointsOnLineItem(breakpoint.location, breakpointActions),
-      disableBreakpointsOnLineItem(breakpoint.location, breakpointActions)
+      disableBreakpointsOnLineItem(breakpoint.location, breakpointActions),
+      { type: "separator" }
     );
   }
 

--- a/src/components/Editor/menus/breakpoints.js
+++ b/src/components/Editor/menus/breakpoints.js
@@ -8,6 +8,7 @@ import actions from "../../../actions";
 import { bindActionCreators } from "redux";
 import type { SourceLocation, Breakpoint } from "../../../types";
 import { features } from "../../../utils/prefs";
+import { enableBreakpointsAtLine } from "../../../actions/breakpoints";
 
 export const addBreakpointItem = (
   location: SourceLocation,
@@ -157,6 +158,14 @@ export function breakpointItems(
 ) {
   const items = [
     removeBreakpointItem(breakpoint, breakpointActions),
+
+    // TODO:  Make this item conditional
+    removeBreakpointsOnLineItem(breakpoint.location, breakpointActions),
+    // TODO:  Make this item conditional
+    enableBreakpointsOnLineItem(breakpoint.location, breakpointActions),
+    // TODO:  Make this item conditional
+    disableBreakpointsOnLineItem(breakpoint.location, breakpointActions),
+
     toggleDisabledBreakpointItem(breakpoint, breakpointActions),
     conditionalBreakpointItem(breakpoint, breakpointActions)
   ];
@@ -182,10 +191,57 @@ export function createBreakpointItems(
   return items;
 }
 
+// ToDo: Only enable if there are more than one breakpoints on a line?
+export const removeBreakpointsOnLineItem = (
+  location: SourceLocation,
+  breakpointActions: BreakpointItemActions
+) => ({
+  id: "node-menu-remove-breakpoints-on-line",
+  label: "Remove Breakpoints on Line",
+  accesskey: "", // TODO
+  disabled: false, // TODO
+  click: () =>
+    breakpointActions.removeBreakpointsAtLine(location.sourceId, location.line),
+  accelerator: "" // TODO
+});
+
+// ToDo: Only enable if there are more than one breakpoints on a line?
+export const enableBreakpointsOnLineItem = (
+  location: SourceLocation,
+  breakpointActions: BreakpointItemActions
+) => ({
+  id: "node-menu-remove-breakpoints-on-line",
+  label: "Enable Breakpoints on Line",
+  accesskey: "", // TODO
+  disabled: false, // TODO
+  click: () =>
+    breakpointActions.enableBreakpointsAtLine(location.sourceId, location.line),
+  accelerator: "" // TODO
+});
+
+// ToDo: Only enable if there are more than one breakpoints on a line?
+export const disableBreakpointsOnLineItem = (
+  location: SourceLocation,
+  breakpointActions: BreakpointItemActions
+) => ({
+  id: "node-menu-remove-breakpoints-on-line",
+  label: "Disable Breakpoints on Line",
+  accesskey: "", // TODO
+  disabled: false, // TODO
+  click: () =>
+    breakpointActions.disableBreakpointsAtLine(
+      location.sourceId,
+      location.line
+    ),
+  accelerator: "" // TODO
+});
+
 export type BreakpointItemActions = {
   addBreakpoint: typeof actions.addBreakpoint,
   removeBreakpoint: typeof actions.removeBreakpoint,
   removeBreakpointsAtLine: typeof actions.removeBreakpointsAtLine,
+  enableBreakpointsAtLine: typeof actions.enableBreakpointsAtLine,
+  disableBreakpointsAtLine: typeof actions.disableBreakpointsAtLine,
   toggleDisabledBreakpoint: typeof actions.toggleDisabledBreakpoint,
   openConditionalPanel: typeof actions.openConditionalPanel
 };
@@ -196,6 +252,8 @@ export function breakpointItemActions(dispatch: Function) {
       addBreakpoint: actions.addBreakpoint,
       removeBreakpoint: actions.removeBreakpoint,
       removeBreakpointsAtLine: actions.removeBreakpointsAtLine,
+      enableBreakpointsAtLine: actions.enableBreakpointsAtLine,
+      disableBreakpointsAtLine: actions.disableBreakpointsAtLine,
       disableBreakpoint: actions.disableBreakpoint,
       toggleDisabledBreakpoint: actions.toggleDisabledBreakpoint,
       openConditionalPanel: actions.openConditionalPanel

--- a/src/components/Editor/menus/breakpoints.js
+++ b/src/components/Editor/menus/breakpoints.js
@@ -164,8 +164,9 @@ export function breakpointItems(
     items.push(
       { type: "separator" },
       removeBreakpointsOnLineItem(breakpoint.location, breakpointActions),
-      enableBreakpointsOnLineItem(breakpoint.location, breakpointActions),
-      disableBreakpointsOnLineItem(breakpoint.location, breakpointActions),
+      breakpoint.disabled
+        ? enableBreakpointsOnLineItem(breakpoint.location, breakpointActions)
+        : disableBreakpointsOnLineItem(breakpoint.location, breakpointActions),
       { type: "separator" }
     );
   }
@@ -200,42 +201,34 @@ export const removeBreakpointsOnLineItem = (
 ) => ({
   id: "node-menu-remove-breakpoints-on-line",
   label: L10N.getStr("breakpointMenuItem.removeAllAtLine.label"),
-  accesskey: "", // TODO
-  disabled: false, // TODO
+  accesskey: L10N.getStr("breakpointMenuItem.removeAllAtLine.accesskey"),
+  disabled: false,
   click: () =>
-    breakpointActions.removeBreakpointsAtLine(location.sourceId, location.line),
-  accelerator: "" // TODO
+    breakpointActions.removeBreakpointsAtLine(location.sourceId, location.line)
 });
 
-// ToDo: Only enable if there are more than one breakpoints on a line?
 export const enableBreakpointsOnLineItem = (
   location: SourceLocation,
   breakpointActions: BreakpointItemActions
 ) => ({
   id: "node-menu-remove-breakpoints-on-line",
   label: L10N.getStr("breakpointMenuItem.enableAllAtLine.label"),
-  accesskey: "", // TODO
-  disabled: false, // TODO
+  accesskey: L10N.getStr("breakpointMenuItem.enableAllAtLine.accesskey"),
+  disabled: false,
   click: () =>
-    breakpointActions.enableBreakpointsAtLine(location.sourceId, location.line),
-  accelerator: "" // TODO
+    breakpointActions.enableBreakpointsAtLine(location.sourceId, location.line)
 });
 
-// ToDo: Only enable if there are more than one breakpoints on a line?
 export const disableBreakpointsOnLineItem = (
   location: SourceLocation,
   breakpointActions: BreakpointItemActions
 ) => ({
   id: "node-menu-remove-breakpoints-on-line",
   label: L10N.getStr("breakpointMenuItem.disableAllAtLine.label"),
-  accesskey: "", // TODO
-  disabled: false, // TODO
+  accesskey: L10N.getStr("breakpointMenuItem.enableAllAtLine.accesskey"),
+  disabled: false,
   click: () =>
-    breakpointActions.disableBreakpointsAtLine(
-      location.sourceId,
-      location.line
-    ),
-  accelerator: "" // TODO
+    breakpointActions.disableBreakpointsAtLine(location.sourceId, location.line)
 });
 
 export type BreakpointItemActions = {

--- a/src/utils/prefs.js
+++ b/src/utils/prefs.js
@@ -55,7 +55,7 @@ if (isDevelopment()) {
   pref("devtools.debugger.features.remove-command-bar-options", true);
   pref("devtools.debugger.features.code-folding", false);
   pref("devtools.debugger.features.outline", true);
-  pref("devtools.debugger.features.column-breakpoints", true);
+  pref("devtools.debugger.features.column-breakpoints", false);
   pref("devtools.debugger.features.pause-points", true);
   pref("devtools.debugger.features.skip-pausing", true);
   pref("devtools.debugger.features.component-pane", false);

--- a/src/utils/prefs.js
+++ b/src/utils/prefs.js
@@ -55,7 +55,7 @@ if (isDevelopment()) {
   pref("devtools.debugger.features.remove-command-bar-options", true);
   pref("devtools.debugger.features.code-folding", false);
   pref("devtools.debugger.features.outline", true);
-  pref("devtools.debugger.features.column-breakpoints", false);
+  pref("devtools.debugger.features.column-breakpoints", true);
   pref("devtools.debugger.features.pause-points", true);
   pref("devtools.debugger.features.skip-pausing", true);
   pref("devtools.debugger.features.component-pane", false);


### PR DESCRIPTION
It's the last item here:  https://github.com/devtools-html/debugger.html/issues/7241

Adds context menu items for disabling/enabling/removing all breakpoints *on a line*.

## To Do
- [x] Add localization strings and accesskeys
- [x] Conditionally add menu items based on column breakpoints pref
- [x] Disable menu item if no breakpoints are enabled/disabled on the line
- [ ] Mochitests