### PR TITLE
Stop waiting for sourceMaps.clearSourceMaps

### DIFF
--- a/src/actions/navigation.js
+++ b/src/actions/navigation.js
@@ -33,8 +33,8 @@ import type { Action, ThunkArgs } from "./types";
  * @static
  */
 export function willNavigate(event: Object) {
-  return async function({ dispatch, getState, client, sourceMaps }: ThunkArgs) {
-    await sourceMaps.clearSourceMaps();
+  return function({ dispatch, getState, client, sourceMaps }: ThunkArgs) {
+    sourceMaps.clearSourceMaps();
     clearWasmStates();
     clearDocuments();
     clearSymbols();


### PR DESCRIPTION
### Summary of Changes

@jswalden and i noticed that the `await` was causing a timing issue while clearing the store. Hopefully this is no longer needed.