### PR TITLE
Fix 7844: Implement ".devtools-monospace" CSS class

### DIFF
--- a/src/components/PrimaryPanes/Outline.css
+++ b/src/components/PrimaryPanes/Outline.css
@@ -30,7 +30,6 @@
   left: 0;
   right: 0;
   list-style-type: none;
-  font-family: var(--monospace-font-family);
   overflow: auto;
 }
 

--- a/src/components/PrimaryPanes/Outline.js
+++ b/src/components/PrimaryPanes/Outline.js
@@ -207,7 +207,7 @@ export class Outline extends Component<Props, State> {
     }
 
     return (
-      <ul className="outline-list">
+      <ul className="outline-list devtools-monospace">
         {namedFunctions.map(func => this.renderFunction(func))}
         {classes.map(klass => this.renderClassFunctions(klass, classFunctions))}
       </ul>

--- a/src/components/SecondaryPanes/Breakpoints/Breakpoint.js
+++ b/src/components/SecondaryPanes/Breakpoints/Breakpoint.js
@@ -170,14 +170,16 @@ class Breakpoint extends PureComponent<Props> {
         />
         <label
           htmlFor={breakpoint.id}
-          className="breakpoint-label cm-s-mozilla"
+          className="breakpoint-label cm-s-mozilla devtools-monospace"
           onClick={this.selectBreakpoint}
           title={text}
         >
           <span dangerouslySetInnerHTML={this.highlightText(text, editor)} />
         </label>
         <div className="breakpoint-line-close">
-          <div className="breakpoint-line">{this.getBreakpointLocation()}</div>
+          <div className="breakpoint-line devtools-monospace">
+            {this.getBreakpointLocation()}
+          </div>
           <CloseButton
             handleClick={e => this.removeBreakpoint(e)}
             tooltip={L10N.getStr("breakpoints.removeBreakpointTooltip")}

--- a/src/components/SecondaryPanes/Breakpoints/Breakpoints.css
+++ b/src/components/SecondaryPanes/Breakpoints/Breakpoints.css
@@ -140,11 +140,6 @@ html .breakpoints-list .breakpoint.paused {
   background-color: var(--search-overlays-semitransparent);
 }
 
-.breakpoints-list .breakpoint .breakpoint-line,
-.breakpoints-list .breakpoint-label {
-  font-family: var(--monospace-font-family);
-}
-
 .breakpoints-list .breakpoint .breakpoint-line {
   font-size: 11px;
   color: var(--theme-comment);

--- a/src/components/SecondaryPanes/Breakpoints/tests/__snapshots__/Breakpoint.spec.js.snap
+++ b/src/components/SecondaryPanes/Breakpoints/tests/__snapshots__/Breakpoint.spec.js.snap
@@ -15,7 +15,7 @@ exports[`Breakpoint disabled 1`] = `
     type="checkbox"
   />
   <label
-    className="breakpoint-label cm-s-mozilla"
+    className="breakpoint-label cm-s-mozilla devtools-monospace"
     onClick={[Function]}
   >
     <span
@@ -30,7 +30,7 @@ exports[`Breakpoint disabled 1`] = `
     className="breakpoint-line-close"
   >
     <div
-      className="breakpoint-line"
+      className="breakpoint-line devtools-monospace"
     >
       53
     </div>
@@ -57,7 +57,7 @@ exports[`Breakpoint paused at a different 1`] = `
     type="checkbox"
   />
   <label
-    className="breakpoint-label cm-s-mozilla"
+    className="breakpoint-label cm-s-mozilla devtools-monospace"
     onClick={[Function]}
   >
     <span
@@ -72,7 +72,7 @@ exports[`Breakpoint paused at a different 1`] = `
     className="breakpoint-line-close"
   >
     <div
-      className="breakpoint-line"
+      className="breakpoint-line devtools-monospace"
     >
       53
     </div>
@@ -99,7 +99,7 @@ exports[`Breakpoint paused at a generatedLocation 1`] = `
     type="checkbox"
   />
   <label
-    className="breakpoint-label cm-s-mozilla"
+    className="breakpoint-label cm-s-mozilla devtools-monospace"
     onClick={[Function]}
   >
     <span
@@ -114,7 +114,7 @@ exports[`Breakpoint paused at a generatedLocation 1`] = `
     className="breakpoint-line-close"
   >
     <div
-      className="breakpoint-line"
+      className="breakpoint-line devtools-monospace"
     >
       53
     </div>
@@ -141,7 +141,7 @@ exports[`Breakpoint paused at an original location 1`] = `
     type="checkbox"
   />
   <label
-    className="breakpoint-label cm-s-mozilla"
+    className="breakpoint-label cm-s-mozilla devtools-monospace"
     onClick={[Function]}
   >
     <span
@@ -156,7 +156,7 @@ exports[`Breakpoint paused at an original location 1`] = `
     className="breakpoint-line-close"
   >
     <div
-      className="breakpoint-line"
+      className="breakpoint-line devtools-monospace"
     >
       5
     </div>
@@ -183,7 +183,7 @@ exports[`Breakpoint simple 1`] = `
     type="checkbox"
   />
   <label
-    className="breakpoint-label cm-s-mozilla"
+    className="breakpoint-label cm-s-mozilla devtools-monospace"
     onClick={[Function]}
   >
     <span
@@ -198,7 +198,7 @@ exports[`Breakpoint simple 1`] = `
     className="breakpoint-line-close"
   >
     <div
-      className="breakpoint-line"
+      className="breakpoint-line devtools-monospace"
     >
       53
     </div>

--- a/src/components/test/__snapshots__/Outline.spec.js.snap
+++ b/src/components/test/__snapshots__/Outline.spec.js.snap
@@ -10,7 +10,7 @@ exports[`Outline renders a list of functions when properties change 1`] = `
       updateFilter={[Function]}
     />
     <ul
-      className="outline-list"
+      className="outline-list devtools-monospace"
     >
       <li
         className="outline-list__element"
@@ -77,7 +77,7 @@ exports[`Outline renders outline renders functions by function class 1`] = `
       updateFilter={[Function]}
     />
     <ul
-      className="outline-list"
+      className="outline-list devtools-monospace"
     >
       <div
         className="outline-list__class"
@@ -204,7 +204,7 @@ exports[`Outline renders outline renders functions by function class, alphabetic
       updateFilter={[Function]}
     />
     <ul
-      className="outline-list"
+      className="outline-list devtools-monospace"
     >
       <div
         className="outline-list__class"
@@ -331,7 +331,7 @@ exports[`Outline renders outline renders ignore anonymous functions 1`] = `
       updateFilter={[Function]}
     />
     <ul
-      className="outline-list"
+      className="outline-list devtools-monospace"
     >
       <li
         className="outline-list__element"
@@ -418,7 +418,7 @@ exports[`Outline renders outline sorts functions alphabetically by function name
       updateFilter={[Function]}
     />
     <ul
-      className="outline-list"
+      className="outline-list devtools-monospace"
     >
       <li
         className="outline-list__element"


### PR DESCRIPTION
Fixes #7844

### Summary of Changes

* Use `.devtools-monospace` in Breakpoints pane (right sidebar)