### PR TITLE
Fix Frames Group style.

### DIFF
--- a/src/components/SecondaryPanes/Frames/Group.css
+++ b/src/components/SecondaryPanes/Frames/Group.css
@@ -2,8 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at <http://mozilla.org/MPL/2.0/>. */
 
-.frames ul .frames-group .group,
-.frames ul .frames-group .group .location {
+.frames [role="list"] .frames-group .group,
+.frames [role="list"] .frames-group .group .location {
   font-weight: 500;
   cursor: default;
   /*
@@ -14,21 +14,21 @@
   direction: ltr;
 }
 
-.frames ul .frames-group.expanded .group,
-.frames ul .frames-group.expanded .group .location {
+.frames [role="list"] .frames-group.expanded .group,
+.frames [role="list"] .frames-group.expanded .group .location {
   color: var(--theme-highlight-blue);
 }
 
-.frames ul .frames-group .frames-list li {
+.frames [role="list"] .frames-group .frames-list [role="listitem"] {
   padding-left: 30px;
 }
 
-.frames ul .frames-group .frames-list {
+.frames [role="list"] .frames-group .frames-list {
   border-top: 1px solid var(--theme-splitter-color);
   border-bottom: 1px solid var(--theme-splitter-color);
 }
 
-.frames ul .frames-group.expanded .badge {
+.frames [role="list"] .frames-group.expanded .badge {
   color: var(--theme-highlight-blue);
 }
 


### PR DESCRIPTION
The CSS was wrongfully reverted to an older version,
which means that we weren't styling those
elements anymore.

Fixes #7953.

<img width="427" alt="image" src="https://user-images.githubusercontent.com/578107/52767977-58eafc00-302c-11e9-9fcb-f7723ca04561.png">

(I'll follow up on the icon issue)
