### PR TITLE
Pass the correct collapsed value to PaneToggleButton in SourceFooter

### DIFF
--- a/src/components/Editor/Footer.js
+++ b/src/components/Editor/Footer.js
@@ -156,7 +156,7 @@ class SourceFooter extends PureComponent<Props, State> {
       <PaneToggleButton
         position="end"
         key="toggle"
-        collapsed={!this.props.endPanelCollapsed}
+        collapsed={this.props.endPanelCollapsed}
         horizontal={this.props.horizontal}
         handleClick={(this.props.togglePaneCollapse: any)}
       />

--- a/src/components/Editor/tests/Footer.spec.js
+++ b/src/components/Editor/tests/Footer.spec.js
@@ -28,6 +28,7 @@ function generateDefaults(overrides) {
         on: jest.fn()
       }
     },
+    endPanelCollapsed: false,
     selectedSource: makeSource("foo").source,
     ...overrides
   };

--- a/src/components/Editor/tests/__snapshots__/Footer.spec.js.snap
+++ b/src/components/Editor/tests/__snapshots__/Footer.spec.js.snap
@@ -11,7 +11,7 @@ exports[`SourceFooter Component default case should render 1`] = `
     (2, 2)
   </span>
   <PaneToggleButton
-    collapsed={true}
+    collapsed={false}
     horizontal={false}
     key="toggle"
     position="end"
@@ -30,7 +30,7 @@ exports[`SourceFooter Component move cursor should render new cursor position 1`
     (6, 11)
   </span>
   <PaneToggleButton
-    collapsed={true}
+    collapsed={false}
     horizontal={false}
     key="toggle"
     position="end"


### PR DESCRIPTION
Fixes #7870

I forgot to update one call site of PaneToggleButton in a previous PR.

Test plan:

1. Open a source file in Debugger, so that the SourceFooter appears.
2. Resize the window width until the layout switches to vertical (with breakpoints at the bottom).
3. The "Toggle panes" button should now be functional (it's broken on master, always setting the UI state to the current state so nothing changes).

A note about the changed test spec and snapshot: it looks like when doing the snapshot, `props.endPanelCollapsed` is undefined, so the `collapsed` attribute is not generated in the JSX snapshot. I added this prop manually in `Footer.spec.js#generateDefaults`, but I'm not sure that's the correct approach. Happy to change it if it's not.
