### PR TITLE
Add syntax highlighting to conditional panel

### DIFF
--- a/src/components/Editor/ConditionalPanel.css
+++ b/src/components/Editor/ConditionalPanel.css
@@ -23,20 +23,6 @@
   width: 30px;
 }
 
-.conditional-breakpoint-panel input {
-  margin: 5px 10px;
-  width: calc(100% - 4em);
-  border: none;
-  background: var(--theme-toolbar-background);
-  font-size: 14px;
-  color: var(--theme-conditional-breakpoint-color);
-  line-height: 30px;
-}
-
-.conditional-breakpoint-panel input:not(:placeholder-shown) {
-  font-family: var(--monospace-font-family);
-}
-
-.conditional-breakpoint-panel input:focus {
-  outline-width: 0;
+.conditional-breakpoint-panel .CodeMirror {
+  margin: 6px 10px;
 }

--- a/src/components/Editor/ConditionalPanel.js
+++ b/src/components/Editor/ConditionalPanel.js
@@ -119,7 +119,7 @@ export class ConditionalPanel extends PureComponent<Props> {
       this.renderConditionalPanel(props),
       {
         coverGutter: true,
-        noHScroll: false
+        noHScroll: true
       }
     );
     if (this.input) {

--- a/src/components/Editor/ConditionalPanel.js
+++ b/src/components/Editor/ConditionalPanel.js
@@ -9,7 +9,6 @@ import { connect } from "../../utils/connect";
 import classNames from "classnames";
 import "./ConditionalPanel.css";
 import { toEditorLine } from "../../utils/editor";
-import { createEditor } from "../../utils/editor/create-editor";
 import actions from "../../actions";
 
 import {
@@ -144,7 +143,7 @@ export class ConditionalPanel extends PureComponent<Props> {
   }
 
   renderConditionalPanel(props: Props) {
-    const { breakpoint, log } = props;
+    const { breakpoint, log, editor } = props;
     const options = (breakpoint && breakpoint.options) || {};
     const condition = log ? options.logValue : options.condition;
 
@@ -162,7 +161,6 @@ export class ConditionalPanel extends PureComponent<Props> {
         <input
           defaultValue={condition}
           ref={input => {
-            const editor = createEditor();
             const codeMirror = editor.CodeMirror.fromTextArea(input, {
               mode: "javascript",
               theme: "mozilla",

--- a/src/components/Editor/ConditionalPanel.js
+++ b/src/components/Editor/ConditionalPanel.js
@@ -3,6 +3,11 @@
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
 // @flow
+const CodeMirror = require("codemirror");
+
+// $FlowIgnore
+require("codemirror/addon/display/placeholder");
+
 import React, { PureComponent } from "react";
 import ReactDOM from "react-dom";
 import { connect } from "../../utils/connect";
@@ -160,15 +165,26 @@ export class ConditionalPanel extends PureComponent<Props> {
         <div className="prompt">»</div>
         <input
           defaultValue={condition}
-          placeholder={L10N.getStr(
-            log
-              ? "editor.conditionalPanel.logPoint.placeholder"
-              : "editor.conditionalPanel.placeholder"
-          )}
-          onKeyDown={this.onKey}
           ref={input => {
+            const codeMirror = CodeMirror.fromTextArea(input, {
+              mode: "javascript",
+              theme: "mozilla",
+              placeholder: L10N.getStr(
+                log
+                  ? "editor.conditionalPanel.logPoint.placeholder"
+                  : "editor.conditionalPanel.placeholder"
+              )
+            });
+            const codeMirrorWrapper = codeMirror.getWrapperElement();
+
+            codeMirrorWrapper.addEventListener("keydown", e => {
+              codeMirror.save();
+              this.onKey(e);
+            });
+
             this.input = input;
-            this.keepFocusOnInput();
+            codeMirror.focus();
+            codeMirror.setCursor(codeMirror.lineCount(), 0);
           }}
         />
       </div>,

--- a/src/components/Editor/ConditionalPanel.js
+++ b/src/components/Editor/ConditionalPanel.js
@@ -3,17 +3,13 @@
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
 // @flow
-const CodeMirror = require("codemirror");
-
-// $FlowIgnore
-require("codemirror/addon/display/placeholder");
-
 import React, { PureComponent } from "react";
 import ReactDOM from "react-dom";
 import { connect } from "../../utils/connect";
 import classNames from "classnames";
 import "./ConditionalPanel.css";
 import { toEditorLine } from "../../utils/editor";
+import { createEditor } from "../../utils/editor/create-editor";
 import actions from "../../actions";
 
 import {
@@ -166,7 +162,8 @@ export class ConditionalPanel extends PureComponent<Props> {
         <input
           defaultValue={condition}
           ref={input => {
-            const codeMirror = CodeMirror.fromTextArea(input, {
+            const editor = createEditor();
+            const codeMirror = editor.CodeMirror.fromTextArea(input, {
               mode: "javascript",
               theme: "mozilla",
               placeholder: L10N.getStr(

--- a/src/utils/editor/source-editor.js
+++ b/src/utils/editor/source-editor.js
@@ -28,6 +28,7 @@ require("codemirror/addon/fold/foldgutter");
 require("codemirror/addon/runmode/runmode");
 require("codemirror/addon/selection/active-line");
 require("codemirror/addon/edit/matchbrackets");
+require("codemirror/addon/display/placeholder");
 require("codemirror/mode/clike/clike");
 require("codemirror/mode/rust/rust");
 

--- a/test/mochitest/helpers.js
+++ b/test/mochitest/helpers.js
@@ -1147,7 +1147,7 @@ const selectors = {
   outlineItem: i =>
     `.outline-list__element:nth-child(${i}) .function-signature`,
   outlineItems: ".outline-list__element",
-  conditionalPanelInput: ".conditional-breakpoint-panel input",
+  conditionalPanelInput: ".conditional-breakpoint-panel textarea",
   searchField: ".search-field",
   blackbox: ".action.black-box",
   projectSearchCollapsed: ".project-text-search .arrow:not(.expanded)",


### PR DESCRIPTION
Fixes #7800 

Please let me know your thoughts and what can be improved. Thank you!

### Summary of Changes

* Used CodeMirror to implement syntax highlighting for the conditional panel. This affects both conditional breakpoints and conditional log points. 
* Deleted code for placeholder/keyDown attributes on the input since the functionality is replaced by the CodeMirror instance


### Test Plan
[x] Added conditional breakpoint condition and saw syntax highlighting was in effect
[x] Edited conditional breakpoint condition and saw syntax highlighting was in effect
[x] Ensured code did not pause when condition was not met
[x] Ensured code paused when condition was met
[x] Removed conditional breakpoint

### Demo

![feb-07-2019 14-43-09](https://user-images.githubusercontent.com/21224637/52447830-ce177800-2ae6-11e9-8a24-53a3e8fa0b39.gif)

