### PR TITLE
add types to source-maps API

### DIFF
--- a/packages/devtools-source-map/src/index.js
+++ b/packages/devtools-source-map/src/index.js
@@ -5,62 +5,123 @@
 // @flow
 
 const {
+  workerUtils: { WorkerDispatcher }
+} = require("devtools-utils");
+
+import type { SourceLocation, Source, SourceId } from "debugger-html";
+import type { SourceMapConsumer } from "source-map";
+import type { locationOptions } from "./source-map";
+
+export const dispatcher = new WorkerDispatcher();
+
+export const setAssetRootURL = async (assetRoot: string): Promise<void> =>
+  dispatcher.invoke("setAssetRootURL", assetRoot);
+
+export const getOriginalURLs = async (
+  generatedSource: Source
+): Promise<SourceMapConsumer> =>
+  dispatcher.invoke("getOriginalURLs", generatedSource);
+
+export const hasOriginalURL = async (url: string): Promise<boolean> =>
+  dispatcher.invoke("hasOriginalURL", url);
+
+export const getOriginalRanges = async (
+  sourceId: SourceId,
+  url: string
+): Promise<
+  Array<{
+    line: number,
+    columnStart: number,
+    columnEnd: number
+  }>
+> => dispatcher.invoke("getOriginalRanges", sourceId, url);
+
+export const getGeneratedRanges = async (
+  location: SourceLocation,
+  originalSource: Source
+): Promise<
+  Array<{
+    line: number,
+    columnStart: number,
+    columnEnd: number
+  }>
+> =>
+  dispatcher.task("getGeneratedRanges", {
+    queue: true
+  })(location, originalSource);
+
+export const getGeneratedLocation = async (
+  location: SourceLocation,
+  originalSource: Source
+): Promise<SourceLocation> =>
+  dispatcher.task("getGeneratedLocation", { queue: true })(
+    location,
+    originalSource
+  );
+
+export const getAllGeneratedLocations = async (
+  location: SourceLocation,
+  originalSource: Source
+): Promise<Array<SourceLocation>> =>
+  dispatcher.task("getAllGeneratedLocations", { queue: true })(
+    location,
+    originalSource
+  );
+
+export const getOriginalLocation = async (
+  location: SourceLocation,
+  options: locationOptions = {}
+): Promise<SourceLocation> =>
+  dispatcher.invoke("getOriginalLocation", location, options);
+
+export const getFileGeneratedRange = async (
+  originalSource: Source
+): Promise<?{ start: any, end: any }> =>
+  dispatcher.invoke("getFileGeneratedRange", originalSource);
+
+export const getLocationScopes = dispatcher.task("getLocationScopes");
+
+export const getOriginalSourceText = async (
+  originalSource: Source
+): Promise<?{
+  text: string,
+  contentType: string
+}> => dispatcher.invoke("getOriginalSourceText", originalSource);
+
+export const applySourceMap = async (
+  generatedId: string,
+  url: string,
+  code: string,
+  mappings: Object
+): Promise<void> =>
+  dispatcher.invoke("applySourceMap", generatedId, url, code, mappings);
+
+export const clearSourceMaps = async (): Promise<void> =>
+  dispatcher.invoke("clearSourceMaps");
+
+export const hasMappedSource = async (
+  location: SourceLocation
+): Promise<boolean> => dispatcher.invoke("hasMappedSource", location);
+
+export const getOriginalStackFrames = async (
+  generatedLocation: SourceLocation
+): Promise<?Array<{
+  displayName: string,
+  location?: SourceLocation
+}>> => dispatcher.invoke("getOriginalStackFrames", generatedLocation);
+
+export {
   originalToGeneratedId,
   generatedToOriginalId,
   isGeneratedId,
   isOriginalId
-} = require("./utils");
+} from "./utils";
 
-const {
-  workerUtils: { WorkerDispatcher }
-} = require("devtools-utils");
-
-const dispatcher = new WorkerDispatcher();
-
-const setAssetRootURL = dispatcher.task("setAssetRootURL");
-const getOriginalURLs = dispatcher.task("getOriginalURLs");
-const hasOriginalURL = dispatcher.task("hasOriginalURL");
-const getOriginalRanges = dispatcher.task("getOriginalRanges");
-const getGeneratedRanges = dispatcher.task("getGeneratedRanges", {
-  queue: true
-});
-const getGeneratedLocation = dispatcher.task("getGeneratedLocation", {
-  queue: true
-});
-const getAllGeneratedLocations = dispatcher.task("getAllGeneratedLocations", {
-  queue: true
-});
-const getOriginalLocation = dispatcher.task("getOriginalLocation");
-const getFileGeneratedRange = dispatcher.task("getFileGeneratedRange");
-const getLocationScopes = dispatcher.task("getLocationScopes");
-const getOriginalSourceText = dispatcher.task("getOriginalSourceText");
-const applySourceMap = dispatcher.task("applySourceMap");
-const clearSourceMaps = dispatcher.task("clearSourceMaps");
-const hasMappedSource = dispatcher.task("hasMappedSource");
-const getOriginalStackFrames = dispatcher.task("getOriginalStackFrames");
-
-module.exports = {
-  originalToGeneratedId,
-  generatedToOriginalId,
-  isGeneratedId,
-  isOriginalId,
-  hasMappedSource,
-  getOriginalURLs,
-  hasOriginalURL,
-  getOriginalRanges,
-  getGeneratedRanges,
-  getGeneratedLocation,
-  getAllGeneratedLocations,
-  getOriginalLocation,
-  getFileGeneratedRange,
-  getLocationScopes,
-  getOriginalSourceText,
-  applySourceMap,
-  clearSourceMaps,
-  getOriginalStackFrames,
-  startSourceMapWorker(url: string, assetRoot: string) {
-    dispatcher.start(url);
-    setAssetRootURL(assetRoot);
-  },
-  stopSourceMapWorker: dispatcher.stop.bind(dispatcher)
+export const startSourceMapWorker = (url: string, assetRoot: string) => {
+  dispatcher.start(url);
+  setAssetRootURL(assetRoot);
 };
+export const stopSourceMapWorker = () => dispatcher.stop.bind(dispatcher);
+
+import * as self from "devtools-source-map";
+export default self;

--- a/packages/devtools-source-map/src/index.js
+++ b/packages/devtools-source-map/src/index.js
@@ -121,7 +121,7 @@ export const startSourceMapWorker = (url: string, assetRoot: string) => {
   dispatcher.start(url);
   setAssetRootURL(assetRoot);
 };
-export const stopSourceMapWorker = () => dispatcher.stop.bind(dispatcher);
+export const stopSourceMapWorker = dispatcher.stop.bind(dispatcher);
 
 import * as self from "devtools-source-map";
 export default self;

--- a/packages/devtools-source-map/src/source-map.js
+++ b/packages/devtools-source-map/src/source-map.js
@@ -35,7 +35,9 @@ const { clearWasmXScopes } = require("./utils/wasmXScopes");
 
 import type { SourceLocation, Source, SourceId } from "debugger-html";
 
-async function getOriginalURLs(generatedSource: Source) {
+async function getOriginalURLs(
+  generatedSource: Source
+): Promise<SourceMapConsumer> {
   const map = await fetchSourceMap(generatedSource);
   return map && map.sources;
 }
@@ -43,7 +45,16 @@ async function getOriginalURLs(generatedSource: Source) {
 const COMPUTED_SPANS = new WeakSet();
 
 const SOURCE_MAPPINGS = new WeakMap();
-async function getOriginalRanges(sourceId: SourceId, url: string) {
+async function getOriginalRanges(
+  sourceId: SourceId,
+  url: string
+): Promise<
+  Array<{
+    line: number,
+    columnStart: number,
+    columnEnd: number
+  }>
+> {
   if (!isOriginalId(sourceId)) {
     return [];
   }
@@ -235,7 +246,7 @@ async function getAllGeneratedLocations(
   }));
 }
 
-type locationOptions = {
+export type locationOptions = {
   search?: "LEAST_UPPER_BOUND" | "GREATEST_LOWER_BOUND"
 };
 async function getOriginalLocation(
@@ -289,7 +300,12 @@ async function getOriginalLocation(
   };
 }
 
-async function getOriginalSourceText(originalSource: Source) {
+async function getOriginalSourceText(
+  originalSource: Source
+): Promise<?{
+  text: string,
+  contentType: string
+}> {
   assert(isOriginalId(originalSource.id), "Source is not an original source");
 
   const generatedSourceId = originalToGeneratedId(originalSource.id);
@@ -310,7 +326,9 @@ async function getOriginalSourceText(originalSource: Source) {
   };
 }
 
-async function getFileGeneratedRange(originalSource: Source) {
+async function getFileGeneratedRange(
+  originalSource: Source
+): Promise<?{ start: any, end: any }> {
   assert(isOriginalId(originalSource.id), "Source is not an original source");
 
   const map = await getSourceMap(originalToGeneratedId(originalSource.id));

--- a/packages/devtools-source-map/src/utils/fetchSourceMap.js
+++ b/packages/devtools-source-map/src/utils/fetchSourceMap.js
@@ -73,7 +73,7 @@ async function _resolveAndFetch(generatedSource: Source): SourceMapConsumer {
   return map;
 }
 
-function fetchSourceMap(generatedSource: Source) {
+function fetchSourceMap(generatedSource: Source): SourceMapConsumer {
   const existingRequest = getSourceMap(generatedSource.id);
 
   // If it has already been requested, return the request. Make sure

--- a/packages/devtools-source-map/src/utils/fetchSourceMap.js
+++ b/packages/devtools-source-map/src/utils/fetchSourceMap.js
@@ -20,7 +20,7 @@ function clearOriginalURLs() {
   originalURLs.clear();
 }
 
-function hasOriginalURL(url: string) {
+function hasOriginalURL(url: string): boolean {
   return originalURLs.has(url);
 }
 

--- a/packages/devtools-source-map/src/utils/index.js
+++ b/packages/devtools-source-map/src/utils/index.js
@@ -62,7 +62,7 @@ const contentMap = {
  * @return String
  *         The content type.
  */
-function getContentType(url: string) {
+function getContentType(url: string): string {
   url = trimUrlQuery(url);
   const dot = url.lastIndexOf(".");
   if (dot >= 0) {

--- a/src/components/SecondaryPanes/Frames/Group.js
+++ b/src/components/SecondaryPanes/Frames/Group.js
@@ -159,7 +159,7 @@ export default class Group extends Component<Props, State> {
         <FrameLocation frame={frame} expanded={expanded} />
         {selectable && <span className="clipboard-only"> </span>}
         <Badge>{this.props.group.length}</Badge>
-        {selectable && <br className="clipboard-only"/>}
+        {selectable && <br className="clipboard-only" />}
       </div>
     );
   }

--- a/src/utils/bootstrap.js
+++ b/src/utils/bootstrap.js
@@ -22,6 +22,7 @@ import App from "../components/App";
 import { asyncStore, prefs } from "./prefs";
 
 import type { Panel } from "../client/firefox/types";
+import typeof SourceMaps from "../../packages/devtools-source-map/src";
 
 function renderPanel(component, store) {
   const root = document.createElement("div");
@@ -41,7 +42,7 @@ function renderPanel(component, store) {
 
 export function bootstrapStore(
   client: any,
-  sourceMaps: Object,
+  sourceMaps: SourceMaps,
   panel: Panel,
   initialState: Object
 ) {


### PR DESCRIPTION
Fixes #7822 

Similar to #6625, I added types to the dispatcher tasks for the source maps worker API. Some of the underlying methods were not typed, so I tried to add types to them.

### Queries
- In some of the methods, types are not named. For example:
```
...
): Promise<
  Array<{
    line: number,
    columnStart: number,
    columnEnd: number
  }>
...
```
Should I create named types for them? Or leave it for another PR?
- I couldn't find any reference to `getLocationScopes`. Should it be removed?
- About this snippet:
```
import * as self from "devtools-source-map";
export default self;
```
I am not sure whether this is the best way to deal with mixed: [default](https://github.com/devtools-html/debugger.html/blob/master/src/utils/test-head.js#L13) and [named](https://github.com/devtools-html/debugger.html/blob/5d826e39d3d0a547116968f2e831155b724c677e/src/test/tests-setup.js#L15) imports. Would love to hear your views on this.

### Summary of Changes

* Adds types to dispatcher tasks for the source maps worker
* Fixes a few related type issues

### Test Plan
I ran `yarn test` before creating this PR and there were no failed tests. 
I don't think any new tests are required.
