### PR TITLE
Improving the contrast of the hover background for the buttons in the dark mode - BUG ID - 1513414.

### DIFF
--- a/src/components/App.css
+++ b/src/components/App.css
@@ -13,7 +13,7 @@ button {
 
 button:hover,
 button:focus {
-  background-color: var(--theme-toolbar-background-hover);
+  background-color: var(--theme-toolbar-hover);
 }
 
 .debugger {

--- a/src/components/App.css
+++ b/src/components/App.css
@@ -13,6 +13,11 @@ button {
 
 button:hover,
 button:focus {
+  background-color: var(--theme-toolbar-background-hover);
+}
+
+.theme-dark button:hover,
+.theme-dark button:focus{
   background-color: var(--theme-toolbar-hover);
 }
 

--- a/src/components/App.css
+++ b/src/components/App.css
@@ -17,7 +17,7 @@ button:focus {
 }
 
 .theme-dark button:hover,
-.theme-dark button:focus{
+.theme-dark button:focus {
   background-color: var(--theme-toolbar-hover);
 }
 

--- a/src/components/shared/Button/styles/CommandBarButton.css
+++ b/src/components/shared/Button/styles/CommandBarButton.css
@@ -20,7 +20,7 @@
 }
 
 .command-bar-button:not(.disabled):hover {
-  background: var(--theme-toolbar-background-hover);
+  background: var(--theme-toolbar-hover);
 }
 
 :root.theme-dark .command-bar-button {

--- a/src/components/shared/Button/styles/CommandBarButton.css
+++ b/src/components/shared/Button/styles/CommandBarButton.css
@@ -20,6 +20,10 @@
 }
 
 .command-bar-button:not(.disabled):hover {
+  background: var(--theme-toolbar-background-hover);
+}
+
+.theme-dark .command-bar-button:not(.disabled):hover {
   background: var(--theme-toolbar-hover);
 }
 


### PR DESCRIPTION
Background color on hover of the following buttons have been fixed (made consistent with the higher level tabs)-
In the debugger mode,
1)Collapse panes both right and left
2)Pause F8
3)Step over F10
4)Step in F11
5)Step out Shift + F11
6)Deactivate breakpoints
7)Keyboard Shortcuts
