### PR TITLE
Fix styling issues with Toggle Panes buttons (fixes #7742)

### DIFF
--- a/images/pane-collapse.svg
+++ b/images/pane-collapse.svg
@@ -1,0 +1,7 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16">
+  <path d="M4 3H2v10h2V3zm7 7V6L8 8l3 2z" fill-opacity=".3"/>
+  <path d="M11.47 10.88A1 1 0 0 0 12 10V6a1 1 0 0 0-1.55-.83l-3 2a1 1 0 0 0 0 1.66l3 2c.3.2.7.23 1.02.05zM8 8l3-2v4L8 8zM2 2h12c.6 0 1 .4 1 1v10c0 .6-.4 1-1 1H2c-.6 0-1-.4-1-1V3c0-.6.4-1 1-1zm12 11V3H5v10h9zM2 13h2V3H2v10z"/>
+</svg>

--- a/images/pane-expand.svg
+++ b/images/pane-expand.svg
@@ -1,0 +1,7 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16">
+  <path d="M4 3H2v10h2V3zM8 6v4l3-2-3-2z" fill-opacity=".3"/>
+  <path d="M7.53 10.88A1 1 0 0 1 7 10V6a1 1 0 0 1 1.55-.83l3 2a1 1 0 0 1 0 1.66l-3 2a1 1 0 0 1-1.02.05zM11 8L8 6v4l3-2zM2 2h12c.6 0 1 .4 1 1v10c0 .6-.4 1-1 1H2c-.6 0-1-.4-1-1V3c0-.6.4-1 1-1zm12 11V3H5v10h9zM2 13h2V3H2v10z"/>
+</svg>

--- a/images/toggle-panes.svg
+++ b/images/toggle-panes.svg
@@ -1,7 +1,0 @@
-<!-- This Source Code Form is subject to the terms of the Mozilla Public
-   - License, v. 2.0. If a copy of the MPL was not distributed with this
-   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
-<svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" fill="#0b0b0b">
-  <path fill-opacity=".3" d="M12,3h2v10h-2V3z M5,9.9V6.1L8,8L5,9.9z"/>
-  <path d="M14,2H2C1.4,2,1,2.4,1,3v10c0,0.6,0.4,1,1,1h12c0.6,0,1-0.4,1-1V3C15,2.4,14.6,2,14,2z M2,13L2,13V3h0h9v10   H2L2,13z M14,13C14,13,14,13,14,13h-2V3h2c0,0,0,0,0,0V13z M8.5,7.2l-3-1.9C4.6,4.7,4,5,4,6.1v3.8c0,1.1,0.6,1.4,1.5,0.8l3-1.9   C9.5,8.3,9.5,7.8,8.5,7.2z M5,9.9V6.1L8,8L5,9.9z"/>
-</svg>

--- a/src/components/App.css
+++ b/src/components/App.css
@@ -9,6 +9,8 @@
 button {
   background: transparent;
   border: none;
+  font-family: inherit;
+  font-size: inherit;
 }
 
 button:hover,

--- a/src/components/Editor/Tabs.js
+++ b/src/components/Editor/Tabs.js
@@ -174,7 +174,7 @@ class Tabs extends PureComponent<Props, State> {
     return (
       <PaneToggleButton
         position="start"
-        collapsed={!this.props.startPanelCollapsed}
+        collapsed={this.props.startPanelCollapsed}
         handleClick={this.props.togglePaneCollapse}
       />
     );
@@ -189,7 +189,7 @@ class Tabs extends PureComponent<Props, State> {
     return (
       <PaneToggleButton
         position="end"
-        collapsed={!endPanelCollapsed}
+        collapsed={endPanelCollapsed}
         handleClick={togglePaneCollapse}
         horizontal={horizontal}
       />

--- a/src/components/WelcomeBox.js
+++ b/src/components/WelcomeBox.js
@@ -35,7 +35,7 @@ export class WelcomeBox extends Component<Props> {
     return (
       <PaneToggleButton
         position="end"
-        collapsed={!endPanelCollapsed}
+        collapsed={endPanelCollapsed}
         horizontal={horizontal}
         handleClick={togglePaneCollapse}
       />

--- a/src/components/shared/AccessibleImage.css
+++ b/src/components/shared/AccessibleImage.css
@@ -4,7 +4,7 @@
   height: 12px;
   /* makes span appear like an image */
   display: inline-block;
-  background: var(--theme-body-color);
+  background: var(--theme-icon-color);
   mask-size: 100%;
 }
 

--- a/src/components/shared/Button/PaneToggleButton.js
+++ b/src/components/shared/Button/PaneToggleButton.js
@@ -23,7 +23,7 @@ class PaneToggleButton extends PureComponent<Props> {
 
   render() {
     const { position, collapsed, horizontal, handleClick } = this.props;
-    const title = !collapsed
+    const title = collapsed
       ? L10N.getStr("expandPanes")
       : L10N.getStr("collapsePanes");
 
@@ -33,10 +33,12 @@ class PaneToggleButton extends PureComponent<Props> {
           collapsed,
           vertical: !horizontal
         })}
-        onClick={() => handleClick(position, collapsed)}
+        onClick={() => handleClick(position, !collapsed)}
         title={title}
       >
-        <AccessibleImage className="toggle-panes" />
+        <AccessibleImage
+          className={collapsed ? "pane-expand" : "pane-collapse"}
+        />
       </CommandBarButton>
     );
   }

--- a/src/components/shared/Button/styles/PaneToggleButton.css
+++ b/src/components/shared/Button/styles/PaneToggleButton.css
@@ -3,19 +3,11 @@
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
 .toggle-button {
-  transform: translate(0, 0px);
-  transition: transform 0.25s ease-in-out;
   padding: 5px;
-  height: inherit;
 }
 
 .toggle-button .img {
-  fill: var(--theme-comment);
-  vertical-align: 0;
-}
-
-:root.theme-dark .toggle-button .img {
-  fill: var(--theme-comment-alt);
+  vertical-align: middle;
 }
 
 .toggle-button.end {
@@ -27,16 +19,11 @@
   margin-inline-start: 0px;
 }
 
-html:not([dir="rtl"]) .toggle-button.end .img,
-html[dir="rtl"] .toggle-button.start .img {
-  transform: rotate(180deg);
+html[dir="ltr"] .toggle-button:not(.vertical).end .img,
+html[dir="rtl"] .toggle-button:not(.vertical).start .img {
+  transform: scaleX(-1);
 }
 
-html .toggle-button.end.vertical .img {
+.toggle-button.end.vertical .img {
   transform: rotate(-90deg);
-}
-
-.toggle-button.start.collapsed,
-.toggle-button.end.collapsed {
-  transform: rotate(180deg);
 }

--- a/src/components/shared/Button/tests/PaneToggleButton.spec.js
+++ b/src/components/shared/Button/tests/PaneToggleButton.spec.js
@@ -39,9 +39,9 @@ describe("PaneToggleButton", () => {
 
   it("handleClick is called", () => {
     const position = "testPosition";
-    const collapsed = "testCollapsed";
+    const collapsed = false;
     wrapper.setProps({ position, collapsed });
     wrapper.simulate("click");
-    expect(handleClickSpy).toBeCalledWith(position, collapsed);
+    expect(handleClickSpy).toBeCalledWith(position, true);
   });
 });

--- a/src/components/shared/Button/tests/__snapshots__/PaneToggleButton.spec.js.snap
+++ b/src/components/shared/Button/tests/__snapshots__/PaneToggleButton.spec.js.snap
@@ -4,10 +4,10 @@ exports[`PaneToggleButton renders default 1`] = `
 <CommandBarButton
   className="toggle-button vertical"
   onClick={[Function]}
-  title="Expand panes"
+  title="Collapse panes"
 >
   <AccessibleImage
-    className="toggle-panes"
+    className="pane-collapse"
   />
 </CommandBarButton>
 `;

--- a/src/components/shared/Svg.css
+++ b/src/components/shared/Svg.css
@@ -208,8 +208,13 @@ span.img.marko {
   mask-size: 100%;
 }
 
-.img.toggle-panes {
-  mask: url(/images/toggle-panes.svg) no-repeat;
+.img.pane-collapse {
+  mask: url(/images/pane-collapse.svg) no-repeat;
+  mask-size: 100%;
+}
+
+.img.pane-expand {
+  mask: url(/images/pane-expand.svg) no-repeat;
   mask-size: 100%;
 }
 

--- a/src/components/test/__snapshots__/WelcomeBox.spec.js.snap
+++ b/src/components/test/__snapshots__/WelcomeBox.spec.js.snap
@@ -63,7 +63,7 @@ exports[`WelomeBox renders with default values 1`] = `
       </p>
     </div>
     <PaneToggleButton
-      collapsed={true}
+      collapsed={false}
       handleClick={[MockFunction]}
       horizontal={false}
       position="end"


### PR DESCRIPTION
Fixes #7742

- Gets updated CSS (variables.css, common.css) from mozilla-central
- Use the new `--theme-icon-color` for icon color
- Sets button font-size and font-family to inherit; on Linux they tend to inherit the system font-size, was 16px (and a 21px line-height) in my case, can be 14.5px by default (11pt), etc. This creates a bunch of alignment issues due to the big line-height. Note: there is a similar style in m-c's common.css, but for some reason it doesn't seem to apply here. Maybe the `html|button` selector syntax doesn't work for the Debugger or doesn't work in all contexts?
- Make sure we have two different icon designs for "expand panes" and "collapse panes". The arrow in "expand" should point away from the sidebar, and the arrow in "collapse" should point towards the sidebar. Just flipping the "expand" icon doesn't make it convey "collapse" correctly. Incidentally, this helps us simplify the CSS code because we don't have to mentally compute the correct rotation for different parameters. :D
- Remove the button's `height:inherit`, which make them 31px and causes misalignments and bluriness. They're flex children with `align-self: stretch`, so not having a height at all is fine.
- The PaneToggleButton component was accepting a `collapsed` boolean prop, but treating it as meaning the opposite of the boolean value. When clicking the button, it would basically say "set the pane's collapsed state to this value I received". As a result, when using the PaneToggleButton we had to invert the "collapsed" state we were passing to it. And also, we were outputting the "collapsed" class on buttons for panes which were NOT collapsed and not outputting that class on buttons for panes which WERE collapsed. Not sure that's clear. But basically, we were doing this _backward_s (and _wrongly_, for the element's class). So, well, I tried to fix that.