### PR TITLE
Remove rogue semicolon in Editor JSX

### DIFF
--- a/src/components/Editor/index.js
+++ b/src/components/Editor/index.js
@@ -606,7 +606,7 @@ class Editor extends PureComponent<Props, State> {
         <HighlightLine />
         <EmptyLines editor={editor} />
         <Breakpoints editor={editor} />
-        <Preview editor={editor} editorRef={this.$editorWrapper} />;
+        <Preview editor={editor} editorRef={this.$editorWrapper} />
         <Footer editor={editor} horizontal={horizontal} />
         <HighlightLines editor={editor} />
         {


### PR DESCRIPTION
No filed issue.

This rogue semicolon gets rendered as a text node in the DOM. It doesn't seem to break anything, but it's best not to have it.