### PR TITLE
[Fix for #7851] After #7796 relativeSources attributes were not updated

### DIFF
--- a/src/actions/sources/tests/blackbox.spec.js
+++ b/src/actions/sources/tests/blackbox.spec.js
@@ -1,0 +1,32 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
+
+// @flow
+
+import {
+  actions,
+  selectors,
+  createStore,
+  makeSource
+} from "../../../utils/test-head";
+
+describe("blackbox", () => {
+  it("should blackbox a source", async () => {
+    const store = createStore({ blackBox: async () => true });
+    const { dispatch, getState } = store;
+
+    const foo1CSR = makeSource("foo1");
+    await dispatch(actions.newSource(foo1CSR));
+    await dispatch(actions.toggleBlackBox(foo1CSR.source));
+
+    const fooSource = selectors.getSource(getState(), "foo1");
+    const relativeSources = selectors.getRelativeSourcesForThread(
+      getState(),
+      foo1CSR.sourceActor.thread
+    );
+
+    expect(relativeSources[fooSource.id].isBlackBoxed).toEqual(true);
+    expect(fooSource.isBlackBoxed).toEqual(true);
+  });
+});

--- a/src/reducers/sources.js
+++ b/src/reducers/sources.js
@@ -276,8 +276,22 @@ function updateSource(state: SourcesState, source: Object) {
 
   state.sources[source.id] = updatedSource;
 
+  updateExistingRelativeSource(state, source);
   updateSourceUrl(state, source);
   updateOriginalSources(state, source);
+}
+
+function updateExistingRelativeSource(state: SourcesState, source: Object) {
+  const relativeSources = { ...state.relativeSources };
+
+  for (const thread in relativeSources) {
+    relativeSources[thread] = { ...relativeSources[thread] };
+    if (relativeSources[thread][source.id]) {
+      const existingRelativeSource = relativeSources[thread][source.id];
+      const updatedRelativeSource = { ...existingRelativeSource, ...source};
+      state.relativeSources[thread][source.id] = updatedRelativeSource;
+    }
+  }
 }
 
 function updateRelativeSource(

--- a/src/reducers/sources.js
+++ b/src/reducers/sources.js
@@ -288,7 +288,7 @@ function updateExistingRelativeSource(state: SourcesState, source: Object) {
     relativeSources[thread] = { ...relativeSources[thread] };
     if (relativeSources[thread][source.id]) {
       const existingRelativeSource = relativeSources[thread][source.id];
-      const updatedRelativeSource = { ...existingRelativeSource, ...source};
+      const updatedRelativeSource = { ...existingRelativeSource, ...source };
       state.relativeSources[thread][source.id] = updatedRelativeSource;
     }
   }

--- a/src/reducers/sources.js
+++ b/src/reducers/sources.js
@@ -285,8 +285,8 @@ function updateExistingRelativeSource(state: SourcesState, source: Object) {
   const relativeSources = { ...state.relativeSources };
 
   for (const thread in relativeSources) {
-    relativeSources[thread] = { ...relativeSources[thread] };
     if (relativeSources[thread][source.id]) {
+      relativeSources[thread] = { ...relativeSources[thread] };
       const existingRelativeSource = relativeSources[thread][source.id];
       const updatedRelativeSource = { ...existingRelativeSource, ...source };
       state.relativeSources[thread][source.id] = updatedRelativeSource;


### PR DESCRIPTION
Fixes #7851 

This issue was caused by splitting source into source/sourceActor PR#7796.

I've added another function to update relative sources as sources are being updated. 

Demo:

relativeSources and sources have same values for attributes like isBlackBoxed, isPrettyPrinted, loadedState:
![issue7851 1](https://user-images.githubusercontent.com/33161837/52446611-61e74500-2ae3-11e9-8c78-0071772c4a42.png)

sourcesTreeItem now has blackbox icon when the source is blackboxed:
![issue7851 2](https://user-images.githubusercontent.com/33161837/52446715-a70b7700-2ae3-11e9-92b8-7109e7696f17.png)

