### PR TITLE
Fix padding for column breakpoint background

### DIFF
--- a/src/components/Editor/ColumnBreakpoints.css
+++ b/src/components/Editor/ColumnBreakpoints.css
@@ -5,7 +5,7 @@
 .column-breakpoint {
   display: inline;
   padding: 0;
-  margin-inline-end: 4px;
+  padding-inline-end: 4px;
 }
 
 .column-breakpoint:hover {


### PR DESCRIPTION
Before:

<img width="577" alt="cbbefore" src="https://user-images.githubusercontent.com/46655/52148113-58b32f80-262e-11e9-8140-9fb4e3780350.png">


After:

<img width="577" alt="cbafter" src="https://user-images.githubusercontent.com/46655/52148110-5650d580-262e-11e9-89bb-ba1eabdee176.png">
