### PR TITLE
Fix mapAwaitExpression for expression with dynamic import.

### DIFF
--- a/src/workers/parser/tests/mapExpression.spec.js
+++ b/src/workers/parser/tests/mapExpression.spec.js
@@ -505,6 +505,24 @@ describe("mapExpression", () => {
       }
     },
     {
+      name: "await (no bindings, dynamic import)",
+      expression: `
+        var {rainbowLog} = await import("./cool-module.js");
+        rainbowLog("dynamic");`,
+      newExpression: `var rainbowLog;
+
+        (async () => {
+          ({rainbowLog} = await import("./cool-module.js"));
+          return rainbowLog("dynamic");
+        })()`,
+      shouldMapBindings: false,
+      expectedMapped: {
+        await: true,
+        bindings: false,
+        originalExpression: false
+      }
+    },
+    {
       name: "simple",
       expression: "a",
       newExpression: "a",

--- a/src/workers/parser/utils/ast.js
+++ b/src/workers/parser/utils/ast.js
@@ -101,7 +101,7 @@ function parseVueScript(code) {
 export function parseConsoleScript(text: string, opts?: Object): Object | null {
   try {
     return _parse(text, {
-      plugins: ["objectRestSpread"],
+      plugins: ["objectRestSpread", "dynamicImport"],
       ...opts,
       allowAwaitOutsideFunction: true
     });


### PR DESCRIPTION
This is done by adding the dynamicImport plugin
to babelParser.parse.
A test is added to ensure this works as expected.

---

I copied an updated parser-worker bundle to my m-c build and was able to use dynamic imports as expected :)
