### PR TITLE
Don't allow duplicate source actors in redux store

### DIFF
--- a/src/reducers/sources.js
+++ b/src/reducers/sources.js
@@ -307,6 +307,12 @@ function updateForNewSourceActor(
   sourceActor: SourceActor
 ) {
   const existing = state.sourceActors[sourceActor.source] || [];
+
+  // Do not allow duplicate source actors in the store.
+  if (existing.some(({ actor }) => actor == sourceActor.actor)) {
+    return;
+  }
+
   state.sourceActors[sourceActor.source] = [...existing, sourceActor];
 
   updateRelativeSource(state, state.sources[sourceActor.source], sourceActor);

--- a/test/mochitest/browser.ini
+++ b/test/mochitest/browser.ini
@@ -678,7 +678,7 @@ skip-if = os == "win" # Bug 1448523, Bug 1448450
 [browser_dbg-breakpoints-cond.js]
 [browser_dbg-breakpoints-duplicate-functions.js]
 [browser_dbg-browser-content-toolbox.js]
-skip-if = true
+skip-if = !e10s || verify # This test is only valid in e10s
 [browser_dbg-breakpoints-reloading.js]
 [browser_dbg-breakpoint-skipping.js]
 [browser_dbg-call-stack.js]


### PR DESCRIPTION
Fixes browser_dbg-browser-content-toolbox.js failures after #7796

### Summary of Changes

* Make sure duplicate source actors are not added to the redux store.  While the newSources action also checks for duplicates, the checks there do not work when the server sends a sources packet containing duplicate entries.  The checks in the action could be removed (there is a similar one for sources) but this patch preserves them as checking for duplicates early is marginally more efficient (especially when a source map needs to be loaded).