### PR TITLE
Add/Edit Log Point: Scroll line into view (#8198)

### DIFF
--- a/src/components/SecondaryPanes/Breakpoints/BreakpointsContextMenu.js
+++ b/src/components/SecondaryPanes/Breakpoints/BreakpointsContextMenu.js
@@ -225,7 +225,10 @@ export default function showContextMenu(props: Props) {
     label: L10N.getStr("editor.addLogPoint"),
     accesskey: L10N.getStr("editor.addLogPoint.accesskey"),
     disabled: false,
-    click: () => openConditionalPanel(selectedLocation, true),
+    click: () => {
+      selectSpecificLocation(cx, selectedLocation);
+      openConditionalPanel(selectedLocation, true);
+    },
     accelerator: L10N.getStr("toggleCondPanel.logPoint.key")
   };
 
@@ -234,7 +237,10 @@ export default function showContextMenu(props: Props) {
     label: L10N.getStr("editor.editLogPoint"),
     accesskey: L10N.getStr("editor.addLogPoint.accesskey"),
     disabled: false,
-    click: () => openConditionalPanel(selectedLocation, true),
+    click: () => {
+      selectSpecificLocation(cx, selectedLocation);
+      openConditionalPanel(selectedLocation, true);
+    },
     accelerator: L10N.getStr("toggleCondPanel.logPoint.key")
   };
 


### PR DESCRIPTION
Fixes #8198 

Here's the Pull Request Doc
https://firefox-dev.tools/debugger/docs/pull-requests.html

### Summary of Changes

* Scroll line into view if a log point shall be added to it or an existing one be edited.

### Test Plan

Tested with a Firefox Nightly artifact build.

Example test plan:

1. Open https://freshman.tech/calculator/
2. Open the debugger.
3. In the left sidebar, open https://jsfiddle.net/js/embed/embed.js
4. Go to line 25, set a breakpoint.
5. Scroll to the top.
6. Check that line 25 is not shown.
7. In the right sidebar, right-click the breakpoint.
8. Choose 'Add log'.

Expected result: Line 25 scrolled into view and text field for adding log point visible.