### PR TITLE
Editing breakpoints - Re-enables breakpoints globally

### DIFF
--- a/src/actions/breakpoints/index.js
+++ b/src/actions/breakpoints/index.js
@@ -79,7 +79,7 @@ export function enableBreakpointsInSource(cx: Context, source: Source) {
     for (const breakpoint of breakpoints) {
       if (breakpoint.disabled) {
         dispatch(enableBreakpoint(cx, breakpoint));
-      if (!getState.disabled) {
+      if (!getSkipPausing(getState())) {
         dispatch(toggleBreakpoints(cx, breakpoint));
         }
       }
@@ -265,7 +265,7 @@ export function addBreakpointAtLine(
       options.logValue = "displayName";
     }
 
-    if (!getState.disabled) {
+    if (!getSkipPausing(getState())) {
         dispatch(toggleBreakpoints(cx, breakpoint));
     }
 

--- a/src/actions/breakpoints/index.js
+++ b/src/actions/breakpoints/index.js
@@ -79,6 +79,9 @@ export function enableBreakpointsInSource(cx: Context, source: Source) {
     for (const breakpoint of breakpoints) {
       if (breakpoint.disabled) {
         dispatch(enableBreakpoint(cx, breakpoint));
+      if (!getState.disabled) {
+        dispatch(toggleBreakpoints(cx, breakpoint));
+        }
       }
     }
   };
@@ -260,6 +263,10 @@ export function addBreakpointAtLine(
     const options = {};
     if (shouldLog) {
       options.logValue = "displayName";
+    }
+
+    if (!getState.disabled) {
+        dispatch(toggleBreakpoints(cx, breakpoint));
     }
 
     return dispatch(addBreakpoint(cx, breakpointLocation, options, disabled));


### PR DESCRIPTION
Fixes #1555333 on Bugzilla: https://bugzilla.mozilla.org/show_bug.cgi?id=1555333

In the file: `devtools/client/debugger/src/actions/breakpoints/index.js`, made the following changes: 

1. When a user clicks on a gutter to add a breakpoint, skipPausing is set to false (if it was set to true).
2. When a user enables a breakpoint in the secondary panel, skipPausing is set to false (if it was set to true).

CC: @jasonLaster @digitarald @darkwing 