### PR TITLE
Fix WelcomeBox height, PaneToggleButton icon direction in RTL

### DIFF
--- a/src/components/WelcomeBox.css
+++ b/src/components/WelcomeBox.css
@@ -3,16 +3,13 @@
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
 .welcomebox {
-  width: calc(100% - 1px);
-
-  /* Offsetting it by 30px for the sources-header area */
-  height: calc(100% - 30px);
   position: absolute;
-  top: 30px;
+  top: var(--editor-header-height);
   left: 0;
+  bottom: 1px;
+  width: calc(100% - 1px);
   padding: 50px 0 0 0;
   text-align: center;
-  font-size: 1.25em;
   background-color: var(--theme-toolbar-background);
   font-weight: lighter;
   z-index: 10;
@@ -36,6 +33,7 @@
 .alignlabel {
   display: flex;
   white-space: nowrap;
+  font-size: 1.25em;
 }
 
 .shortcutKeys {

--- a/src/components/WelcomeBox.js
+++ b/src/components/WelcomeBox.js
@@ -92,8 +92,8 @@ export class WelcomeBox extends Component<Props> {
               <span className="shortcutLabel">{allShortcutsLabel}</span>
             </p>
           </div>
-          {this.renderToggleButton()}
         </div>
+        {this.renderToggleButton()}
       </div>
     );
   }

--- a/src/components/shared/Button/styles/PaneToggleButton.css
+++ b/src/components/shared/Button/styles/PaneToggleButton.css
@@ -3,7 +3,7 @@
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
 .toggle-button {
-  padding: 5px;
+  padding: 4px 6px;
 }
 
 .toggle-button .img {
@@ -19,8 +19,8 @@
   margin-inline-start: 0px;
 }
 
-html[dir="ltr"] .toggle-button:not(.vertical).end .img,
-html[dir="rtl"] .toggle-button:not(.vertical).start .img {
+html[dir="rtl"] .toggle-button.start .img,
+html[dir="ltr"] .toggle-button.end:not(.vertical) .img {
   transform: scaleX(-1);
 }
 

--- a/src/components/test/__snapshots__/WelcomeBox.spec.js.snap
+++ b/src/components/test/__snapshots__/WelcomeBox.spec.js.snap
@@ -62,12 +62,12 @@ exports[`WelomeBox renders with default values 1`] = `
         </span>
       </p>
     </div>
-    <PaneToggleButton
-      collapsed={false}
-      handleClick={[MockFunction]}
-      horizontal={false}
-      position="end"
-    />
   </div>
+  <PaneToggleButton
+    collapsed={false}
+    handleClick={[MockFunction]}
+    horizontal={false}
+    position="end"
+  />
 </div>
 `;


### PR DESCRIPTION
Looks like I introduced a small issue with the WelcomeBox height in vertical mode in #7873, and I hadn't correctly tested the PaneToggleButton changes in #7862 in right-to-left.

So here are two followup fixes.
Also fixes a button size / icon alignment issue with the bottom PaneToggleButton used in WelcomeBox in vertical mode.

