### PR TITLE
When rewinding, reverse step past invalid step locations

### DIFF
--- a/src/actions/pause/paused.js
+++ b/src/actions/pause/paused.js
@@ -7,7 +7,8 @@ import {
   getHiddenBreakpoint,
   isEvaluatingExpression,
   getSelectedFrame,
-  getSources
+  getSources,
+  getLastCommand
 } from "../../selectors";
 
 import { mapFrames } from ".";
@@ -50,7 +51,11 @@ export function paused(pauseInfo: Pause) {
       await dispatch(loadSourceText(source));
 
       if (shouldStep(mappedFrame, getState(), sourceMaps)) {
-        dispatch(command("stepOver"));
+        // When stepping past a location we shouldn't pause at according to the
+        // source map, make sure we continue stepping in the same direction we
+        // were going previously.
+        const rewind = getLastCommand(getState(), thread) == "reverseStepOver";
+        dispatch(command(rewind ? "reverseStepOver" : "stepOver"));
         return;
       }
     }

--- a/src/reducers/pause.js
+++ b/src/reducers/pause.js
@@ -68,6 +68,7 @@ type ThreadPauseState = {
   shouldPauseOnExceptions: boolean,
   shouldPauseOnCaughtExceptions: boolean,
   command: Command,
+  lastCommand: Command,
   previousLocation: ?MappedLocation,
   skipPausing: boolean
 };
@@ -104,6 +105,7 @@ const createInitialPauseState = () => ({
   shouldPauseOnCaughtExceptions: prefs.pauseOnCaughtExceptions,
   canRewind: false,
   command: null,
+  lastCommand: null,
   previousLocation: null,
   skipPausing: prefs.skipPausing
 });
@@ -264,6 +266,7 @@ function update(
         return updateThreadState({
           ...resumedPauseState,
           command: action.command,
+          lastCommand: action.command,
           previousLocation: getPauseLocation(threadState(), action)
         });
       }
@@ -350,6 +353,10 @@ export function getPauseReason(state: OuterState): ?Why {
 
 export function getPauseCommand(state: OuterState): Command {
   return getCurrentPauseState(state).command;
+}
+
+export function getLastCommand(state: OuterState, thread: string) {
+  return getThreadPauseState(state.pause, thread).lastCommand;
 }
 
 export function isStepping(state: OuterState) {


### PR DESCRIPTION
Fixes a bug when using web replay where reverse stepping can keep landing in the same place.  The problem is that when a step goes to an invalid pause location we issue another step, but we always issue a forward step-over which will undo any reverse-step that just happened.

### Summary of Changes

* Keep track of the last command issued to each thread in redux state.
* Use new redux state to issue steps in the correct direction past invalid pause points.