### PR TITLE
Fix 7864: Set required node ver to 10.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "homepage": "https://github.com/devtools-html/debugger.html#readme",
   "engineStrict": true,
   "engines": {
-    "node": ">=7.7.0"
+    "node": ">=10.3.0"
   },
   "scripts": {
     "start": "node bin/dev-server",


### PR DESCRIPTION
Fixes #7864

### Summary of Changes

* Updated minimum node version to 10.3.0 in `package.json`

@fvsch I have used https://node.green/#ES2018-features-Promise-prototype-finally for deciding the minimum node version required, I think it's a pretty reliable resource as they run automated tests against all node versions.

I ran tests on `10.3.0` on my end they work as expected
