### PR TITLE
Fix pretty printing in source list

### DIFF
--- a/src/components/PrimaryPanes/SourcesTreeItem.js
+++ b/src/components/PrimaryPanes/SourcesTreeItem.js
@@ -15,7 +15,7 @@ import AccessibleImage from "../shared/AccessibleImage";
 import {
   getGeneratedSourceByURL,
   getHasSiblingOfSameName,
-  hasPrettySource
+  hasPrettySource as checkHasPrettySource
 } from "../../selectors";
 import actions from "../../actions";
 
@@ -261,7 +261,7 @@ const mapStateToProps = (state, props) => {
   return {
     hasMatchingGeneratedSource: getHasMatchingGeneratedSource(state, source),
     hasSiblingOfSameName: getHasSiblingOfSameName(state, source),
-    hasPrettySource: source ? hasPrettySource(state, source.id) : false
+    hasPrettySource: source ? checkHasPrettySource(state, source.id) : false
   };
 };
 

--- a/src/components/PrimaryPanes/SourcesTreeItem.js
+++ b/src/components/PrimaryPanes/SourcesTreeItem.js
@@ -14,7 +14,8 @@ import AccessibleImage from "../shared/AccessibleImage";
 
 import {
   getGeneratedSourceByURL,
-  getHasSiblingOfSameName
+  getHasSiblingOfSameName,
+  hasPrettySource
 } from "../../selectors";
 import actions from "../../actions";
 
@@ -40,6 +41,7 @@ type Props = {
   expanded: boolean,
   hasMatchingGeneratedSource: boolean,
   hasSiblingOfSameName: boolean,
+  hasPrettySource: boolean,
   focusItem: TreeNode => void,
   selectItem: TreeNode => void,
   setExpanded: (TreeNode, boolean, boolean) => void,
@@ -60,7 +62,7 @@ type ContextMenu = Array<MenuOption>;
 
 class SourceTreeItem extends Component<Props, State> {
   getIcon(item: TreeNode, depth: number) {
-    const { debuggeeUrl, projectRoot, source } = this.props;
+    const { debuggeeUrl, projectRoot, source, hasPrettySource } = this.props;
 
     if (item.path === "webpack://") {
       return <AccessibleImage className="webpack" />;
@@ -82,6 +84,10 @@ class SourceTreeItem extends Component<Props, State> {
 
     if (isDirectory(item)) {
       return <AccessibleImage className="folder" />;
+    }
+
+    if (hasPrettySource) {
+      return <AccessibleImage className="prettyPrint" />;
     }
 
     if (source) {
@@ -254,7 +260,8 @@ const mapStateToProps = (state, props) => {
   const { source } = props;
   return {
     hasMatchingGeneratedSource: getHasMatchingGeneratedSource(state, source),
-    hasSiblingOfSameName: getHasSiblingOfSameName(state, source)
+    hasSiblingOfSameName: getHasSiblingOfSameName(state, source),
+    hasPrettySource: source ? hasPrettySource(state, source.id) : false
   };
 };
 

--- a/src/components/shared/SourceIcon.css
+++ b/src/components/shared/SourceIcon.css
@@ -11,11 +11,17 @@
   height: 15px;
 }
 
-.source-icon.prettyPrint {
+.img.prettyPrint {
   mask: url(/images/prettyPrint.svg) no-repeat;
   mask-size: 100%;
   background: var(--theme-highlight-blue);
   fill: var(--theme-textbox-box-shadow);
+  position: relative;
+}
+
+.sources-list .img.prettyPrint {
+  top: 2px;
+  margin-inline-start: 3px;
 }
 
 .source-icon.vue {


### PR DESCRIPTION
Fixes #7784 

Pretty printing a source now shows the pretty print icon beside the source in the source list pane.
<details><summary>GIF</summary>
<img src="https://user-images.githubusercontent.com/15959269/51993904-b2c0c300-247d-11e9-980d-7a5aeb0ef13c.gif">
</details><br/>
<img width="563" alt="screen shot 2019-01-30 at 10 55 14 am" src="https://user-images.githubusercontent.com/15959269/51993934-c79d5680-247d-11e9-88b1-4ab0664609b3.png">

