### PR TITLE
Prevent renovate from reopening PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,7 @@
     "config:base",
     ":preserveSemverRanges"
   ],
+  "recreateClosed": false,
   "statusCheckVerify": true,
   "ignoreDeps": [
     "react",


### PR DESCRIPTION
According to https://renovatebot.com/docs/configuration-options/#recreateclosed , we shouldn't need this, but it's worth a shot to prevent renovate from reopening the same PR over and over.