### PR TITLE
Align tabs with source items.

### DIFF
--- a/src/components/Editor/Tabs.css
+++ b/src/components/Editor/Tabs.css
@@ -49,6 +49,7 @@
   height: 30px;
   font-size: 12px;
   background-color: transparent;
+  vertical-align: bottom;
 }
 
 .source-tab::before {


### PR DESCRIPTION
Fixes #7833

### Summary of Changes

A bug in Firefox around `flex` and `overflow: hidden` made this work
in Firefox. @emilio figured out the root cause and suggested this
fix. Works in Chrome now and still works in Firefox.

See: https://bugzilla.mozilla.org/show_bug.cgi?id=1518715

*  add `vertical-align: bottom;` to `.source-tab`

### Test Plan

- [x] Open debugger in Chrome
- [x] Open tab in Firefox, go to https://jsfiddle.net/chrisvfritz/50wL7mdz/
- [x] In sources pane, try opening `unpkg.com>vue` and `jsfiddle.usesfathom.com>tracker.js`
- [x] Source icon may not appear immediately, give it a few seconds
