### PR TITLE
Change editor line-height to 15px (#7929)

### DIFF
--- a/images/breakpoint.svg
+++ b/images/breakpoint.svg
@@ -1,6 +1,6 @@
 <!-- This Source Code Form is subject to the terms of the Mozilla Public
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 60 14">
-  <path d="M53.07.5H1.5a1 1 0 0 0-1 1v11a1 1 0 0 0 1 1h51.57a2 2 0 0 0 1.53-.7L59.3 7l-4.7-5.8a2 2 0 0 0-1.53-.7z"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 60 15" width="60" height="15">
+  <path d="M53.07.5H1.5c-.54 0-1 .46-1 1v12c0 .54.46 1 1 1h51.57c.58 0 1.15-.26 1.53-.7l4.7-6.3-4.7-6.3c-.38-.44-.95-.7-1.53-.7z"/>
 </svg>

--- a/images/column-breakpoint.svg
+++ b/images/column-breakpoint.svg
@@ -1,6 +1,0 @@
-<!-- This Source Code Form is subject to the terms of the Mozilla Public
-   - License, v. 2.0. If a copy of the MPL was not distributed with this
-   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 17 14">
-  <path id="base-path" d="m10.9,0l-9.9,0c-0.6,0 -1,0.4 -1,1l0,10c0,0.6 0.4,1 1,1l9.9,0c0.6,0 1.2,-0.3 1.5,-0.7l4.6,-5.3l-4.4,-5.3c-0.475,-0.525 -1.1,-0.7 -1.7,-0.7z"/>
-</svg>

--- a/images/column-marker.svg
+++ b/images/column-marker.svg
@@ -1,5 +1,6 @@
-<svg width="9px" height="12px" viewBox="0 0 9 12" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <g id="columnmarkergroup" stroke-width="1" fill-rule="evenodd">
-        <polygon id="columnmarker" points="0 0 4 0 9 6 4 12 0 12"></polygon>
-    </g>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 11 13" width="11" height="13">
+  <path d="M5.07.5H1.5c-.54 0-1 .46-1 1v10c0 .54.46 1 1 1h3.57c.58 0 1.15-.26 1.53-.7l3.7-5.3-3.7-5.3C6.22.76 5.65.5 5.07.5z"/>
 </svg>

--- a/src/components/Editor/ColumnBreakpoints.css
+++ b/src/components/Editor/ColumnBreakpoints.css
@@ -4,8 +4,8 @@
 
 .column-breakpoint {
   display: inline;
-  padding: 0;
-  padding-inline-end: 4px;
+  padding-inline-start: 1px;
+  padding-inline-end: 3px;
 }
 
 .column-breakpoint:hover {
@@ -13,10 +13,10 @@
 }
 
 .column-breakpoint svg {
-  display: inline;
+  display: inline-block;
   cursor: pointer;
-  height: 12px;
-  width: 9px;
+  height: 13px;
+  width: 11px;
   vertical-align: top;
 }
 

--- a/src/components/Editor/Editor.css
+++ b/src/components/Editor/Editor.css
@@ -78,20 +78,6 @@ html[dir="rtl"] .editor-mount {
   color: var(--grey-50);
 }
 
-:not(.empty-line):not(.new-breakpoint)
-  > .CodeMirror-gutter-wrapper:hover
-  > .CodeMirror-linenumber {
-  height: 13px;
-  color: var(--theme-body-color);
-  /* Add 1px offset to the background to match it
-    with the actual breakpoint image dimensions */
-  background: linear-gradient(
-    to bottom,
-    transparent 1px,
-    var(--gutter-hover-background-color) 0
-  );
-}
-
 .new-breakpoint .CodeMirror-linenumber {
   pointer-events: none;
 }
@@ -101,12 +87,16 @@ html[dir="rtl"] .editor-mount {
   > .CodeMirror-linenumber::after {
   content: "";
   position: absolute;
-  top: 1px;
-  height: 12px;
-  width: 9px;
+  /* paint below the number */
+  z-index: -1;
+  top: 0;
+  left: 0;
+  right: -7px;
+  bottom: 0;
+  height: 15px;
   background-color: var(--gutter-hover-background-color);
   mask: url(/images/breakpoint.svg) no-repeat;
-  mask-size: auto 12px;
+  mask-size: auto 15px;
   mask-position: right;
 }
 
@@ -126,7 +116,7 @@ html[dir="rtl"] .editor-mount {
 }
 
 .editor.hit-marker {
-  height: 14px;
+  height: 15px;
 }
 
 .editor-wrapper .highlight-lines {
@@ -137,7 +127,7 @@ html[dir="rtl"] .editor-mount {
   fill: var(--breakpoint-fill);
   stroke: var(--breakpoint-stroke);
   width: 60px;
-  height: 14px;
+  height: 15px;
   position: absolute;
   top: 0px;
   right: -4px;
@@ -182,7 +172,7 @@ html[dir="rtl"] .editor-mount {
   fill: var(--theme-selection-background);
   vertical-align: middle;
   width: 17px;
-  height: 14px;
+  height: 15px;
 }
 
 .editor.column-breakpoint.breakpoint-disabled svg {
@@ -197,11 +187,8 @@ html[dir="rtl"] .editor-mount {
 .editor-wrapper .editor-mount {
   width: 100%;
   background-color: var(--theme-body-background);
-}
-
-.CodeMirror-linenumber {
-  font-size: 11px;
-  line-height: 14px;
+  font-size: var(--theme-code-font-size);
+  line-height: var(--theme-code-line-height);
 }
 
 .folding-enabled .CodeMirror-linenumber {
@@ -220,10 +207,6 @@ html[dir="rtl"] .editor-mount {
 /* move the breakpoint below the other gutter elements */
 .new-breakpoint .CodeMirror-gutter-elt:nth-child(2) {
   z-index: 0;
-}
-
-.editor-wrapper .CodeMirror-line {
-  font-size: 11px;
 }
 
 .theme-dark .editor-wrapper .CodeMirror-line .cm-comment {

--- a/src/components/variables.css
+++ b/src/components/variables.css
@@ -9,6 +9,8 @@
   --editor-footer-height: 25px;
   /* searchbar height is 24px + 1px for its top border */
   --editor-searchbar-height: 25px;
+  /* Remove once https://bugzilla.mozilla.org/show_bug.cgi?id=1520440 lands */
+  --theme-code-line-height: calc(15 / 11);
 }
 
 :root.theme-light,

--- a/src/utils/editor/source-editor.css
+++ b/src/utils/editor/source-editor.css
@@ -47,33 +47,6 @@
   pointer-events: none;
 }
 
-.CodeMirror-linenumber:before {
-  content: " ";
-  display: block;
-  width: calc(100% - 3px);
-  position: absolute;
-  top: 1px;
-  left: 0;
-  height: 12px;
-  z-index: -1;
-  background-size: calc(100% - 2px) 12px;
-  background-repeat: no-repeat;
-  background-position: right center;
-  padding-inline-end: 9px;
-}
-
-.breakpoint .CodeMirror-linenumber {
-  color: var(--theme-body-background);
-}
-
-.breakpoint .CodeMirror-linenumber:before {
-  background-image: var(--breakpoint-background) !important;
-}
-
-.conditional .CodeMirror-linenumber:before {
-  background-image: var(--breakpoint-conditional-background) !important;
-}
-
 .theme-dark .debug-line .CodeMirror-linenumber {
   color: #c0c0c0;
 }

--- a/test/mochitest/browser_dbg-preview-module.js
+++ b/test/mochitest/browser_dbg-preview-module.js
@@ -1,11 +1,15 @@
-/* Any copyright is dedicated to the Public Domain.
- * http://creativecommons.org/publicdomain/zero/1.0/ */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
 // Test hovering in a script that is paused on load
 // and doesn't have functions.
 add_task(async function() {
   const dbg = await initDebugger("doc-scripts.html");
-  const { selectors: { getSelectedSource }, getState } = dbg;
+  const {
+    selectors: { getSelectedSource },
+    getState
+  } = dbg;
 
   navigate(dbg, "doc-on-load.html");
 

--- a/test/mochitest/helpers.js
+++ b/test/mochitest/helpers.js
@@ -768,9 +768,9 @@ function findBreakpoint(dbg, url, line) {
     Services.prefs.getBoolPref("devtools.debugger.features.column-breakpoints")
   ) {
     ({ column } = dbg.selectors.getFirstVisibleBreakpointPosition(
-      dbg.store.getState(), 
+      dbg.store.getState(),
       {
-        sourceId: source.id, 
+        sourceId: source.id,
         line
       }
     ));
@@ -1106,7 +1106,7 @@ const selectors = {
   scopeValue: i =>
     `.scopes-list .tree-node:nth-child(${i}) .object-delimiter + *`,
   frame: i => `.frames [role="list"] [role="listitem"]:nth-child(${i})`,
-  frames: `.frames [role="list"] [role="listitem"]`,
+  frames: '.frames [role="list"] [role="listitem"]',
   gutter: i => `.CodeMirror-code *:nth-child(${i}) .CodeMirror-linenumber`,
   // These work for bobth the breakpoint listing and gutter marker
   gutterContextMenu: {
@@ -1317,7 +1317,14 @@ async function hoverAtPos(dbg, { line, ch }) {
   await waitForScrolling(cm);
 
   const coords = getCoordsFromPosition(cm, { line: line - 1, ch });
-  const tokenEl = dbg.win.document.elementFromPoint(coords.left, coords.top);
+
+  const { left, top } = coords;
+  const lineHeightOffset = 3;
+
+  const tokenEl = dbg.win.document.elementFromPoint(
+    left,
+    top + line * lineHeightOffset
+  );
 
   if (!tokenEl) {
     return false;

--- a/test/mochitest/helpers.js
+++ b/test/mochitest/helpers.js
@@ -94,7 +94,7 @@ function _afterDispatchDone(store, type) {
 function waitForDispatch(dbg, type, eventRepeat = 1) {
   let count = 0;
 
-  return Task.spawn(function*() {
+  return Task.spawn(function* () {
     info(`Waiting for ${type} to dispatch ${eventRepeat} time(s)`);
     while (count < eventRepeat) {
       yield _afterDispatchDone(dbg.store, type);
@@ -947,7 +947,7 @@ function waitForActive(dbg) {
  */
 function invokeInTab(fnc, ...args) {
   info(`Invoking in tab: ${fnc}(${args.map(uneval).join(",")})`);
-  return ContentTask.spawn(gBrowser.selectedBrowser, { fnc, args }, function*({
+  return ContentTask.spawn(gBrowser.selectedBrowser, { fnc, args }, function* ({
     fnc,
     args
   }) {
@@ -1323,7 +1323,7 @@ async function hoverAtPos(dbg, { line, ch }) {
 
   const tokenEl = dbg.win.document.elementFromPoint(
     left,
-    top + line * lineHeightOffset
+    top + lineHeightOffset
   );
 
   if (!tokenEl) {

--- a/test/mochitest/helpers.js
+++ b/test/mochitest/helpers.js
@@ -94,7 +94,7 @@ function _afterDispatchDone(store, type) {
 function waitForDispatch(dbg, type, eventRepeat = 1) {
   let count = 0;
 
-  return Task.spawn(function* () {
+  return Task.spawn(function*() {
     info(`Waiting for ${type} to dispatch ${eventRepeat} time(s)`);
     while (count < eventRepeat) {
       yield _afterDispatchDone(dbg.store, type);
@@ -947,7 +947,7 @@ function waitForActive(dbg) {
  */
 function invokeInTab(fnc, ...args) {
   info(`Invoking in tab: ${fnc}(${args.map(uneval).join(",")})`);
-  return ContentTask.spawn(gBrowser.selectedBrowser, { fnc, args }, function* ({
+  return ContentTask.spawn(gBrowser.selectedBrowser, { fnc, args }, function*({
     fnc,
     args
   }) {
@@ -1319,6 +1319,9 @@ async function hoverAtPos(dbg, { line, ch }) {
   const coords = getCoordsFromPosition(cm, { line: line - 1, ch });
 
   const { left, top } = coords;
+
+  // Adds a vertical offset due to increased line height
+  // https://github.com/devtools-html/debugger.html/pull/7934
   const lineHeightOffset = 3;
 
   const tokenEl = dbg.win.document.elementFromPoint(


### PR DESCRIPTION
Fixes #7929 (rationale for the change is explained there)

### Summary of Changes

- Specify line-height in Editor as `calc(15 / 11)` (resulting in 15px for a 11px font-size; we could used a fixed value but they don't inherit well when changing the font-size, while ratio values do).
- Tweak the breakpoint SVGs and relevant styles to be 15px tall (line breakpoint) and 13px tall (column breakpoint); remove duplicate column-breakpoint.svg
- Change line number hover style that used a background-color on the element itself and a `::after` pseudo-element for the right part to just use a `::after` pseudo-element painted behind the number; removes some extra CSS.
- Remove legacy styles for `.CodeMirror-linenumber:before` that was used for breakpoint indicators in the past, but don't seem used at all anymore.
